### PR TITLE
Preserve dim in `vec_data()`

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -74,7 +74,11 @@ vec_data <- function(x) {
   # TODO: implement with ALTREP to avoid making a copy
   if (is_record(x)) {
     attributes(x) <- list(names = fields(x))
-  } else {
+  }
+  else if (has_dim(x)) {
+    attributes(x) <- list(dim = dim(x), dimnames = dimnames(x))
+  }
+  else {
     attributes(x) <- list(names = names(x))
   }
 
@@ -101,3 +105,6 @@ is_record.POSIXlt <- function(x) TRUE
 is_record.vctrs_rcrd <- function(x) TRUE
 is_record.default <- function(x) FALSE
 
+has_dim <- function(x) {
+  !is.null(attr(x, "dim"))
+}

--- a/R/data.R
+++ b/R/data.R
@@ -74,11 +74,9 @@ vec_data <- function(x) {
   # TODO: implement with ALTREP to avoid making a copy
   if (is_record(x)) {
     attributes(x) <- list(names = fields(x))
-  }
-  else if (has_dim(x)) {
+  } else if (has_dim(x)) {
     attributes(x) <- list(dim = dim(x), dimnames = dimnames(x))
-  }
-  else {
+  } else {
     attributes(x) <- list(names = names(x))
   }
 

--- a/R/data.R
+++ b/R/data.R
@@ -104,7 +104,3 @@ is_record <- function(x) {
 is_record.POSIXlt <- function(x) TRUE
 is_record.vctrs_rcrd <- function(x) TRUE
 is_record.default <- function(x) FALSE
-
-has_dim <- function(x) {
-  !is.null(attr(x, "dim"))
-}

--- a/R/utils.R
+++ b/R/utils.R
@@ -169,3 +169,7 @@ check_dots_empty_s3_extensions <- function(...) {
     ))
   }
 }
+
+has_dim <- function(x) {
+  !is.null(attr(x, "dim"))
+}

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -8,6 +8,12 @@ test_that("strips vector attributes apart from names", {
   expect_equal(vec_data(x), c(x = 1, y = 2))
 })
 
+test_that("strips attributes apart from dim and dimnames", {
+  x <- new_vctr(1, a = 1, dim = c(1L, 1L), dimnames = list("foo", "bar"))
+  expect <- matrix(1, nrow = 1L, ncol = 1L, dimnames = list("foo", "bar"))
+  expect_equal(vec_data(x), expect)
+})
+
 test_that("vec_is_data_vector() detects data vectors", {
   for (x in vectors) {
     expect_true(vec_is_data_vector(!!x))

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -36,6 +36,11 @@ test_that("vec_unique matches unique", {
   expect_equal(unique(x), unique(x))
 })
 
+test_that("vec_unique matches unique for matrices", {
+  x <- matrix(c(1, 1, 2, 2), ncol = 2)
+  expect_equal(vec_unique(x), unique(x))
+})
+
 test_that("vec_unique_count matches length + unique", {
   x <- sample(100, 1000, replace = TRUE)
   expect_equal(vec_unique_count(x), length(unique(x)))


### PR DESCRIPTION
Closes #266 
Fixes part of #245 (This might be a complete fix unless you want to do something special with `vec_names()`)

This makes a simple change to `vec_data()` that preserves the `dim` and `dimnames` of `x` rather than the `names` if `x` has a `dim` attribute.

I noticed there is an unexported C `has_dim()` function. If that was exposed at the R level I suppose that could be used here instead.

If you would like a test for `vec_unique()` with matrices as well (#266), I can add one.