### PR TITLE
`vec_slice()` fails when slicing shaped objects by name

### DIFF
--- a/src/slice.c
+++ b/src/slice.c
@@ -392,7 +392,7 @@ static SEXP chr_as_index(SEXP i, SEXP x) {
 
   if (has_dim(x)) {
     SEXP dim_nms = Rf_getAttrib(x, R_DimNamesSymbol);
-    if (dim_nms != R_NilValue) {
+    if (dim_nms != R_NilValue && Rf_length(dim_nms) >= 1) {
       nms = VECTOR_ELT(dim_nms, 0);
     }
   } else {

--- a/src/slice.c
+++ b/src/slice.c
@@ -387,7 +387,6 @@ static SEXP lgl_as_index(SEXP i, SEXP x) {
 }
 
 static SEXP chr_as_index(SEXP i, SEXP x) {
-
   SEXP nms = R_NilValue;
 
   if (has_dim(x)) {

--- a/src/slice.c
+++ b/src/slice.c
@@ -387,7 +387,17 @@ static SEXP lgl_as_index(SEXP i, SEXP x) {
 }
 
 static SEXP chr_as_index(SEXP i, SEXP x) {
-  SEXP nms = Rf_getAttrib(x, R_NamesSymbol);
+
+  SEXP nms = R_NilValue;
+
+  if (has_dim(x)) {
+    SEXP dim_nms = Rf_getAttrib(x, R_DimNamesSymbol);
+    if (dim_nms != R_NilValue) {
+      nms = VECTOR_ELT(dim_nms, 0);
+    }
+  } else {
+    nms = Rf_getAttrib(x, R_NamesSymbol);
+  }
 
   if (nms == R_NilValue) {
     Rf_errorcall(R_NilValue, "Can't use character to index an unnamed vector.");

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -299,6 +299,17 @@ test_that("dimensions are preserved by vec_slice()", {
   expect_identical(attrib, exp)
 })
 
+test_that("can slice shaped objects by name", {
+  x <- matrix(1:2)
+
+  expect_error(vec_slice(x, "foo"), "unnamed")
+
+  dimnames(x) <- list(c("foo", "bar"))
+
+  expect_equal(vec_slice(x, "foo"), vec_slice(x, 1L))
+  expect_error(vec_slice(x, "baz"), "non-existing")
+})
+
 test_that("vec_slice_native() unclasses input before calling `vec_restore()`", {
   class <- NULL
   scoped_global_bindings(


### PR DESCRIPTION
The following currently fails:

``` r
library(vctrs)

x <- matrix(1:2)
dimnames(x) <- list(c("foo", "bar"))

vec_slice(x, "foo")
#> Error: Can't use character to index an unnamed vector.
```

I know eventually shaped object slicing will be incorporated fully, but this might be a general solution for `chr_as_index()`.