### PR TITLE
Use .data rather than x in the docs of new_vctr()

### DIFF
--- a/R/vctr.R
+++ b/R/vctr.R
@@ -50,7 +50,7 @@
 #' * `dims()`, `dims<-()`, `dimnames()`, `dimnames<-`, `levels()`, and
 #'   `levels<-` methods throw errors.
 #'
-#' @param x Foundation of class. Must be a vector
+#' @param .data Foundation of class. Must be a vector
 #' @param ... Name-value pairs defining attributes
 #' @param class Name of subclass.
 #' @export

--- a/man/new_vctr.Rd
+++ b/man/new_vctr.Rd
@@ -8,11 +8,11 @@
 new_vctr(.data, ..., class = character())
 }
 \arguments{
+\item{.data}{Foundation of class. Must be a vector}
+
 \item{...}{Name-value pairs defining attributes}
 
 \item{class}{Name of subclass.}
-
-\item{x}{Foundation of class. Must be a vector}
 }
 \description{
 This abstract class provides a set of useful default methods that makes it


### PR DESCRIPTION
* Updated docs of `new_vctr()` to use `.data` rather than `x`

Closes #126 