### PR TITLE
Handle names and coercion in argument tags

### DIFF
--- a/src/arg.c
+++ b/src/arg.c
@@ -113,7 +113,6 @@ static r_ssize_t counter_arg_fill(struct vctrs_arg* self, char* buf, r_ssize_t r
 
 struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
                                          R_len_t* i,
-                                         int offset,
                                          SEXP* names,
                                          R_len_t* names_i) {
   struct vctrs_arg_counter counter = {
@@ -122,7 +121,6 @@ struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
       .fill = &counter_arg_fill
     },
     .i = i,
-    .offset = offset,
     .names = names,
     .names_i = names_i
   };
@@ -132,10 +130,10 @@ struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
 
 static r_ssize_t counter_arg_fill(struct vctrs_arg* self, char* buf, r_ssize_t remaining) {
   struct vctrs_arg_counter* counter = (struct vctrs_arg_counter*) self;
-  R_len_t i = *counter->i + counter->offset;
+  R_len_t i = *counter->i;
 
   SEXP names = *counter->names;
-  R_len_t names_i = *counter->names_i + counter->offset;
+  R_len_t names_i = *counter->names_i;
 
   int len;
   if (r_has_name_at(names, names_i)) {

--- a/src/arg.c
+++ b/src/arg.c
@@ -113,13 +113,15 @@ static r_ssize_t counter_arg_fill(struct vctrs_arg* self, char* buf, r_ssize_t r
 
 struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
                                          R_len_t* i,
+                                         int offset,
                                          SEXP* names) {
   struct vctrs_arg_counter counter = {
     .iface = {
       .parent = parent,
       .fill = &counter_arg_fill
     },
-    .i = (void*) i,
+    .i = i,
+    .offset = offset,
     .names = names
   };
 
@@ -128,7 +130,7 @@ struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
 
 static r_ssize_t counter_arg_fill(struct vctrs_arg* self, char* buf, r_ssize_t remaining) {
   struct vctrs_arg_counter* counter = (struct vctrs_arg_counter*) self;
-  R_len_t i = *counter->i;
+  R_len_t i = *counter->i + counter->offset;
   SEXP names = *counter->names;
 
   int len;

--- a/src/arg.c
+++ b/src/arg.c
@@ -114,7 +114,8 @@ static r_ssize_t counter_arg_fill(struct vctrs_arg* self, char* buf, r_ssize_t r
 struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
                                          R_len_t* i,
                                          int offset,
-                                         SEXP* names) {
+                                         SEXP* names,
+                                         R_len_t* names_i) {
   struct vctrs_arg_counter counter = {
     .iface = {
       .parent = parent,
@@ -122,7 +123,8 @@ struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
     },
     .i = i,
     .offset = offset,
-    .names = names
+    .names = names,
+    .names_i = names_i
   };
 
   return counter;
@@ -131,12 +133,14 @@ struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
 static r_ssize_t counter_arg_fill(struct vctrs_arg* self, char* buf, r_ssize_t remaining) {
   struct vctrs_arg_counter* counter = (struct vctrs_arg_counter*) self;
   R_len_t i = *counter->i + counter->offset;
+
   SEXP names = *counter->names;
+  R_len_t names_i = *counter->names_i + counter->offset;
 
   int len;
-  if (r_has_name_at(names, i)) {
+  if (r_has_name_at(names, names_i)) {
     // FIXME: Check for syntactic names
-    len = snprintf(buf, remaining, "list(...)$%s", r_chr_get_c_string(names, i));
+    len = snprintf(buf, remaining, "list(...)$%s", r_chr_get_c_string(names, names_i));
   } else {
     len = snprintf(buf, remaining, "list(...)[[%d]]", i + 1);
   }

--- a/src/arg.c
+++ b/src/arg.c
@@ -138,7 +138,7 @@ static r_ssize_t counter_arg_fill(struct vctrs_arg* self, char* buf, r_ssize_t r
   int len;
   if (r_has_name_at(names, names_i)) {
     // FIXME: Check for syntactic names
-    len = snprintf(buf, remaining, "list(...)$%s", r_chr_get_c_string(names, names_i));
+    len = snprintf(buf, remaining, "%s", r_chr_get_c_string(names, names_i));
   } else {
     len = snprintf(buf, remaining, "list(...)[[%d]]", i + 1);
   }

--- a/src/arg.h
+++ b/src/arg.h
@@ -40,6 +40,7 @@ struct vctrs_arg_wrapper {
 struct vctrs_arg_counter {
   struct vctrs_arg iface;
   R_len_t* i;
+  int offset;
   SEXP* names;
 };
 
@@ -51,6 +52,7 @@ struct vctrs_arg_wrapper new_wrapper_arg(struct vctrs_arg* parent,
                                          const char* arg);
 struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
                                          R_len_t* i,
+                                         int offset,
                                          SEXP* names);
 
 /**

--- a/src/arg.h
+++ b/src/arg.h
@@ -53,7 +53,6 @@ struct vctrs_arg_wrapper new_wrapper_arg(struct vctrs_arg* parent,
                                          const char* arg);
 struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
                                          R_len_t* i,
-                                         int offset,
                                          SEXP* names,
                                          R_len_t* names_i);
 

--- a/src/arg.h
+++ b/src/arg.h
@@ -40,14 +40,18 @@ struct vctrs_arg_wrapper {
 struct vctrs_arg_counter {
   struct vctrs_arg iface;
   R_len_t* i;
+  SEXP* names;
 };
 
 
 /**
  * Constructors for argument wrapper and counters.
  */
-struct vctrs_arg_wrapper new_wrapper_arg(struct vctrs_arg* parent, const char* arg);
-struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent, R_len_t* i);
+struct vctrs_arg_wrapper new_wrapper_arg(struct vctrs_arg* parent,
+                                         const char* arg);
+struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
+                                         R_len_t* i,
+                                         SEXP* names);
 
 /**
  * Materialise an argument tag. Returns a CHARSXP.

--- a/src/arg.h
+++ b/src/arg.h
@@ -42,6 +42,7 @@ struct vctrs_arg_counter {
   R_len_t* i;
   int offset;
   SEXP* names;
+  R_len_t* names_i;
 };
 
 
@@ -53,7 +54,8 @@ struct vctrs_arg_wrapper new_wrapper_arg(struct vctrs_arg* parent,
 struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
                                          R_len_t* i,
                                          int offset,
-                                         SEXP* names);
+                                         SEXP* names,
+                                         R_len_t* names_i);
 
 /**
  * Materialise an argument tag. Returns a CHARSXP.

--- a/src/type.c
+++ b/src/type.c
@@ -76,24 +76,24 @@ struct counters {
   struct vctrs_arg* temp_arg;
 };
 
-struct counters new_counters(SEXP names, struct vctrs_arg* temp_arg) {
-  struct counters counters = {
-    .curr = 0,
-    .next = 0,
-    .names = names,
-    .names_curr = 0,
-    .names_next = 0
-  };
+void init_counters(struct counters* counters,
+                   SEXP names,
+                   struct vctrs_arg* temp_arg) {
+  counters->curr = 0;
+  counters->next = 0;
 
-  counters.curr_counter = new_counter_arg(NULL, &counters.curr, 0, &counters.names, &counters.names_curr);
-  counters.next_counter = new_counter_arg(NULL, &counters.next, 0, &counters.names, &counters.names_next);
+  counters->names = names;
+  counters->names_curr = 0;
+  counters->names_next = 0;
 
-  counters.curr_arg = (struct vctrs_arg*) &counters.curr_counter;
-  counters.next_arg = (struct vctrs_arg*) &counters.next_counter;
+  counters->curr_counter = new_counter_arg(NULL, &counters->curr, 0, &counters->names, &counters->names_curr);
+  counters->next_counter = new_counter_arg(NULL, &counters->next, 0, &counters->names, &counters->names_next);
 
-  counters.temp_arg = temp_arg;
+  counters->curr_arg = (struct vctrs_arg*) &counters->curr_counter;
+  counters->next_arg = (struct vctrs_arg*) &counters->next_counter;
 
-  return counters;
+  counters->temp_arg = temp_arg;
+  counters->temp_arg = counters->curr_arg;
 }
 
 void counters_inc(struct counters* counters) {
@@ -179,10 +179,11 @@ SEXP vctrs_type_common(SEXP call, SEXP op, SEXP args, SEXP env) {
   }
 
   SEXP types = PROTECT(rlang_env_dots_values(env));
-
   SEXP names = PROTECT(r_names(types));
+
   struct vctrs_arg_wrapper ptype_arg = new_wrapper_arg(NULL, ".ptype");
-  struct counters counters = new_counters(names, (struct vctrs_arg*) &ptype_arg);
+  struct counters counters;
+  init_counters(&counters, names, (struct vctrs_arg*) &ptype_arg);
 
   SEXP type = PROTECT(vctrs_type_common_impl(ptype, types, &counters, false));
   type = vec_type_finalise(type);

--- a/src/type.c
+++ b/src/type.c
@@ -56,10 +56,8 @@ bool vec_is_partial(SEXP x) {
 
 
 struct counters {
-  // Actual counters
+  // Global counter
   R_len_t i;
-  R_len_t j;
-
   SEXP names;
 
   // `vctrs_arg`-derived objects
@@ -74,12 +72,11 @@ struct counters {
 struct counters new_counters(SEXP names, struct vctrs_arg* first_arg) {
   struct counters counters = {
     .i = 0,
-    .j = 1,
     .names = names
   };
 
-  counters.x_counter = new_counter_arg(NULL, &counters.i, &counters.names);
-  counters.y_counter = new_counter_arg(NULL, &counters.j, &counters.names);
+  counters.x_counter = new_counter_arg(NULL, &counters.i, 0, &counters.names);
+  counters.y_counter = new_counter_arg(NULL, &counters.i, 1, &counters.names);
   counters.x = first_arg;
   counters.y = (struct vctrs_arg*) &counters.x_counter;
 
@@ -139,7 +136,7 @@ static SEXP vctrs_type_common_impl(SEXP current,
   counters->y = (struct vctrs_arg*) &counters->y_counter;
 
 
-  for (R_len_t i = 1; i < n; ++i, ++(counters->i), ++(counters->j)) {
+  for (R_len_t i = 1; i < n; ++i, ++(counters->i)) {
     SEXP elt = VECTOR_ELT(types, i);
 
     if (elt == R_NilValue) {

--- a/src/type.c
+++ b/src/type.c
@@ -86,8 +86,8 @@ void init_counters(struct counters* counters,
   counters->names_curr = 0;
   counters->names_next = 0;
 
-  counters->curr_counter = new_counter_arg(NULL, &counters->curr, 0, &counters->names, &counters->names_curr);
-  counters->next_counter = new_counter_arg(NULL, &counters->next, 0, &counters->names, &counters->names_next);
+  counters->curr_counter = new_counter_arg(NULL, &counters->curr, &counters->names, &counters->names_curr);
+  counters->next_counter = new_counter_arg(NULL, &counters->next, &counters->names, &counters->names_next);
 
   counters->curr_arg = (struct vctrs_arg*) &counters->curr_counter;
   counters->next_arg = (struct vctrs_arg*) &counters->next_counter;

--- a/src/type.c
+++ b/src/type.c
@@ -111,7 +111,12 @@ static SEXP vctrs_type_common_type(SEXP current,
   // spliced list because it's expensive
   if (spliced || !rlang_is_splice_box(elt)) {
     SEXP elt_type = PROTECT(vec_type(elt));
-    current = vec_type2(current, elt_type, counters->curr_arg, counters->next_arg);
+    int left;
+    current = vec_type2(current,
+                        elt_type,
+                        counters->curr_arg,
+                        counters->next_arg,
+                        &left);
     UNPROTECT(1);
     return current;
   }

--- a/src/type2-dispatch.c
+++ b/src/type2-dispatch.c
@@ -11,181 +11,191 @@
  * entries.
  */
 
-// [[ include("utils.h") ]]
-enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x, enum vctrs_type type_y) {
+/**
+ * [[ include("utils.h") ]]
+ *
+ * @param left Output parameter. Set to 1 when the common type comes
+ *   from the left, 0 when it comes from the right, and -1 when it
+ *   comes from both sides. This means that "left" is the default
+ *   when coerced to a boolean value.
+ */
+enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
+                                  enum vctrs_type type_y,
+                                  int* left) {
   switch (type_x) {
   case vctrs_type_null: {
     switch (type_y) {
-    case vctrs_type_null:      return vctrs_type2_null_null;
-    case vctrs_type_logical:   return vctrs_type2_null_logical;
-    case vctrs_type_integer:   return vctrs_type2_null_integer;
-    case vctrs_type_double:    return vctrs_type2_null_double;
-    case vctrs_type_complex:   return vctrs_type2_null_complex;
-    case vctrs_type_character: return vctrs_type2_null_character;
-    case vctrs_type_raw:       return vctrs_type2_null_raw;
-    case vctrs_type_list:      return vctrs_type2_null_list;
-    case vctrs_type_dataframe: return vctrs_type2_null_dataframe;
-    case vctrs_type_s3:        return vctrs_type2_null_s3;
-    case vctrs_type_scalar:    return vctrs_type2_null_scalar;
+    case vctrs_type_null:      *left = -1; return vctrs_type2_null_null;
+    case vctrs_type_logical:   *left =  0; return vctrs_type2_null_logical;
+    case vctrs_type_integer:   *left =  0; return vctrs_type2_null_integer;
+    case vctrs_type_double:    *left =  0; return vctrs_type2_null_double;
+    case vctrs_type_complex:   *left =  0; return vctrs_type2_null_complex;
+    case vctrs_type_character: *left =  0; return vctrs_type2_null_character;
+    case vctrs_type_raw:       *left =  0; return vctrs_type2_null_raw;
+    case vctrs_type_list:      *left =  0; return vctrs_type2_null_list;
+    case vctrs_type_dataframe: *left =  0; return vctrs_type2_null_dataframe;
+    case vctrs_type_s3:        *left =  0; return vctrs_type2_null_s3;
+    case vctrs_type_scalar:    *left =  0; return vctrs_type2_null_scalar;
     }
   }
   case vctrs_type_logical: {
     switch (type_y) {
-    case vctrs_type_null:      return vctrs_type2_null_logical;
-    case vctrs_type_logical:   return vctrs_type2_logical_logical;
-    case vctrs_type_integer:   return vctrs_type2_logical_integer;
-    case vctrs_type_double:    return vctrs_type2_logical_double;
-    case vctrs_type_complex:   return vctrs_type2_logical_complex;
-    case vctrs_type_character: return vctrs_type2_logical_character;
-    case vctrs_type_raw:       return vctrs_type2_logical_raw;
-    case vctrs_type_list:      return vctrs_type2_logical_list;
-    case vctrs_type_dataframe: return vctrs_type2_logical_dataframe;
-    case vctrs_type_s3:        return vctrs_type2_logical_s3;
-    case vctrs_type_scalar:    return vctrs_type2_logical_scalar;
+    case vctrs_type_null:      *left =  1; return vctrs_type2_null_logical;
+    case vctrs_type_logical:   *left = -1; return vctrs_type2_logical_logical;
+    case vctrs_type_integer:   *left =  0; return vctrs_type2_logical_integer;
+    case vctrs_type_double:    *left =  0; return vctrs_type2_logical_double;
+    case vctrs_type_complex:   *left =  0; return vctrs_type2_logical_complex;
+    case vctrs_type_character: *left =  0; return vctrs_type2_logical_character;
+    case vctrs_type_raw:       *left =  0; return vctrs_type2_logical_raw;
+    case vctrs_type_list:      *left =  0; return vctrs_type2_logical_list;
+    case vctrs_type_dataframe: *left =  0; return vctrs_type2_logical_dataframe;
+    case vctrs_type_s3:        *left =  0; return vctrs_type2_logical_s3;
+    case vctrs_type_scalar:    *left =  0; return vctrs_type2_logical_scalar;
     }
   }
   case vctrs_type_integer: {
     switch (type_y) {
-    case vctrs_type_null:      return vctrs_type2_null_integer;
-    case vctrs_type_logical:   return vctrs_type2_logical_integer;
-    case vctrs_type_integer:   return vctrs_type2_integer_integer;
-    case vctrs_type_double:    return vctrs_type2_integer_double;
-    case vctrs_type_complex:   return vctrs_type2_integer_complex;
-    case vctrs_type_character: return vctrs_type2_integer_character;
-    case vctrs_type_raw:       return vctrs_type2_integer_raw;
-    case vctrs_type_list:      return vctrs_type2_integer_list;
-    case vctrs_type_dataframe: return vctrs_type2_integer_dataframe;
-    case vctrs_type_s3:        return vctrs_type2_integer_s3;
-    case vctrs_type_scalar:    return vctrs_type2_integer_scalar;
+    case vctrs_type_null:      *left =  1; return vctrs_type2_null_integer;
+    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_integer;
+    case vctrs_type_integer:   *left = -1; return vctrs_type2_integer_integer;
+    case vctrs_type_double:    *left =  0; return vctrs_type2_integer_double;
+    case vctrs_type_complex:   *left =  0; return vctrs_type2_integer_complex;
+    case vctrs_type_character: *left =  0; return vctrs_type2_integer_character;
+    case vctrs_type_raw:       *left =  0; return vctrs_type2_integer_raw;
+    case vctrs_type_list:      *left =  0; return vctrs_type2_integer_list;
+    case vctrs_type_dataframe: *left =  0; return vctrs_type2_integer_dataframe;
+    case vctrs_type_s3:        *left =  0; return vctrs_type2_integer_s3;
+    case vctrs_type_scalar:    *left =  0; return vctrs_type2_integer_scalar;
     }
   }
   case vctrs_type_double: {
     switch (type_y) {
-    case vctrs_type_null:      return vctrs_type2_null_double;
-    case vctrs_type_logical:   return vctrs_type2_logical_double;
-    case vctrs_type_integer:   return vctrs_type2_integer_double;
-    case vctrs_type_double:    return vctrs_type2_double_double;
-    case vctrs_type_complex:   return vctrs_type2_double_complex;
-    case vctrs_type_character: return vctrs_type2_double_character;
-    case vctrs_type_raw:       return vctrs_type2_double_raw;
-    case vctrs_type_list:      return vctrs_type2_double_list;
-    case vctrs_type_dataframe: return vctrs_type2_double_dataframe;
-    case vctrs_type_s3:        return vctrs_type2_double_s3;
-    case vctrs_type_scalar:    return vctrs_type2_double_scalar;
+    case vctrs_type_null:      *left =  1; return vctrs_type2_null_double;
+    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_double;
+    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_double;
+    case vctrs_type_double:    *left = -1; return vctrs_type2_double_double;
+    case vctrs_type_complex:   *left =  0; return vctrs_type2_double_complex;
+    case vctrs_type_character: *left =  0; return vctrs_type2_double_character;
+    case vctrs_type_raw:       *left =  0; return vctrs_type2_double_raw;
+    case vctrs_type_list:      *left =  0; return vctrs_type2_double_list;
+    case vctrs_type_dataframe: *left =  0; return vctrs_type2_double_dataframe;
+    case vctrs_type_s3:        *left =  0; return vctrs_type2_double_s3;
+    case vctrs_type_scalar:    *left =  0; return vctrs_type2_double_scalar;
     }
   }
   case vctrs_type_complex: {
     switch (type_y) {
-    case vctrs_type_null:      return vctrs_type2_null_complex;
-    case vctrs_type_logical:   return vctrs_type2_logical_complex;
-    case vctrs_type_integer:   return vctrs_type2_integer_complex;
-    case vctrs_type_double:    return vctrs_type2_double_complex;
-    case vctrs_type_complex:   return vctrs_type2_complex_complex;
-    case vctrs_type_character: return vctrs_type2_complex_character;
-    case vctrs_type_raw:       return vctrs_type2_complex_raw;
-    case vctrs_type_list:      return vctrs_type2_complex_list;
-    case vctrs_type_dataframe: return vctrs_type2_complex_dataframe;
-    case vctrs_type_s3:        return vctrs_type2_complex_s3;
-    case vctrs_type_scalar:    return vctrs_type2_complex_scalar;
+    case vctrs_type_null:      *left =  1; return vctrs_type2_null_complex;
+    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_complex;
+    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_complex;
+    case vctrs_type_double:    *left =  1; return vctrs_type2_double_complex;
+    case vctrs_type_complex:   *left = -1; return vctrs_type2_complex_complex;
+    case vctrs_type_character: *left =  0; return vctrs_type2_complex_character;
+    case vctrs_type_raw:       *left =  0; return vctrs_type2_complex_raw;
+    case vctrs_type_list:      *left =  0; return vctrs_type2_complex_list;
+    case vctrs_type_dataframe: *left =  0; return vctrs_type2_complex_dataframe;
+    case vctrs_type_s3:        *left =  0; return vctrs_type2_complex_s3;
+    case vctrs_type_scalar:    *left =  0; return vctrs_type2_complex_scalar;
     }
   }
   case vctrs_type_character: {
     switch (type_y) {
-    case vctrs_type_null:      return vctrs_type2_null_character;
-    case vctrs_type_logical:   return vctrs_type2_logical_character;
-    case vctrs_type_integer:   return vctrs_type2_integer_character;
-    case vctrs_type_double:    return vctrs_type2_double_character;
-    case vctrs_type_complex:   return vctrs_type2_complex_character;
-    case vctrs_type_character: return vctrs_type2_character_character;
-    case vctrs_type_raw:       return vctrs_type2_character_raw;
-    case vctrs_type_list:      return vctrs_type2_character_list;
-    case vctrs_type_dataframe: return vctrs_type2_character_dataframe;
-    case vctrs_type_s3:        return vctrs_type2_character_s3;
-    case vctrs_type_scalar:    return vctrs_type2_character_scalar;
+    case vctrs_type_null:      *left =  1; return vctrs_type2_null_character;
+    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_character;
+    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_character;
+    case vctrs_type_double:    *left =  1; return vctrs_type2_double_character;
+    case vctrs_type_complex:   *left =  1; return vctrs_type2_complex_character;
+    case vctrs_type_character: *left = -1; return vctrs_type2_character_character;
+    case vctrs_type_raw:       *left =  0; return vctrs_type2_character_raw;
+    case vctrs_type_list:      *left =  0; return vctrs_type2_character_list;
+    case vctrs_type_dataframe: *left =  0; return vctrs_type2_character_dataframe;
+    case vctrs_type_s3:        *left =  0; return vctrs_type2_character_s3;
+    case vctrs_type_scalar:    *left =  0; return vctrs_type2_character_scalar;
     }
   }
   case vctrs_type_raw: {
     switch (type_y) {
-    case vctrs_type_null:      return vctrs_type2_null_raw;
-    case vctrs_type_logical:   return vctrs_type2_logical_raw;
-    case vctrs_type_integer:   return vctrs_type2_integer_raw;
-    case vctrs_type_double:    return vctrs_type2_double_raw;
-    case vctrs_type_complex:   return vctrs_type2_complex_raw;
-    case vctrs_type_character: return vctrs_type2_character_raw;
-    case vctrs_type_raw:       return vctrs_type2_raw_raw;
-    case vctrs_type_list:      return vctrs_type2_raw_list;
-    case vctrs_type_dataframe: return vctrs_type2_raw_dataframe;
-    case vctrs_type_s3:        return vctrs_type2_raw_s3;
-    case vctrs_type_scalar:    return vctrs_type2_raw_scalar;
+    case vctrs_type_null:      *left =  1; return vctrs_type2_null_raw;
+    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_raw;
+    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_raw;
+    case vctrs_type_double:    *left =  1; return vctrs_type2_double_raw;
+    case vctrs_type_complex:   *left =  1; return vctrs_type2_complex_raw;
+    case vctrs_type_character: *left =  1; return vctrs_type2_character_raw;
+    case vctrs_type_raw:       *left = -1; return vctrs_type2_raw_raw;
+    case vctrs_type_list:      *left =  0; return vctrs_type2_raw_list;
+    case vctrs_type_dataframe: *left =  0; return vctrs_type2_raw_dataframe;
+    case vctrs_type_s3:        *left =  0; return vctrs_type2_raw_s3;
+    case vctrs_type_scalar:    *left =  0; return vctrs_type2_raw_scalar;
     }
   }
   case vctrs_type_list: {
     switch (type_y) {
-    case vctrs_type_null:      return vctrs_type2_null_list;
-    case vctrs_type_logical:   return vctrs_type2_logical_list;
-    case vctrs_type_integer:   return vctrs_type2_integer_list;
-    case vctrs_type_double:    return vctrs_type2_double_list;
-    case vctrs_type_complex:   return vctrs_type2_complex_list;
-    case vctrs_type_character: return vctrs_type2_character_list;
-    case vctrs_type_raw:       return vctrs_type2_raw_list;
-    case vctrs_type_list:      return vctrs_type2_list_list;
-    case vctrs_type_dataframe: return vctrs_type2_list_dataframe;
-    case vctrs_type_s3:        return vctrs_type2_list_s3;
-    case vctrs_type_scalar:    return vctrs_type2_list_scalar;
+    case vctrs_type_null:      *left =  1; return vctrs_type2_null_list;
+    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_list;
+    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_list;
+    case vctrs_type_double:    *left =  1; return vctrs_type2_double_list;
+    case vctrs_type_complex:   *left =  1; return vctrs_type2_complex_list;
+    case vctrs_type_character: *left =  1; return vctrs_type2_character_list;
+    case vctrs_type_raw:       *left =  1; return vctrs_type2_raw_list;
+    case vctrs_type_list:      *left = -1; return vctrs_type2_list_list;
+    case vctrs_type_dataframe: *left =  0; return vctrs_type2_list_dataframe;
+    case vctrs_type_s3:        *left =  0; return vctrs_type2_list_s3;
+    case vctrs_type_scalar:    *left =  0; return vctrs_type2_list_scalar;
     }
   }
   case vctrs_type_dataframe: {
     switch (type_y) {
-    case vctrs_type_null:      return vctrs_type2_null_dataframe;
-    case vctrs_type_logical:   return vctrs_type2_logical_dataframe;
-    case vctrs_type_integer:   return vctrs_type2_integer_dataframe;
-    case vctrs_type_double:    return vctrs_type2_double_dataframe;
-    case vctrs_type_complex:   return vctrs_type2_complex_dataframe;
-    case vctrs_type_character: return vctrs_type2_character_dataframe;
-    case vctrs_type_raw:       return vctrs_type2_raw_dataframe;
-    case vctrs_type_list:      return vctrs_type2_list_dataframe;
-    case vctrs_type_dataframe: return vctrs_type2_dataframe_dataframe;
-    case vctrs_type_s3:        return vctrs_type2_dataframe_s3;
-    case vctrs_type_scalar:    return vctrs_type2_dataframe_scalar;
+    case vctrs_type_null:      *left =  1; return vctrs_type2_null_dataframe;
+    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_dataframe;
+    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_dataframe;
+    case vctrs_type_double:    *left =  1; return vctrs_type2_double_dataframe;
+    case vctrs_type_complex:   *left =  1; return vctrs_type2_complex_dataframe;
+    case vctrs_type_character: *left =  1; return vctrs_type2_character_dataframe;
+    case vctrs_type_raw:       *left =  1; return vctrs_type2_raw_dataframe;
+    case vctrs_type_list:      *left =  1; return vctrs_type2_list_dataframe;
+    case vctrs_type_dataframe: *left = -1; return vctrs_type2_dataframe_dataframe;
+    case vctrs_type_s3:        *left =  0; return vctrs_type2_dataframe_s3;
+    case vctrs_type_scalar:    *left =  0; return vctrs_type2_dataframe_scalar;
     }
   }
   case vctrs_type_s3: {
     switch (type_y) {
-    case vctrs_type_null:      return vctrs_type2_null_s3;
-    case vctrs_type_logical:   return vctrs_type2_logical_s3;
-    case vctrs_type_integer:   return vctrs_type2_integer_s3;
-    case vctrs_type_double:    return vctrs_type2_double_s3;
-    case vctrs_type_complex:   return vctrs_type2_complex_s3;
-    case vctrs_type_character: return vctrs_type2_character_s3;
-    case vctrs_type_raw:       return vctrs_type2_raw_s3;
-    case vctrs_type_list:      return vctrs_type2_list_s3;
-    case vctrs_type_dataframe: return vctrs_type2_dataframe_s3;
-    case vctrs_type_s3:        return vctrs_type2_s3_s3;
-    case vctrs_type_scalar:    return vctrs_type2_s3_scalar;
+    case vctrs_type_null:      *left =  1; return vctrs_type2_null_s3;
+    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_s3;
+    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_s3;
+    case vctrs_type_double:    *left =  1; return vctrs_type2_double_s3;
+    case vctrs_type_complex:   *left =  1; return vctrs_type2_complex_s3;
+    case vctrs_type_character: *left =  1; return vctrs_type2_character_s3;
+    case vctrs_type_raw:       *left =  1; return vctrs_type2_raw_s3;
+    case vctrs_type_list:      *left =  1; return vctrs_type2_list_s3;
+    case vctrs_type_dataframe: *left =  1; return vctrs_type2_dataframe_s3;
+    case vctrs_type_s3:        *left = -1; return vctrs_type2_s3_s3;
+    case vctrs_type_scalar:    *left =  0; return vctrs_type2_s3_scalar;
     }
   }
   case vctrs_type_scalar: {
     switch (type_y) {
-    case vctrs_type_null:      return vctrs_type2_null_scalar;
-    case vctrs_type_logical:   return vctrs_type2_logical_scalar;
-    case vctrs_type_integer:   return vctrs_type2_integer_scalar;
-    case vctrs_type_double:    return vctrs_type2_double_scalar;
-    case vctrs_type_complex:   return vctrs_type2_complex_scalar;
-    case vctrs_type_character: return vctrs_type2_character_scalar;
-    case vctrs_type_raw:       return vctrs_type2_raw_scalar;
-    case vctrs_type_list:      return vctrs_type2_list_scalar;
-    case vctrs_type_dataframe: return vctrs_type2_dataframe_scalar;
-    case vctrs_type_s3:        return vctrs_type2_s3_scalar;
-    case vctrs_type_scalar:    return vctrs_type2_scalar_scalar;
+    case vctrs_type_null:      *left =  1; return vctrs_type2_null_scalar;
+    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_scalar;
+    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_scalar;
+    case vctrs_type_double:    *left =  1; return vctrs_type2_double_scalar;
+    case vctrs_type_complex:   *left =  1; return vctrs_type2_complex_scalar;
+    case vctrs_type_character: *left =  1; return vctrs_type2_character_scalar;
+    case vctrs_type_raw:       *left =  1; return vctrs_type2_raw_scalar;
+    case vctrs_type_list:      *left =  1; return vctrs_type2_list_scalar;
+    case vctrs_type_dataframe: *left =  1; return vctrs_type2_dataframe_scalar;
+    case vctrs_type_s3:        *left =  1; return vctrs_type2_s3_scalar;
+    case vctrs_type_scalar:    *left = -1; return vctrs_type2_scalar_scalar;
     }
   }}
 
-  never_reached("vec_typeof2_impl");
+  never_reached("vec_typeof2_impl()");
 }
 
 // [[ include("vctrs.h") ]]
 enum vctrs_type2 vec_typeof2(SEXP x, SEXP y) {
-  return vec_typeof2_impl(vec_typeof(x), vec_typeof(y));
+  int _;
+  return vec_typeof2_impl(vec_typeof(x), vec_typeof(y), &_);
 }
 
 const char* vctrs_type2_as_str(enum vctrs_type2 type) {

--- a/src/type2.c
+++ b/src/type2.c
@@ -24,17 +24,22 @@ static SEXP vctrs_type2_dispatch(SEXP x,
 }
 
 // [[ include("vctrs.h") ]]
-SEXP vec_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) {
+SEXP vec_type2(SEXP x, SEXP y,
+               struct vctrs_arg* x_arg,
+               struct vctrs_arg* y_arg,
+               int* left) {
   if (x == R_NilValue) {
     if (!vec_is_partial(y)) {
       vec_assert(y, y_arg);
     }
+    *left = y == R_NilValue;
     return y;
   }
   if (y == R_NilValue) {
     if (!vec_is_partial(x)) {
       vec_assert(x, x_arg);
     }
+    *left = x == R_NilValue;
     return x;
   }
 
@@ -52,8 +57,9 @@ SEXP vec_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg)
     stop_scalar_type(y, y_arg);
   }
 
-  int left;
-  switch (vec_typeof2_impl(type_x, type_y, &left)) {
+  enum vctrs_type2 type2 = vec_typeof2_impl(type_x, type_y, left);
+
+  switch (type2) {
   case vctrs_type2_null_null:
     return R_NilValue;
 
@@ -100,7 +106,8 @@ SEXP vctrs_type2(SEXP x, SEXP y, SEXP x_arg, SEXP y_arg) {
   struct vctrs_arg_wrapper x_arg_ = new_wrapper_arg(NULL, r_chr_get_c_string(x_arg, 0));
   struct vctrs_arg_wrapper y_arg_ = new_wrapper_arg(NULL, r_chr_get_c_string(y_arg, 0));
 
-  return vec_type2(x, y, (struct vctrs_arg*) &x_arg_, (struct vctrs_arg*) &y_arg_);
+  int _left;
+  return vec_type2(x, y, (struct vctrs_arg*) &x_arg_, (struct vctrs_arg*) &y_arg_, &_left);
 }
 
 void vctrs_init_type2(SEXP ns) {

--- a/src/type2.c
+++ b/src/type2.c
@@ -52,7 +52,8 @@ SEXP vec_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg)
     stop_scalar_type(y, y_arg);
   }
 
-  switch (vec_typeof2_impl(type_x, type_y)) {
+  int left;
+  switch (vec_typeof2_impl(type_x, type_y, &left)) {
   case vctrs_type2_null_null:
     return R_NilValue;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -320,6 +320,24 @@ SEXP r_call(SEXP fn, SEXP* tags, SEXP* cars) {
   return Rf_lcons(fn, r_pairlist(tags, cars));
 }
 
+SEXP r_names(SEXP x) {
+  return Rf_getAttrib(x, R_NamesSymbol);
+}
+
+bool r_has_name_at(SEXP names, R_len_t i) {
+  if (TYPEOF(names) != STRSXP) {
+    return false;
+  }
+
+  R_len_t n = Rf_length(names);
+  if (n <= i) {
+    Rf_error("Internal error: Names shorter than expected: (%d/%d)", i + 1, n);
+  }
+
+  SEXP elt = STRING_ELT(names, i);
+  return elt != NA_STRING && elt != Rf_mkChar("");
+}
+
 
 SEXP vctrs_ns_env = NULL;
 SEXP vctrs_shared_empty_str = NULL;

--- a/src/utils.h
+++ b/src/utils.h
@@ -53,6 +53,9 @@ SEXP r_peek_option(const char* option);
 SEXP r_pairlist(SEXP* tags, SEXP* cars);
 SEXP r_call(SEXP fn, SEXP* tags, SEXP* cars);
 
+SEXP r_names(SEXP x);
+bool r_has_name_at(SEXP names, R_len_t i);
+
 static inline const char* r_chr_get_c_string(SEXP chr, R_len_t i) {
   return CHAR(STRING_ELT(chr, i));
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,7 +23,7 @@ struct vctrs_arg args_empty;
 
 void never_reached(const char* fn) __attribute__((noreturn));
 
-enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x, enum vctrs_type type_y);
+enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x, enum vctrs_type type_y, int* left);
 
 bool is_compact_rownames(SEXP x);
 R_len_t compact_rownames_length(SEXP x);

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,6 +2,13 @@
 #define VCTRS_UTILS_H
 
 
+#define SWAP(T, x, y) do {                      \
+    T tmp = x;                                  \
+    x = y;                                      \
+    y = tmp;                                    \
+  } while (0)
+
+
 bool is_bool(SEXP x);
 
 SEXP vctrs_dispatch_n(SEXP fn_sym, SEXP fn,

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -146,8 +146,13 @@ SEXP vec_slice(SEXP x, SEXP index);
 SEXP vec_restore(SEXP x, SEXP to, SEXP i);
 SEXP vec_type(SEXP x);
 SEXP vec_type_finalise(SEXP x);
-SEXP vec_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
 bool vec_is_unspecified(SEXP x);
+
+SEXP vec_type2(SEXP x,
+               SEXP y,
+               struct vctrs_arg* x_arg,
+               struct vctrs_arg* y_arg,
+               int* left);
 
 bool is_data_frame(SEXP x);
 bool is_record(SEXP x);

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -67,3 +67,7 @@ try2 <- function(expr) {
   cat(paste0("\n", as_label2(substitute(expr)), ":\n\n"))
   cat(catch_cnd(expr, classes = "error")$message, "\n\n")
 }
+
+expect_known_output_nobang <- function(object, file, ...) {
+  expect_known_output(object, file, ...)
+}

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -67,5 +67,6 @@ test_that("vec_c() includes index in argument tag", {
   expect_known_output(file = test_path("test-type-vec-c-error.txt"), {
     try2(vec_c(df1, df2))
     try2(vec_c(df1, df1, df2))
+    try2(vec_c(foo = df1, bar = df2))
   })
 })

--- a/tests/testthat/test-type-vec-c-error.txt
+++ b/tests/testthat/test-type-vec-c-error.txt
@@ -11,5 +11,5 @@ No common type for `list(...)[[1]]$x$y$z` <double> and `list(...)[[3]]$x$y$z` <c
 
 vec_c(foo = df1, bar = df2):
 
-No common type for `list(...)$foo$x$y$z` <double> and `list(...)$bar$x$y$z` <character>. 
+No common type for `foo$x$y$z` <double> and `bar$x$y$z` <character>. 
 

--- a/tests/testthat/test-type-vec-c-error.txt
+++ b/tests/testthat/test-type-vec-c-error.txt
@@ -8,3 +8,8 @@ vec_c(df1, df1, df2):
 
 No common type for `list(...)[[2]]$x$y$z` <double> and `list(...)[[3]]$x$y$z` <character>. 
 
+
+vec_c(foo = df1, bar = df2):
+
+No common type for `list(...)[[1]]$x$y$z` <double> and `list(...)[[2]]$x$y$z` <character>. 
+

--- a/tests/testthat/test-type-vec-c-error.txt
+++ b/tests/testthat/test-type-vec-c-error.txt
@@ -6,7 +6,7 @@ No common type for `list(...)[[1]]$x$y$z` <double> and `list(...)[[2]]$x$y$z` <c
 
 vec_c(df1, df1, df2):
 
-No common type for `list(...)[[2]]$x$y$z` <double> and `list(...)[[3]]$x$y$z` <character>. 
+No common type for `list(...)[[1]]$x$y$z` <double> and `list(...)[[3]]$x$y$z` <character>. 
 
 
 vec_c(foo = df1, bar = df2):

--- a/tests/testthat/test-type-vec-c-error.txt
+++ b/tests/testthat/test-type-vec-c-error.txt
@@ -11,5 +11,5 @@ No common type for `list(...)[[1]]$x$y$z` <double> and `list(...)[[3]]$x$y$z` <c
 
 vec_c(foo = df1, bar = df2):
 
-No common type for `list(...)[[1]]$x$y$z` <double> and `list(...)[[2]]$x$y$z` <character>. 
+No common type for `list(...)$foo$x$y$z` <double> and `list(...)$bar$x$y$z` <character>. 
 

--- a/tests/testthat/test-type-vec-type-common-error.txt
+++ b/tests/testthat/test-type-vec-type-common-error.txt
@@ -6,7 +6,7 @@ No common type for `list(...)[[1]]$x$y$z` <double> and `list(...)[[2]]$x$y$z` <c
 
 vec_type_common(df1, df1, df2):
 
-No common type for `list(...)[[2]]$x$y$z` <double> and `list(...)[[3]]$x$y$z` <character>. 
+No common type for `list(...)[[1]]$x$y$z` <double> and `list(...)[[3]]$x$y$z` <character>. 
 
 
 vec_type_common(large_df1, large_df2):
@@ -21,25 +21,45 @@ No common type for `list(...)$foo` <logical> and `list(...)$bar` <character>.
 
 vec_type_common(foo = TRUE, baz = FALSE, bar = "foo"):
 
-No common type for `list(...)$baz` <logical> and `list(...)$bar` <character>. 
-
-
-vec_type_common(foo = TRUE, !!!list(FALSE, FALSE), bar = "foo"):
-
-No common type for `list(...)[[3]]` <logical> and `list(...)$bar` <character>. 
+No common type for `list(...)$foo` <logical> and `list(...)$bar` <character>. 
 
 
 vec_type_common(TRUE, !!!list(1, "foo")):
 
-No common type for `list(...)[[1]]` <double> and `list(...)[[2]]` <character>. 
+No common type for `list(...)[[2]]` <double> and `list(...)[[3]]` <character>. 
+
+
+vec_type_common(TRUE, !!!list(1, 2), "foo"):
+
+No common type for `list(...)[[2]]` <double> and `list(...)[[5]]` <character>. 
+
+
+vec_type_common(1, !!!list(TRUE, FALSE), "foo"):
+
+No common type for `list(...)[[1]]` <double> and `list(...)[[5]]` <character>. 
+
+
+vec_type_common(foo = TRUE, !!!list(FALSE, FALSE), bar = "foo"):
+
+No common type for `list(...)$foo` <logical> and `list(...)$bar` <character>. 
 
 
 vec_type_common(foo = TRUE, !!!list(bar = 1, "foo")):
 
-No common type for `list(...)[[1]]` <double> and `list(...)[[2]]` <character>. 
+No common type for `list(...)[[2]]` <double> and `list(...)[[3]]` <character>. 
 
 
 vec_type_common(foo = TRUE, !!!list(bar = "foo")):
 
 No common type for `list(...)[[1]]` <logical> and `list(...)[[2]]` <character>. 
+
+
+vec_type_common(foo = TRUE, !!!list(bar = FALSE), baz = "chr"):
+
+No common type for `list(...)$foo` <logical> and `list(...)$baz` <character>. 
+
+
+vec_type_common(foo = TRUE, !!!list(bar = FALSE), !!!list(baz = "chr")):
+
+No common type for `list(...)[[1]]` <logical> and `list(...)[[4]]` <character>. 
 

--- a/tests/testthat/test-type-vec-type-common-error.txt
+++ b/tests/testthat/test-type-vec-type-common-error.txt
@@ -13,3 +13,28 @@ vec_type_common(large_df1, large_df2):
 
 No common type for `list(...)[[1]]$foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar$y$z` <double> and `list(...)[[2]]$foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar$y$z` <character>. 
 
+
+vec_type_common(foo = TRUE, bar = "foo"):
+
+No common type for `list(...)$foo` <logical> and `list(...)$bar` <character>. 
+
+
+vec_type_common(foo = TRUE, baz = FALSE, bar = "foo"):
+
+No common type for `list(...)$baz` <logical> and `list(...)$bar` <character>. 
+
+
+vec_type_common(TRUE, !!!list(1, "foo")):
+
+No common type for `list(...)[[1]]` <double> and `list(...)[[2]]` <character>. 
+
+
+vec_type_common(foo = TRUE, !!!list(bar = 1, "foo")):
+
+No common type for `list(...)[[1]]` <double> and `list(...)[[2]]` <character>. 
+
+
+vec_type_common(foo = TRUE, !!!list(bar = "foo")):
+
+No common type for `list(...)[[1]]` <logical> and `list(...)[[2]]` <character>. 
+

--- a/tests/testthat/test-type-vec-type-common-error.txt
+++ b/tests/testthat/test-type-vec-type-common-error.txt
@@ -24,6 +24,11 @@ vec_type_common(foo = TRUE, baz = FALSE, bar = "foo"):
 No common type for `list(...)$baz` <logical> and `list(...)$bar` <character>. 
 
 
+vec_type_common(foo = TRUE, !!!list(FALSE, FALSE), bar = "foo"):
+
+No common type for `list(...)[[3]]` <logical> and `list(...)$bar` <character>. 
+
+
 vec_type_common(TRUE, !!!list(1, "foo")):
 
 No common type for `list(...)[[1]]` <double> and `list(...)[[2]]` <character>. 

--- a/tests/testthat/test-type-vec-type-common-error.txt
+++ b/tests/testthat/test-type-vec-type-common-error.txt
@@ -16,22 +16,22 @@ No common type for `list(...)[[1]]$foobarfoobarfoobarfoobarfoobarfoobarfoobarfoo
 
 vec_type_common(foo = TRUE, bar = "foo"):
 
-No common type for `list(...)$foo` <logical> and `list(...)$bar` <character>. 
+No common type for `foo` <logical> and `bar` <character>. 
 
 
 vec_type_common(foo = TRUE, baz = FALSE, bar = "foo"):
 
-No common type for `list(...)$foo` <logical> and `list(...)$bar` <character>. 
+No common type for `foo` <logical> and `bar` <character>. 
 
 
 vec_type_common(foo = df1, bar = df2):
 
-No common type for `list(...)$foo$x$y$z` <double> and `list(...)$bar$x$y$z` <character>. 
+No common type for `foo$x$y$z` <double> and `bar$x$y$z` <character>. 
 
 
 vec_type_common(df1, df1, bar = df2):
 
-No common type for `list(...)[[1]]$x$y$z` <double> and `list(...)$bar$x$y$z` <character>. 
+No common type for `list(...)[[1]]$x$y$z` <double> and `bar$x$y$z` <character>. 
 
 
 vec_type_common(TRUE, !!!list(1, "foo")):
@@ -51,25 +51,25 @@ No common type for `list(...)[[1]]` <double> and `list(...)[[5]]` <character>.
 
 vec_type_common(foo = TRUE, !!!list(FALSE, FALSE), bar = "foo"):
 
-No common type for `list(...)$foo` <logical> and `list(...)$bar` <character>. 
+No common type for `foo` <logical> and `bar` <character>. 
 
 
 vec_type_common(foo = TRUE, !!!list(bar = 1, "foo")):
 
-No common type for `list(...)$bar` <double> and `list(...)[[3]]` <character>. 
+No common type for `bar` <double> and `list(...)[[3]]` <character>. 
 
 
 vec_type_common(foo = TRUE, !!!list(bar = "foo")):
 
-No common type for `list(...)$foo` <logical> and `list(...)$bar` <character>. 
+No common type for `foo` <logical> and `bar` <character>. 
 
 
 vec_type_common(foo = TRUE, !!!list(bar = FALSE), baz = "chr"):
 
-No common type for `list(...)$foo` <logical> and `list(...)$baz` <character>. 
+No common type for `foo` <logical> and `baz` <character>. 
 
 
 vec_type_common(foo = TRUE, !!!list(bar = FALSE), !!!list(baz = "chr")):
 
-No common type for `list(...)$foo` <logical> and `list(...)$baz` <character>. 
+No common type for `foo` <logical> and `baz` <character>. 
 

--- a/tests/testthat/test-type-vec-type-common-error.txt
+++ b/tests/testthat/test-type-vec-type-common-error.txt
@@ -24,6 +24,16 @@ vec_type_common(foo = TRUE, baz = FALSE, bar = "foo"):
 No common type for `list(...)$foo` <logical> and `list(...)$bar` <character>. 
 
 
+vec_type_common(foo = df1, bar = df2):
+
+No common type for `list(...)$foo$x$y$z` <double> and `list(...)$bar$x$y$z` <character>. 
+
+
+vec_type_common(df1, df1, bar = df2):
+
+No common type for `list(...)[[1]]$x$y$z` <double> and `list(...)$bar$x$y$z` <character>. 
+
+
 vec_type_common(TRUE, !!!list(1, "foo")):
 
 No common type for `list(...)[[2]]` <double> and `list(...)[[3]]` <character>. 

--- a/tests/testthat/test-type-vec-type-common-error.txt
+++ b/tests/testthat/test-type-vec-type-common-error.txt
@@ -46,12 +46,12 @@ No common type for `list(...)$foo` <logical> and `list(...)$bar` <character>.
 
 vec_type_common(foo = TRUE, !!!list(bar = 1, "foo")):
 
-No common type for `list(...)[[2]]` <double> and `list(...)[[3]]` <character>. 
+No common type for `list(...)$bar` <double> and `list(...)[[3]]` <character>. 
 
 
 vec_type_common(foo = TRUE, !!!list(bar = "foo")):
 
-No common type for `list(...)[[1]]` <logical> and `list(...)[[2]]` <character>. 
+No common type for `list(...)$foo` <logical> and `list(...)$bar` <character>. 
 
 
 vec_type_common(foo = TRUE, !!!list(bar = FALSE), baz = "chr"):
@@ -61,5 +61,5 @@ No common type for `list(...)$foo` <logical> and `list(...)$baz` <character>.
 
 vec_type_common(foo = TRUE, !!!list(bar = FALSE), !!!list(baz = "chr")):
 
-No common type for `list(...)[[1]]` <logical> and `list(...)[[4]]` <character>. 
+No common type for `list(...)$foo` <logical> and `list(...)$baz` <character>. 
 

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -69,6 +69,8 @@ test_that("vec_type_common() includes index in argument tag", {
     # Names
     try2(vec_type_common(foo = TRUE, bar = "foo"))
     try2(vec_type_common(foo = TRUE, baz = FALSE, bar = "foo"))
+    try2(vec_type_common(foo = df1, bar = df2))
+    try2(vec_type_common(df1, df1, bar = df2))
 
     # One splice box
     try2(vec_type_common(TRUE, !!!list(1, "foo")))

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -66,12 +66,22 @@ test_that("vec_type_common() includes index in argument tag", {
     try2(vec_type_common(df1, df1, df2))
     try2(vec_type_common(large_df1, large_df2))
 
+    # Names
     try2(vec_type_common(foo = TRUE, bar = "foo"))
     try2(vec_type_common(foo = TRUE, baz = FALSE, bar = "foo"))
-    try2(vec_type_common(foo = TRUE, !!!list(FALSE, FALSE), bar = "foo"))
 
+    # One splice box
     try2(vec_type_common(TRUE, !!!list(1, "foo")))
+    try2(vec_type_common(TRUE, !!!list(1, 2), "foo"))
+    try2(vec_type_common(1, !!!list(TRUE, FALSE), "foo"))
+
+    # One named splice box
+    try2(vec_type_common(foo = TRUE, !!!list(FALSE, FALSE), bar = "foo"))
     try2(vec_type_common(foo = TRUE, !!!list(bar = 1, "foo")))
     try2(vec_type_common(foo = TRUE, !!!list(bar = "foo")))
+    try2(vec_type_common(foo = TRUE, !!!list(bar = FALSE), baz = "chr"))
+
+    # Two splice boxes in next and current
+    try2(vec_type_common(foo = TRUE, !!!list(bar = FALSE), !!!list(baz = "chr")))
   })
 })

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -61,9 +61,16 @@ test_that("vec_type_common() includes index in argument tag", {
   large_df1 <- set_names(df1, nm)
   large_df2 <- set_names(df2, nm)
 
-  expect_known_output(file = test_path("test-type-vec-type-common-error.txt"), {
+  expect_known_output_nobang(file = test_path("test-type-vec-type-common-error.txt"), {
     try2(vec_type_common(df1, df2))
     try2(vec_type_common(df1, df1, df2))
     try2(vec_type_common(large_df1, large_df2))
+
+    try2(vec_type_common(foo = TRUE, bar = "foo"))
+    try2(vec_type_common(foo = TRUE, baz = FALSE, bar = "foo"))
+
+    try2(vec_type_common(TRUE, !!!list(1, "foo")))
+    try2(vec_type_common(foo = TRUE, !!!list(bar = 1, "foo")))
+    try2(vec_type_common(foo = TRUE, !!!list(bar = "foo")))
   })
 })

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -68,6 +68,7 @@ test_that("vec_type_common() includes index in argument tag", {
 
     try2(vec_type_common(foo = TRUE, bar = "foo"))
     try2(vec_type_common(foo = TRUE, baz = FALSE, bar = "foo"))
+    try2(vec_type_common(foo = TRUE, !!!list(FALSE, FALSE), bar = "foo"))
 
     try2(vec_type_common(TRUE, !!!list(1, "foo")))
     try2(vec_type_common(foo = TRUE, !!!list(bar = 1, "foo")))


### PR DESCRIPTION
This PR fixes support for names and coercions in `vec_type_common()` error messages. Ideally these two issues would be implemented in different PRs, unfortunately it would be hard to untangle the development history.

#### Coercion

The error message is currently confusing when an argument was coerced along the way:

```r
vec_type_common(1, TRUE, "chr")
#> Error: No common type for `list(...)[[2]]` <double> and `list(...)[[3]]` <character>.
```

One way to fix this would be to describe the coercion pattern:

```r
#> Error: No common type for `list(...)[[2]]` <double> coerced from <logical> and `list(...)[[3]]` <character>.
```

However this would be hard to implement with recursive data structures like data frames. A simpler solution is to keep track of the argument corresponding to the current type:

```r
#> Error: No common type for `list(...)[[1]]` <double> and `list(...)[[3]]` <character>.
```

To support this, `vec_type2()` now takes an output parameter `int* left` that indicates if the common type comes from the LHS or the RHS. It returns 1 for the LHS, 0 for the RHS, and -1 when both types are the same. The last value means that the LHS is taken as the default when `left` is coerced to a boolean.


#### Names

This PR also adds support for names:

```r
vec_type_common(foo = 1, bar = "")
Error: No common type for `foo` <double> and `bar` <character>.

vec_type_common(foo = df1, bar = df2)
#> Error: No common type for `foo$x$y$z` <double> and `bar$x$y$z` <character>.
```

The implementation is a bit more complicated than I expected because of the need to keep track of counters within splice boxes. When I first implemented `vec_type_common()` with `rlang::dots_values()` to avoid copies on splicing, I did not realise this would introduce such complexity later on. Not sure it was worth it in the end:

```r
many <- rep(list(1.5, 1:10), 1000)
bench::mark(
  dots_values = vec_type_common(!!!many),
  dots_list = vec_type_common_splice(!!!many)
)[1:6]
#>   expression       min     mean   median      max `itr/sec`
#>   <chr>       <bch:tm> <bch:tm> <bch:tm> <bch:tm>     <dbl>
#> 1 dots_values    224µs    280µs    229µs 732.52µs     3572.
#> 2 dots_list      276µs    352µs    299µs   1.45ms     2842.
```