### PR TITLE
Fix `vec_assert()` issues

### DIFF
--- a/R/assert.R
+++ b/R/assert.R
@@ -39,7 +39,7 @@ vec_assert <- function(x, ptype = NULL, size = NULL, arg = as_label(substitute(x
 
   if (!is_null(ptype)) {
     ptype <- vec_type(ptype)
-    x_type <- vec_type(x)
+    x_type <- ununspecify(vec_type(x))
     if (!is_same_type(x_type, ptype)) {
       msg <- paste0("`", arg, "` must be <", vec_ptype_abbr(ptype), ">, not <", vec_ptype_abbr(x_type), ">.")
       abort(
@@ -76,7 +76,7 @@ vec_is <- function(x, ptype = NULL, size = NULL) {
 
   if (!is_null(ptype)) {
     ptype <- vec_type(ptype)
-    x_type <- vec_type(x)
+    x_type <- ununspecify(vec_type(x))
     if (!is_same_type(x_type, ptype)) {
       return(FALSE)
     }

--- a/R/assert.R
+++ b/R/assert.R
@@ -93,11 +93,6 @@ vec_is <- function(x, ptype = NULL, size = NULL) {
   TRUE
 }
 
-# Bare prototypes act as partial types. Only the SEXPTYPE is checked.
 is_same_type <- function(x, ptype) {
-  if (!is.object(x) || !is.object(ptype)) {
-    typeof(x) == typeof(ptype)
-  } else {
-    identical(x, ptype)
-  }
+  identical(x, ptype)
 }

--- a/R/assert.R
+++ b/R/assert.R
@@ -32,16 +32,14 @@
 #'   invisibly.
 #' @export
 vec_assert <- function(x, ptype = NULL, size = NULL, arg = as_label(substitute(x))) {
-  proxy <- vec_proxy(x)
-
-  if (!vec_is_vector(proxy)) {
-    msg <- glue::glue("`{ arg }` must be a vector, not { friendly_type_of(proxy) }")
-    abort(msg, "vctrs_error_assert_scalar", actual = proxy)
+  if (!vec_is_vector(x)) {
+    msg <- glue::glue("`{ arg }` must be a vector, not { friendly_type_of(x) }")
+    abort(msg, "vctrs_error_assert_scalar", actual = x)
   }
 
   if (!is_null(ptype)) {
     ptype <- vec_type(ptype)
-    x_type <- vec_type(proxy)
+    x_type <- vec_type(x)
     if (!is_same_type(x_type, ptype)) {
       msg <- paste0("`", arg, "` must be <", vec_ptype_abbr(ptype), ">, not <", vec_ptype_abbr(x_type), ">.")
       abort(
@@ -55,7 +53,7 @@ vec_assert <- function(x, ptype = NULL, size = NULL, arg = as_label(substitute(x
 
   if (!is_null(size)) {
     size <- vec_recycle(vec_cast(size, integer()), 1L)
-    x_size <- vec_size(proxy)
+    x_size <- vec_size(x)
     if (!identical(x_size, size)) {
       msg <- paste0("`", arg, "` must have size ", size, ", not size ", x_size, ".")
       abort(
@@ -67,13 +65,11 @@ vec_assert <- function(x, ptype = NULL, size = NULL, arg = as_label(substitute(x
     }
   }
 
-  invisible(proxy)
+  invisible(x)
 }
 #' @rdname vec_assert
 #' @export
 vec_is <- function(x, ptype = NULL, size = NULL) {
-  x <- vec_proxy(x)
-
   if (!vec_is_vector(x)) {
     return(FALSE)
   }

--- a/R/unspecified.R
+++ b/R/unspecified.R
@@ -48,7 +48,14 @@ vec_unspecified_cast <- function(x, to) {
 
 #' @export
 vec_type_finalise.vctrs_unspecified <- function(x) {
-  logical()
+  ununspecify(x)
+}
+ununspecify <- function(x) {
+  if (is_unspecified(x)) {
+    new_logical(length(x))
+  } else {
+    x
+  }
 }
 
 # Type system -------------------------------------------------------------

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -149,3 +149,18 @@ test_that("bare prototypes act as partial types", {
 test_that("data frames are always classified as such even when dispatch is off", {
   expect_identical(vec_typeof_bare(mtcars), "dataframe")
 })
+
+test_that("assertion is not applied on proxy", {
+  scoped_global_bindings(
+    vec_proxy.vctrs_foobar = unclass,
+    vec_restore.vctrs_foobar = function(x, ...) foobar(x),
+    `[.vctrs_foobar` = function(x, i) vec_slice_native(x, i)
+  )
+  x <- foobar(list())
+
+  expect_true(vec_is(x, x))
+  expect_false(vec_is(x, list()))
+
+  expect_error(vec_assert(x, list()), class = "vctrs_error_assert_ptype")
+  expect_error(vec_assert(x, x), regexp = NA)
+})

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -173,3 +173,8 @@ test_that("attributes of unclassed vectors are asserted", {
   expect_true(vec_is(y, x))
   expect_true(vec_is(x, y))
 })
+
+test_that("unspecified is finalised before assertion", {
+  expect_true(vec_is(NA, TRUE))
+  expect_error(regexp = NA, vec_is(NA, TRUE))
+})

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -164,3 +164,12 @@ test_that("assertion is not applied on proxy", {
   expect_error(vec_assert(x, list()), class = "vctrs_error_assert_ptype")
   expect_error(vec_assert(x, x), regexp = NA)
 })
+
+test_that("attributes of unclassed vectors are asserted", {
+  x <- structure(FALSE, foo = "bar")
+  y <- structure(TRUE, foo = "bar")
+  expect_false(vec_is(x, FALSE))
+  expect_false(vec_is(FALSE, x))
+  expect_true(vec_is(y, x))
+  expect_true(vec_is(x, y))
+})

--- a/tests/testthat/test-unspecified.R
+++ b/tests/testthat/test-unspecified.R
@@ -63,3 +63,8 @@ test_that("S3 vectors and shaped vectors are never unspecified", {
   expect_false(is_unspecified(foobar(lgl(NA, NA))))
   expect_false(is_unspecified(matrix(NA, 2)))
 })
+
+test_that("can finalise lengthy unspecified vectors", {
+  expect_identical(vec_type_finalise(unspecified(3)), rep(NA, 3))
+  expect_identical(ununspecify(unspecified(3)), rep(NA, 3))
+})


### PR DESCRIPTION
* Don't assert the proxy, assert the full type.
* No longer treat bare types as partial types, so that `vec_assert(factor(), int())` throws.
* Fix `vec_assert(NA, lgl())`.