### PR TITLE
Optimization) `shape_broadcast()`

### DIFF
--- a/R/shape.R
+++ b/R/shape.R
@@ -22,28 +22,33 @@ shape_common <- function(x, y) {
 }
 
 shape_broadcast <- function(x, to) {
-  if (is.null(x) || is.null(to))
+  if (is.null(x) || is.null(to)) {
     return(x)
+  }
 
   dim_x <- vec_dim(x)
   dim_to <- vec_dim(to)
 
   # Don't set dimensions for vectors
-  if (length(dim_x) == 1L && length(dim_to) == 1L)
+  if (length(dim_x) == 1L && length(dim_to) == 1L) {
     return(x)
+  }
 
-  if (length(dim_x) > length(dim_to))
+  if (length(dim_x) > length(dim_to)) {
     stop_incompatible_cast(x, to, details = "Can not decrease dimensions")
+  }
 
   dim_x <- dim2(dim_x, dim_to)$x
   dim_to[[1]] <- dim_x[[1]] # don't change number of observations
   ok <- dim_x == dim_to | dim_x == 1 | dim_to == 0
-  if (any(!ok))
+  if (any(!ok)) {
     stop_incompatible_cast(x, to, details = "Non-recyclable dimensions")
+  }
 
   # Increase dimensionality if required
-  if (vec_dims(x) != length(dim_x))
+  if (vec_dims(x) != length(dim_x)) {
     dim(x) <- dim_x
+  }
 
   recycle <- dim_x != dim_to
 

--- a/R/shape.R
+++ b/R/shape.R
@@ -33,9 +33,8 @@ shape_broadcast <- function(x, to) {
     return(x)
 
   # Don't broadcast if nothing changes
-  if (identical(dim_x[-1], dim_to[-1])) {
+  if (identical(dim_x[-1], dim_to[-1]))
     return(x)
-  }
 
   if (length(dim_x) > length(dim_to))
     stop_incompatible_cast(x, to, details = "Can not decrease dimensions")

--- a/R/shape.R
+++ b/R/shape.R
@@ -32,6 +32,11 @@ shape_broadcast <- function(x, to) {
   if (length(dim_x) == 1L && length(dim_to) == 1L)
     return(x)
 
+  # Don't broadcast if nothing changes
+  if (identical(dim_x[-1], dim_to[-1])) {
+    return(x)
+  }
+
   if (length(dim_x) > length(dim_to))
     stop_incompatible_cast(x, to, details = "Can not decrease dimensions")
 

--- a/R/shape.R
+++ b/R/shape.R
@@ -50,7 +50,9 @@ shape_broadcast <- function(x, to) {
   indices <- rep(list(missing_arg()), length(dim_to))
   indices[recycle] <- map(dim_to[recycle], rep_len, x = 1L)
 
-  dim(x) <- dim_x
+  if (vec_dims(x) != length(dim_x))
+    dim(x) <- dim_x
+
   eval_bare(expr(x[!!!indices, drop = FALSE]))
 }
 


### PR DESCRIPTION
I've noticed that sometimes `shape_broadcast()` can be an expensive function to call when it often doesn't need to be. With the following:

```
library(vctrs)

x <- matrix(1:10000) + 0L
y <- matrix(1:10000) + 0L

vec_cast(x, y)
```

- 3 copies are made on 3.5.2 (1 from `dim(x)<- dim_x`, and two from the final `[` call)
- 2 copies are made on 3.6.0 (the `dim(x)<- dim_x` copy is ALTREPed away)

For this example, I really think it should be much cheaper to call `vec_cast()`, so this PR makes two changes:

- If the shape of `x` and `y` are the same, return `x` early
- If the dimensionality of `x` does not change, do not set the dim of `x`

The first change helps on 3.5.2 and 3.6, the second change probably only helps on 3.5.2 but I don't think it hurts.