### PR TITLE
Fix) Recursively call `vec_slice()` when subsetting data frames

### DIFF
--- a/R/size.R
+++ b/R/size.R
@@ -108,7 +108,7 @@ vec_slice <- function(x, i) {
     NULL
   } else if (is.data.frame(x)) {
     # Much faster, and avoids creating rownames
-    out <- lapply(x, `[`, i)
+    out <- lapply(x, vec_slice, i)
     vec_restore(out, x)
   } else if (is_vector(x)) {
     d <- vec_dims(x)

--- a/tests/testthat/test-size.R
+++ b/tests/testthat/test-size.R
@@ -50,12 +50,10 @@ test_that("can subset object of any dimensionality", {
 })
 
 test_that("can subset data frame columns", {
-  df <- data.frame(x = c(1, 2), y = I(data.frame(z = c(1, 2), w = c(1, 2))))
+  df <- data.frame(x = 1:2)
+  df$y <- data.frame(a = 2:1)
 
-  base_slice <- df[1, , drop = FALSE]
-  rownames(base_slice) <- NULL
-
-  expect_equal(vec_slice(df, 1L), base_slice)
+  expect_equal(vec_slice(df, 1L)$y, vec_slice(df$y, 1L))
 })
 
 test_that("can modify subset", {

--- a/tests/testthat/test-size.R
+++ b/tests/testthat/test-size.R
@@ -49,6 +49,11 @@ test_that("can subset object of any dimensionality", {
   expect_equal(vec_slice(x4, 1L), ones(1, 3, 4, 5))
 })
 
+test_that("can subset data frame columns", {
+  df <- data.frame(x = c(1, 2), y = I(data.frame(z = c(1, 2), w = c(1, 2))))
+  expect_equal(vec_slice(df, 1L), df[1, , drop = FALSE])
+})
+
 test_that("can modify subset", {
   x1 <- c(2, 1)
   vec_slice(x1, 1L) <- 1

--- a/tests/testthat/test-size.R
+++ b/tests/testthat/test-size.R
@@ -51,7 +51,11 @@ test_that("can subset object of any dimensionality", {
 
 test_that("can subset data frame columns", {
   df <- data.frame(x = c(1, 2), y = I(data.frame(z = c(1, 2), w = c(1, 2))))
-  expect_equal(vec_slice(df, 1L), df[1, , drop = FALSE])
+
+  base_slice <- df[1, , drop = FALSE]
+  rownames(base_slice) <- NULL
+
+  expect_equal(vec_slice(df, 1L), base_slice)
 })
 
 test_that("can modify subset", {


### PR DESCRIPTION
I also added a test for data frame columns (I believe that is the correct base R approach). Feel free to drop it if you don't think it is necessary.

Closes #142 