### PR TITLE
Fix `vec_count()` with 3D+ arrays

### DIFF
--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -57,7 +57,7 @@ vec_count <- function(x, sort = c("count", "key", "location", "none")) {
     count = order(-kv$val)
   )
 
-  df <- df[idx, , drop = FALSE]
+  df <- vec_slice(df, idx)
   reset_rownames(df)
 }
 

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -8,6 +8,13 @@ test_that("vec_count counts number observations", {
   expect_equal(x, data.frame(key = 1:3, count = 1:3))
 })
 
+test_that("vec_count works with arrays", {
+  x <- array(c(rep(1, 3), rep(2, 3)), dim = c(3, 2, 1))
+  expect <- data.frame(key = NA, count = 3)
+  expect$key <- vec_slice(x, 1L)
+  expect_equal(vec_count(x), expect)
+})
+
 test_that("vec_count works for zero-length input", {
   x <- vec_count(integer(), sort = "none")
   expect_equal(x, data.frame(key = integer(), count = integer()))


### PR DESCRIPTION
For whatever reason, base R flattens data frame "array columns" of dimensionality 3+ when you try and subset rows of the data frame with `[`. It doesn't do this for matrix columns. Luckily, `vec_slice()` does the right thing, so I replaced a call to `[` with `vec_slice()` to reorder rows in `vec_count()`.

``` r
library(vctrs)

vec <- c(1, 1, 5, 2, 2, 5)

# fine
vec_1d <- array(vec)
vec_count(vec_1d)
#>   key count
#> 1   2     2
#> 2   1     2
#> 3   5     2

# fine
mat <- array(vec, c(3, 2))
vec_count(mat)
#>   key.1 key.2 count
#> 1     1     2     2
#> 2     5     5     1

# flattened
arr_3d <- array(vec, c(3, 2, 1))
vec_count(arr_3d)
#>   key count
#> 1   1     2
#> 2   5     1

# flattened
arr_4d <- array(vec, c(3, 2, 1, 1))
vec_count(arr_4d)
#>   key count
#> 1   1     2
#> 2   5     1
```

Expected result you get with the fix:

``` r
library(vctrs)

vec <- c(1, 1, 5, 2, 2, 5)

# flattened
arr_3d <- array(vec, c(3, 2, 1))
vec_count(arr_3d)
#>   key.1 key.2 count
#> 1     1     2     2
#> 2     5     5     1

# flattened
arr_4d <- array(vec, c(3, 2, 1, 1))
vec_count(arr_4d)
#>   key.1 key.2 count
#> 1     1     2     2
#> 2     5     5     1
```