### PR TITLE
Dynamically register method needed for test

### DIFF
--- a/tests/testthat/test-vctr.R
+++ b/tests/testthat/test-vctr.R
@@ -195,6 +195,7 @@ test_that("can use [ and [[ with names", {
 test_that("can use [[<- to replace n-dimensional elements", {
   x <- new_vctr(rep(1, times = 4), dim = c(2, 2), class = "vctrs_mtrx")
   vec_restore.vctrs_mtrx <- function(x, to) x
+  s3_register("vctrs::vec_restore", "vctrs_mtrx", vec_restore.vctrs_mtrx)
   x[[2, 2]] <- 4
   expect_equal(x[[2, 2]], 4)
 })


### PR DESCRIPTION
My test passed interactively, but I forgot that I needed to dynamically register the method when the tests are run by `devtools::test()`. Sorry!