### PR TITLE
Fix assertion of partial frames

### DIFF
--- a/R/assert.R
+++ b/R/assert.R
@@ -100,6 +100,9 @@ is_same_type <- function(x, ptype) {
   if (!is.object(x) || !is.object(ptype)) {
     typeof(x) == typeof(ptype)
   } else {
+    if (is_partial(ptype)) {
+      ptype <- vec_type_common(x, ptype)
+    }
     identical(x, ptype)
   }
 }

--- a/R/partial-frame.R
+++ b/R/partial-frame.R
@@ -76,8 +76,5 @@ vec_type2.data.frame.vctrs_partial_frame <- function(x, y) {
 
 #' @export
 vec_type_finalise.vctrs_partial_frame <- function(x) {
-  out <- x$learned
-  out[names(x$partial)] <- x$partial
-
-  out
+  x$learned
 }

--- a/tests/testthat/test-partial-frame.R
+++ b/tests/testthat/test-partial-frame.R
@@ -18,9 +18,10 @@ test_that("order of variables comes from data", {
   expect_named(vec_type_common(df, pf), c("x", "y"))
 })
 
-test_that("partial variables added to end if not in data", {
+test_that("partial variables are forgotten if not in data", {
   pf <- partial_frame(y = 1)
   df <- data.frame(x = 1)
-  expect_named(vec_type_common(pf, df), c("x", "y"))
-  expect_named(vec_type_common(df, pf), c("x", "y"))
+  expect_named(vec_type_common(pf, df), "x")
+  expect_named(vec_type_common(df, pf), "x")
+})
 })

--- a/tests/testthat/test-partial-frame.R
+++ b/tests/testthat/test-partial-frame.R
@@ -24,4 +24,9 @@ test_that("partial variables are forgotten if not in data", {
   expect_named(vec_type_common(pf, df), "x")
   expect_named(vec_type_common(df, pf), "x")
 })
+
+test_that("can assert partial frames", {
+  partial <- partial_frame(col_name = character(), measure = character())
+  expect_true(vec_is(data.frame(x = 1, col_name = 2), partial))
+  expect_true(vec_is(data.frame(col_name = 2, x = 1), partial))
 })


### PR DESCRIPTION
Closes #198.

* Forget unlearned columns when partial frame is finalised.
* Finalise partial types in `vec_assert()`.

I'm not sure this is the right approach as I'm just learning about partial types.