### PR TITLE
Fix) replacement op for `vctrs_vctr`

### DIFF
--- a/R/vctr.R
+++ b/R/vctr.R
@@ -214,7 +214,7 @@ diff.vctrs_vctr <- function(x, lag = 1L, differences = 1L, ...) {
 # Modification -------------------------------------------------------------
 
 #' @export
-`[[<-.vctrs_vctr` <- function(x, i, value) {
+`[[<-.vctrs_vctr` <- function(x, ..., value) {
   if (!is.list(x)) {
     value <- vec_cast(value, x)
   }

--- a/tests/testthat/test-vctr.R
+++ b/tests/testthat/test-vctr.R
@@ -192,6 +192,13 @@ test_that("can use [ and [[ with names", {
   expect_equal(y[["d"]], 4)
 })
 
+test_that("can use [[<- to replace n-dimensional elements", {
+  x <- new_vctr(rep(1, times = 4), dim = c(2, 2), class = "vctrs_mtrx")
+  vec_restore.vctrs_mtrx <- function(x, to) x
+  x[[2, 2]] <- 4
+  expect_equal(x[[2, 2]], 4)
+})
+
 test_that("subsetting preserves attributes", {
   x <- new_vctr(c(a = 1, b = 2))
   attr(x, "extra") <- TRUE


### PR DESCRIPTION
Closes #133 

* `i` is also used for `vctrs_sclr`, `vctrs_list_of`, and `vctrs_rcrd`, but only `vctrs_list_of` calls `NextMethod()` so it would be the only other one where I think this might apply. I did not make the change for it though.

* I added a test that somewhat shows what I was trying to do.