### PR TITLE
warn_lossy_cast() is a no-op if the location argument is empty

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -361,9 +361,8 @@ report_lossy_cast <- function(x, y, lossy, details = NULL) {
       details = "All elements of vectorised cast failed"
     )
   }
-  if (any(lossy)) {
-    warn_lossy_cast(x, y, locations = which(lossy), details = details)
-  }
+
+  warn_lossy_cast(x, y, locations = which(lossy), details = details)
 }
 
 lossy_floor <- function(x, to) {

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -8,7 +8,8 @@
 #' @param details Any additional human readable details
 #' @param subclass Use if you want to further customise the class
 #' @param locations For `warn_lossy_cast()`, an optional vector giving the
-#'   locations where `x` lost information.
+#'   locations where `x` lost information.  If the vector is given and empty,
+#'   no warning is issued.
 #' @param ...,message,.subclass Only use these fields when creating a subclass.
 #' @name vctrs-conditions
 NULL
@@ -81,6 +82,10 @@ stop_incompatible_op <- function(op, x, y, details = NULL, ..., message = NULL, 
 #' @rdname vctrs-conditions
 #' @export
 warn_lossy_cast <- function(x, y, locations = NULL, details = NULL, ..., message = NULL, .subclass = NULL) {
+
+  if (!is.null(locations) && is_empty(locations)) {
+    return()
+  }
 
   message <- message %||% glue_lines(
     "Lossy cast from <{vec_ptype_full(x)}> to <{vec_ptype_full(y)}>.",

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -1,6 +1,8 @@
 #' Custom conditions for vctrs package
 #'
-#' These errors and warnings have custom classes and structures to make
+#' These functions are called for their side effect of raising
+#' errors and warnings.
+#' These conditions have custom classes and structures to make
 #' testing easier.
 #'
 #' @keywords internal
@@ -25,6 +27,10 @@ stop_incompatible <- function(x, y, details = NULL, ..., message = NULL, .subcla
   )
 }
 
+#' @return
+#' `stop_incompatible_*()` unconditionally raise an error of class `"vctrs_error_incompatible_*"`
+#' and `"vctrs_error_incompatible"`.
+#'
 #' @rdname vctrs-conditions
 #' @export
 stop_incompatible_type <- function(x, y, details = NULL, ..., message = NULL, .subclass = NULL) {
@@ -79,6 +85,11 @@ stop_incompatible_op <- function(op, x, y, details = NULL, ..., message = NULL, 
   )
 }
 
+#' @return
+#' `warn_lossy_cast()` emits a warning of class `"vctrs_warning_lossy_cast"` if there
+#' are problem locations to report, i.e. if the `locations` argument is a nonzero-length
+#' vector.
+#'
 #' @rdname vctrs-conditions
 #' @export
 warn_lossy_cast <- function(x, y, locations = NULL, details = NULL, ..., message = NULL, .subclass = NULL) {
@@ -100,7 +111,7 @@ warn_lossy_cast <- function(x, y, locations = NULL, details = NULL, ..., message
     locations = locations,
     details = details,
     ...,
-    .subclass = c(.subclass, "warning_lossy_cast"),
+    .subclass = c(.subclass, "vctrs_warning_lossy_cast"),
   )
 }
 

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -156,12 +156,10 @@ df_col_cast <- function(x, to) {
   # Drop extra columns
   out <- out[names(to)]
   extra <- setdiff(names(x), names(to))
-  if (length(extra) > 0 ) {
-    warn_lossy_cast(
-      x, to,
-      details = inline_list("Dropped variables: ", extra, quote = "`")
-    )
-  }
+  warn_lossy_cast(
+    x, to, extra,
+    details = inline_list("Dropped variables: ", extra, quote = "`")
+  )
 
   # Casting doesn't affect number of rows
   attr(out, "row.names") <- attr(x, "row.names")

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -157,7 +157,8 @@ df_col_cast <- function(x, to) {
   out <- out[names(to)]
   extra <- setdiff(names(x), names(to))
   warn_lossy_cast(
-    x, to, extra,
+    x, to,
+    locations = extra,
     details = inline_list("Dropped variables: ", extra, quote = "`")
   )
 

--- a/R/type-factor.R
+++ b/R/type-factor.R
@@ -123,9 +123,7 @@ vec_cast.factor.factor <- function(x, to) {
     factor(as.character(x), levels = unique(x), ordered = is.ordered(to))
   } else {
     lossy <- !(x %in% levels(to) | is.na(x))
-    if (any(lossy)) {
-      warn_lossy_cast(x, to, locations = which(lossy))
-    }
+    warn_lossy_cast(x, to, locations = which(lossy))
 
     factor(x, levels = levels(to), ordered = is.ordered(to))
   }

--- a/man/vctrs-conditions.Rd
+++ b/man/vctrs-conditions.Rd
@@ -33,8 +33,18 @@ no warning is issued.}
 
 \item{subclass}{Use if you want to further customise the class}
 }
+\value{
+\code{stop_incompatible_*()} unconditionally raise an error of class \code{"vctrs_error_incompatible_*"}
+and \code{"vctrs_error_incompatible"}.
+
+\code{warn_lossy_cast()} emits a warning of class \code{"vctrs_warning_lossy_cast"} if there
+are problem locations to report, i.e. if the \code{locations} argument is a nonzero-length
+vector.
+}
 \description{
-These errors and warnings have custom classes and structures to make
+These functions are called for their side effect of raising
+errors and warnings.
+These conditions have custom classes and structures to make
 testing easier.
 }
 \keyword{internal}

--- a/man/vctrs-conditions.Rd
+++ b/man/vctrs-conditions.Rd
@@ -28,7 +28,8 @@ warn_lossy_cast(x, y, locations = NULL, details = NULL, ...,
 \item{..., message, .subclass}{Only use these fields when creating a subclass.}
 
 \item{locations}{For \code{warn_lossy_cast()}, an optional vector giving the
-locations where \code{x} lost information.}
+locations where \code{x} lost information.  If the vector is given and empty,
+no warning is issued.}
 
 \item{subclass}{Use if you want to further customise the class}
 }

--- a/tests/testthat/helper-cast.R
+++ b/tests/testthat/helper-cast.R
@@ -9,7 +9,7 @@ expect_lossy_cast <- function(expr) {
     }),
     expr
   )
