### PR TITLE
Support additional suscripts in index methods

### DIFF
--- a/R/rcrd.R
+++ b/R/rcrd.R
@@ -113,8 +113,7 @@ vec_cast.vctrs_rcrd.default <- function(x, to) {
 
 #' @export
 `[.vctrs_rcrd` <-  function(x, i, ...) {
-  check_dots_empty_s3_consistency(...)
-  vec_slice_native(x, i)
+  vec_index(x, i, ...)
 }
 
 #' @export

--- a/R/slice.R
+++ b/R/slice.R
@@ -94,6 +94,20 @@ vec_as_index <- function(i, x) {
   .Call(vctrs_as_index, i, x)
 }
 
+vec_index <- function(x, i, ...) {
+  i <- maybe_missing(i, TRUE)
+
+  if (!dots_n(...)) {
+    return(vec_slice_native(x, i))
+  }
+
+  out <- unclass(vec_proxy(x))
+  vec_assert(out)
+
+  i <- vec_as_index(i, out)
+  vec_restore(out[i, ..., drop = FALSE], x, i = i)
+}
+
 #' Create a missing vector
 #'
 #' @param x Template of missing vector

--- a/R/vctr.R
+++ b/R/vctr.R
@@ -157,8 +157,7 @@ format.vctrs_vctr <- function(x, ...) {
 
 #' @export
 `[.vctrs_vctr` <- function(x, i, ...) {
-  check_dots_empty_s3_consistency(...)
-  vec_slice_native(x, maybe_missing(i, TRUE))
+  vec_index(x, i, ...)
 }
 
 #' @export

--- a/tests/testthat/test-rcrd.R
+++ b/tests/testthat/test-rcrd.R
@@ -210,8 +210,8 @@ test_that("dangerous methods marked as unimplemented", {
 
 # slicing -----------------------------------------------------------------
 
-test_that("dots must be empty", {
-  expect_error(new_rcrd(list(foo = "foo"))[1, 2], "is not empty")
+test_that("dots are forwarded", {
+  expect_error(new_rcrd(list(foo = "foo"))[1, 2], "incorrect number of dimensions")
 })
 
 test_that("records are restored after slicing the proxy", {

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -373,6 +373,19 @@ test_that("vec_restore() is called after slicing data frames", {
   expect_identical(vec_slice(df, 1), "dispatched")
 })
 
+test_that("additional subscripts are forwarded to `[`", {
+  scoped_global_bindings(
+    `[.vctrs_foobar` = function(x, i, ...) vec_index(x, i, ...)
+  )
+
+  x <- foobar(c("foo", "bar", "quux", "hunoz"))
+  dim(x) <- c(2, 2)
+
+  exp <- foobar("quux")
+  dim(exp) <- c(1, 1)
+
+  expect_identical(x[1, 2], exp)
+})
 
 # vec_na ------------------------------------------------------------------
 

--- a/tests/testthat/test-vctr.R
+++ b/tests/testthat/test-vctr.R
@@ -385,6 +385,13 @@ test_that("can't transpose", {
 
 # slicing -----------------------------------------------------------------
 
-test_that("dots must be empty", {
-  expect_error(new_vctr("foo")[1, 2], "is not empty")
+test_that("additional subscripts are handled (#269)", {
+  new_2d <- function(.data, dim) {
+    vctrs::new_vctr(.data, dim = dim, class = "vctrs_2d")
+  }
+  x <- new_2d(c(1, 2), dim = c(2L, 1L))
+
+  expect_identical(x[1], new_2d(1, dim = c(1, 1)))
+  expect_identical(x[1, 1], new_2d(1, dim = c(1, 1)))
+  expect_identical(x[, 1], new_2d(c(1, 2), dim = c(2, 1)))
 })


### PR DESCRIPTION
Closes #269

Eventually `vec_index()` should be exported to make it easy to create `[` methods with vctrs semantics.

How does this look @DavisVaughan?