### PR TITLE
Fix row-binding of unspecified vectors

### DIFF
--- a/R/bind.R
+++ b/R/bind.R
@@ -188,6 +188,10 @@ as_df_row.NULL <- function(x, quiet = FALSE) x
 
 #' @export
 as_df_row.default <- function(x, quiet = FALSE) {
+  if (is_unspecified(x) && identical(names(x), NULL)) {
+    return(x)
+  }
+
   if (vec_dims(x) == 1L) {
     x <- as.list(x)
     if (is_installed("tibble")) {

--- a/R/bind.R
+++ b/R/bind.R
@@ -178,20 +178,21 @@ vec_cbind <- function(..., .ptype = NULL, .size = NULL) {
 
 # as_df --------------------------------------------------------------
 
-as_df_row <- function(x) UseMethod("as_df_row")
+as_df_row <- function(x, quiet = FALSE) UseMethod("as_df_row")
 
 #' @export
-as_df_row.data.frame <- function(x) x
+as_df_row.data.frame <- function(x, quiet = FALSE) x
 
 #' @export
-as_df_row.NULL <- function(x) x
+as_df_row.NULL <- function(x, quiet = FALSE) x
 
 #' @export
-as_df_row.default <- function(x) {
+as_df_row.default <- function(x, quiet = FALSE) {
   if (vec_dims(x) == 1L) {
     x <- as.list(x)
-    if (is_installed("tibble"))
-      x <- tibble::set_tidy_names(x)
+    if (is_installed("tibble")) {
+      x <- tibble::set_tidy_names(x, quiet = quiet)
+    }
     new_data_frame(x, n = 1L)
   } else {
     as.data.frame(x)

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -83,7 +83,7 @@ vec_type2.data.frame.data.frame <- function(x, y, ...) df_col_type2(x, y, ...)
 #' @method vec_type2.data.frame default
 #' @export
 vec_type2.data.frame.default <- function(x, y, ..., x_arg = "", y_arg = "") {
-  stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
+  vec_default_type2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 
 

--- a/R/type2.R
+++ b/R/type2.R
@@ -54,6 +54,13 @@ vec_type2.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 
+vec_default_type2 <- function(x, y, ..., x_arg = "", y_arg = "") {
+  if (is_unspecified(y)) {
+    return(vec_type(x))
+  }
+  stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
+}
+
 vec_typeof2 <- function(x, y) {
   .Call(vctrs_typeof2, x, y)
 }

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -80,6 +80,8 @@ test_that("can bind data.frame columns", {
 test_that("can rbind unspecified vectors", {
   df <- data.frame(x = 1)
   expect_identical(vec_rbind(NA, df), data.frame(x = c(NA, 1)))
+  expect_identical(vec_rbind(df, NA), data.frame(x = c(1, NA)))
+  expect_identical(vec_rbind(NA, df, NA), data.frame(x = c(NA, 1, NA)))
   expect_identical(vec_rbind(c(x = NA), data.frame(x = 1)), data.frame(x = c(NA, 1)))
   expect_identical(vec_rbind(c(y = NA), df), data.frame(y = c(NA, NA), x = c(NA, 1)))
 

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -77,6 +77,24 @@ test_that("can bind data.frame columns", {
   expect_equal(vec_rbind(df, df), expected)
 })
 
+test_that("can rbind unspecified vectors", {
+  df <- data.frame(x = 1)
+  expect_identical(vec_rbind(NA, df), data.frame(x = c(NA, 1)))
+  expect_identical(vec_rbind(c(x = NA), data.frame(x = 1)), data.frame(x = c(NA, 1)))
+  expect_identical(vec_rbind(c(y = NA), df), data.frame(y = c(NA, NA), x = c(NA, 1)))
+
+  out <- suppressMessages(vec_rbind(c(x = NA, x = NA), df))
+  exp <- data.frame(x..1 = c(NA, NA), x..2 = c(NA, NA), x = c(NA, 1))
+  expect_identical(out, exp)
+})
+
+test_that("as_df_row() tidies the names of unspecified vectors", {
+  expect_identical(as_df_row(c(NA, NA)), c(NA, NA))
+  expect_identical(as_df_row(unspecified(2)), unspecified(2))
+  expect_identical(as_df_row(c(a = NA, a = NA), quiet = TRUE), data.frame(a..1 = NA, a..2 = NA))
+  expect_identical(as_df_row(c(a = TRUE, a = TRUE), quiet = TRUE), data.frame(a..1 = TRUE, a..2 = TRUE))
+})
+
 
 # cols --------------------------------------------------------------------
 


### PR DESCRIPTION
Only unnamed unspecified vectors are treated as unspecified.

Introduces `vec_default_type2()` which can be used to decrease method boilerplate.