### PR TITLE
i argument to vec_slice() gains NULL default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     backports,
     digest,
     glue,
-    rlang (>= 0.3.2.9000),
+    rlang (>= 0.3.3),
     zeallot
 Suggests: 
     bit64,
@@ -33,8 +33,6 @@ Suggests:
     rmarkdown,
     testthat,
     tibble
-Remotes: 
-    r-lib/rlang
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     backports,
     digest,
     glue,
-    rlang (>= 0.3.1),
+    rlang (>= 0.3.2.9000),
     zeallot
 Suggests: 
     bit64,
@@ -33,6 +33,8 @@ Suggests:
     rmarkdown,
     testthat,
     tibble
+Remotes: 
+    r-lib/rlang
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/R/slice.R
+++ b/R/slice.R
@@ -5,8 +5,10 @@
 #' that matches [vec_size()] instead of `length()`.
 #'
 #' @param x A vector
-#' @param i An integer or character vector specifying the positions or
+#' @param i An integer, character or logical vector specifying the positions or
 #'   names of the observations to get/set.
+#'   Specify `TRUE` to index all elements (as in `x[]`), or `NULL`, `FALSE` or
+#'   `integer()` to index none (as in `x[NULL]`).
 #' @param value Replacement values.
 #'
 #' @details
@@ -34,7 +36,7 @@
 #' x
 #'
 #' vec_slice(mtcars, 1:3)
