### PR TITLE
Alter the examples in vec_cast() to demonstrate the lossy-cast condition system

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -79,9 +79,14 @@
 #' # x is a double, but no information is lost
 #' vec_cast(1, integer())
 #'
-#' # Information is lost so a warning is generated
+#' # Information is lost in all conversions so an error is generated
 #' \dontrun{
 #' vec_cast(1.5, integer())
+#' }
+#'
+#' # Information is lost in some conversions so a warning is generated
+#' \dontrun{
+#' vec_cast(c(1, 1.5), integer())
 #' }
 #'
 #' # No sensible coercion is possible so an error is generated

--- a/R/cast.R
+++ b/R/cast.R
@@ -85,9 +85,7 @@
 #' }
 #'
 #' # Information is lost in some conversions so a warning is generated
-#' \dontrun{
 #' vec_cast(c(1, 1.5), integer())
-#' }
 #'
 #' # No sensible coercion is possible so an error is generated
 #' \dontrun{

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -123,9 +123,7 @@ vec_cast(1.5, integer())
 }
 
 # Information is lost in some conversions so a warning is generated
-\dontrun{
 vec_cast(c(1, 1.5), integer())
-}
 
 # No sensible coercion is possible so an error is generated
 \dontrun{

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -117,9 +117,14 @@ attributes that don't require special handling for your class.
 # x is a double, but no information is lost
 vec_cast(1, integer())
 
-# Information is lost so a warning is generated
+# Information is lost in all conversions so an error is generated
 \dontrun{
 vec_cast(1.5, integer())
+}
+
+# Information is lost in some conversions so a warning is generated
+\dontrun{
+vec_cast(c(1, 1.5), integer())
 }
 
 # No sensible coercion is possible so an error is generated


### PR DESCRIPTION
I think the original example was incorrect because it says a warning is thrown when in reality an error is thrown because none of the conversions are lossless. I think it may have been a warning in an early version of vctrs.