### PR TITLE
Refactor: replace goto by helper functions

### DIFF
--- a/src/slice.c
+++ b/src/slice.c
@@ -103,23 +103,16 @@ static SEXP vec_slice_switch(SEXP x, SEXP index, bool dispatch) {
     return list_slice(x, index);
 
   default:
-    break;
+    return R_NilValue;
   }
-
-  return R_NilValue;
 }
 
 static SEXP vec_slice_impl(SEXP x, SEXP index, bool dispatch) {
-  if (index == R_MissingArg) {
-    return x;
-  }
-
   SEXP out = R_NilValue;
 
   if (!has_dim(x)) {
     out = vec_slice_switch(x, index, dispatch);
   }
-
   if (out == R_NilValue) {
     return vec_slice_dispatch(x, index);
   }
@@ -146,7 +139,7 @@ static void slice_names(SEXP x, SEXP to, SEXP index) {
 }
 
 SEXP vctrs_slice(SEXP x, SEXP index, SEXP dispatch) {
-  if (x == R_NilValue) {
+  if (x == R_NilValue || index == R_MissingArg) {
     return x;
   }
 

--- a/src/slice.c
+++ b/src/slice.c
@@ -76,13 +76,18 @@ static SEXP list_slice(SEXP x, SEXP index) {
 
 #undef SLICE_BARRIER
 
+static SEXP vec_slice_dispatch(SEXP x, SEXP index) {
+  return vctrs_dispatch2(syms_vec_slice_dispatch, fns_vec_slice_dispatch,
+                         syms_x, x,
+                         syms_i, index);
+}
 
 static SEXP vec_slice_impl(SEXP x, SEXP index, bool dispatch) {
   if (index == R_MissingArg) {
     return x;
   }
   if (has_dim(x)) {
-    goto dispatch;
+    return vec_slice_dispatch(x, index);
   }
 
   SEXP out = NULL;
@@ -121,10 +126,7 @@ static SEXP vec_slice_impl(SEXP x, SEXP index, bool dispatch) {
   }
 
   default:
-  dispatch:
-    return vctrs_dispatch2(syms_vec_slice_dispatch, fns_vec_slice_dispatch,
-                           syms_x, x,
-                           syms_i, index);
+    return vec_slice_dispatch(x, index);
   }
 
   slice_names(out, x, index);

--- a/src/type2.c
+++ b/src/type2.c
@@ -6,9 +6,15 @@
 static SEXP fns_vec_type2_dispatch = NULL;
 static SEXP syms_vec_type2_dispatch = NULL;
 
+static SEXP vctrs_type2_dispatch(SEXP x, SEXP y) {
+  return vctrs_dispatch2(syms_vec_type2_dispatch, fns_vec_type2_dispatch,
+                         syms_x, x,
+                         syms_y, y);
+}
+
 SEXP vctrs_type2(SEXP x, SEXP y) {
   if (has_dim(x) || has_dim(y)) {
-    goto dispatch;
+    return vctrs_type2_dispatch(x, y);
   }
 
   switch (vec_dispatch_typeof(x, y)) {
@@ -37,10 +43,7 @@ SEXP vctrs_type2(SEXP x, SEXP y) {
     return vctrs_shared_empty_list;
 
   default:
-  dispatch:
-    return vctrs_dispatch2(syms_vec_type2_dispatch, fns_vec_type2_dispatch,
-                           syms_x, x,
-                           syms_y, y);
+    return vctrs_type2_dispatch(x, y);
   }
 }
 


### PR DESCRIPTION
- Separate repetitive `switch` code from more complex logic.
- Hide details of double-dispatch function invocation

This might fix a possible protection error in `vec_slice_impl()` too.