### PR TITLE
Fix typo in `vec_unique()` test

### DIFF
--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -33,7 +33,7 @@ test_that("vec_duplicate_id gives position of first found", {
 
 test_that("vec_unique matches unique", {
   x <- sample(100, 1000, replace = TRUE)
-  expect_equal(unique(x), unique(x))
+  expect_equal(vec_unique(x), unique(x))
 })
 
 test_that("vec_unique_count matches length + unique", {


### PR DESCRIPTION
Saw a small typo. Now we actually call `vec_unique()` to compare against `unique()`