### PR TITLE
Call `vec_restore()` from `vec_slice()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs 0.1.0.9000
 
+* `vec_slice()` now calls `vec_restore()` automatically. Attributes of
+  unclassed structures are preserved by default.
+
 * `vec_slice()` is now a generic. Its default method calls `[`.
 
 * `vec_size()` now works with positive short row names. This fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # vctrs 0.1.0.9000
 
-* `vec_slice()` now calls `vec_restore()` automatically. Attributes of
-  unclassed structures are preserved by default.
+* `vec_slice()` now calls `vec_restore()` automatically. Unlike the
+  default `[` method from base R, attributes are preserved by default.
 
 * `vec_slice()` is now a generic. Its default method calls `[`.
 

--- a/R/cast.R
+++ b/R/cast.R
@@ -67,8 +67,13 @@
 #' additional metadata that is important to them, so you should preserve any
 #' attributes that don't require special handling for your class.
 #'
-#' @param x,... Vectors to cast.
+#' @param x Vectors to cast.
+#' @param ... For `vec_cast()`, vectors to cast. For `vec_restore()`,
+#'   these dots are only for future extensions and should be empty.
 #' @param to,.to Type to cast to. If `NULL`, `x` will be returned as is.
+#' @param i The index vector used to slice `x` when restoration is
+#'   triggered by [vec_slice()]. In most cases you don't need this
+#'   information and can safely ignore that argument.
 #' @return A vector the same length as `x` with the same type as `to`,
 #'   or an error if the cast is not possible. A warning is generated if
 #'   information is lost when casting between compatible types (i.e. when
@@ -118,15 +123,16 @@ vec_cast.default <- function(x, to) {
 
 #' @export
 #' @rdname vec_cast
-vec_restore <- function(x, to) {
-  return(.Call(vctrs_restore, x, to))
+vec_restore <- function(x, to, ..., i = NULL) {
+  check_dots_empty_s3_extensions(...)
+  return(.Call(vctrs_restore, x, to, i))
   UseMethod("vec_restore", to)
 }
-vec_restore_dispatch <- function(x, to) {
+vec_restore_dispatch <- function(x, to, ..., i = NULL) {
   UseMethod("vec_restore", to)
 }
 #' @export
-vec_restore.default <- function(x, to) {
+vec_restore.default <- function(x, to, ...) {
   .Call(vctrs_restore_default, x, to)
 }
 

--- a/R/slice.R
+++ b/R/slice.R
@@ -4,16 +4,26 @@
 #' for all vector types, regardless of dimensionality. It is an analog to `[`
 #' that matches [vec_size()] instead of `length()`.
 #'
+#' @param x A vector
+#' @param i An integer or character vector specifying the positions or
+#'   names of the observations to get/set.
+#' @param value Replacement values.
+#'
+#' @details
+#'
 #' * `vec_slice()` is an S3 generic for which you can implement methods.
 #'   The default method calls `[`.
 #'
 #' * [vec_restore()] is called on the slice vector to restore
 #'   the class and attributes.
 #'
-#' @param x A vector
-#' @param i An integer or character vector specifying the positions or
-#'   names of the observations to get/set.
-#' @param value Replacement values.
+#' @section Differences with base R subsetting:
+#'
+#' * `vec_slice()` only slices along one dimension. For
+#'   two-dimensional types, the first dimension is subsetted.
+#'
+#' * `vec_slice()` preserves attributes by default.
+#'
 #' @export
 #' @keywords internal
 #' @examples

--- a/R/slice.R
+++ b/R/slice.R
@@ -36,8 +36,7 @@ vec_slice.default <- function(x, i) {
   if (is.data.frame(x)) {
     # Much faster, and avoids creating rownames
     out <- lapply(x, vec_slice, i)
-    attr(out, "row.names") <- .set_row_names(length(i))
-    return(vec_restore(out, x))
+    return(vec_restore(out, x, i = i))
   }
 
   vec_assert(x)

--- a/R/slice.R
+++ b/R/slice.R
@@ -4,8 +4,11 @@
 #' for all vector types, regardless of dimensionality. It is an analog to `[`
 #' that matches [vec_size()] instead of `length()`.
 #'
-#' `vec_slice()` is an S3 generic for which you can implement methods.
-#' The default method calls `[`.
+#' * `vec_slice()` is an S3 generic for which you can implement methods.
+#'   The default method calls `[`.
+#'
+#' * [vec_restore()] is called on the slice vector to restore
+#'   the class and attributes.
 #'
 #' @param x A vector
 #' @param i An integer or character vector specifying the positions or

--- a/R/slice.R
+++ b/R/slice.R
@@ -33,10 +33,6 @@ vec_slice_dispatch <- function(x, i) {
 }
 #' @export
 vec_slice.default <- function(x, i) {
-  if (is.data.frame(x)) {
-    return(lapply(x, vec_slice, i))
-  }
-
   vec_assert(x)
 
   d <- vec_dims(x)

--- a/R/slice.R
+++ b/R/slice.R
@@ -34,9 +34,7 @@ vec_slice_dispatch <- function(x, i) {
 #' @export
 vec_slice.default <- function(x, i) {
   if (is.data.frame(x)) {
-    # Much faster, and avoids creating rownames
-    out <- lapply(x, vec_slice, i)
-    return(vec_restore(out, x, i = i))
+    return(lapply(x, vec_slice, i))
   }
 
   vec_assert(x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -161,3 +161,11 @@ check_dots_empty_s3_consistency <- function(...) {
     ))
   }
 }
+check_dots_empty_s3_extensions <- function(...) {
+  if (dots_n(...)) {
+    abort(paste_line(
+      "`...` is not empty.",
+      "These dots only exist to allow future extensions and should be empty."
+    ))
+  }
+}

--- a/R/vctr.R
+++ b/R/vctr.R
@@ -148,13 +148,13 @@ format.vctrs_vctr <- function(x, ...) {
 
 #' @export
 vec_slice.vctrs_vctr <- function(x, i) {
-  vec_restore(vec_slice_bare(x, i), x)
+  vec_slice_bare(x, i)
 }
 
 #' @export
 `[.vctrs_vctr` <- function(x, i, ...) {
   check_dots_empty_s3_consistency(...)
-  vec_restore(vec_slice_bare(x, i), x)
+  vec_slice_bare(x, i)
 }
 
 #' @export

--- a/R/vctr.R
+++ b/R/vctr.R
@@ -80,7 +80,7 @@ names_all_or_nothing <- function(names) {
 }
 
 #' @export
-vec_restore.vctrs_vctr <- function(x, to) {
+vec_restore.vctrs_vctr <- function(x, to, ...) {
   if (typeof(x) != typeof(to)) {
     stop_incompatible_cast(x, to)
   }

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -16,7 +16,7 @@ vec_cast(x, to)
 
 vec_cast_common(..., .to = NULL)
 
-vec_restore(x, to)
+vec_restore(x, to, ..., i = NULL)
 
 \method{vec_cast}{logical}(x, to)
 
@@ -31,9 +31,16 @@ vec_restore(x, to)
 \method{vec_cast}{list}(x, to)
 }
 \arguments{
-\item{x, ...}{Vectors to cast.}
+\item{x}{Vectors to cast.}
 
 \item{to, .to}{Type to cast to. If \code{NULL}, \code{x} will be returned as is.}
+
+\item{...}{For \code{vec_cast()}, vectors to cast. For \code{vec_restore()},
+these dots are only for future extensions and should be empty.}
+
+\item{i}{The index vector used to slice \code{x} when restoration is
+triggered by \code{\link[=vec_slice]{vec_slice()}}. In most cases you don't need this
+information and can safely ignore that argument.}
 }
 \value{
 A vector the same length as \code{x} with the same type as \code{to},

--- a/man/vec_slice.Rd
+++ b/man/vec_slice.Rd
@@ -30,6 +30,15 @@ The default method calls \code{[}.
 the class and attributes.
 }
 }
+\section{Differences with base R subsetting}{
+
+\itemize{
+\item \code{vec_slice()} only slices along one dimension. For
+two-dimensional types, the first dimension is subsetted.
+\item \code{vec_slice()} preserves attributes by default.
+}
+}
+
 \examples{
 x <- sample(10)
 x

--- a/man/vec_slice.Rd
+++ b/man/vec_slice.Rd
@@ -23,8 +23,12 @@ for all vector types, regardless of dimensionality. It is an analog to \code{[}
 that matches \code{\link[=vec_size]{vec_size()}} instead of \code{length()}.
 }
 \details{
-\code{vec_slice()} is an S3 generic for which you can implement methods.
+\itemize{
+\item \code{vec_slice()} is an S3 generic for which you can implement methods.
 The default method calls \code{[}.
+\item \code{\link[=vec_restore]{vec_restore()}} is called on the slice vector to restore
+the class and attributes.
+}
 }
 \examples{
 x <- sample(10)

--- a/src/cast.c
+++ b/src/cast.c
@@ -336,7 +336,7 @@ SEXP df_restore(SEXP x, SEXP to, SEXP i) {
   return x;
 }
 
-SEXP vctrs_restore(SEXP x, SEXP to, SEXP i) {
+SEXP vec_restore(SEXP x, SEXP to, SEXP i) {
   switch (vec_typeof(to)) {
   case vctrs_type_dataframe:
     return df_restore(x, to, i);

--- a/src/cast.c
+++ b/src/cast.c
@@ -265,6 +265,10 @@ SEXP vec_cast(SEXP x, SEXP to) {
 
 // Copy attributes except names. This duplicates `x` if needed.
 SEXP vctrs_restore_default(SEXP x, SEXP to) {
+  if (has_dim(x)) {
+    return x;
+  }
+
   int n_protect = 0;
 
   SEXP attrib = PROTECT(Rf_shallow_duplicate(ATTRIB(to)));

--- a/src/cast.c
+++ b/src/cast.c
@@ -263,12 +263,8 @@ SEXP vec_cast(SEXP x, SEXP to) {
   return out;
 }
 
-// Copy attributes except names. This duplicates `x` if needed.
+// Copy attributes except names and dim. This duplicates `x` if needed.
 SEXP vctrs_restore_default(SEXP x, SEXP to) {
-  if (has_dim(x)) {
-    return x;
-  }
-
   int n_protect = 0;
 
   SEXP attrib = PROTECT(Rf_shallow_duplicate(ATTRIB(to)));
@@ -284,10 +280,16 @@ SEXP vctrs_restore_default(SEXP x, SEXP to) {
     ++n_protect;
   }
 
-  // Copy attributes but keep names
-  SEXP nms = Rf_getAttrib(x, R_NamesSymbol);
+  // Copy attributes but keep names and dims
+  SEXP nms = PROTECT(Rf_getAttrib(x, R_NamesSymbol));
+  ++n_protect;
+
+  SEXP dim = PROTECT(Rf_getAttrib(x, R_DimSymbol));
+  ++n_protect;
+
   SET_ATTRIB(x, attrib);
   Rf_setAttrib(x, R_NamesSymbol, nms);
+  Rf_setAttrib(x, R_DimSymbol, dim);
 
   // SET_ATTRIB() does not set object bit when attributes include class
   if (OBJECT(to)) {

--- a/src/cast.c
+++ b/src/cast.c
@@ -335,9 +335,10 @@ SEXP vctrs_restore(SEXP x, SEXP to, SEXP i) {
   case vctrs_type_dataframe:
     return df_restore(x, to, i);
   case vctrs_type_s3:
-    return vctrs_dispatch2(syms_vec_restore_dispatch, fns_vec_restore_dispatch,
+    return vctrs_dispatch3(syms_vec_restore_dispatch, fns_vec_restore_dispatch,
                            syms_x, x,
-                           syms_to, to);
+                           syms_to, to,
+                           syms_i, i);
   default:
     return vctrs_restore_default(x, to);
   }

--- a/src/cast.c
+++ b/src/cast.c
@@ -294,7 +294,7 @@ SEXP vctrs_restore_default(SEXP x, SEXP to) {
   return x;
 }
 
-static SEXP df_restore(SEXP x, SEXP to) {
+static SEXP df_restore(SEXP x, SEXP to, SEXP i) {
   if (TYPEOF(x) != VECSXP) {
     Rf_errorcall(R_NilValue, "Internal error: Attempt to restore data frame from a %s.",
                  Rf_type2char(TYPEOF(x)));
@@ -302,8 +302,13 @@ static SEXP df_restore(SEXP x, SEXP to) {
 
   int n_protect = 0;
 
-  // Compute size before changing attributes
-  R_len_t size = df_raw_size(x);
+  // Compute size before changing attributes of `x`
+  R_len_t size;
+  if (i == R_NilValue) {
+    size = df_raw_size(x);
+  } else {
+    size = Rf_length(i);
+  }
 
   if (MAYBE_REFERENCED(x)) {
     x = PROTECT(Rf_shallow_duplicate(x));
@@ -325,10 +330,10 @@ static SEXP df_restore(SEXP x, SEXP to) {
   return x;
 }
 
-SEXP vctrs_restore(SEXP x, SEXP to) {
+SEXP vctrs_restore(SEXP x, SEXP to, SEXP i) {
   switch (vec_typeof(to)) {
   case vctrs_type_dataframe:
-    return df_restore(x, to);
+    return df_restore(x, to, i);
   case vctrs_type_s3:
     return vctrs_dispatch2(syms_vec_restore_dispatch, fns_vec_restore_dispatch,
                            syms_x, x,

--- a/src/cast.c
+++ b/src/cast.c
@@ -300,7 +300,7 @@ SEXP vctrs_restore_default(SEXP x, SEXP to) {
   return x;
 }
 
-static SEXP df_restore(SEXP x, SEXP to, SEXP i) {
+SEXP df_restore(SEXP x, SEXP to, SEXP i) {
   if (TYPEOF(x) != VECSXP) {
     Rf_errorcall(R_NilValue, "Internal error: Attempt to restore data frame from a %s.",
                  Rf_type2char(TYPEOF(x)));

--- a/src/dim.c
+++ b/src/dim.c
@@ -1,7 +1,6 @@
 #include "vctrs.h"
 #include "utils.h"
 
-R_len_t df_size(SEXP x);
 R_len_t rcrd_size(SEXP x);
 
 R_len_t vec_size(SEXP x) {

--- a/src/init.c
+++ b/src/init.c
@@ -38,7 +38,7 @@ extern SEXP vctrs_dispatch_typeof(SEXP, SEXP);
 extern SEXP vec_cast(SEXP, SEXP);
 extern SEXP vec_as_index(SEXP, SEXP);
 extern SEXP vctrs_slice(SEXP, SEXP, SEXP);
-extern SEXP vctrs_restore(SEXP, SEXP, SEXP);
+extern SEXP vec_restore(SEXP, SEXP, SEXP);
 extern SEXP vctrs_restore_default(SEXP, SEXP);
 
 // Defined below
@@ -76,7 +76,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_cast",                       (DL_FUNC) &vec_cast, 2},
   {"vctrs_as_index",                   (DL_FUNC) &vec_as_index, 2},
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 3},
-  {"vctrs_restore",                    (DL_FUNC) &vctrs_restore, 3},
+  {"vctrs_restore",                    (DL_FUNC) &vec_restore, 3},
   {"vctrs_restore_default",            (DL_FUNC) &vctrs_restore_default, 2},
   {NULL, NULL, 0}
 };

--- a/src/init.c
+++ b/src/init.c
@@ -38,7 +38,7 @@ extern SEXP vctrs_dispatch_typeof(SEXP, SEXP);
 extern SEXP vec_cast(SEXP, SEXP);
 extern SEXP vec_as_index(SEXP, SEXP);
 extern SEXP vctrs_slice(SEXP, SEXP, SEXP);
-extern SEXP vctrs_restore(SEXP, SEXP);
+extern SEXP vctrs_restore(SEXP, SEXP, SEXP);
 extern SEXP vctrs_restore_default(SEXP, SEXP);
 
 // Defined below
@@ -76,7 +76,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_cast",                       (DL_FUNC) &vec_cast, 2},
   {"vctrs_as_index",                   (DL_FUNC) &vec_as_index, 2},
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 3},
-  {"vctrs_restore",                    (DL_FUNC) &vctrs_restore, 2},
+  {"vctrs_restore",                    (DL_FUNC) &vctrs_restore, 3},
   {"vctrs_restore_default",            (DL_FUNC) &vctrs_restore_default, 2},
   {NULL, NULL, 0}
 };

--- a/src/slice.c
+++ b/src/slice.c
@@ -119,10 +119,10 @@ static SEXP vec_slice_impl(SEXP x, SEXP index, bool dispatch) {
 
   PROTECT(out);
   slice_names(out, x, index);
-  out = vctrs_restore(out, x);
+
+  out = vctrs_restore(out, x, index);
 
   UNPROTECT(1);
-
   return out;
 }
 

--- a/src/slice.c
+++ b/src/slice.c
@@ -139,7 +139,7 @@ static SEXP vec_slice_impl(SEXP x, SEXP index, bool dispatch) {
 
   case vctrs_type_dataframe:
     out = PROTECT(df_slice(x, index));
-    out = vctrs_restore(out, x, index);
+    out = df_restore(out, x, index);
     UNPROTECT(1);
     return out;
 

--- a/src/slice.c
+++ b/src/slice.c
@@ -95,13 +95,9 @@ static SEXP df_slice(SEXP x, SEXP index) {
 
 
 static SEXP vec_slice_dispatch(SEXP x, SEXP index) {
-  SEXP out = PROTECT(vctrs_dispatch2(syms_vec_slice_dispatch, fns_vec_slice_dispatch,
-                                     syms_x, x,
-                                     syms_i, index));
-  out = vec_restore(out, x, index);
-
-  UNPROTECT(1);
-  return out;
+  return vctrs_dispatch2(syms_vec_slice_dispatch, fns_vec_slice_dispatch,
+                         syms_x, x,
+                         syms_i, index);
 }
 
 static SEXP vec_slice_impl(SEXP x, SEXP index, bool dispatch) {
@@ -144,7 +140,10 @@ static SEXP vec_slice_impl(SEXP x, SEXP index, bool dispatch) {
     return out;
 
   default:
-    return vec_slice_dispatch(x, index);
+    out = PROTECT(vec_slice_dispatch(x, index));
+    out = vec_restore(out, x, index);
+    UNPROTECT(1);
+    return out;
   }
 
   PROTECT(out);

--- a/src/slice.c
+++ b/src/slice.c
@@ -119,6 +119,8 @@ static SEXP vec_slice_impl(SEXP x, SEXP index, bool dispatch) {
 
   PROTECT(out);
   slice_names(out, x, index);
+  out = vctrs_restore(out, x);
+
   UNPROTECT(1);
 
   return out;

--- a/src/slice.c
+++ b/src/slice.c
@@ -98,7 +98,7 @@ static SEXP vec_slice_dispatch(SEXP x, SEXP index) {
   SEXP out = PROTECT(vctrs_dispatch2(syms_vec_slice_dispatch, fns_vec_slice_dispatch,
                                      syms_x, x,
                                      syms_i, index));
-  out = vctrs_restore(out, x, index);
+  out = vec_restore(out, x, index);
 
   UNPROTECT(1);
   return out;
@@ -150,7 +150,7 @@ static SEXP vec_slice_impl(SEXP x, SEXP index, bool dispatch) {
   PROTECT(out);
   slice_names(out, x, index);
 
-  out = vctrs_restore(out, x, index);
+  out = vec_restore(out, x, index);
 
   UNPROTECT(1);
   return out;

--- a/src/slice.c
+++ b/src/slice.c
@@ -76,10 +76,15 @@ static SEXP list_slice(SEXP x, SEXP index) {
 
 #undef SLICE_BARRIER
 
+
 static SEXP vec_slice_dispatch(SEXP x, SEXP index) {
-  return vctrs_dispatch2(syms_vec_slice_dispatch, fns_vec_slice_dispatch,
-                         syms_x, x,
-                         syms_i, index);
+  SEXP out = PROTECT(vctrs_dispatch2(syms_vec_slice_dispatch, fns_vec_slice_dispatch,
+                                     syms_x, x,
+                                     syms_i, index));
+  out = vctrs_restore(out, x, index);
+
+  UNPROTECT(1);
+  return out;
 }
 
 static SEXP vec_slice_switch(SEXP x, SEXP index, bool dispatch) {

--- a/src/slice.c
+++ b/src/slice.c
@@ -8,6 +8,7 @@ SEXP fns_vec_slice_dispatch = NULL;
 // Defined below
 SEXP vec_as_index(SEXP i, SEXP x);
 static void slice_names(SEXP x, SEXP to, SEXP index);
+static SEXP vec_slice_impl(SEXP x, SEXP index, bool dispatch);
 
 
 static void stop_bad_index_length(R_len_t data_n, R_len_t i) {
@@ -76,6 +77,22 @@ static SEXP list_slice(SEXP x, SEXP index) {
 
 #undef SLICE_BARRIER
 
+static SEXP df_slice(SEXP x, SEXP index) {
+  R_len_t n = Rf_length(x);
+  SEXP out = PROTECT(Rf_allocVector(VECSXP, n));
+
+  SEXP nms = Rf_getAttrib(x, R_NamesSymbol);
+  Rf_setAttrib(out, R_NamesSymbol, nms);
+
+  for (R_len_t i = 0; i < n; ++i) {
+    SEXP sliced = vec_slice_impl(VECTOR_ELT(x, i), index, true);
+    SET_VECTOR_ELT(out, i, sliced);
+  }
+
+  UNPROTECT(1);
+  return out;
+}
+
 
 static SEXP vec_slice_dispatch(SEXP x, SEXP index) {
   SEXP out = PROTECT(vctrs_dispatch2(syms_vec_slice_dispatch, fns_vec_slice_dispatch,
@@ -87,38 +104,46 @@ static SEXP vec_slice_dispatch(SEXP x, SEXP index) {
   return out;
 }
 
-static SEXP vec_slice_switch(SEXP x, SEXP index, bool dispatch) {
+static SEXP vec_slice_impl(SEXP x, SEXP index, bool dispatch) {
+  if (has_dim(x)) {
+    return vec_slice_dispatch(x, index);
+  }
+
+  SEXP out = R_NilValue;
+
   switch (vec_typeof_impl(x, dispatch)) {
   case vctrs_type_null:
     Rf_error("Internal error: Unexpected `NULL` in `vec_slice_impl()`.");
 
   case vctrs_type_logical:
-    return lgl_slice(x, index);
+    out = lgl_slice(x, index);
+    break;
   case vctrs_type_integer:
-    return int_slice(x, index);
+    out = int_slice(x, index);
+    break;
   case vctrs_type_double:
-    return dbl_slice(x, index);
+    out = dbl_slice(x, index);
+    break;
   case vctrs_type_complex:
-    return cpl_slice(x, index);
+    out = cpl_slice(x, index);
+    break;
   case vctrs_type_character:
-    return chr_slice(x, index);
+    out = chr_slice(x, index);
+    break;
   case vctrs_type_raw:
-    return raw_slice(x, index);
+    out = raw_slice(x, index);
+    break;
   case vctrs_type_list:
-    return list_slice(x, index);
+    out = list_slice(x, index);
+    break;
+
+  case vctrs_type_dataframe:
+    out = PROTECT(df_slice(x, index));
+    out = vctrs_restore(out, x, index);
+    UNPROTECT(1);
+    return out;
 
   default:
-    return R_NilValue;
-  }
-}
-
-static SEXP vec_slice_impl(SEXP x, SEXP index, bool dispatch) {
-  SEXP out = R_NilValue;
-
-  if (!has_dim(x)) {
-    out = vec_slice_switch(x, index, dispatch);
-  }
-  if (out == R_NilValue) {
     return vec_slice_dispatch(x, index);
   }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -12,10 +12,10 @@ bool is_bool(SEXP x) {
  * Dispatch with two arguments
  *
  * @param fn The method to call.
- * @param x,y Arguments passed to the method.
- * @param fn_sym,x_sym,y_sym Symbols to which `x` and `y` should be
- *   assigned.  The assignment occurs in `env` and the dispatch call
- *   refers to these symbols.
+ * @param x,y,z Arguments passed to the method.
+ * @param fn_sym,x_sym,y_sym,z_sym Symbols to which `x`, `y` and `z`
+ *   should be assigned.  The assignment occurs in `env` and the
+ *   dispatch call refers to these symbols.
  * @param env The environment in which to dispatch. Should be the
  *   global environment or inherit from it so methods defined there
  *   are picked up. If the global environment, a child is created so
@@ -40,6 +40,32 @@ SEXP vctrs_dispatch2(SEXP fn_sym, SEXP fn,
     dispatch_call = PROTECT(Rf_lang3(fn, x, y));
   } else {
     dispatch_call = PROTECT(Rf_lang4(fn, x, y, syms_dots));
+  }
+
+  SEXP out = Rf_eval(dispatch_call, env);
+
+  UNPROTECT(2);
+  return out;
+}
+SEXP vctrs_dispatch3(SEXP fn_sym, SEXP fn,
+                     SEXP x_sym, SEXP x,
+                     SEXP y_sym, SEXP y,
+                     SEXP z_sym, SEXP z) {
+  // Create a child so we can mask the call components
+  SEXP env = PROTECT(r_new_environment(R_GlobalEnv, 3));
+
+  // Forward new values in the dispatch environment
+  Rf_defineVar(fn_sym, fn, env);
+  Rf_defineVar(x_sym, x, env);
+  Rf_defineVar(y_sym, y, env);
+  Rf_defineVar(z_sym, z, env);
+
+  // Forward dots to methods if they exist
+  SEXP dispatch_call;
+  if (Rf_findVar(syms_dots, env) == R_UnboundValue) {
+    dispatch_call = PROTECT(Rf_lang4(fn, x, y, z));
+  } else {
+    dispatch_call = PROTECT(Rf_lang5(fn, x, y, z, syms_dots));
   }
 
   SEXP out = Rf_eval(dispatch_call, env);

--- a/src/utils.c
+++ b/src/utils.c
@@ -42,6 +42,10 @@ SEXP vctrs_dispatch2(SEXP fn_sym, SEXP fn,
     dispatch_call = PROTECT(Rf_lang4(fn, x, y, syms_dots));
   }
 
+  SEXP elt = CDR(dispatch_call);
+  SET_TAG(elt, x_sym); elt = CDR(elt);
+  SET_TAG(elt, y_sym); elt = CDR(elt);
+
   SEXP out = Rf_eval(dispatch_call, env);
 
   UNPROTECT(2);
@@ -67,6 +71,11 @@ SEXP vctrs_dispatch3(SEXP fn_sym, SEXP fn,
   } else {
     dispatch_call = PROTECT(Rf_lang5(fn, x, y, z, syms_dots));
   }
+
+  SEXP elt = CDR(dispatch_call);
+  SET_TAG(elt, x_sym); elt = CDR(elt);
+  SET_TAG(elt, y_sym); elt = CDR(elt);
+  SET_TAG(elt, z_sym); elt = CDR(elt);
 
   SEXP out = Rf_eval(dispatch_call, env);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -7,6 +7,10 @@ bool is_bool(SEXP x);
 SEXP vctrs_dispatch2(SEXP fn_sym, SEXP fn,
                      SEXP x_sym, SEXP x,
                      SEXP y_sym, SEXP y);
+SEXP vctrs_dispatch3(SEXP fn_sym, SEXP fn,
+                     SEXP x_sym, SEXP x,
+                     SEXP y_sym, SEXP y,
+                     SEXP z_sym, SEXP z);
 
 bool is_compact_rownames(SEXP x);
 R_len_t compact_rownames_length(SEXP x);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -132,6 +132,7 @@ extern Rcomplex vctrs_shared_na_cpl;
 R_len_t vec_size(SEXP x);
 SEXP vec_cast(SEXP x, SEXP to);
 SEXP vec_slice(SEXP x, SEXP index);
+SEXP vctrs_restore(SEXP x, SEXP to);
 
 bool is_data_frame(SEXP x);
 bool is_record(SEXP x);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -132,7 +132,7 @@ extern Rcomplex vctrs_shared_na_cpl;
 R_len_t vec_size(SEXP x);
 SEXP vec_cast(SEXP x, SEXP to);
 SEXP vec_slice(SEXP x, SEXP index);
-SEXP vctrs_restore(SEXP x, SEXP to);
+SEXP vctrs_restore(SEXP x, SEXP to, SEXP i);
 
 bool is_data_frame(SEXP x);
 bool is_record(SEXP x);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -132,7 +132,7 @@ extern Rcomplex vctrs_shared_na_cpl;
 R_len_t vec_size(SEXP x);
 SEXP vec_cast(SEXP x, SEXP to);
 SEXP vec_slice(SEXP x, SEXP index);
-SEXP vctrs_restore(SEXP x, SEXP to, SEXP i);
+SEXP vec_restore(SEXP x, SEXP to, SEXP i);
 
 bool is_data_frame(SEXP x);
 bool is_record(SEXP x);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -138,6 +138,7 @@ bool is_data_frame(SEXP x);
 bool is_record(SEXP x);
 bool is_scalar(SEXP x);
 
+R_len_t df_size(SEXP x);
 R_len_t df_rownames_size(SEXP x);
 R_len_t df_raw_size(SEXP x);
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -141,6 +141,7 @@ bool is_scalar(SEXP x);
 R_len_t df_size(SEXP x);
 R_len_t df_rownames_size(SEXP x);
 R_len_t df_raw_size(SEXP x);
+SEXP df_restore(SEXP x, SEXP to, SEXP i);
 
 // Most vector predicates return `int` because missing values are
 // propagated as `NA_LOGICAL`

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -188,3 +188,10 @@ test_that("can use vctrs primitives from vec_restore() without inflooping", {
   foobar <- new_vctr(1:3, class = "vctrs_foobar")
   expect_identical(vec_slice(foobar, 2), "woot")
 })
+
+test_that("vec_restore() passes `i` argument to methods", {
+  scoped_global_bindings(
+    vec_restore.vctrs_foobar = function(x, to, ..., i) i
+  )
+  expect_identical(vec_slice(foobar(1:3), 2), 2L)
+})

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -176,7 +176,7 @@ test_that("data frame vec_restore() checks type", {
 
 test_that("can use vctrs primitives from vec_restore() without inflooping", {
   scoped_global_bindings(
-    vec_restore.vctrs_foobar = function(x, to) {
+    vec_restore.vctrs_foobar = function(x, to, ...) {
       vec_type(x)
       vec_na(x)
       vec_assert(x)

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -168,7 +168,6 @@ test_that("can slice with missing argument", {
 })
 
 test_that("slicing unclassed structures preserves attributes", {
-  skip("TODO")
   x <- structure(1:3, foo = "bar")
   expect_identical(vec_slice(x, 1L), structure(1L, foo = "bar"))
 })

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -226,6 +226,13 @@ test_that("can `vec_slice()` records", {
   expect_size(out, 2)
 })
 
+test_that("vec_restore() is called after slicing", {
+  scoped_global_bindings(
+    vec_restore.vctrs_foobar = function(x, to, ..., i) "dispatch"
+  )
+  expect_identical(vec_slice(foobar(1:3), 2), "dispatch")
+})
+
 
 # vec_na ------------------------------------------------------------------
 

--- a/tests/testthat/test-vctr.R
+++ b/tests/testthat/test-vctr.R
@@ -204,7 +204,7 @@ test_that("can use [ and [[ with names", {
 
 test_that("can use [[<- to replace n-dimensional elements", {
   x <- new_vctr(rep(1, times = 4), dim = c(2, 2), class = "vctrs_mtrx")
-  vec_restore.vctrs_mtrx <- function(x, to) x
+  vec_restore.vctrs_mtrx <- function(x, to, ...) x
   s3_register("vctrs::vec_restore", "vctrs_mtrx", vec_restore.vctrs_mtrx)
   x[[2, 2]] <- 4
   expect_equal(x[[2, 2]], 4)

--- a/vignettes/s3-vector.Rmd
+++ b/vignettes/s3-vector.Rmd
@@ -472,7 +472,7 @@ x[1:2]
 To fix this, you need to provide a `vec_restore()` method. Note that this method dispatches on the `to` argument.
 
 ```{r}
-vec_restore.vctrs_cached_sum <- function(x, to) {
+vec_restore.vctrs_cached_sum <- function(x, to, ..., i = NULL) {
   new_cached_sum(x, sum(x))
 }
 


### PR DESCRIPTION
* `[` methods can now just call `vec_slice()` and get a fully formed object.

* Restoration after slicing requires index information (at least the vector size) because zero-cols data frames do not carry size information in the raw data (an empty list).

  For this reason, `vec_restore()` gains an `i` argument that is non-null after slicing and contains the standardised index vector. This argument can be safely ignored most of the time.