### PR TITLE
Only call `vec_proxy_equal()` once in `vec_unique()`

### DIFF
--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -180,8 +180,7 @@ vec_duplicate_id <- function(x) {
 #' # But they are for the purposes of considering uniqueness
 #' vec_unique(c(NA, NA, NA, NA, 1, 2, 1))
 vec_unique <- function(x) {
-  px <- vec_proxy_equal(x)
-  vec_slice(x, vec_unique_loc(px))
+  vec_slice(x, vec_unique_loc(x))
 }
 
 #' @rdname vec_unique


### PR DESCRIPTION
`vec_unique_loc()` already calls `vec_proxy_equal()` so I don't think there is need to do it in `vec_unique()` as well.