### PR TITLE
Fix) Use `x` not `.data`

### DIFF
--- a/R/vctr.R
+++ b/R/vctr.R
@@ -56,26 +56,26 @@
 #' @export
 #' @keywords internal
 #' @aliases vctr
-new_vctr <- function(.data, ..., class = character()) {
-  if (!is_vector(.data)) {
-    stop("`.data` must be a vector type", call. = FALSE)
+new_vctr <- function(x, ..., class = character()) {
+  if (!is_vector(x)) {
+    stop("`x` must be a vector type", call. = FALSE)
   }
-  check_attr(.data)
+  check_attr(x)
 
-  structure(.data, ..., class = c(class, "vctrs_vctr"))
+  structure(x, ..., class = c(class, "vctrs_vctr"))
 }
 
-check_attr <- function(.data) {
-  attr <- attributes(.data)
+check_attr <- function(x) {
+  attr <- attributes(x)
   if (is.null(attr))
     return()
 
   if (!identical(names(attr), "names")) {
-    stop("`.data` must not have attributes apart from names", call. = FALSE)
+    stop("`x` must not have attributes apart from names", call. = FALSE)
   }
 
   if (!names_all_or_nothing(attr[[1]])) {
-    stop("If any elements of `.data` are named, all must be named", call. = FALSE)
+    stop("If any elements of `x` are named, all must be named", call. = FALSE)
   }
 }
 

--- a/man/new_vctr.Rd
+++ b/man/new_vctr.Rd
@@ -5,14 +5,14 @@
 \alias{vctr}
 \title{vctr (vector) S3 class}
 \usage{
-new_vctr(.data, ..., class = character())
+new_vctr(x, ..., class = character())
 }
 \arguments{
+\item{x}{Foundation of class. Must be a vector}
+
 \item{...}{Name-value pairs defining attributes}
 
 \item{class}{Name of subclass.}
-
-\item{x}{Foundation of class. Must be a vector}
 }
 \description{
 This abstract class provides a set of useful default methods that makes it

--- a/tests/testthat/test-vctr.R
+++ b/tests/testthat/test-vctr.R
@@ -1,15 +1,15 @@
 context("test-vctr")
 
 test_that("constructor sets attributes", {
-  x <- new_vctr(1:4, class = "x", x = 1)
-  expect_equal(x, structure(1:4, class = c("x", "vctrs_vctr"), x = 1))
+  x <- new_vctr(1:4, class = "x", y = 1)
+  expect_equal(x, structure(1:4, class = c("x", "vctrs_vctr"), y = 1))
 })
 
-test_that(".data must be a vector", {
+test_that("x must be a vector", {
   expect_error(new_vctr(mean), "vector type")
 })
 
-test_that(".data must not have attributes, apart from names", {
+test_that("x must not have attributes, apart from names", {
   expect_error(new_vctr(structure(1, a = 1)), "attributes")
   expect_error(new_vctr(c(a = 1)), NA)
 })


### PR DESCRIPTION
- Updated `new_vctr()` and `check_attr()` to consistently use `x` rather than `.data` in argument names and error messages.
- Updated 2 tests to use `x` rather than `.data` in their description.
- Updated 1 test that tried to use `x` as an attribute, which failed after this change.

Closes #126 

(getting rate limited on travis)