### PR TITLE
Typos and vignette proofreading

### DIFF
--- a/R/prototype.R
+++ b/R/prototype.R
@@ -163,7 +163,7 @@ vec_ptype <- function(...) {
       step_lines <- apply(steps, 2, paste0, collapse = "")
     }
 
-    cat_line("Protoype: ", out_full[[n]])
+    cat_line("Prototype: ", out_full[[n]])
     cat_line(step_lines)
   }
 

--- a/vignettes/s3-vector.Rmd
+++ b/vignettes/s3-vector.Rmd
@@ -75,7 +75,7 @@ In this section you'll learn how to create a new vctrs class by calling `new_vct
   data-independent, and can easily be customised when the attributes do 
   depend on the data.
 
-* Default subset-assignment methods (`[<-`, `[[<-`, `$<-`) follow theprinciple 
+* Default subset-assignment methods (`[<-`, `[[<-`, `$<-`) follow the principle 
   that the new values should be coerced to match the existing vector. This 
   gives predictable behaviour and clear error messages.
 
@@ -99,7 +99,7 @@ str(x)
 
 Note that we prefix the name of the class with the name of the package. This prevents conflicting definitions between packages.
 
-We then then follow up with a user friendly [helper](https://adv-r.hadley.nz/s3.html#helpers). Here we'll use `vec_cast()`  to allow it to accept anything coercible to a double:
+We then follow up with a user friendly [helper](https://adv-r.hadley.nz/s3.html#helpers). Here we'll use `vec_cast()`  to allow it to accept anything coercible to a double:
 
 ```{r}
 percent <- function(x = double()) {
@@ -167,7 +167,7 @@ The next set of methods you are likely to need are those related to coercion and
 One of the main goals of vctrs is to put coercion and casting on a robust theoretical footing so it's possible to make accurate predictions about what (e.g.) `c(x, y)` should do when `x` and `y` have different prototypes. vctrs achieves this goal through two generics:
 
 * `vec_type2(x, y)` defines possible set of coercions. It returns a prototype
-  if can `x` and `y` can be safely coerced to the same prototype; otherwise
+  if `x` and `y` can be safely coerced to the same prototype; otherwise
   it returns an error. The set of automatic coercions is usually quite small
   because too many tend to make code harder to reason about and silently 
   propagate mistakes.
@@ -179,19 +179,19 @@ One of the main goals of vctrs is to put coercion and casting on a robust theore
 
 ### Double dispatch
 
-Both generics uses __[double dispatch](https://en.wikipedia.org/wiki/Double_dispatch)__ which means that the implementation is selected based on the class of two arguments, not just one. S3 does not natively support double dispatch, but we can implement with a trick: doing single dispatch twice. In practice, this means you end up with method names with two classes, like `vec_type2.foo.bar()`, and you need a little boilerplate to get started. The key idea that makes double dispatch work without any modifications to S3 is that a function (like `vec_type2.foo()`) can be both an S3 generic and an S3 method.
+Both generics use __[double dispatch](https://en.wikipedia.org/wiki/Double_dispatch)__ which means that the implementation is selected based on the class of two arguments, not just one. S3 does not natively support double dispatch, but we can implement with a trick: doing single dispatch twice. In practice, this means you end up with method names with two classes, like `vec_type2.foo.bar()`, and you need a little boilerplate to get started. The key idea that makes double dispatch work without any modifications to S3 is that a function (like `vec_type2.foo()`) can be both an S3 generic and an S3 method.
 
 ```{r}
 vec_type2.MYCLASS <- function(x, y) UseMethod("vec_type2.MYCLASS")
 vec_type2.MYCLASS.default <- function(x, y) stop_incompatible_type(x, y)
 vec_type2.MYCLASS.vctrs_unspecified <- function(x, y) x
 
-vec_cast.MYCLASS <- function(x, to) UseMethod("vec_cast.vctrs_percent")
+vec_cast.MYCLASS <- function(x, to) UseMethod("vec_cast.MYCLASS")
 vec_cast.MYCLASS.default <- function(x, to) stop_incompatible_cast(x, to)
 vec_cast.MYCLASS.logical <- function(x, to) vec_unspecified_cast(x, to)
 ```
 
-We'll discuss what this boilerplate does in the upcoming sections; just remember you'll always need to copy and paste it in when creating a new S3 class.
+We'll discuss what this boilerplate does in the upcoming sections; just remember you'll always need to copy and paste it when creating a new S3 class.
 
 ### Percent class {#percent}
 
@@ -469,7 +469,7 @@ vctrs makes it easy to create new record-style classes using `new_rcrd()`, which
 
 A fraction, or rational number can be represented by a pair of integer vectors representing the numerator (the number on top) and the denominator (the number on bottom), where the length of each vector must be the same. To represent such a data structure we turn to a new base data type: the record (or rcrd for short).
 
-As usual we start with low-level and user-friendly constructors. The low-level constructor calls `new_rcrd()` which need a named list of equal-length vectors.
+As usual we start with low-level and user-friendly constructors. The low-level constructor calls `new_rcrd()` which needs a named list of equal-length vectors.
 
 ```{r}
 new_rational <- function(n = integer(), d = integer()) {
@@ -556,7 +556,7 @@ vec_c(rational(1, 2), 1L, NA)
 
 The previous implementation of `decimal` was built on top of doubles. This is a bad idea because decimal vectors are typically used when you care about precise values (i.e. dollars and cents in a bank account), and double values suffer from floating point problems. 
 
-A better implementation of a decimal class would use be to use pair of integers, one for the value to the left of the decimal point, and the other for the value to the right (divided by a `scale`). The code is a very quick sketch of how you might start creating such a class:
+A better implementation of a decimal class would be to use pair of integers, one for the value to the left of the decimal point, and the other for the value to the right (divided by a `scale`). The code is a very quick sketch of how you might start creating such a class:
 
 ```{r}
 new_decimal2 <- function(l, r, scale = 2L) {
@@ -589,7 +589,7 @@ decimal2(10, c(0, 5, 99))
 
 vctrs provides two "proxy" generics that lets you control how your class determines equality and ordering:
 
-* `vec_proxy_equal()` specifies how to test the elements of your for equality. 
+* `vec_proxy_equal()` specifies how to test the elements of your vector for equality. 
   This proxy underpins `==` and `!=`, but also `unique()`, `anyDuplicated()`, 
   and `is.na()`.
 
@@ -661,7 +661,7 @@ sort(x)
 
 ### Polynomial class
 
-A related problem occurs if we build our vector on top of a list. The following code defines a polynomial class that represents polynomials (like `1 + 3x - 2x ^2`) using a list of integer vectors (like `c(1, 3, -2)`).
+A related problem occurs if we build our vector on top of a list. The following code defines a polynomial class that represents polynomials (like `1 + 3x - 2x^2`) using a list of integer vectors (like `c(1, 3, -2)`).
 
 ```{r}
 new_poly <- function(x) {
@@ -815,7 +815,7 @@ To allow these infix functions to work, we'll need to provide `vec_arith()` gene
 
 * It makes sense to add and subtract meters: that yields another meter.
   We can divide a meter by another meter (yielding a unitless number), but
-  we can't multiple to meters (because that would yield an area.)
+  we can't multiply meters (because that would yield an area.)
   
 * It makes sense to do any arithmetic operation with a number and a meter
   unit _except_ dividing a number by a meter.
@@ -907,7 +907,7 @@ vec_cast.vctrs_percent <- function(x, y) {
 } 
 ```
 
-You also need to register the individual double-dispatch methods. Again, this is hard that it should be because roxygen's heuristics aren't quite right. That means you need to describe the `@method` explicitly:
+You also need to register the individual double-dispatch methods. Again, this is harder than it should be because roxygen's heuristics aren't quite right. That means you need to describe the `@method` explicitly:
 
 ```{r}
 #' @method vec_cast.binned double

--- a/vignettes/stability.Rmd
+++ b/vignettes/stability.Rmd
@@ -29,23 +29,23 @@ We say a function is __type-stable__ iif:
 1.  You can predict the output type knowing only the input types. 
 1.  The order of arguments in ... does not affect the output type.
 
-Similary, a function is __size-stable__ iif:
+Similarly, a function is __size-stable__ iif:
 
 1.  You can predict the output size knowing only the input sizes, or
     there is a single numeric input that specifies the output size.
 
-Very few base R functions are size-stable, so I'll also define a slightly weaker condition. I'll call a function is __length-stable__ iif:
+Very few base R functions are size-stable, so I'll also define a slightly weaker condition. I'll call a function __length-stable__ iif:
 
 1.  You can predict the output _length_ knowing only the input _lengths_, or
     there is a single numeric input that specifies the output _length_.
 
 (But note that length-stable is not a particularly robust definition because `length()` returns a value for things that are not vectors.)
 
-We'll call functions that don't obey these principle __type-unstable__ and __size-unstable__ respectively.
+We'll call functions that don't obey these principles __type-unstable__ and __size-unstable__ respectively.
 
 On top of type- and size-stability, it's also desirable to have a single set of rules that are applied consistently. We want one set of type-coercion and size-recycling rules that apply everywhere, not many sets of rules that apply to different functions.
 
-The goal of these principles is to minimse cognitive overhead. Rather than having to memory many special cases, you should be able to learn one set of principles and apply them again and again.
+The goal of these principles is to minimise cognitive overhead. Rather than having to memorise many special cases, you should be able to learn one set of principles and apply them again and again.
 
 ### Examples
 
@@ -119,7 +119,7 @@ In this section we'll compare and contrast `c()` and `vec_c()`. `vec_c()` is bot
 * `vec_type(vec_c(x, y))` equals `vec_type_common(x, y)`.
 * `vec_size(vec_c(X, y))` equals `vec_size(x) + vec_size(y)`.
 
-`c()` has another undesirable property in that it's not consistent with `unlist()`, i.e. `unlist(list(x, y))` does not always equal `c(x, y)`; i.e. base R has multiple sets of type-coerion rules. I won't this problem further consider here.
+`c()` has another undesirable property in that it's not consistent with `unlist()`, i.e. `unlist(list(x, y))` does not always equal `c(x, y)`; i.e. base R has multiple sets of type-coerion rules. I won't consider this problem further here.
 
 I have two goals here: 
 
@@ -195,7 +195,7 @@ c(fa, fb)
 
 (this is documented in `c()` but is still undesirable.)
 
-`vec_c()` returns a factor taking the union of the levels. This is behaviour is motivated by pragmatics: there are many places in base R that automatically convert character vectors to factors, so enforcing stricter behaviour would be unnecessarily onerous. (This is backed up by experience with `dplyr::bind_rows()` which is stricter, and is a common source of user difficulty.) 
+`vec_c()` returns a factor taking the union of the levels. This behaviour is motivated by pragmatics: there are many places in base R that automatically convert character vectors to factors, so enforcing stricter behaviour would be unnecessarily onerous. (This is backed up by experience with `dplyr::bind_rows()` which is stricter, and is a common source of user difficulty.) 
 
 ```{r}
 vec_c(fa, fb)
@@ -219,7 +219,7 @@ This behaviour is documented in `?DateTimeClasses`, but is the source of conside
 vec_c(datetime_nz)
 ```
 
-What time zone should the output have if inputs have different time zones? One option would be to strict and force the user to manually align all the time zones. However, this is onerous (particularly because theres no easy way to change the time zone in base R), so vctrs chooses to use the first non-local time zone:
+What time zone should the output have if inputs have different time zones? One option would be to strict and force the user to manually align all the time zones. However, this is onerous (particularly because there's no easy way to change the time zone in base R), so vctrs chooses to use the first non-local time zone:
 
 ```{r}
 datetime_local <- as.POSIXct("2020-01-01 09:00")

--- a/vignettes/type-size.Rmd
+++ b/vignettes/type-size.Rmd
@@ -117,11 +117,11 @@ It's often important to combine vectors with multiple types. vctrs provides a co
   
 * `vec_type_common(x, NULL) == x`.
 
-i.e. `vec_type_common()` is both commutative and associative (with respect to class), and has an identity element, `NULL`, i.e. it's a __commutative monoid__. This means the underlying implementation is quite simple: we can find the common type of any number of any number of objects by progressively finding the common type of pairs of objects.
+i.e. `vec_type_common()` is both commutative and associative (with respect to class), and has an identity element, `NULL`, i.e. it's a __commutative monoid__. This means the underlying implementation is quite simple: we can find the common type of any number of objects by progressively finding the common type of pairs of objects.
 
 Like with `vec_type()`, the easiest way to explore `vec_type_common()` is with `vec_ptype()`: when given multiple inputs, it will print their common prototype. (In other words: program with `vec_type_common()` but play with `vec_ptype()`.)
 
-*   The common type of atomic vectors follows very similar to rules to base 
+*   The common type of atomic vectors is computed very similar to rules of base 
     R, except that we do not coerce to character automatically:
     
     ```{r, error = TRUE}
@@ -251,13 +251,13 @@ vec_cast(c(1.5, 2), integer())
 
 The set of casts is more permissive than the set of coercions and is summarised in the diagram below. Coercions are shown by arrows; possible casts are shown with circles.
 
-```{r, echo = FALSE, fig.cap="Summary of vctrs recycling rules"}
+```{r, echo = FALSE, fig.cap="Summary of vctrs casting rules"}
 knitr::include_graphics("../man/figures/combined.png", dpi = 300)
 ```
 
 ## Size
 
-`vec_size()` was motivated by the need to have a invariant that describes the number of "observations" in a data structure. This particularly important for data frames as it useful to have some function such that `f(data.frame(x))` equals `f(x)`. No base function has this property:
+`vec_size()` was motivated by the need to have an invariant that describes the number of "observations" in a data structure. This is particularly important for data frames as it's useful to have some function such that `f(data.frame(x))` equals `f(x)`. No base function has this property:
 
 * `length(data.frame(x))` equals `1`, because the length of a data frame 
    is the number of columns.

--- a/vignettes/type-size.Rmd
+++ b/vignettes/type-size.Rmd
@@ -22,7 +22,7 @@ Size and prototype are motivated by thinking about the optimal behaviour for `c(
 library(vctrs)
 ```
 
-## Protoype
+## Prototype
 
 The idea of a prototype is to capture the metadata associated with a vector, without capturing any data. Unfortunately, the `class()` of an object is inadequate for this purpose:
 


### PR DESCRIPTION
I really enjoyed reading vignettes of this package and can't wait for it to reach "stable" lifecycle. Along the way found these improvement opportunities. Sorry for mixing in one PR code and vignette updates.

Extra thoughts:

- In 's3-vector.Rmd' vignette [there is a description](https://github.com/r-lib/vctrs/blob/4d848c977556d19af320e9dbfd2a3487eb62999b/vignettes/s3-vector.Rmd#L820) about arithmetic between meters and numbers. I would argue that only both multiplications and division by a number are acceptable, as, strictly speaking, meter and number are object of different nature and can't be used with `+` and `-`.
- In 'stability.Rmd' vignette `c()` [is called length-stable](https://github.com/echasnovski/vctrs/blob/1b165d0c0e78634a3dace8e649a793a4a2fd9a95/vignettes/stability.Rmd#L90) (using "always") with [later attempt](https://github.com/echasnovski/vctrs/blob/1b165d0c0e78634a3dace8e649a793a4a2fd9a95/vignettes/stability.Rmd#L169) to rightfully refute this. That is an attempt, because it doesn't actually show the breaking behaviour (see [pkgdown site](https://vctrs.r-lib.org/articles/stability.html#non-vectors)), so extra objects in global environment needed. Maybe it is better to use "almost length-stable" in the examples and [later "Data frames" section](https://github.com/echasnovski/vctrs/blob/1b165d0c0e78634a3dace8e649a793a4a2fd9a95/vignettes/stability.Rmd#L274)