### PR TITLE
Minor fix on the doc of `vec_method_register()`

### DIFF
--- a/R/register-s3.R
+++ b/R/register-s3.R
@@ -4,7 +4,7 @@
 #' `S3Method()` namespace directive (often generated automatically be the
 #' `@export` roxygen2 tag). However, this technique requires that the generic
 #' be in an imported package, and sometimes you want to suggest a package,
-#' and only provide a method when that package is loaded. `vec_method_dynamic()`
+#' and only provide a method when that package is loaded. `vec_method_register()`
 #' should be called from your package's `.onLoad()` to dynamically register
 #' a method only if the generic's package is loaded.
 #'
@@ -24,8 +24,8 @@
 #' # printing when they are used.
 #'
 #' .onLoad <- function(...) {
-#'   vec_method_dynamic("pillar::pillar_shaft.vctrs_vctr")
-#'   vec_method_dynamic("tibble::type_sum.vctrs_vctr")
+#'   vec_method_register("pillar::pillar_shaft.vctrs_vctr")
+#'   vec_method_register("tibble::type_sum.vctrs_vctr")
 #' }
 #' @keywords internal
 vec_method_register <- function(method_name, method = NULL) {

--- a/man/vec_method_register.Rd
+++ b/man/vec_method_register.Rd
@@ -18,7 +18,7 @@ Generally, the recommend way to register an S3 method is to use the
 \code{S3Method()} namespace directive (often generated automatically be the
 \code{@export} roxygen2 tag). However, this technique requires that the generic
 be in an imported package, and sometimes you want to suggest a package,
-and only provide a method when that package is loaded. \code{vec_method_dynamic()}
+and only provide a method when that package is loaded. \code{vec_method_register()}
 should be called from your package's \code{.onLoad()} to dynamically register
 a method only if the generic's package is loaded.
 }
@@ -34,8 +34,8 @@ the lexical scope.
 # printing when they are used.
 
 .onLoad <- function(...) {
-  vec_method_dynamic("pillar::pillar_shaft.vctrs_vctr")
-  vec_method_dynamic("tibble::type_sum.vctrs_vctr")
+  vec_method_register("pillar::pillar_shaft.vctrs_vctr")
+  vec_method_register("tibble::type_sum.vctrs_vctr")
 }
 }
 \keyword{internal}


### PR DESCRIPTION
It seems there's no function like `vec_method_dynamic()`, I guess they should be `vec_method_register()`.