### PR TITLE
Set `dim` attribute before any names in default `vec_restore()` method

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -291,8 +291,8 @@ SEXP vctrs_restore_default(SEXP x, SEXP to) {
   ++n_protect;
 
   SET_ATTRIB(x, attrib);
-  Rf_setAttrib(x, R_NamesSymbol, nms);
   Rf_setAttrib(x, R_DimSymbol, dim);
+  Rf_setAttrib(x, R_NamesSymbol, nms);
   Rf_setAttrib(x, R_DimNamesSymbol, dimnames);
 
   // SET_ATTRIB() does not set object bit when attributes include class

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -207,3 +207,16 @@ test_that("dimensions are preserved by default restore method", {
 
   expect_identical(vec_slice(x, 1), exp)
 })
+
+test_that("names attribute isn't set when restoring 1D arrays using 2D+ objects", {
+  x <- foobar(1:2)
+  dim(x) <- c(2)
+  nms <- c("foo", "bar")
+  dimnames(x) <- list(nms)
+
+  res <- vec_restore(x, matrix(1))
+
+  expect_null(attributes(res)$names)
+  expect_equal(attr(res, "names"), nms)
+  expect_equal(names(res), nms)
+})


### PR DESCRIPTION
I hit a weird bug with the default `vec_restore()` method that has to do with how R treats names of 1D arrays. Here's the minimal example:

``` r
library(vctrs)

x <- array(c(1, 2), dimnames = list(c("nm1", "nm2")))
x
#> nm1 nm2 
#>   1   2

# `names` attribute is actually set?
vec_restore(x, matrix(1))
#> nm1 nm2 
#>   1   2 
#> attr(,"names")
#> [1] "nm1" "nm2"
```

A bit of exploring shows that R treats `names` special for 1D arrays

``` r
library(vctrs)

x <- array(c(1, 2), dimnames = list(c("nm1", "nm2")))
x
#> nm1 nm2 
#>   1   2

# only dimnames
attributes(x)
#> $dim
#> [1] 2
#> 
#> $dimnames
#> $dimnames[[1]]
#> [1] "nm1" "nm2"

# but this registers names
names(x)
#> [1] "nm1" "nm2"

# so does this
attr(x, "names", exact = TRUE)
#> [1] "nm1" "nm2"

# no problems here
vec_restore(x, 1L)
#> nm1 nm2 
#>   1   2

# `names` attribute is actually set?
vec_restore(x, matrix(1))
#> nm1 nm2 
#>   1   2 
#> attr(,"names")
#> [1] "nm1" "nm2"

x_2D <- as.matrix(x)
x_2D
#>     [,1]
#> nm1    1
#> nm2    2

# no problem here
vec_restore(x_2D, matrix(1))
#>     [,1]
#> nm1    1
#> nm2    2
```

I think what is happening on the vctrs side is that the default `vec_restore()`:

- Collects the `R_NamesSymbol` from `x` as `nms`, which is actually a thing for 1D arrays, but otherwise returns NULL for 2D+ structures.
- Calls `SET_ATTRIB(x, attrib)` which sets `dim = c(1,1)`, so its now 2D
- Calls `Rf_setAttrib(x, R_NamesSymbol, nms);`, which actually sets the names attribute with `nms` for a matrix. Great. If this was a 1D array still, I think it would skip over it and wouldn't set the `"names"` attribute directly.
- Then `Rf_setAttrib(x, R_DimSymbol, dim);` restores the 1D dimensionality.

I think that _ideally_ `SET_ATTRIB(x, attrib)` call wouldn't set incorrect attributes to begin with (meaning it shouldn't have used the names, dim, and dimnames of `to`, which immediately get overwritten anyways).

The easiest alternative solution is implemented here. I just set the `R_DimSymbol` first so that the setting of the `R_NamesSymbol` is skipped over.