-  expect_is(cnd, "warning_lossy_cast")
+  expect_is(cnd, "vctrs_warning_lossy_cast")
 
   out
 }

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -30,12 +30,12 @@ test_that("safe casts work as expected", {
 })
 
 test_that("lossy casts generate warning", {
-  expect_condition(vec_cast(c(2L, 1L), logical()), class = "warning_lossy_cast")
-  expect_condition(vec_cast(c(2, 1), logical()), class = "warning_lossy_cast")
-  expect_condition(vec_cast(c("x", "TRUE"), logical()), class = "warning_lossy_cast")
-  expect_condition(vec_cast(list(c(TRUE, FALSE), TRUE), logical()), class = "warning_lossy_cast")
-  expect_condition(vec_cast(c("t", "T"), logical()), class = "warning_lossy_cast")
-  expect_condition(vec_cast(c("f", "F"), logical()), class = "warning_lossy_cast")
+  expect_condition(vec_cast(c(2L, 1L), logical()), class = "vctrs_warning_lossy_cast")
+  expect_condition(vec_cast(c(2, 1), logical()), class = "vctrs_warning_lossy_cast")
+  expect_condition(vec_cast(c("x", "TRUE"), logical()), class = "vctrs_warning_lossy_cast")
+  expect_condition(vec_cast(list(c(TRUE, FALSE), TRUE), logical()), class = "vctrs_warning_lossy_cast")
+  expect_condition(vec_cast(c("t", "T"), logical()), class = "vctrs_warning_lossy_cast")
+  expect_condition(vec_cast(c("f", "F"), logical()), class = "vctrs_warning_lossy_cast")
 })
 
 test_that("invalid casts generate error", {
@@ -64,8 +64,8 @@ test_that("safe casts work as expected", {
 })
 
 test_that("lossy casts generate warning", {
-  expect_condition(vec_cast(c(2.5, 2), integer()), class = "warning_lossy_cast")
-  expect_condition(vec_cast(c("2.5", "2"), integer()), class = "warning_lossy_cast")
+  expect_condition(vec_cast(c(2.5, 2), integer()), class = "vctrs_warning_lossy_cast")
+  expect_condition(vec_cast(c("2.5", "2"), integer()), class = "vctrs_warning_lossy_cast")
 
   out <- expect_lossy_cast(vec_cast(c(.Machine$integer.max + 1, 1), int()))
   expect_identical(out, int(NA, 1L))
@@ -90,7 +90,7 @@ test_that("safe casts work as expected", {
 })
 
 test_that("lossy casts generate warning", {
-  expect_condition(vec_cast(c("2.5", "x"), double()), class = "warning_lossy_cast")
+  expect_condition(vec_cast(c("2.5", "x"), double()), class = "vctrs_warning_lossy_cast")
 })
 
 test_that("invalid casts generate error", {

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -1,0 +1,12 @@
+context("test-conditions")
+
+test_that("warn_lossy_cast", {
+  expect_warning(
+    warn_lossy_cast(integer(), character(), locations = 1:3),
+    class = "warning_lossy_cast"
+  )
+  expect_warning(
+    warn_lossy_cast(integer(), character(), locations = integer()),
+    NA
+  )
+})

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -3,7 +3,7 @@ context("test-conditions")
 test_that("warn_lossy_cast", {
   expect_warning(
     warn_lossy_cast(integer(), character(), locations = 1:3),
-    class = "warning_lossy_cast"
+    class = "vctrs_warning_lossy_cast"
   )
   expect_warning(
     warn_lossy_cast(integer(), character(), locations = integer()),

--- a/tests/testthat/test-list_of.R
+++ b/tests/testthat/test-list_of.R
@@ -153,7 +153,7 @@ test_that("safe casts work as expected", {
 
 test_that("lossy casts generate warning", {
   x <- list_of(1L)
-  expect_condition(vec_cast(list(c(1.5, 1), 1L), x), class = "warning_lossy_cast")
+  expect_condition(vec_cast(list(c(1.5, 1), 1L), x), class = "vctrs_warning_lossy_cast")
 })
 
 test_that("invalid casts generate error", {

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -79,8 +79,8 @@ test_that("warn about lossy coercions", {
   df1 <- data.frame(x = 1, y = 1)
   df2 <- data.frame(x = c("a", 1), stringsAsFactors = FALSE)
 
-  expect_condition(vec_cast(df1, df1[1]), class = "warning_lossy_cast")
-  expect_condition(vec_cast(df2, df1), class = "warning_lossy_cast")
+  expect_condition(vec_cast(df1, df1[1]), class = "vctrs_warning_lossy_cast")
+  expect_condition(vec_cast(df2, df1), class = "vctrs_warning_lossy_cast")
 })
 
 test_that("invalid cast generates error", {

--- a/tests/testthat/test-type-date-time.R
+++ b/tests/testthat/test-type-date-time.R
@@ -82,7 +82,7 @@ test_that("lossy casts generate warning", {
   date <- as.Date("2018-01-01")
   datetime <- as.POSIXct(date) + c(0, 3600)
 
-  expect_condition(vec_cast(datetime, date), class = "warning_lossy_cast")
+  expect_condition(vec_cast(datetime, date), class = "vctrs_warning_lossy_cast")
 })
 
 test_that("invalid casts generate error", {
@@ -219,16 +219,16 @@ test_that("date-time vs difftime", {
   expect_equal(vec_arith("+", dt, t), dt + t)
   expect_equal(vec_arith("+", d, t), d + t)
   expect_equal(vec_arith("+", dt, th), dt + th)
-  expect_warning(expect_equal(vec_arith("+", d, th), d + th), class = "warning_lossy_cast")
+  expect_warning(expect_equal(vec_arith("+", d, th), d + th), class = "vctrs_warning_lossy_cast")
   expect_equal(vec_arith("-", dt, t), dt - t)
   expect_equal(vec_arith("-", d, t), d - t)
   expect_equal(vec_arith("-", dt, th), dt - th)
-  expect_warning(expect_equal(vec_arith("-", d, th), d - th), class = "warning_lossy_cast")
+  expect_warning(expect_equal(vec_arith("-", d, th), d - th), class = "vctrs_warning_lossy_cast")
 
   expect_equal(vec_arith("+", t, dt), dt + t)
   expect_equal(vec_arith("+", t, d), d + t)
   expect_equal(vec_arith("+", th, dt), dt + th)
-  expect_warning(expect_equal(vec_arith("+", th, d), d + th), class = "warning_lossy_cast")
+  expect_warning(expect_equal(vec_arith("+", th, d), d + th), class = "vctrs_warning_lossy_cast")
 
   expect_error(vec_arith("-", t, dt), class = "vctrs_error_incompatible_op")
   expect_error(vec_arith("-", t, d), class = "vctrs_error_incompatible_op")

--- a/tests/testthat/test-type-factor.R
+++ b/tests/testthat/test-type-factor.R
@@ -79,8 +79,8 @@ test_that("lossy casts generate warning", {
   fa <- factor("a")
   fb <- factor("b")
 
-  expect_condition(vec_cast(fa, fb), class = "warning_lossy_cast")
-  expect_condition(vec_cast("a", fb), class = "warning_lossy_cast")
+  expect_condition(vec_cast(fa, fb), class = "vctrs_warning_lossy_cast")
+  expect_condition(vec_cast("a", fb), class = "vctrs_warning_lossy_cast")
 })
 
 test_that("invalid casts generate error", {


### PR DESCRIPTION
This makes it easier for the callers, especially in other packages. Need to think about exporting `report_lossy_cast()` or an equivalent.