### PR TITLE
Propagate missing values in recursive `vec_equal()`

### DIFF
--- a/R/equal.R
+++ b/R/equal.R
@@ -74,6 +74,6 @@ vec_equal_na <- function(x) {
   .Call(vctrs_equal_na, x)
 }
 
-obj_equal <- function(x, y) {
-  .Call(vctrs_equal_object, x, y)
+obj_equal <- function(x, y, na_equal = TRUE) {
+  .Call(vctrs_equal_object, x, y, na_equal)
 }

--- a/src/init.c
+++ b/src/init.c
@@ -16,7 +16,7 @@ extern SEXP vctrs_fields(SEXP);
 extern SEXP vctrs_n_fields(SEXP);
 extern SEXP vctrs_hash(SEXP);
 extern SEXP vctrs_hash_object(SEXP);
-extern SEXP vctrs_equal_object(SEXP);
+extern SEXP vctrs_equal_object(SEXP, SEXP, SEXP);
 extern SEXP vctrs_in(SEXP, SEXP);
 extern SEXP vctrs_duplicated(SEXP);
 extern SEXP vctrs_duplicate_split(SEXP);
@@ -41,7 +41,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"vctrs_n_fields",    (DL_FUNC) &vctrs_n_fields,  1},
     {"vctrs_hash",        (DL_FUNC) &vctrs_hash,  1},
     {"vctrs_hash_object", (DL_FUNC) &vctrs_hash_object,  1},
-    {"vctrs_equal_object", (DL_FUNC) &vctrs_equal_object,  2},
+    {"vctrs_equal_object", (DL_FUNC) &vctrs_equal_object,  3},
     {"vctrs_in",          (DL_FUNC) &vctrs_in,  2},
     {"vctrs_unique_loc",  (DL_FUNC) &vctrs_unique_loc,  1},
     {"vctrs_duplicated",  (DL_FUNC) &vctrs_duplicated,  1},

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -12,7 +12,9 @@ bool is_data_frame(SEXP x);
 bool is_record(SEXP x);
 bool is_scalar(SEXP x);
 
-bool equal_object(SEXP x, SEXP y);
+// Most vector predicates return `int` because missing values are
+// propagated as `NA_LOGICAL`
+int equal_object(SEXP x, SEXP y, bool na_equal);
 bool equal_names(SEXP x, SEXP y);
 
 int equal_scalar(SEXP x, int i, SEXP y, int j, bool na_equal);

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -165,6 +165,28 @@ test_that("NA propagate from data frames columns", {
   expect_identical(vec_equal(y, x, na_equal = TRUE), c(FALSE, FALSE, FALSE))
 })
 
+test_that("NA propagate from list components", {
+  expect_identical(obj_equal(NA, NA, na_equal = FALSE), NA)
+  expect_identical(vec_equal(list(NA), list(NA)), NA)
+
+  expect_true(obj_equal(NA, NA, na_equal = TRUE))
+  expect_true(vec_equal(list(NA), list(NA), na_equal = TRUE))
+})
+
+test_that("NA propagate from vector names when comparing objects (#217)", {
+  x <- set_names(1:3, c("a", "b", NA))
+  y <- set_names(1:3, c("a", NA, NA))
+
+  expect_identical(obj_equal(x, x, na_equal = FALSE), NA)
+  expect_identical(obj_equal(x, x, na_equal = TRUE), TRUE)
+
+  expect_identical(obj_equal(x, y, na_equal = FALSE), NA)
+  expect_identical(obj_equal(x, y, na_equal = TRUE), FALSE)
+
+  expect_identical(vec_equal(list(x, x, y), list(x, y, y)), c(NA, NA, NA))
+  expect_identical(vec_equal(list(x, x, y), list(x, y, y), na_equal = TRUE), c(TRUE, FALSE, TRUE))
+})
+
 
 # proxy -------------------------------------------------------------------
 

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -174,6 +174,9 @@ test_that("NA propagate from list components", {
 })
 
 test_that("NA propagate from vector names when comparing objects (#217)", {
+  # FIXME: Not clear what should we do in the recursive case. Should we
+  # compare attributes of non S3 vectors at all?
+
   x <- set_names(1:3, c("a", "b", NA))
   y <- set_names(1:3, c("a", NA, NA))
 
@@ -185,6 +188,29 @@ test_that("NA propagate from vector names when comparing objects (#217)", {
 
   expect_identical(vec_equal(list(x, x, y), list(x, y, y)), c(NA, NA, NA))
   expect_identical(vec_equal(list(x, x, y), list(x, y, y), na_equal = TRUE), c(TRUE, FALSE, TRUE))
+})
+
+test_that("NA do not propagate from attributes", {
+  x <- structure(1:3, foo = NA)
+  y <- structure(1:3, foo = "")
+  expect_true(obj_equal(x, x))
+  expect_false(obj_equal(x, y))
+})
+
+test_that("NA do not propagate from function bodies or formals", {
+  fn <- other <- function() NA
+  body(other) <- TRUE
+
+  expect_true(vec_equal(list(fn), list(fn)))
+  expect_false(vec_equal(list(fn), list(other)))
+  expect_true(obj_equal(fn, fn))
+  expect_false(obj_equal(fn, other))
+
+  fn <- other <- function(x = NA) NULL
+  formals(other) <- list(x = NULL)
+
+  expect_true(vec_equal(list(fn), list(fn)))
+  expect_false(vec_equal(list(fn), list(other)))
 })
 
 


### PR DESCRIPTION
So that

```r
vec_equal(list(NA), list(NA))
#> [1] NA

vec_equal(list(NA), list(NA), na_equal = TRUE)
#> [1] TRUE
```

Missingness is never propagated from attributes, except for vector names.

Closes #217.