-vec_slice <- function(x, i = NULL) {
+vec_slice <- function(x, i) {
   .Call(vctrs_slice, x, i, FALSE)
 }
 
@@ -61,7 +63,7 @@ vec_slice_native <- function(x, i) {
 
 #' @export
 #' @rdname vec_slice
-`vec_slice<-` <- function(x, i = NULL, value) {
+`vec_slice<-` <- function(x, i, value) {
   if (is_null(x)) {
     return(x)
   }

--- a/R/slice.R
+++ b/R/slice.R
@@ -34,8 +34,8 @@
 #' x
 #'
 #' vec_slice(mtcars, 1:3)
-vec_slice <- function(x, i) {
-  .Call(vctrs_slice, x, maybe_missing(i), FALSE)
+vec_slice <- function(x, i = NULL) {
+  .Call(vctrs_slice, x, i, FALSE)
 }
 
 # Called when `x` has dimensions
@@ -56,12 +56,12 @@ vec_slice_fallback <- function(x, i) {
 
 # No dispatch on `[`, should be called in `[` methods
 vec_slice_native <- function(x, i) {
-  .Call(vctrs_slice, x, maybe_missing(i), TRUE)
+  .Call(vctrs_slice, x, i, TRUE)
 }
 
 #' @export
 #' @rdname vec_slice
-`vec_slice<-` <- function(x, i, value) {
+`vec_slice<-` <- function(x, i = NULL, value) {
   if (is_null(x)) {
     return(x)
   }
@@ -89,7 +89,7 @@ vec_slice_native <- function(x, i) {
 }
 
 vec_as_index <- function(i, x) {
-  .Call(vctrs_as_index, maybe_missing(i), x)
+  .Call(vctrs_as_index, i, x)
 }
 
 #' Create a missing vector

--- a/R/vctr.R
+++ b/R/vctr.R
@@ -157,6 +157,8 @@ format.vctrs_vctr <- function(x, ...) {
 
 #' @export
 `[.vctrs_vctr` <- function(x, i, ...) {
+  # r-lib/rlang#746
+  if (missing(i)) i <- NULL
   check_dots_empty_s3_consistency(...)
   vec_slice_native(x, i)
 }

--- a/R/vctr.R
+++ b/R/vctr.R
@@ -157,10 +157,8 @@ format.vctrs_vctr <- function(x, ...) {
 
 #' @export
 `[.vctrs_vctr` <- function(x, i, ...) {
-  # r-lib/rlang#746
-  if (missing(i)) i <- NULL
   check_dots_empty_s3_consistency(...)
-  vec_slice_native(x, i)
+  vec_slice_native(x, maybe_missing(i, TRUE))
 }
 
 #' @export

--- a/man/vec_slice.Rd
+++ b/man/vec_slice.Rd
@@ -5,9 +5,9 @@
 \alias{vec_slice<-}
 \title{Get or set observations in a vector}
 \usage{
-vec_slice(x, i)
+vec_slice(x, i = NULL)
 
-vec_slice(x, i) <- value
+vec_slice(x, i = NULL) <- value
 }
 \arguments{
 \item{x}{A vector}

--- a/man/vec_slice.Rd
+++ b/man/vec_slice.Rd
@@ -5,15 +5,17 @@
 \alias{vec_slice<-}
 \title{Get or set observations in a vector}
 \usage{
-vec_slice(x, i = NULL)
+vec_slice(x, i)
 
-vec_slice(x, i = NULL) <- value
+vec_slice(x, i) <- value
 }
 \arguments{
 \item{x}{A vector}
 
-\item{i}{An integer or character vector specifying the positions or
-names of the observations to get/set.}
+\item{i}{An integer, character or logical vector specifying the positions or
+names of the observations to get/set.
+Specify \code{TRUE} to index all elements (as in \code{x[]}), or \code{NULL}, \code{FALSE} or
+\code{integer()} to index none (as in \code{x[NULL]}).}
 
 \item{value}{Replacement values.}
 }

--- a/src/slice.c
+++ b/src/slice.c
@@ -202,7 +202,7 @@ static SEXP vec_slice_impl(SEXP x, SEXP index, SEXP to, bool dispatch) {
 
 // [[export]]
 SEXP vctrs_slice(SEXP x, SEXP index, SEXP native) {
-  if (x == R_NilValue || index == R_MissingArg) {
+  if (x == R_NilValue || index == R_NilValue) {
     return x;
   }
 
@@ -402,11 +402,11 @@ static SEXP chr_as_index(SEXP i, SEXP x) {
 
 SEXP vec_as_index(SEXP i, SEXP x) {
   switch (TYPEOF(i)) {
+  case NILSXP: return lgl_as_index(Rf_ScalarLogical(1), x);
   case INTSXP: return int_as_index(i, x);
   case REALSXP: return dbl_as_index(i, x);
   case LGLSXP: return lgl_as_index(i, x);
   case STRSXP: return chr_as_index(i, x);
-  case SYMSXP: if (i == R_MissingArg) return i;
 
   default: Rf_errorcall(R_NilValue, "`i` must be an integer, character, or logical vector, not a %s.",
                         Rf_type2char(TYPEOF(i)));

--- a/src/slice.c
+++ b/src/slice.c
@@ -402,7 +402,7 @@ static SEXP chr_as_index(SEXP i, SEXP x) {
 
 SEXP vec_as_index(SEXP i, SEXP x) {
   switch (TYPEOF(i)) {
-  case NILSXP: return lgl_as_index(Rf_ScalarLogical(1), x);
+  case NILSXP: return lgl_as_index(vctrs_shared_true, x);
   case INTSXP: return int_as_index(i, x);
   case REALSXP: return dbl_as_index(i, x);
   case LGLSXP: return lgl_as_index(i, x);

--- a/src/slice.c
+++ b/src/slice.c
@@ -202,7 +202,7 @@ static SEXP vec_slice_impl(SEXP x, SEXP index, SEXP to, bool dispatch) {
 
 // [[export]]
 SEXP vctrs_slice(SEXP x, SEXP index, SEXP native) {
-  if (x == R_NilValue || index == R_NilValue) {
+  if (x == R_NilValue) {
     return x;
   }
 
@@ -402,7 +402,7 @@ static SEXP chr_as_index(SEXP i, SEXP x) {
 
 SEXP vec_as_index(SEXP i, SEXP x) {
   switch (TYPEOF(i)) {
-  case NILSXP: return lgl_as_index(vctrs_shared_true, x);
+  case NILSXP: return vctrs_shared_empty_int;
   case INTSXP: return int_as_index(i, x);
   case REALSXP: return dbl_as_index(i, x);
   case LGLSXP: return lgl_as_index(i, x);

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -161,17 +161,55 @@ test_that("ignores NA in integer subsetting", {
   expect_equal(`vec_slice<-`(x, c(NA, 2:3), c(NA, 2:1)), c(0, 2, 1))
 })
 
-test_that("can slice with missing argument", {
-  expect_identical(vec_slice(1:3), 1:3)
-  expect_identical(vec_slice(mtcars), mtcars)
-  expect_identical(vec_slice(new_vctr(1:3)), new_vctr(1:3))
+test_that("can't slice with missing argument", {
+  expect_error(vec_slice(1:3))
+  expect_error(vec_slice(mtcars))
+  expect_error(vec_slice(new_vctr(1:3)))
 })
 
-test_that("can modify subset with missing argument", {
+test_that("can slice with TRUE argument", {
+  expect_identical(vec_slice(1:3, TRUE), 1:3)
+  # Row names are stripped!
+  expect_identical(vec_slice(iris, TRUE), iris)
+  expect_identical(vec_slice(new_vctr(1:3), TRUE), new_vctr(1:3))
+})
+
+test_that("can slice with FALSE argument", {
+  expect_identical(vec_slice(1:3, FALSE), integer())
+  expect_identical(vec_slice(iris, FALSE), iris[0, ])
+  expect_identical(vec_slice(new_vctr(1:3), FALSE), new_vctr(integer()))
+})
+
+test_that("can slice with NULL argument", {
+  expect_identical(vec_slice(1:3, NULL), integer())
+  expect_identical(vec_slice(iris, NULL), iris[0, ])
+  expect_identical(vec_slice(new_vctr(1:3), NULL), new_vctr(integer()))
+})
+
+test_that("can't modify subset with missing argument", {
   x <- 1:3
-  vec_slice(x, ) <- 2L
+  expect_error(vec_slice(x, ) <- 2L)
+})
+
+test_that("can modify subset with TRUE argument", {
+  x <- 1:3
+  vec_slice(x, TRUE) <- 2L
 
   expect_identical(x, rep(2L, 3))
+})
+
+test_that("can modify subset with FALSE argument", {
+  x <- 1:3
+  vec_slice(x, FALSE) <- 2L
+
+  expect_identical(x, 1:3)
+})
+
+test_that("can modify subset with NULL argument", {
+  x <- 1:3
+  vec_slice(x, NULL) <- 2L
+
+  expect_identical(x, 1:3)
 })
 
 test_that("slicing unclassed structures preserves attributes", {

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -167,6 +167,13 @@ test_that("can slice with missing argument", {
   expect_identical(vec_slice(new_vctr(1:3)), new_vctr(1:3))
 })
 
+test_that("can modify subset with missing argument", {
+  x <- 1:3
+  vec_slice(x, ) <- 2L
+
+  expect_identical(x, rep(2L, 3))
+})
+
 test_that("slicing unclassed structures preserves attributes", {
   x <- structure(1:3, foo = "bar")
   expect_identical(vec_slice(x, 1L), structure(1L, foo = "bar"))

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -26,16 +26,19 @@ test_that("can subset with missing indices", {
 test_that("can subset with a recycled NA", {
   expect_identical(vec_slice(1:3, NA), int(NA, NA, NA))
   expect_identical(vec_slice(mtcars, NA), unrownames(mtcars[NA, ]))
+  expect_identical(vec_slice(new_vctr(1:3), NA), new_vctr(int(NA, NA, NA)))
 })
 
 test_that("can subset with a recycled TRUE", {
   expect_identical(vec_slice(1:3, TRUE), 1:3)
   expect_identical(vec_slice(mtcars, TRUE), unrownames(mtcars))
+  expect_identical(vec_slice(new_vctr(1:3), TRUE), new_vctr(1:3))
 })
 
 test_that("can subset with a recycled FALSE", {
   expect_identical(vec_slice(1:3, FALSE), int())
   expect_identical(vec_slice(mtcars, FALSE), unrownames(mtcars[NULL, ]))
+  expect_identical(vec_slice(new_vctr(1:3), FALSE), new_vctr(integer()))
 })
 
 test_that("can't index beyond the end of a vector", {
@@ -167,19 +170,6 @@ test_that("can't slice with missing argument", {
   expect_error(vec_slice(new_vctr(1:3)))
 })
 
-test_that("can slice with TRUE argument", {
-  expect_identical(vec_slice(1:3, TRUE), 1:3)
-  # Row names are stripped!
-  expect_identical(vec_slice(iris, TRUE), iris)
-  expect_identical(vec_slice(new_vctr(1:3), TRUE), new_vctr(1:3))
-})
-
-test_that("can slice with FALSE argument", {
-  expect_identical(vec_slice(1:3, FALSE), integer())
-  expect_identical(vec_slice(iris, FALSE), iris[0, ])
-  expect_identical(vec_slice(new_vctr(1:3), FALSE), new_vctr(integer()))
-})
-
 test_that("can slice with NULL argument", {
   expect_identical(vec_slice(1:3, NULL), integer())
   expect_identical(vec_slice(iris, NULL), iris[0, ])
@@ -191,17 +181,21 @@ test_that("can't modify subset with missing argument", {
   expect_error(vec_slice(x, ) <- 2L)
 })
 
-test_that("can modify subset with TRUE argument", {
+test_that("can modify subset with recycled NA argument", {
+  x <- 1:3
+  vec_slice(x, NA) <- 2L
+  expect_identical(x, 1:3)
+})
+
+test_that("can modify subset with recycled TRUE argument", {
   x <- 1:3
   vec_slice(x, TRUE) <- 2L
-
   expect_identical(x, rep(2L, 3))
 })
 
-test_that("can modify subset with FALSE argument", {
+test_that("can modify subset with recycled FALSE argument", {
   x <- 1:3
   vec_slice(x, FALSE) <- 2L
-
   expect_identical(x, 1:3)
 })
 


### PR DESCRIPTION
I'm sure this can also be fixed using missing arguments, but explicit `NULL`s seem to be much easier to reason about.

Conflicts with #249, but easy to redo on top of that.

Closes #246.