### PR TITLE
Allow downgrading lossy cast errors to deprecation warnings

### DIFF
--- a/man/vctrs-conditions.Rd
+++ b/man/vctrs-conditions.Rd
@@ -19,7 +19,8 @@ stop_incompatible_op(op, x, y, details = NULL, ..., message = NULL,
   .subclass = NULL)
 
 maybe_lossy_cast(result, x, to, lossy = NULL, locations = NULL,
-  details = NULL, ..., message = NULL, .subclass = NULL)
+  details = NULL, ..., message = NULL, .subclass = NULL,
+  .deprecation = FALSE)
 
 allow_lossy_cast(expr, x_ptype = NULL, to_ptype = NULL)
 }
@@ -43,6 +44,11 @@ own location vector, possibly empty.}
 
 \item{locations}{An optional integer vector giving the
 locations where \code{x} lost information.}
+
+\item{.deprecation}{If \code{TRUE}, the error is downgraded to a
+deprecation warning. This is useful for transitioning your class
+to a stricter conversion scheme. The warning advises your users
+to wrap their code with \code{allow_lossy_cast()}.}
 
 \item{x_ptype, to_ptype}{Suppress only the casting errors where \code{x}
 or \code{to} match these \link[=vec_type]{prototypes}.}

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -230,3 +230,16 @@ test_that("can suppress cast errors selectively", {
   expect_error(allow_lossy_cast(f(), x_ptype = factor("b"), to_ptype = factor("a")), class = "vctrs_error_cast_lossy")
   expect_error(allow_lossy_cast(f(), x_ptype = factor("a"), to_ptype = factor("c")), class = "vctrs_error_cast_lossy")
 })
+
+test_that("can signal deprecation warnings for lossy casts", {
+  scoped_lifecycle_warnings()
+
+  lossy_cast <- function() {
+    maybe_lossy_cast(TRUE, factor("foo"), factor("bar"), lossy = TRUE, .deprecation = TRUE)
+  }
+
+  expect_true(expect_warning(lossy_cast(), "detected a lossy transformation"))
+  expect_true(expect_warning(regexp = NA, allow_lossy_cast(lossy_cast())))
+  expect_true(expect_warning(regexp = NA, allow_lossy_cast(lossy_cast(), factor("foo"), factor("bar"))))
+  expect_true(expect_warning(allow_lossy_cast(lossy_cast(), factor("bar"), double())))
+})


### PR DESCRIPTION
Closes #280

To detect that the user has wrapped their code in `allow_lossy_cast()`, we signal a lossy cast error with a fake restart point. If the latter is invoked, it means the user has correctly called `allow_lossy_cast()` with the right prototypes.