### PR TITLE
Fix vec_c() and vec_rbind() to handle data.frame columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
 # vctrs 0.1.0.9000
 
 * Added a `NEWS.md` file to track changes to the package.
+
+* `vec_c()` and `vec_rbind()` now handle data.frame columns properly (@yutannihilation, #182)

--- a/R/bind.R
+++ b/R/bind.R
@@ -110,7 +110,7 @@ vec_rbind <- function(..., .ptype = NULL) {
 
     tbl_i <- vec_data(vec_cast(tbls[[i]], to = ptype))
     for (j in seq_along(out)) {
-      out[[j]][pos:(pos + n - 1)] <- tbl_i[[j]]
+      vec_slice(out[[j]], pos:(pos + n - 1)) <- tbl_i[[j]]
     }
     pos <- pos + n
   }

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -114,8 +114,8 @@ vec_cast.data.frame.default    <- function(x, to) stop_incompatible_cast(x, to)
 # Helpers -----------------------------------------------------------------
 
 df_length <- function(x) {
-  if (length(x) > 0) {
-    length(x[[1]])
+  if (vec_size(x) > 0) {
+    vec_size(x[[1]])
   } else {
     0L
   }

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -67,6 +67,16 @@ test_that("matrix becomes data frame", {
   expect_equal(vec_rbind(x), data.frame(V1 = 1:2, V2 = 3:4))
 })
 
+test_that("can bind data.frame columns", {
+  df <- data.frame(x = NA, y = 1:2)
+  df$x <- data.frame(a = 1:2)
+
+  expected <- data.frame(x = NA, y = c(1:2, 1:2))
+  expected$x <- data.frame(a = c(1:2, 1:2))
+
+  expect_equal(vec_rbind(df, df), expected)
+})
+
 
 # cols --------------------------------------------------------------------
 

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -44,3 +44,13 @@ test_that("combines outer an inner names", {
   expect_equal(vec_c(c(x = 1:2)), c(x1 = 1, x2 = 2))
   expect_equal(vec_c(y = c(x = 1)), c(y..x = 1))
 })
+
+test_that("can bind data.frame columns", {
+  df <- data.frame(x = NA, y = 1:2)
+  df$x <- data.frame(a = 1:2)
+
+  expected <- data.frame(x = NA, y = c(1:2, 1:2))
+  expected$x <- data.frame(a = c(1:2, 1:2))
+
+  expect_equal(vec_c(df, df), expected)
+})

--- a/tests/testthat/test-size.R
+++ b/tests/testthat/test-size.R
@@ -63,11 +63,13 @@ test_that("can subset using logical index", {
   )
 })
 
-test_that("can subset data frame columns", {
-  df <- data.frame(x = 1:2)
-  df$y <- data.frame(a = 2:1)
+test_that("can subset 0-column data.fames", {
+  df_empty <- as.data.frame(matrix(nrow = 3, ncol = 0))
+  expect_equal(vec_slice(df_empty, 1:3), df_empty)
 
-  expect_equal(vec_slice(df, 1L)$y, vec_slice(df$y, 1L))
+  df <- df_empty
+  df$x <- df_empty
+  expect_equal(vec_slice(df, 1:3), df)
 })
 
 test_that("can modify subset", {

--- a/tests/testthat/test-size.R
+++ b/tests/testthat/test-size.R
@@ -63,13 +63,11 @@ test_that("can subset using logical index", {
   )
 })
 
-test_that("can subset 0-column data.fames", {
-  df_empty <- as.data.frame(matrix(nrow = 3, ncol = 0))
-  expect_equal(vec_slice(df_empty, 1:3), df_empty)
+test_that("can subset data frame columns", {
+  df <- data.frame(x = 1:2)
+  df$y <- data.frame(a = 2:1)
 
-  df <- df_empty
-  df$x <- df_empty
-  expect_equal(vec_slice(df, 1:3), df)
+  expect_equal(vec_slice(df, 1L)$y, vec_slice(df$y, 1L))
 })
 
 test_that("can modify subset", {

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -97,8 +97,10 @@ test_that("casts preserve outer class", {
 })
 
 test_that("restore generates correct row/col names", {
-  df1 <- data.frame(x = 1:4, y = 1:4, z = 1:4)
-  df2 <- vec_restore(lapply(df1[1:3], `[`, 1:2), df1)
+  df1 <- data.frame(x = NA, y = 1:4, z = 1:4)
+  df1$x <- data.frame(a = 1:4, b = 1:4)
+
+  df2 <- vec_restore(lapply(df1[1:3], vec_slice, 1:2), df1)
 
   expect_named(df2, c("x", "y", "z"))
   expect_equal(.row_names_info(df2), -2)


### PR DESCRIPTION
Fix #178 

* `df_length()` should use `vec_size()` instead of `length()`.
* `vec_rbind()` should use `vec_slice<-()` to replace columns