### PR TITLE
Fail early when partial type doesn't match

### DIFF
--- a/R/assert.R
+++ b/R/assert.R
@@ -95,12 +95,11 @@ vec_is <- function(x, ptype = NULL, size = NULL) {
 
 is_same_type <- function(x, ptype) {
   if (is_partial(ptype)) {
-    ptype <- maybe(vec_type_common(x, ptype), "vctrs_error_incompatible_type")
-
-    if (!is_null(ptype$error)) {
-      return(FALSE)
-    }
-    ptype <- ptype$value
+    env <- environment()
+    ptype <- tryCatch(
+      vctrs_error_incompatible_type = function(...) return_from(env, FALSE),
+      vec_type_common(x, ptype)
+    )
   }
 
   identical(x, ptype)

--- a/R/assert.R
+++ b/R/assert.R
@@ -95,8 +95,14 @@ vec_is <- function(x, ptype = NULL, size = NULL) {
 
 is_same_type <- function(x, ptype) {
   if (is_partial(ptype)) {
-    ptype <- vec_type_common(x, ptype)
+    ptype <- maybe(vec_type_common(x, ptype), "vctrs_error_incompatible_type")
+
+    if (!is_null(ptype$error)) {
+      return(FALSE)
+    }
+    ptype <- ptype$value
   }
+
   identical(x, ptype)
 }
 

--- a/R/partial-frame.R
+++ b/R/partial-frame.R
@@ -23,8 +23,13 @@ partial_frame <- function(...) {
 }
 
 new_partial_frame <- function(partial = data.frame(), learned = data.frame()) {
-  stopifnot(is.data.frame(partial))
-  stopifnot(is.data.frame(learned))
+  stopifnot(
+    is.data.frame(partial),
+    is.data.frame(learned)
+  )
+
+  # Fails if `learned` is not compatible with `partial`
+  vec_type2(partial, learned)
 
   new_partial(
     partial = partial,

--- a/R/type-tibble.R
+++ b/R/type-tibble.R
@@ -16,4 +16,7 @@ vec_type2.data.frame.tbl_df <- function(x, y) vec_restore(df_col_type2(x, y), y)
 
 #' @method vec_type2.tbl_df default
 #' @export
-vec_type2.tbl_df.default <- function(x, y) stop_incompatible_type(x, y)
+vec_type2.tbl_df.default <- function(x, y) {
+  # FIXME: Do we need some sort of `next_vec_type2()`?
+  vec_type2.data.frame(x, y)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -173,3 +173,17 @@ check_dots_empty_s3_extensions <- function(...) {
 has_dim <- function(x) {
   !is.null(attr(x, "dim"))
 }
+
+value <- function(expr) {
+  eval_bare(enexpr(expr), caller_env())
+}
+new_maybe <- function(value, error = NULL) {
+  list(value = value, error = error)
+}
+maybe <- function(expr, class = "error") {
+  env <- environment()
+  hnd <- function(cnd) return_from(env, new_maybe(NULL, cnd))
+
+  handlers <- rep_named(class, list(hnd))
+  new_maybe(value(tryCatch(expr, !!!handlers)))
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -173,17 +173,3 @@ check_dots_empty_s3_extensions <- function(...) {
 has_dim <- function(x) {
   !is.null(attr(x, "dim"))
 }
-
-value <- function(expr) {
-  eval_bare(enexpr(expr), caller_env())
-}
-new_maybe <- function(value, error = NULL) {
-  list(value = value, error = error)
-}
-maybe <- function(expr, class = "error") {
-  env <- environment()
-  hnd <- function(cnd) return_from(env, new_maybe(NULL, cnd))
-
-  handlers <- rep_named(class, list(hnd))
-  new_maybe(value(tryCatch(expr, !!!handlers)))
-}

--- a/tests/testthat/test-partial-frame.R
+++ b/tests/testthat/test-partial-frame.R
@@ -46,3 +46,9 @@ test_that("can assert partial frames based on column type", {
   pf <- partial_frame(y = 1)
   expect_false(vec_is(data.frame(y = "2"), pf))
 })
+
+test_that("incompatible data frames are an error", {
+  df <- data.frame(y = 1)
+  expect_error(vec_type2(df, partial_frame(y = chr())), class = "vctrs_error_incompatible_type")
+  expect_error(new_partial_frame(df, data.frame(y = chr())), class = "vctrs_error_incompatible_type")
+})

--- a/tests/testthat/test-partial-frame.R
+++ b/tests/testthat/test-partial-frame.R
@@ -52,3 +52,9 @@ test_that("incompatible data frames are an error", {
   expect_error(vec_type2(df, partial_frame(y = chr())), class = "vctrs_error_incompatible_type")
   expect_error(new_partial_frame(df, data.frame(y = chr())), class = "vctrs_error_incompatible_type")
 })
+
+test_that("dispatch is symmetric with tibbles", {
+  left <- vec_type2(partial_frame(x = 1), tibble::tibble(x = 1))
+  right <- vec_type2(tibble::tibble(x = 1), partial_frame(x = 1))
+  expect_identical(left, right)
+})


### PR DESCRIPTION
* `vec_type2(df, pf)` is now an error when the type don't match

* `vec_is()` wraps `vec_type_common()` in a `maybe()` to catch incompatible types errors.