### PR TITLE
Explain type differences when assertion fails

### DIFF
--- a/R/assert.R
+++ b/R/assert.R
@@ -41,7 +41,7 @@ vec_assert <- function(x, ptype = NULL, size = NULL, arg = as_label(substitute(x
     ptype <- vec_type(ptype)
     x_type <- ununspecify(vec_type(x))
     if (!is_same_type(x_type, ptype)) {
-      msg <- paste0("`", arg, "` must be <", vec_ptype_abbr(ptype), ">, not <", vec_ptype_abbr(x_type), ">.")
+      msg <- vec_assert_type_explain(x_type, ptype, arg)
       abort(
         msg,
         .subclass = c("vctrs_error_assert_ptype", "vctrs_error_assert"),
@@ -95,4 +95,34 @@ vec_is <- function(x, ptype = NULL, size = NULL) {
 
 is_same_type <- function(x, ptype) {
   identical(x, ptype)
+}
+
+vec_assert_type_explain <- function(x, type, arg) {
+  arg <- str_backtick(arg)
+  x <- vec_ptype_full(x)
+  type <- vec_ptype_full(type)
+
+  intro <- paste0(arg, " must be a vector with type")
+  intro <- layout_type(intro, type)
+
+  outro <- paste0("Instead, it has type")
+  outro <- layout_type(outro, x)
+
+  paste_line(
+    !!!intro,
+    if (str_is_multiline(intro)) "",
+    !!!outro
+  )
+}
+
+layout_type <- function(start, type) {
+  if (str_is_multiline(type)) {
+    paste_line(
+      paste0(start, ":"),
+      "",
+      paste0("  ", indent(type, 2))
+    )
+  } else {
+    paste0(start, " ", type, ".")
+  }
 }

--- a/R/utils-cli.R
+++ b/R/utils-cli.R
@@ -41,3 +41,10 @@ pad_width <- function(x) {
   lines <- map(lines, format, width = width)
   map_chr(lines, paste, collapse = "\n")
 }
+
+str_backtick <- function(x) {
+  paste0("`", x, "`")
+}
+str_is_multiline <- function(x) {
+  grepl("\n", x)
+}

--- a/tests/testthat/helper-output.R
+++ b/tests/testthat/helper-output.R
@@ -1,0 +1,11 @@
+
+try_cat <- function(expr) {
+  cat(paste0("> ", as_label(substitute(expr)), ":\n\n"))
+
+  out <- tryCatch(expr, error = function(err) {
+    cat(paste0("Error: ", err$message, "\n"))
+  })
+
+  cat("\n\n\n")
+  out
+}

--- a/tests/testthat/helper-s3.R
+++ b/tests/testthat/helper-s3.R
@@ -16,3 +16,7 @@ new_proxy <- function(x) {
 proxy_deref <- function(x) {
   x[[1]]$x
 }
+
+scoped_no_stringsAsFactors <- function(frame = caller_env()) {
+  scoped_options(.frame = frame, stringsAsFactors = FALSE)
+}

--- a/tests/testthat/test-assert-explanations.txt
+++ b/tests/testthat/test-assert-explanations.txt
@@ -1,0 +1,138 @@
+> vec_assert(lgl(), chr()):
+
+Error: `lgl()` must be a vector with type character.
+Instead, it has type logical.
+
+
+
+> vec_assert(lgl(), factor()):
+
+Error: `lgl()` must be a vector with type factor<>.
+Instead, it has type logical.
+
+
+
+> vec_assert(lgl(), factor(levels = "foo")):
+
+Error: `lgl()` must be a vector with type factor<bd40e>.
+Instead, it has type logical.
+
+
+
+> vec_assert(factor(levels = "bar"), factor(levels = "foo")):
+
+Error: `factor(levels = "bar")` must be a vector with type factor<bd40e>.
+Instead, it has type factor<cbd21>.
+
+
+
+> vec_assert(factor(), chr()):
+
+Error: `factor()` must be a vector with type character.
+Instead, it has type factor<>.
+
+
+
+> vec_assert(lgl(), data.frame()):
+
+Error: `lgl()` must be a vector with type data.frame<>.
+Instead, it has type logical.
+
+
+
+> vec_assert(lgl(), data.frame(x = 1)):
+
+Error: `lgl()` must be a vector with type data.frame<x:double>.
+Instead, it has type logical.
+
+
+
+> vec_assert(lgl(), data.frame(x = 1, y = 2)):
+
+Error: `lgl()` must be a vector with type:
+
+  data.frame<
+    x: double
+    y: double
+  >
+
+Instead, it has type logical.
+
+
+
+> vec_assert(data.frame(), chr()):
+
+Error: `data.frame()` must be a vector with type character.
+Instead, it has type data.frame<>.
+
+
+
+> vec_assert(data.frame(x = 1), chr()):
+
+Error: `data.frame(x = 1)` must be a vector with type character.
+Instead, it has type data.frame<x:double>.
+
+
+
+> vec_assert(data.frame(x = 1), data.frame(x = "foo")):
+
+Error: `data.frame(x = 1)` must be a vector with type data.frame<x:character>.
+Instead, it has type data.frame<x:double>.
+
+
+
+> vec_assert(data.frame(x = 1), data.frame(x = "foo", y = 2)):
+
+Error: `data.frame(x = 1)` must be a vector with type:
+
+  data.frame<
+    x: character
+    y: double
+  >
+
+Instead, it has type data.frame<x:double>.
+
+
+
+> vec_assert(data.frame(x = 1, y = 2), chr()):
+
+Error: `data.frame(x = 1, y = 2)` must be a vector with type character.
+Instead, it has type:
+
+  data.frame<
+    x: double
+    y: double
+  >
+
+
+
+> vec_assert(data.frame(x = 1, y = 2), data.frame(x = "foo")):
+
+Error: `data.frame(x = 1, y = 2)` must be a vector with type data.frame<x:character>.
+Instead, it has type:
+
+  data.frame<
+    x: double
+    y: double
+  >
+
+
+
+> vec_assert(data.frame(x = 1, y = 2), data.frame(x = "foo", y = 2)):
+
+Error: `data.frame(x = 1, y = 2)` must be a vector with type:
+
+  data.frame<
+    x: character
+    y: double
+  >
+
+Instead, it has type:
+
+  data.frame<
+    x: double
+    y: double
+  >
+
+
+

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -178,3 +178,32 @@ test_that("unspecified is finalised before assertion", {
   expect_true(vec_is(NA, TRUE))
   expect_error(regexp = NA, vec_is(NA, TRUE))
 })
+
+test_that("assertion failures are explained", {
+  expect_known_output(file = test_path("test-assert-explanations.txt"), {
+    scoped_no_stringsAsFactors()
+    scoped_options(rlang_backtrace_on_error = "none")
+
+    try_cat(vec_assert(lgl(), chr()))
+
+    try_cat(vec_assert(lgl(), factor()))
+    try_cat(vec_assert(lgl(), factor(levels = "foo")))
+
+    try_cat(vec_assert(factor(levels = "bar"), factor(levels = "foo")))
+    try_cat(vec_assert(factor(), chr()))
+
+    try_cat(vec_assert(lgl(), data.frame()))
+    try_cat(vec_assert(lgl(), data.frame(x = 1)))
+    try_cat(vec_assert(lgl(), data.frame(x = 1, y = 2)))
+
+    try_cat(vec_assert(data.frame(), chr()))
+
+    try_cat(vec_assert(data.frame(x = 1), chr()))
+    try_cat(vec_assert(data.frame(x = 1), data.frame(x = "foo")))
+    try_cat(vec_assert(data.frame(x = 1), data.frame(x = "foo", y = 2)))
+
+    try_cat(vec_assert(data.frame(x = 1, y = 2), chr()))
+    try_cat(vec_assert(data.frame(x = 1, y = 2), data.frame(x = "foo")))
+    try_cat(vec_assert(data.frame(x = 1, y = 2), data.frame(x = "foo", y = 2)))
+  })
+})


### PR DESCRIPTION
Fixes #260

I wonder if we should lay out factors in the same way as data frames and only hash the labels when there are too many?