### PR TITLE
Improve `vec_equal()` performance

### DIFF
--- a/src/compare.c
+++ b/src/compare.c
@@ -20,7 +20,7 @@ int scmp(SEXP x, SEXP y) {
   return cmp / abs(cmp);
 }
 
-int compare_scalar(SEXP x, int i, SEXP y, int j, bool na_equal) {
+int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
   if (TYPEOF(x) != TYPEOF(y))
     stop_not_comparable(x, y, "different types");
 

--- a/src/equal.c
+++ b/src/equal.c
@@ -1,27 +1,46 @@
+#include <math.h>
 #include "vctrs.h"
 
 int lgl_equal_scalar(int* x, int* y, bool na_equal) {
-  if (*x == NA_LOGICAL) return na_equal ? *y == NA_LOGICAL : NA_LOGICAL;
-  if (*y == NA_LOGICAL) return na_equal ? *x == NA_LOGICAL : NA_LOGICAL;
-  return *x == *y;
+  int xi = *x;
+  int yj = *y;
+  if (na_equal) {
+    return xi == yj;
+  } else {
+    return (xi == NA_LOGICAL || yj == NA_LOGICAL) ? NA_LOGICAL : xi == yj;
+  }
 }
 int int_equal_scalar(int* x, int* y, bool na_equal) {
-  if (*x == NA_INTEGER) return na_equal ? *y == NA_INTEGER : NA_LOGICAL;
-  if (*y == NA_INTEGER) return na_equal ? *x == NA_INTEGER : NA_LOGICAL;
-  return *x == *y;
+  int xi = *x;
+  int yj = *y;
+  if (na_equal) {
+    return xi == yj;
+  } else {
+    return (xi == NA_INTEGER || yj == NA_INTEGER) ? NA_LOGICAL : xi == yj;
+  }
 }
 int dbl_equal_scalar(double* x, double* y, bool na_equal) {
-  if (R_IsNA(*x)) return na_equal ? R_IsNA(*y) : NA_LOGICAL;
-  if (R_IsNaN(*x)) return na_equal ? R_IsNaN(*y) : NA_LOGICAL;
-  if (R_IsNA(*y)) return na_equal ? R_IsNA(*x) : NA_LOGICAL;
-  if (R_IsNaN(*y)) return na_equal ? R_IsNaN(*x) : NA_LOGICAL;
-  return *x == *y;
+  double xi = *x;
+  double yj = *y;
+  if (na_equal) {
+    if (R_IsNA(xi)) return R_IsNA(yj);
+    if (R_IsNaN(xi)) return R_IsNaN(yj);
+    if (R_IsNA(yj)) return R_IsNA(xi);
+    if (R_IsNaN(yj)) return R_IsNaN(xi);
+  } else {
+    if (isnan(xi) || isnan(yj)) return NA_LOGICAL;
+  }
+  return xi == yj;
 }
 int chr_equal_scalar(SEXP* x, SEXP* y, bool na_equal) {
-  if (*x == NA_STRING) return na_equal ? *y == NA_STRING : NA_LOGICAL;
-  if (*y == NA_STRING) return na_equal ? *x == NA_STRING : NA_LOGICAL;
-  // Ignoring encoding for now
-  return *x == *y;
+  SEXP xi = *x;
+  SEXP yj = *y;
+  if (na_equal) {
+    // Ignoring encoding for now
+    return xi == yj;
+  } else {
+    return (xi == NA_STRING || yj == NA_STRING) ? NA_LOGICAL : xi == yj;
+  }
 }
 
 int list_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {

--- a/src/equal.c
+++ b/src/equal.c
@@ -1,6 +1,9 @@
 #include <math.h>
 #include "vctrs.h"
 
+// Storing pointed values on the stack helps performance for the
+// `!na_equal` cases
+
 int lgl_equal_scalar(int* x, int* y, bool na_equal) {
   int xi = *x;
   int yj = *y;

--- a/src/equal.c
+++ b/src/equal.c
@@ -76,8 +76,6 @@ int df_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
   return true;
 }
 
-// Caller must ensure proper types and sizes. This function is meant
-// to be used in loops. These must check bounds.
 int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
   switch (vec_typeof(x)) {
   case vctrs_type_logical: return lgl_equal_scalar(LOGICAL(x) + i, LOGICAL(y) + j, na_equal);

--- a/src/types.c
+++ b/src/types.c
@@ -11,3 +11,22 @@ bool is_record(SEXP x) {
 bool is_scalar(SEXP x) {
   return Rf_inherits(x, "vctrs_sclr");
 }
+
+enum vctrs_type vec_typeof(SEXP x) {
+  switch (TYPEOF(x)) {
+  case LGLSXP: return vctrs_type_logical;
+  case INTSXP: return vctrs_type_integer;
+  case REALSXP: return vctrs_type_double;
+  case CPLXSXP: return vctrs_type_double;
+  case STRSXP: return vctrs_type_character;
+  case RAWSXP: return vctrs_type_raw;
+  case VECSXP:
+    if (is_data_frame(x)) {
+      return vctrs_type_dataframe;
+    } else {
+      return vctrs_type_list;
+    }
+  default:
+    Rf_error("Unsupported type", Rf_type2char(TYPEOF(x)));
+  }
+}

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -35,8 +35,15 @@ bool is_scalar(SEXP x);
 int equal_object(SEXP x, SEXP y, bool na_equal);
 bool equal_names(SEXP x, SEXP y);
 
-// Caller must ensure proper types and sizes. These functions are meant
-// to be used in loops. These must check bounds.
+/**
+ * These functions are meant to be used in loops so it is the callers
+ * responsibility to ensure that:
+ *
+ * - `x` and `y` have identical SEXTYPEs
+ * - `i` is a valid index into `x`, and `j` is a valid index into `y`.
+ *
+ * The behaviour is undefined if these conditions are not true.
+ */
 int equal_scalar(SEXP x, int i, SEXP y, int j, bool na_equal);
 int compare_scalar(SEXP x, int i, SEXP y, int j, bool na_equal);
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -44,8 +44,8 @@ bool equal_names(SEXP x, SEXP y);
  *
  * The behaviour is undefined if these conditions are not true.
  */
-int equal_scalar(SEXP x, int i, SEXP y, int j, bool na_equal);
-int compare_scalar(SEXP x, int i, SEXP y, int j, bool na_equal);
+int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal);
+int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal);
 
 int32_t hash_object(SEXP x);
 int32_t hash_scalar(SEXP x, R_len_t i);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -35,6 +35,8 @@ bool is_scalar(SEXP x);
 int equal_object(SEXP x, SEXP y, bool na_equal);
 bool equal_names(SEXP x, SEXP y);
 
+// Caller must ensure proper types and sizes. These functions are meant
+// to be used in loops. These must check bounds.
 int equal_scalar(SEXP x, int i, SEXP y, int j, bool na_equal);
 int compare_scalar(SEXP x, int i, SEXP y, int j, bool na_equal);
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -5,6 +5,24 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+
+// Vector types -------------------------------------------------
+
+enum vctrs_type {
+  vctrs_type_null      = 0,
+  vctrs_type_logical   = 1,
+  vctrs_type_integer   = 2,
+  vctrs_type_double    = 3,
+  vctrs_type_complex   = 4,
+  vctrs_type_character = 5,
+  vctrs_type_raw       = 6,
+  vctrs_type_list      = 7,
+  vctrs_type_dataframe = 8
+};
+
+enum vctrs_type vec_typeof(SEXP x);
+
+
 // Vector methods ------------------------------------------------
 R_len_t vec_size(SEXP x);
 


### PR DESCRIPTION
This pulls the dereference of atomic SEXP arrays out of the `vec_equal()` loop to improve performance. A new `vctrs_type` enum supports the genericity over types.

I have tried several ways:

- `no_deref`: Pass a reference object to `equal_scalar()` that contains an array pointer if applicable:

    ```c
    struct vctrs_ref {
      SEXP object;
      enum vctrs_type type;
      void* pointer;
      R_len_t i;
    };
    ```

  This approach improved performance but not enough.

- `no_branch`: Same as above, but pulls the `if (na_equal)` branch out of the loop. This had no impact.

- `template`: switch over vctrs types with the same loop template. This is the approach that is implemented in this PR.

- `template_full`: Like `template` but with no `na_equal` branch. Again, no impact.

![faster-loop-desktop](https://user-images.githubusercontent.com/4465050/53836887-6cd1b000-3f91-11e9-893f-098b8cbb74e1.png)

The `dotcall` case directly `.Call()`s into `vctrs_equal()` for better comparison with base R's `==`.