### PR TITLE
Fix typo in S3 vignette

### DIFF
--- a/vignettes/s3-vector.Rmd
+++ b/vignettes/s3-vector.Rmd
@@ -693,7 +693,7 @@ vec_proxy_compare.vctrs_rational <- function(x) {
 sort(x)
 ```
 
-(We could have used the same approach in `vec_proxy_equality()`, but when working with floating point numbers it's not necessarily true that `x == y` implies that `d * x == d * y`.)
+(We could have used the same approach in `vec_proxy_equal()`, but when working with floating point numbers it's not necessarily true that `x == y` implies that `d * x == d * y`.)
 
 ### Polynomial class
 


### PR DESCRIPTION
Correct reference to `vec_proxy_equal()`