### PR TITLE
Fix array restoration

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -46,14 +46,25 @@
 #' [vec_unspecified_cast()]).
 #'
 #' See `vignette("s3-vector")` for full details.
+#'
+#'
 #' @section Restoring attributes:
 #'
-#' A restore is a specialised type of cast, primarily used in conjunction
-#' with `NextMethod()` or a C-level function that works on the underlying
-#' data structure. A `vec_restore()` method can assume that `x` has the
-#' correct type (although the length may be different) but all attributes
-#' have been lost and need to be restored. In other words,
-#' `vec_restore(vec_data(x), x)` should yield `x`.
+#' A restore is a specialised type of cast, primarily used in
+#' conjunction with `NextMethod()` or a C-level function that works on
+#' the underlying data structure. A `vec_restore()` method can make
+#' the following assumptions about `x`:
+#'
+#' * It has the correct type.
+#' * It has the correct names.
+#' * It has the correct `dim` and `dimnames` attributes.
+#' * It is unclassed. This way you can call vctrs generics with `x`
+#'   without triggering an infinite loop of restoration.
+#'
+#' The length may be different (for example after [vec_slice()] has
+#' been called), and all other attributes may have been lost. The
+#' method should restore all attributes so that after restoration,
+#' `vec_restore(vec_data(x), x)` yields `x`.
 #'
 #' To understand the difference between `vec_cast()` and `vec_restore()`
 #' think about factors: it doesn't make sense to cast an integer to a factor,

