### PR TITLE
Use tidy names in `vec_c()`

### DIFF
--- a/R/c.R
+++ b/R/c.R
@@ -42,7 +42,6 @@ vec_c <- function(..., .ptype = NULL) {
   out <- vec_na(ptype, sum(ns))
 
   has_names <- !is.null(names(args)) || has_inner_names(args)
-
   if (has_names) {
     names <- vec_na(character(), sum(ns))
   } else {

--- a/R/c.R
+++ b/R/c.R
@@ -40,10 +40,13 @@ vec_c <- function(..., .ptype = NULL) {
 
   ns <- map_int(args, vec_size)
   out <- vec_na(ptype, sum(ns))
-  if (is.null(names(args)) && !has_inner_names(args)) {
-    names <- NULL
-  } else {
+
+  has_names <- !is.null(names(args)) || has_inner_names(args)
+
+  if (has_names) {
     names <- vec_na(character(), sum(ns))
+  } else {
+    names <- NULL
   }
 
   pos <- 1
@@ -54,7 +57,12 @@ vec_c <- function(..., .ptype = NULL) {
 
     x <- vec_cast(args[[i]], to = ptype)
 
-    names[pos:(pos + n - 1)] <- outer_names(names(args)[[i]], vec_names(args[[i]]), length(x))
+    if (has_names) {
+      n_x <- length(x)
+      names_i <- outer_names(names(args)[[i]], vec_names(args[[i]]), n_x)
+      names[pos:(pos + n - 1)] <- names_i %||% rep("", times = n_x)
+    }
+
     vec_slice(out, pos:(pos + n - 1)) <- x
     pos <- pos + n
   }

--- a/R/c.R
+++ b/R/c.R
@@ -67,8 +67,12 @@ vec_c <- function(..., .ptype = NULL) {
     pos <- pos + n
   }
 
-  if (!is.null(names))
+  if (!is.null(names)) {
+    if (is_installed("tibble")) {
+      names <- tibble::tidy_names(names)
+    }
     vec_names(out) <- names
+  }
 
   out
 }


### PR DESCRIPTION
Closes #271 

I compared `vec_c()` with `vec_c/rbind()` and realized it might benefit from the use of `tibble::tidy_names()`, which could solve #271. If you don't want this, no harm done. I'll add some tests if you like the idea.

This also alters the current way the names are built up in `vec_c()`. If any of the inputs are named, then any of the _unnamed_ inputs get `""` as their default name until `tibble::tidy_names()` can fix that. This is a similar approach as `vec_cbind()` I believe.

You can now do the following, which previously were errors:

``` r
library(vctrs)
library(rray)

# adds names to unnamed input
y <- 1
names(y) <- "a"
vec_c(y, 1)
#> New names:
#>  -> ..2
#>   a ..2 
#>   1   1

# works on matrices
x <- matrix(1:2, dimnames = list(letters[1:2], "c1"))
vec_c(x, 1)
#> New names:
#>  -> ..3
#>     [,1]
#> a      1
#> b      2
#> ..3    1

# - works on vctrs_vctr types
# - duplicate names are deduped
# - note that vec_c() also loses shape names (col names here)
mat <- rray(1, dim = c(1, 1), dim_names = list("r1", "c1"))
vec_c(mat, 2, mat)
#> New names:
#> r1 -> r1..1
#>  -> ..2
#> r1 -> r1..3
#> <vctrs_rray<double>[,1][3]>
#>       [,1]
#> r1..1    1
#> ..2      2
#> r1..3    1
```

<sup>Created on 2019-04-03 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>