### PR TITLE
Downcast percent to double

### DIFF
--- a/vignettes/s3-vector.Rmd
+++ b/vignettes/s3-vector.Rmd
@@ -237,17 +237,19 @@ Next, start by saying that a `vctrs_percent` combined with a `vctrs_percent` yie
 vec_type2.vctrs_percent.vctrs_percent <- function(x, y) new_percent()
 ```
 
-Next we define methods that say that combining a `percent` and double should yield a `percent`. Because double dispatch is a bit of a hack, we need to provide two methods. It's your responsibility to ensure that each pair return the same result: if they don't you will get weird and unpredictable behaviour.
+Next we define methods that say that combining a `percent` and double should yield a `double`. We avoid returning a `percent` here, because errors in the scale (1 vs. 0.01) are more obvious with raw numbers.
+
+Because double dispatch is a bit of a hack, we need to provide two methods. It's your responsibility to ensure that each pair return the same result: if they don't you will get weird and unpredictable behaviour.
 
 ```{r}
-vec_type2.vctrs_percent.double  <- function(x, y) new_percent()
-vec_type2.double.vctrs_percent  <- function(x, y) new_percent()
+vec_type2.vctrs_percent.double  <- function(x, y) double()
+vec_type2.double.vctrs_percent  <- function(x, y) double()
 ```
 
 We can check that we've implemented this correctly with `vec_ptype()`:
 
 ```{r}
-vec_ptype(double(), percent(), percent())
+vec_ptype(percent(), double(), percent())
 ```
 
 Next we implement explicit casting, again starting with the boilerplate:


### PR DESCRIPTION
Safer solution, avoids confusion. An example for an upcast is shown further below.