--- a/R/slice.R
+++ b/R/slice.R
@@ -43,16 +43,18 @@ vec_slice_fallback <- function(x, i) {
   d <- vec_dims(x)
   if (d == 1) {
     if (is.object(x)) {
-      x[i]
+      out <- x[i]
     } else {
-      x[i, drop = FALSE]
+      out <- x[i, drop = FALSE]
     }
   } else if (d == 2) {
-    x[i, , drop = FALSE]
+    out <- x[i, , drop = FALSE]
   } else {
     miss_args <- rep(list(missing_arg()), d - 1)
-    eval_bare(expr(x[i, !!!miss_args, drop = FALSE]))
+    out <- eval_bare(expr(x[i, !!!miss_args, drop = FALSE]))
   }
+
+  vec_restore(out, x)
 }
 
 vec_slice_bare <- function(x, i) {

--- a/R/slice.R
+++ b/R/slice.R
@@ -37,21 +37,20 @@
 vec_slice <- function(x, i) {
   .Call(vctrs_slice, x, maybe_missing(i), TRUE)
 }
-vec_slice_fallback <- function(x, i) {
-  vec_assert(x)
 
-  d <- vec_dims(x)
+# Only called when `x` has dimensions
+vec_slice_fallback <- function(x, i) {
+  out <- unclass(vec_proxy(x))
+  vec_assert(out)
+
+  d <- vec_dims(out)
   if (d == 1) {
-    if (is.object(x)) {
-      out <- x[i]
-    } else {
-      out <- x[i, drop = FALSE]
-    }
+    out <- out[i, drop = FALSE]
   } else if (d == 2) {
-    out <- x[i, , drop = FALSE]
+    out <- out[i, , drop = FALSE]
   } else {
     miss_args <- rep(list(missing_arg()), d - 1)
-    out <- eval_bare(expr(x[i, !!!miss_args, drop = FALSE]))
+    out <- eval_bare(expr(out[i, !!!miss_args, drop = FALSE]))
   }
 
   vec_restore(out, x)

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -103,12 +103,22 @@ See \code{vignette("s3-vector")} for full details.
 \section{Restoring attributes}{
 
 
-A restore is a specialised type of cast, primarily used in conjunction
-with \code{NextMethod()} or a C-level function that works on the underlying
-data structure. A \code{vec_restore()} method can assume that \code{x} has the
-correct type (although the length may be different) but all attributes
-have been lost and need to be restored. In other words,
-\code{vec_restore(vec_data(x), x)} should yield \code{x}.
+A restore is a specialised type of cast, primarily used in
+conjunction with \code{NextMethod()} or a C-level function that works on
+the underlying data structure. A \code{vec_restore()} method can make
+the following assumptions about \code{x}:
+\itemize{
+\item It has the correct type.
+\item It has the correct names.
+\item It has the correct \code{dim} and \code{dimnames} attributes.
+\item It is unclassed. This way you can call vctrs generics with \code{x}
+without triggering an infinite loop of restoration.
+}
+
+The length may be different (for example after \code{\link[=vec_slice]{vec_slice()}} has
+been called), and all other attributes may have been lost. The
+method should restore all attributes so that after restoration,
+\code{vec_restore(vec_data(x), x)} yields \code{x}.
 
 To understand the difference between \code{vec_cast()} and \code{vec_restore()}
 think about factors: it doesn't make sense to cast an integer to a factor,

--- a/src/cast.c
+++ b/src/cast.c
@@ -287,9 +287,13 @@ SEXP vctrs_restore_default(SEXP x, SEXP to) {
   SEXP dim = PROTECT(Rf_getAttrib(x, R_DimSymbol));
   ++n_protect;
 
+  SEXP dimnames = PROTECT(Rf_getAttrib(x, R_DimNamesSymbol));
+  ++n_protect;
+
   SET_ATTRIB(x, attrib);
   Rf_setAttrib(x, R_NamesSymbol, nms);
   Rf_setAttrib(x, R_DimSymbol, dim);
+  Rf_setAttrib(x, R_DimNamesSymbol, dimnames);
 
   // SET_ATTRIB() does not set object bit when attributes include class
   if (OBJECT(to)) {

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -195,3 +195,13 @@ test_that("vec_restore() passes `i` argument to methods", {
   )
   expect_identical(vec_slice(foobar(1:3), 2), 2L)
 })
+
+test_that("dimensions are preserved by default restore method", {
+  x <- foobar(1:4)
+  dim(x) <- c(2, 2)
+
+  exp <- foobar(c(1L, 3L))
+  dim(exp) <- c(1, 2)
+
+  expect_identical(vec_slice(x, 1), exp)
+})

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -199,9 +199,11 @@ test_that("vec_restore() passes `i` argument to methods", {
 test_that("dimensions are preserved by default restore method", {
   x <- foobar(1:4)
   dim(x) <- c(2, 2)
+  dimnames(x) <- list(a = c("foo", "bar"), b = c("quux", "hunoz"))
 
   exp <- foobar(c(1L, 3L))
   dim(exp) <- c(1, 2)
+  dimnames(exp) <- list(a = "foo", b = c("quux", "hunoz"))
 
   expect_identical(vec_slice(x, 1), exp)
 })

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -243,6 +243,23 @@ test_that("vec_slice() is proxied", {
   expect_identical(proxy_deref(x), 2:3)
 })
 
+test_that("dimensions are preserved by vec_slice()", {
+  attrib <- NULL
+
+  scoped_global_bindings(
+    vec_restore.vctrs_foobar = function(x, ...) attrib <<- attributes(x)
+  )
+
+  x <- foobar(1:4)
+  dim(x) <- c(2, 2)
+  dimnames(x) <- list(a = c("foo", "bar"), b = c("quux", "hunoz"))
+
+  vec_slice(x, 1)
+
+  exp <- list(dim = 1:2, dimnames = list(a = "foo", b = c("quux", "hunoz")))
+  expect_identical(attrib, exp)
+})
+
 
 # vec_na ------------------------------------------------------------------
 

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -280,6 +280,19 @@ test_that("vec_slice() unclasses input before calling `vec_restore()`", {
   expect_identical(class, "character")
 })
 
+test_that("can call `vec_slice()` from `[` methods with shaped objects without infloop", {
+  scoped_global_bindings(
+    `[.vctrs_foobar` = function(x, i, ...) vec_slice(x, i)
+  )
+
+  x <- foobar(1:4)
+  dim(x) <- c(2, 2)
+
+  exp <- foobar(c(1L, 3L))
+  dim(exp) <- c(1, 2)
+  expect_identical(x[1], exp)
+})
+
 
 # vec_na ------------------------------------------------------------------
 

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -260,6 +260,26 @@ test_that("dimensions are preserved by vec_slice()", {
   expect_identical(attrib, exp)
 })
 
+test_that("vec_slice() unclasses input before calling `vec_restore()`", {
+  class <- NULL
+  scoped_global_bindings(
+    vec_restore.vctrs_foobar = function(x, ...) class <<- class(x)
+  )
+
+  x <- foobar(1:4)
+  dim(x) <- c(2, 2)
+
+  vec_slice(x, 1)
+  expect_identical(class, "matrix")
+
+  scoped_global_bindings(
+    `[.vctrs_foobar` = function(x, i) class <<- class(x)
+  )
+
+  vec_slice(foobar(1:2), 1)
+  expect_identical(class, "character")
+})
+
 
 # vec_na ------------------------------------------------------------------
 


### PR DESCRIPTION
* `vec_restore()` is called after `vec_slice()` fallbacks to `[`.
* The default restore method preserves dimnames.
* Review assumptions that can be made by restoration methods in `?vec_restore`

Closes #153.

Does this look good @DavisVaughan?