### PR TITLE
Pass dots to `format()`, not `vec_data()`

### DIFF
--- a/R/vctr.R
+++ b/R/vctr.R
@@ -150,7 +150,7 @@ type_sum.vctrs_vctr <- function(x) {
 
 #' @export
 format.vctrs_vctr <- function(x, ...) {
-  format(vec_data(x, ...))
+  format(vec_data(x), ...)
 }
 
 # Subsetting --------------------------------------------------------------


### PR DESCRIPTION
Closes #292 

`...` should probably be passed for `format()` not `vec_data()`