### PR TITLE
Fix `vec_assert()`

### DIFF
--- a/R/assert.R
+++ b/R/assert.R
@@ -12,7 +12,7 @@
 #' * If the prototype doesn't match, an error of class
 #'   `"vctrs_error_assert_ptype"` is raised.
 #'
-#' * If the prototype doesn't match, an error of class
+#' * If the size doesn't match, an error of class
 #' `"vctrs_error_assert_size"` is raised.
 #'
 #' Both errors inherit from `"vctrs_error_assert"`.

--- a/R/assert.R
+++ b/R/assert.R
@@ -43,8 +43,6 @@ vec_assert <- function(x, ptype = NULL, size = NULL, arg = NULL) {
     ptype <- vec_type(ptype)
     x_type <- vec_type(x)
     if (!is_same_type(x_type, ptype)) {
-      ptype <- vec_type(ptype)
-      x_type <- vec_type(x)
       msg <- paste0("`", arg, "` must be <", vec_ptype_abbr(ptype), ">, not <", vec_ptype_abbr(x_type), ">.")
       abort(
         msg,

--- a/man/vec_assert.Rd
+++ b/man/vec_assert.Rd
@@ -40,7 +40,7 @@ prototype and/or a size.
 \itemize{
 \item If the prototype doesn't match, an error of class
 \code{"vctrs_error_assert_ptype"} is raised.
-\item If the prototype doesn't match, an error of class
+\item If the size doesn't match, an error of class
 \code{"vctrs_error_assert_size"} is raised.
 }
 


### PR DESCRIPTION
- Typo
- `vec_type()` was being computed twice for the same objects