### PR TITLE
Implement unique names repair in C

### DIFF
--- a/R/names.R
+++ b/R/names.R
@@ -229,13 +229,7 @@ minimal_names <- function(x) {
 }
 
 vec_names <- function(x) {
-  if (vec_dims(x) == 1) {
-    names(x)
-  } else if (is.data.frame(x)) {
-    NULL
-  } else {
-    rownames(x)
-  }
+  .Call(vctrs_names, x)
 }
 `vec_names<-` <- function(x, value) {
   if (vec_dims(x) == 1) {

--- a/R/names.R
+++ b/R/names.R
@@ -228,7 +228,7 @@ minimal_names <- function(x) {
   .Call(vctrs_minimal_names, x)
 }
 unique_names <- function(x, quiet = FALSE) {
-  .Call(vctrs_unique_names, x)
+  .Call(vctrs_unique_names, x, quiet)
 }
 
 vec_names <- function(x) {
@@ -250,13 +250,7 @@ as_minimal_names <- function(names) {
   .Call(vctrs_as_minimal_names, names)
 }
 as_unique_names <- function(names, quiet = FALSE) {
-  out <- .Call(vctrs_as_unique_names, names)
-
-  if (!quiet) {
-    describe_repair(names, out)
-  }
-
-  out
+  .Call(vctrs_as_unique_names, names, quiet)
 }
 as_universal_names <- function(names, quiet = FALSE) {
   as_unique_names_impl(names, quiet, TRUE)
@@ -374,7 +368,12 @@ re_match <- function(text, pattern, perl = TRUE, ...) {
 
 
 describe_repair <- function(orig_names, names) {
-  stopifnot(length(orig_names) == length(names))
+  if (is_null(orig_names)) {
+    orig_names <- rep_along(names, "")
+  }
+  if (length(orig_names) != length(names)) {
+    stop("Internal error: New names and old names don't have same length")
+  }
 
   new_names <- names != as_minimal_names(orig_names)
   if (any(new_names)) {

--- a/R/names.R
+++ b/R/names.R
@@ -225,13 +225,7 @@ vec_repair_names <- function(x,
 }
 
 minimal_names <- function(x) {
-  names <- vec_names(x)
-
-  if (is.null(names)) {
-    rep_len("", vec_size(x))
-  } else {
-    as_minimal_names(names)
-  }
+  .Call(vctrs_minimal_names, x)
 }
 
 vec_names <- function(x) {
@@ -256,10 +250,7 @@ vec_names <- function(x) {
 set_names2 <- `vec_names<-`
 
 as_minimal_names <- function(names) {
-  if (!is_character(names)) {
-    abort("`names` must be a character vector")
-  }
-  names %|% ""
+  .Call(vctrs_as_minimal_names, names)
 }
 as_unique_names <- function(names, quiet = FALSE) {
   as_unique_names_impl(names, quiet, FALSE)

--- a/R/names.R
+++ b/R/names.R
@@ -250,8 +250,13 @@ as_minimal_names <- function(names) {
   .Call(vctrs_as_minimal_names, names)
 }
 as_unique_names <- function(names, quiet = FALSE) {
-  # as_unique_names_impl(names, quiet, FALSE)
-  .Call(vctrs_as_unique_names, names)
+  out <- .Call(vctrs_as_unique_names, names)
+
+  if (!quiet) {
+    describe_repair(names, out)
+  }
+
+  out
 }
 as_universal_names <- function(names, quiet = FALSE) {
   as_unique_names_impl(names, quiet, TRUE)

--- a/R/names.R
+++ b/R/names.R
@@ -213,7 +213,7 @@ vec_names2 <- function(x,
 
   switch(arg_match(repair),
     minimal = minimal_names(x),
-    unique = as_unique_names(minimal_names(x), quiet = quiet),
+    unique = unique_names(x, quiet = quiet),
     universal = as_universal_names(minimal_names(x), quiet = quiet)
   )
 }
@@ -226,6 +226,9 @@ vec_repair_names <- function(x,
 
 minimal_names <- function(x) {
   .Call(vctrs_minimal_names, x)
+}
+unique_names <- function(x, quiet = FALSE) {
+  .Call(vctrs_unique_names, x)
 }
 
 vec_names <- function(x) {

--- a/R/names.R
+++ b/R/names.R
@@ -161,7 +161,7 @@ vec_as_names <- function(names,
 
   switch(arg_match(repair),
     minimal = as_minimal_names(names),
-    unique = as_unique_names(as_minimal_names(names), quiet = quiet),
+    unique = as_unique_names(names, quiet = quiet),
     universal = as_universal_names(as_minimal_names(names), quiet = quiet)
   )
 }
@@ -250,7 +250,8 @@ as_minimal_names <- function(names) {
   .Call(vctrs_as_minimal_names, names)
 }
 as_unique_names <- function(names, quiet = FALSE) {
-  as_unique_names_impl(names, quiet, FALSE)
+  # as_unique_names_impl(names, quiet, FALSE)
+  .Call(vctrs_as_unique_names, names)
 }
 as_universal_names <- function(names, quiet = FALSE) {
   as_unique_names_impl(names, quiet, TRUE)

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -1,0 +1,22 @@
+
+#define DICT_EMPTY -1
+
+
+// The dictionary structure is a little peculiar since R has no notion of
+// a scalar, so the `key`s are indexes into vector `x`. This means we can
+// only store values from a single vector, but we can still lookup using
+// another vector, provided that they're of the same type (which is ensured
+// at the R-level).
+
+struct dictionary {
+  SEXP x;
+  R_len_t* key;
+  uint32_t size;
+  uint32_t used;
+};
+typedef struct dictionary dictionary;
+
+void dict_init(dictionary* d, SEXP x);
+void dict_free(dictionary* d);
+uint32_t dict_find(dictionary* d, SEXP y, R_len_t i);
+void dict_put(dictionary* d, uint32_t k, R_len_t i);

--- a/src/hash.c
+++ b/src/hash.c
@@ -58,10 +58,8 @@ int32_t hash_scalar(SEXP x, R_len_t i) {
 
     return hash_double(val);
   }
-  case STRSXP: {
-    // currently assuming 64-bit pointer size
-    return hash_int64((intptr_t) STRING_ELT(x, i));
-  }
+  case STRSXP:
+    return hash_object(STRING_ELT(x, i));
   case VECSXP: {
     if (is_data_frame(x)) {
       uint32_t hash = 0;

--- a/src/init.c
+++ b/src/init.c
@@ -45,10 +45,10 @@ extern SEXP vctrs_unspecified(SEXP);
 extern SEXP vec_type(SEXP);
 extern SEXP vec_type_finalise(SEXP);
 extern SEXP vctrs_minimal_names(SEXP);
-extern SEXP vctrs_unique_names(SEXP);
+extern SEXP vctrs_unique_names(SEXP, SEXP);
 extern SEXP vctrs_as_minimal_names(SEXP);
 extern SEXP vec_names(SEXP);
-extern SEXP vctrs_as_unique_names(SEXP);
+extern SEXP vctrs_as_unique_names(SEXP, SEXP);
 
 // Defined below
 SEXP vctrs_init(SEXP);
@@ -92,10 +92,10 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_type",                       (DL_FUNC) &vec_type, 1},
   {"vctrs_type_finalise",              (DL_FUNC) &vec_type_finalise, 1},
   {"vctrs_minimal_names",              (DL_FUNC) &vctrs_minimal_names, 1},
-  {"vctrs_unique_names",               (DL_FUNC) &vctrs_unique_names, 1},
+  {"vctrs_unique_names",               (DL_FUNC) &vctrs_unique_names, 2},
   {"vctrs_as_minimal_names",           (DL_FUNC) &vctrs_as_minimal_names, 1},
   {"vctrs_names",                      (DL_FUNC) &vec_names, 1},
-  {"vctrs_as_unique_names",            (DL_FUNC) &vctrs_as_unique_names, 1},
+  {"vctrs_as_unique_names",            (DL_FUNC) &vctrs_as_unique_names, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -46,6 +46,7 @@ extern SEXP vec_type(SEXP);
 extern SEXP vec_type_finalise(SEXP);
 extern SEXP vctrs_minimal_names(SEXP);
 extern SEXP vctrs_as_minimal_names(SEXP);
+extern SEXP vec_names(SEXP);
 
 // Defined below
 SEXP vctrs_init(SEXP);
@@ -90,6 +91,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_type_finalise",              (DL_FUNC) &vec_type_finalise, 1},
   {"vctrs_minimal_names",              (DL_FUNC) &vctrs_minimal_names, 1},
   {"vctrs_as_minimal_names",           (DL_FUNC) &vctrs_as_minimal_names, 1},
+  {"vctrs_names",                      (DL_FUNC) &vec_names, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -45,6 +45,7 @@ extern SEXP vctrs_unspecified(SEXP);
 extern SEXP vec_type(SEXP);
 extern SEXP vec_type_finalise(SEXP);
 extern SEXP vctrs_minimal_names(SEXP);
+extern SEXP vctrs_unique_names(SEXP);
 extern SEXP vctrs_as_minimal_names(SEXP);
 extern SEXP vec_names(SEXP);
 
@@ -90,6 +91,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_type",                       (DL_FUNC) &vec_type, 1},
   {"vctrs_type_finalise",              (DL_FUNC) &vec_type_finalise, 1},
   {"vctrs_minimal_names",              (DL_FUNC) &vctrs_minimal_names, 1},
+  {"vctrs_unique_names",               (DL_FUNC) &vctrs_unique_names, 1},
   {"vctrs_as_minimal_names",           (DL_FUNC) &vctrs_as_minimal_names, 1},
   {"vctrs_names",                      (DL_FUNC) &vec_names, 1},
   {NULL, NULL, 0}

--- a/src/init.c
+++ b/src/init.c
@@ -44,6 +44,8 @@ extern SEXP vec_proxy(SEXP);
 extern SEXP vctrs_unspecified(SEXP);
 extern SEXP vec_type(SEXP);
 extern SEXP vec_type_finalise(SEXP);
+extern SEXP vctrs_minimal_names(SEXP);
+extern SEXP vctrs_as_minimal_names(SEXP);
 
 // Defined below
 SEXP vctrs_init(SEXP);
@@ -86,6 +88,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_unspecified",                (DL_FUNC) &vctrs_unspecified, 1},
   {"vctrs_type",                       (DL_FUNC) &vec_type, 1},
   {"vctrs_type_finalise",              (DL_FUNC) &vec_type_finalise, 1},
+  {"vctrs_minimal_names",              (DL_FUNC) &vctrs_minimal_names, 1},
+  {"vctrs_as_minimal_names",           (DL_FUNC) &vctrs_as_minimal_names, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -48,6 +48,7 @@ extern SEXP vctrs_minimal_names(SEXP);
 extern SEXP vctrs_unique_names(SEXP);
 extern SEXP vctrs_as_minimal_names(SEXP);
 extern SEXP vec_names(SEXP);
+extern SEXP vctrs_as_unique_names(SEXP);
 
 // Defined below
 SEXP vctrs_init(SEXP);
@@ -94,6 +95,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_unique_names",               (DL_FUNC) &vctrs_unique_names, 1},
   {"vctrs_as_minimal_names",           (DL_FUNC) &vctrs_as_minimal_names, 1},
   {"vctrs_names",                      (DL_FUNC) &vec_names, 1},
+  {"vctrs_as_unique_names",            (DL_FUNC) &vctrs_as_unique_names, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/names.c
+++ b/src/names.c
@@ -3,28 +3,7 @@
 #include "utils.h"
 
 
-struct cow {
-  SEXP obj;
-  PROTECT_INDEX i;
-};
-
-struct cow PROTECT_COW(SEXP x) {
-  PROTECT_INDEX pi;
-  PROTECT_WITH_INDEX(x, &pi);
-
-  struct cow cow = { x, pi };
-  return cow;
-}
-
-struct cow cow_maybe_copy(struct cow cow) {
-  if (MAYBE_REFERENCED(cow.obj)) {
-    cow.obj = Rf_shallow_duplicate(cow.obj);
-    REPROTECT(cow.obj, cow.i);
-  }
-  return cow;
-}
-
-static struct cow as_minimal_names(struct cow cow_names) {
+static struct sexp_cow as_minimal_names(struct sexp_cow cow_names) {
   SEXP names = cow_names.obj;
 
   if (TYPEOF(names) != STRSXP) {
@@ -45,7 +24,7 @@ static struct cow as_minimal_names(struct cow cow_names) {
     return cow_names;
   }
 
-  cow_names = cow_maybe_copy(cow_names);
+  cow_names = r_maybe_copy(cow_names);
   names = cow_names.obj;
 
   for (; i < n; ++i, ++ptr) {
@@ -59,7 +38,7 @@ static struct cow as_minimal_names(struct cow cow_names) {
 }
 
 SEXP vctrs_as_minimal_names(SEXP names) {
-  struct cow cow_names = PROTECT_COW(names);
+  struct sexp_cow cow_names = PROTECT_COW(names);
   cow_names = as_minimal_names(cow_names);
 
   UNPROTECT(1);
@@ -98,7 +77,7 @@ SEXP vctrs_minimal_names(SEXP x) {
     return Rf_allocVector(STRSXP, vec_size(x));
   }
 
-  struct cow cow_names = PROTECT_COW(names);
+  struct sexp_cow cow_names = PROTECT_COW(names);
   cow_names = as_minimal_names(cow_names);
 
   UNPROTECT(2);
@@ -110,7 +89,7 @@ void stop_large_name();
 bool is_dotdotint(const char* name);
 ptrdiff_t suffix_pos(const char* name);
 
-static struct cow as_unique_names(struct cow cow_names) {
+static struct sexp_cow as_unique_names(struct sexp_cow cow_names) {
   SEXP names = cow_names.obj;
 
   if (TYPEOF(names) != STRSXP) {
@@ -155,7 +134,7 @@ static struct cow as_unique_names(struct cow cow_names) {
   }
 
 
-  cow_names = cow_maybe_copy(cow_names);
+  cow_names = r_maybe_copy(cow_names);
   names = cow_names.obj;
   ptr = STRING_PTR(names) + i;
 
@@ -229,7 +208,7 @@ static struct cow as_unique_names(struct cow cow_names) {
 }
 
 SEXP vctrs_as_unique_names(SEXP names) {
-  struct cow cow_names = PROTECT_COW(names);
+  struct sexp_cow cow_names = PROTECT_COW(names);
   cow_names = as_unique_names(cow_names);
 
   UNPROTECT(1);

--- a/src/names.c
+++ b/src/names.c
@@ -2,6 +2,30 @@
 #include "dictionary.h"
 #include "utils.h"
 
+// [[ register() ]]
+SEXP vec_names(SEXP x) {
+  if (OBJECT(x) && Rf_inherits(x, "data.frame")) {
+    return R_NilValue;
+  }
+
+  if (vec_dim(x) == 1) {
+    if (OBJECT(x)) {
+      return vctrs_dispatch1(syms_names, fns_names, syms_x, x);
+    } else {
+      return r_names(x);
+    }
+  }
+
+  SEXP dimnames = PROTECT(Rf_getAttrib(x, R_DimNamesSymbol));
+  if (dimnames == R_NilValue || Rf_length(dimnames) < 1) {
+    UNPROTECT(1);
+    return R_NilValue;
+  }
+
+  SEXP out = VECTOR_ELT(dimnames, 0);
+  UNPROTECT(1);
+  return out;
+}
 
 static struct sexp_cow as_minimal_names(struct sexp_cow cow_names) {
   SEXP names = cow_names.obj;
@@ -43,30 +67,6 @@ SEXP vctrs_as_minimal_names(SEXP names) {
 
   UNPROTECT(1);
   return cow_names.obj;
-}
-
-SEXP vec_names(SEXP x) {
-  if (OBJECT(x) && Rf_inherits(x, "data.frame")) {
-    return R_NilValue;
-  }
-
-  if (vec_dim(x) == 1) {
-    if (OBJECT(x)) {
-      return vctrs_dispatch1(syms_names, fns_names, syms_x, x);
-    } else {
-      return r_names(x);
-    }
-  }
-
-  SEXP dimnames = PROTECT(Rf_getAttrib(x, R_DimNamesSymbol));
-  if (dimnames == R_NilValue || Rf_length(dimnames) < 1) {
-    UNPROTECT(1);
-    return R_NilValue;
-  }
-
-  SEXP out = VECTOR_ELT(dimnames, 0);
-  UNPROTECT(1);
-  return out;
 }
 
 SEXP vctrs_minimal_names(SEXP x) {

--- a/src/names.c
+++ b/src/names.c
@@ -1,0 +1,80 @@
+#include "vctrs.h"
+#include "utils.h"
+
+
+struct cow {
+  SEXP obj;
+  const PROTECT_INDEX i;
+};
+
+struct cow PROTECT_COW(SEXP x) {
+  PROTECT_INDEX pi;
+  PROTECT_WITH_INDEX(x, &pi);
+
+  struct cow cow = { x, pi };
+  return cow;
+}
+
+void cow_maybe_copy(struct cow* cow) {
+  if (MAYBE_REFERENCED(cow->obj)) {
+    cow->obj = Rf_shallow_duplicate(cow->obj);
+    REPROTECT(cow->obj, cow->i);
+  }
+}
+
+
+static SEXP as_minimal_names(struct cow* cow_names) {
+  SEXP names = cow_names->obj;
+
+  if (TYPEOF(names) != STRSXP) {
+    Rf_errorcall(R_NilValue, "`names` must be a character vector");
+  }
+
+  R_len_t i = 0;
+  R_len_t n = Rf_length(names);
+  SEXP* ptr = STRING_PTR(names);
+
+  for (; i < n; ++i, ++ptr) {
+    SEXP elt = *ptr;
+    if (elt == NA_STRING) {
+      break;
+    }
+  }
+  if (i == n) {
+    return names;
+  }
+
+  cow_maybe_copy(cow_names);
+  names = cow_names->obj;
+
+  for (; i < n; ++i, ++ptr) {
+    SEXP elt = *ptr;
+    if (elt == NA_STRING) {
+      SET_STRING_ELT(names, i, vctrs_shared_empty_str_elt);
+    }
+  }
+
+  return names;
+}
+
+SEXP vctrs_as_minimal_names(SEXP names) {
+  struct cow cow_names = PROTECT_COW(names);
+  SEXP out = as_minimal_names(&cow_names);
+
+  UNPROTECT(1);
+  return out;
+}
+
+SEXP vctrs_minimal_names(SEXP x) {
+  SEXP names = Rf_getAttrib(x, R_NamesSymbol);
+
+  if (names == R_NilValue) {
+    return Rf_allocVector(STRSXP, Rf_length(x));
+  }
+
+  struct cow cow_names = PROTECT_COW(names);
+  names = as_minimal_names(&cow_names);
+
+  UNPROTECT(1);
+  return names;
+}

--- a/src/names.c
+++ b/src/names.c
@@ -67,11 +67,16 @@ SEXP vctrs_as_minimal_names(SEXP names) {
 }
 
 SEXP vec_names(SEXP x) {
-  if (Rf_inherits(x, "data.frame")) {
+  if (OBJECT(x) && Rf_inherits(x, "data.frame")) {
     return R_NilValue;
   }
+
   if (vec_dim(x) == 1) {
-    return r_names(x);
+    if (OBJECT(x)) {
+      return vctrs_dispatch1(syms_names, fns_names, syms_x, x);
+    } else {
+      return r_names(x);
+    }
   }
 
   SEXP dimnames = PROTECT(Rf_getAttrib(x, R_DimNamesSymbol));

--- a/src/names.c
+++ b/src/names.c
@@ -65,16 +65,36 @@ SEXP vctrs_as_minimal_names(SEXP names) {
   return out;
 }
 
+SEXP vec_names(SEXP x) {
+  if (Rf_inherits(x, "data.frame")) {
+    return R_NilValue;
+  }
+  if (vec_dim(x) == 1) {
+    return r_names(x);
+  }
+
+  SEXP dimnames = PROTECT(Rf_getAttrib(x, R_DimNamesSymbol));
+  if (dimnames == R_NilValue || Rf_length(dimnames) < 1) {
+    UNPROTECT(1);
+    return R_NilValue;
+  }
+
+  SEXP out = VECTOR_ELT(dimnames, 0);
+  UNPROTECT(1);
+  return out;
+}
+
 SEXP vctrs_minimal_names(SEXP x) {
-  SEXP names = Rf_getAttrib(x, R_NamesSymbol);
+  SEXP names = PROTECT(vec_names(x));
 
   if (names == R_NilValue) {
-    return Rf_allocVector(STRSXP, Rf_length(x));
+    UNPROTECT(1);
+    return Rf_allocVector(STRSXP, vec_size(x));
   }
 
   struct cow cow_names = PROTECT_COW(names);
   names = as_minimal_names(&cow_names);
 
-  UNPROTECT(1);
+  UNPROTECT(2);
   return names;
 }

--- a/src/names.c
+++ b/src/names.c
@@ -98,3 +98,46 @@ SEXP vctrs_minimal_names(SEXP x) {
   UNPROTECT(2);
   return names;
 }
+
+
+static SEXP names_iota(R_len_t n);
+
+SEXP vctrs_unique_names(SEXP x) {
+  SEXP names = PROTECT(Rf_getAttrib(x, R_NamesSymbol));
+
+  if (names == R_NilValue) {
+    UNPROTECT(1);
+    return(names_iota(vec_size(x)));
+  }
+
+  UNPROTECT(1);
+  return names;
+}
+
+
+// 3 leading '.' + 1 trailing '\0' + 24 characters
+#define TOTAL_BUF_SIZE 28
+#define FREE_BUF_SIZE 25
+
+static SEXP names_iota(R_len_t n) {
+  SEXP nms = PROTECT(Rf_allocVector(STRSXP, n));
+
+  char buf[TOTAL_BUF_SIZE] = "...";
+  char* beg = buf + 3;
+
+  for (R_len_t i = 0; i < n; ++i) {
+    int written = snprintf(beg, FREE_BUF_SIZE, "%d", i + 1);
+
+    if (written >= FREE_BUF_SIZE) {
+      Rf_errorcall(R_NilValue, "Can't write repaired names as there are too many.");
+    }
+
+    SET_STRING_ELT(nms, i, Rf_mkChar(buf));
+  }
+
+  UNPROTECT(1);
+  return nms;
+}
+
+#undef TOTAL_BUF_SIZE
+#undef FREE_BUF_SIZE

--- a/src/size.c
+++ b/src/size.c
@@ -3,6 +3,15 @@
 
 R_len_t rcrd_size(SEXP x);
 
+
+R_len_t vec_dim(SEXP x) {
+  if (has_dim(x)) {
+    return Rf_length(x);
+  } else {
+    return 1;
+  }
+}
+
 static R_len_t vec_size_impl(SEXP x, bool dispatch) {
   switch (vec_typeof_impl(x, dispatch)) {
   case vctrs_type_null:

--- a/src/utils.c
+++ b/src/utils.c
@@ -501,20 +501,12 @@ bool r_is_function(SEXP x) {
   }
 }
 
-struct sexp_cow PROTECT_COW(SEXP x) {
-  PROTECT_INDEX pi;
-  PROTECT_WITH_INDEX(x, &pi);
-
-  struct sexp_cow cow = { x, pi };
-  return cow;
-}
-
-struct sexp_cow r_maybe_copy(struct sexp_cow cow) {
-  if (MAYBE_REFERENCED(cow.obj)) {
-    cow.obj = Rf_shallow_duplicate(cow.obj);
-    REPROTECT(cow.obj, cow.i);
+SEXP r_maybe_duplicate(SEXP x) {
+  if (MAYBE_REFERENCED(x)) {
+    return Rf_shallow_duplicate(x);
+  } else {
+    return x;
   }
-  return cow;
 }
 
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -504,6 +504,7 @@ bool r_is_function(SEXP x) {
 
 SEXP vctrs_ns_env = NULL;
 SEXP vctrs_shared_empty_str = NULL;
+SEXP vctrs_shared_empty_str_elt = NULL;
 
 SEXP syms_i = NULL;
 SEXP syms_x = NULL;
@@ -523,6 +524,8 @@ void vctrs_init_utils(SEXP ns) {
 
   vctrs_shared_empty_str = Rf_mkString("");
   R_PreserveObject(vctrs_shared_empty_str);
+
+  vctrs_shared_empty_str_elt = STRING_ELT(vctrs_shared_empty_str, 0);
 
 
   classes_data_frame = Rf_allocVector(STRSXP, 1);

--- a/src/utils.c
+++ b/src/utils.c
@@ -504,7 +504,10 @@ bool r_is_function(SEXP x) {
 
 SEXP vctrs_ns_env = NULL;
 SEXP vctrs_shared_empty_str = NULL;
-SEXP vctrs_shared_empty_str_elt = NULL;
+
+SEXP strings = NULL;
+SEXP strings_empty = NULL;
+SEXP strings_dots = NULL;
 
 SEXP syms_i = NULL;
 SEXP syms_x = NULL;
@@ -525,7 +528,17 @@ void vctrs_init_utils(SEXP ns) {
   vctrs_shared_empty_str = Rf_mkString("");
   R_PreserveObject(vctrs_shared_empty_str);
 
-  vctrs_shared_empty_str_elt = STRING_ELT(vctrs_shared_empty_str, 0);
+
+  // Holds the CHARSXP objects because unlike symbols they can be
+  // garbage collected
+  strings = Rf_allocVector(STRSXP, 2);
+  R_PreserveObject(strings);
+
+  strings_dots = Rf_mkChar("...");
+  SET_STRING_ELT(strings, 0, strings_dots);
+
+  strings_empty = Rf_mkChar("");
+  SET_STRING_ELT(strings, 1, strings_empty);
 
 
   classes_data_frame = Rf_allocVector(STRSXP, 1);

--- a/src/utils.c
+++ b/src/utils.c
@@ -501,6 +501,22 @@ bool r_is_function(SEXP x) {
   }
 }
 
+struct sexp_cow PROTECT_COW(SEXP x) {
+  PROTECT_INDEX pi;
+  PROTECT_WITH_INDEX(x, &pi);
+
+  struct sexp_cow cow = { x, pi };
+  return cow;
+}
+
+struct sexp_cow r_maybe_copy(struct sexp_cow cow) {
+  if (MAYBE_REFERENCED(cow.obj)) {
+    cow.obj = Rf_shallow_duplicate(cow.obj);
+    REPROTECT(cow.obj, cow.i);
+  }
+  return cow;
+}
+
 
 SEXP vctrs_ns_env = NULL;
 SEXP vctrs_shared_empty_str = NULL;

--- a/src/utils.c
+++ b/src/utils.c
@@ -520,6 +520,7 @@ SEXP syms_y_arg = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
+SEXP fns_names = NULL;
 
 void vctrs_init_utils(SEXP ns) {
   vctrs_ns_env = ns;
@@ -571,6 +572,7 @@ void vctrs_init_utils(SEXP ns) {
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);
+  fns_names = Rf_findVar(Rf_install("names"), R_BaseEnv);
 
   new_env_call = r_parse_eval("as.call(list(new.env, TRUE, NULL, NULL))", R_BaseEnv);
   R_PreserveObject(new_env_call);

--- a/src/utils.h
+++ b/src/utils.h
@@ -99,9 +99,11 @@ static inline double r_dbl_get(SEXP x, R_len_t i) {
 
 extern SEXP vctrs_ns_env;
 extern SEXP vctrs_shared_empty_str;
-extern SEXP vctrs_shared_empty_str_elt;
 
 extern SEXP classes_data_frame;
+
+extern SEXP strings_dots;
+extern SEXP strings_empty;
 
 extern SEXP syms_i;
 extern SEXP syms_x;

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,6 +9,15 @@
   } while (0)
 
 
+struct sexp_cow {
+  SEXP obj;
+  PROTECT_INDEX i;
+};
+
+struct sexp_cow PROTECT_COW(SEXP x);
+struct sexp_cow r_maybe_copy(struct sexp_cow cow);
+
+
 bool is_bool(SEXP x);
 
 SEXP vctrs_dispatch_n(SEXP fn_sym, SEXP fn,

--- a/src/utils.h
+++ b/src/utils.h
@@ -113,9 +113,11 @@ extern SEXP syms_dots;
 extern SEXP syms_bracket;
 extern SEXP syms_x_arg;
 extern SEXP syms_y_arg;
+#define syms_names R_NamesSymbol
 
 extern SEXP fns_bracket;
 extern SEXP fns_quote;
+extern SEXP fns_names;
 
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -99,6 +99,7 @@ static inline double r_dbl_get(SEXP x, R_len_t i) {
 
 extern SEXP vctrs_ns_env;
 extern SEXP vctrs_shared_empty_str;
+extern SEXP vctrs_shared_empty_str_elt;
 
 extern SEXP classes_data_frame;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,15 +9,6 @@
   } while (0)
 
 
-struct sexp_cow {
-  SEXP obj;
-  PROTECT_INDEX i;
-};
-
-struct sexp_cow PROTECT_COW(SEXP x);
-struct sexp_cow r_maybe_copy(struct sexp_cow cow);
-
-
 bool is_bool(SEXP x);
 
 SEXP vctrs_dispatch_n(SEXP fn_sym, SEXP fn,
@@ -74,6 +65,7 @@ bool r_is_true(SEXP x);
 bool r_is_string(SEXP x);
 SEXP r_peek_option(const char* option);
 SEXP r_names(SEXP x);
+SEXP r_maybe_duplicate(SEXP x);
 
 SEXP r_pairlist(SEXP* tags, SEXP* cars);
 SEXP r_call(SEXP fn, SEXP* tags, SEXP* cars);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -143,6 +143,7 @@ SEXP vec_proxy(SEXP x);
 SEXP vec_proxy_method(SEXP x);
 SEXP vec_proxy_invoke(SEXP x, SEXP method);
 R_len_t vec_size(SEXP x);
+R_len_t vec_dim(SEXP x);
 SEXP vec_cast(SEXP x, SEXP to);
 SEXP vec_slice(SEXP x, SEXP index);
 SEXP vec_restore(SEXP x, SEXP to, SEXP i);

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -10,6 +10,13 @@ test_that("vec_names() retrieves names", {
   expect_identical(vec_names(Titanic), dimnames(Titanic)[[1]])
 })
 
+test_that("vec_names() dispatches", {
+  scoped_global_bindings(
+    names.vctrs_foobar = function(x) "dispatched!"
+  )
+  expect_identical(vec_names(foobar()), "dispatched!")
+})
+
 test_that("vec_names<- sets names", {
   x <- letters
   vec_names(x) <- letters

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -126,6 +126,16 @@ test_that("minimal_names() treats data frames and arrays as vectors", {
   expect_identical(minimal_names(as.matrix(mtcars)), row.names(mtcars))
 })
 
+test_that("as_minimal_names() copies on write", {
+  nms <- chr(NA, NA)
+  as_minimal_names(nms)
+  expect_identical(nms, chr(NA, NA))
+
+  nms <- c("a", "b")
+  out <- as_minimal_names(nms)
+  expect_true(is_reference(nms, out))
+})
+
 
 # unique names -------------------------------------------------------------
 

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -242,6 +242,14 @@ test_that("unique-ification has an 'algebraic'-y property", {
   expect_identical(z1, z4)
 })
 
+test_that("unique_names() and as_unique_names() are verbose or silent", {
+  expect_message(unique_names(1:2), "-> ...1", fixed = TRUE)
+  expect_message(as_unique_names(c("", "")), "-> ...1", fixed = TRUE)
+
+  expect_message(regexp = NA, unique_names(1:2, quiet = TRUE))
+  expect_message(regexp = NA, as_unique_names(c("", ""), quiet = TRUE))
+})
+
 
 # Universal names ----------------------------------------------------------
 

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -143,6 +143,13 @@ test_that("unique_names() handles unnamed vectors", {
   expect_identical(unique_names(1:3), c("...1", "...2", "...3"))
 })
 
+test_that("as_unique_names() is a no-op when no repairs are needed", {
+  x <- c("x", "y")
+  out <- as_unique_names(x)
+  expect_true(is_reference(out, x))
+  expect_identical(out, c("x", "y"))
+})
+
 test_that("as_unique_names() eliminates emptiness and duplication", {
   x <- c("", "x", "y", "x")
   expect_identical(as_unique_names(x), c("...1", "x...2", "y", "x...4"))

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -139,6 +139,10 @@ test_that("as_minimal_names() copies on write", {
 
 # unique names -------------------------------------------------------------
 
+test_that("unique_names() handles unnamed vectors", {
+  expect_identical(unique_names(1:3), c("...1", "...2", "...3"))
+})
+
 test_that("as_unique_names() eliminates emptiness and duplication", {
   x <- c("", "x", "y", "x")
   expect_identical(as_unique_names(x), c("...1", "x...2", "y", "x...4"))


### PR DESCRIPTION
Expects #309.

* Export dictionary declarations to `dictionary.h` so we can detect duplicates in other files.

* New `sexp_cow` structure that wraps a `SEXP` and a `PROTECT_INDEX`. With this, an object protected from up high can be duplicated only if necessary. Used in names repair to avoid duplicating names vector if no repairs are needed.

* `repair = "unique"` is now implemented in C.

```r
old <- tibble:::unique_names
new <- vctrs::as_unique_names

bench::mark(
  old = old(letters),
  new = new(letters)
)[1:6]
#>   expression      min     mean   median      max `itr/sec`
#>   <chr>      <bch:tm> <bch:tm> <bch:tm> <bch:tm>     <dbl>
#> 1 old        155.94µs 183.04µs 174.42µs  405.1µs     5463.
#> 2 new          4.71µs   5.57µs   5.14µs   95.8µs   179546.

dups <- rep_along(letters, "")
bench::mark(
  old = old(dups, quiet = TRUE),
  new = new(dups, quiet = TRUE)
)[1:6]
#>   expression      min     mean   median      max `itr/sec`
#>   <chr>      <bch:tm> <bch:tm> <bch:tm> <bch:tm>     <dbl>
#> 1 old        120.42µs 141.11µs 134.38µs    371µs     7087.
#> 2 new          6.64µs   8.16µs   7.24µs     51µs   122471.


long <- as.character(seq(1:1000))

bench::mark(
  old = old(long),
  new = new(long)
)[1:6]
#>   expression      min     mean   median      max `itr/sec`
#>   <chr>      <bch:tm> <bch:tm> <bch:tm> <bch:tm>     <dbl>
#> 1 old          1.03ms   1.25ms   1.19ms   1.99ms      802.
#> 2 new         95.19µs 106.35µs  98.41µs  291.5µs     9403.


long_dups <- rep_len("", 1000)

bench::mark(
  old = old(long_dups, quiet = TRUE),
  new = new(long_dups, quiet = TRUE)
)[1:6]
#>   expression      min     mean   median      max `itr/sec`
#>   <chr>      <bch:tm> <bch:tm> <bch:tm> <bch:tm>     <dbl>
#> 1 old          1.22ms   1.34ms   1.31ms   2.11ms      748.
#> 2 new        219.35µs 234.38µs 220.91µs 510.17µs     4267.
```

cc @jennybc @krlmlr 