### PR TITLE
Fix fallback to `[`

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -16,17 +16,16 @@
 #'
 #' @section Genericity:
 #'
-#' * If the input is a class instance, `vec_slice()` falls back to the
-#'   base generic `[`. Note that S3 lists are treated as scalars by
-#'   default, and will cause an error if they don't implement a
-#'   [vec_proxy()] method.
+#' Support for S3 objects depends on whether the object implements a
+#' [vec_proxy()] method.
 #'
-#' * The vctrs class methods for `[` call back into `vec_slice()`.
-#'   They slice the [vec_proxy()] and [vec_restore()] the result.
+#' * When a `vec_proxy()` method exists, the proxy is sliced and
+#'   `vec_restore()` is called on the result.
 #'
-#'   The tools for calling back into `vec_slice()` are not exported
-#'   yet, but you can take advantage of this mechanism by inheriting
-#'   from [vctrs_vctr][new_vctr] or [vctrs_rcrd][new_rcrd].
+#' * Otherwise `vec_slice()` falls back to the base generic `[`.
+#'
+#' Note that S3 lists are treated as scalars by default, and will
+#' cause an error if they don't implement a [vec_proxy()] method.
 #'
 #' @section Differences with base R subsetting:
 #'
@@ -77,7 +76,7 @@
 #' # vector:
 #' try(vec_slice(x, 2) <- "20")
 vec_slice <- function(x, i) {
-  .Call(vctrs_slice, x, i, FALSE)
+  .Call(vctrs_slice, x, i)
 }
 
 # Called when `x` has dimensions
@@ -94,11 +93,6 @@ vec_slice_fallback <- function(x, i) {
   }
 
   vec_restore(out, x)
-}
-
-# No dispatch on `[`, should be called in `[` methods
-vec_slice_native <- function(x, i) {
-  .Call(vctrs_slice, x, i, TRUE)
 }
 
 #' @export
@@ -139,7 +133,7 @@ vec_index <- function(x, i, ...) {
   i <- maybe_missing(i, TRUE)
 
   if (!dots_n(...)) {
-    return(vec_slice_native(x, i))
+    return(vec_slice(x, i))
   }
 
   out <- unclass(vec_proxy(x))

--- a/man/vec_slice.Rd
+++ b/man/vec_slice.Rd
@@ -31,18 +31,17 @@ that matches \code{\link[=vec_size]{vec_size()}} instead of \code{length()}.
 }
 \section{Genericity}{
 
-\itemize{
-\item If the input is a class instance, \code{vec_slice()} falls back to the
-base generic \code{[}. Note that S3 lists are treated as scalars by
-default, and will cause an error if they don't implement a
-\code{\link[=vec_proxy]{vec_proxy()}} method.
-\item The vctrs class methods for \code{[} call back into \code{vec_slice()}.
-They slice the \code{\link[=vec_proxy]{vec_proxy()}} and \code{\link[=vec_restore]{vec_restore()}} the result.
 
-The tools for calling back into \code{vec_slice()} are not exported
-yet, but you can take advantage of this mechanism by inheriting
-from \link[=new_vctr]{vctrs_vctr} or \link[=new_rcrd]{vctrs_rcrd}.
+Support for S3 objects depends on whether the object implements a
+\code{\link[=vec_proxy]{vec_proxy()}} method.
+\itemize{
+\item When a \code{vec_proxy()} method exists, the proxy is sliced and
+\code{vec_restore()} is called on the result.
+\item Otherwise \code{vec_slice()} falls back to the base generic \code{[}.
 }
+
+Note that S3 lists are treated as scalars by default, and will
+cause an error if they don't implement a \code{\link[=vec_proxy]{vec_proxy()}} method.
 }
 
 \section{Differences with base R subsetting}{

--- a/src/data.c
+++ b/src/data.c
@@ -22,7 +22,7 @@ SEXP vec_proxy(SEXP x) {
 }
 // [[ include("vctrs.h") ]]
 SEXP vec_proxy_method(SEXP x) {
-  return s3_method(x, "vec_proxy");
+  return s3_find_method(x, "vec_proxy");
 }
 // [[ include("vctrs.h") ]]
 SEXP vec_proxy_invoke(SEXP x, SEXP method) {

--- a/src/data.c
+++ b/src/data.c
@@ -22,7 +22,7 @@ SEXP vec_proxy(SEXP x) {
 }
 // [[ include("vctrs.h") ]]
 SEXP vec_proxy_method(SEXP x) {
-  return s3_find_method(x, "vec_proxy");
+  return s3_find_method("vec_proxy", x);
 }
 // [[ include("vctrs.h") ]]
 SEXP vec_proxy_invoke(SEXP x, SEXP method) {

--- a/src/data.c
+++ b/src/data.c
@@ -2,6 +2,7 @@
 #include "utils.h"
 
 // Initialised at load time
+SEXP syms_vec_proxy = NULL;
 SEXP syms_vec_proxy_dispatch = NULL;
 SEXP fns_vec_proxy_dispatch = NULL;
 
@@ -11,7 +12,7 @@ static SEXP vec_proxy_dispatch(SEXP x) {
                          syms_x, x);
 }
 
-// [[register]]
+// [[ register(); include("vctrs.h") ]]
 SEXP vec_proxy(SEXP x) {
   if (vec_typeof(x) == vctrs_type_s3) {
     return vec_proxy_dispatch(x);
@@ -19,9 +20,20 @@ SEXP vec_proxy(SEXP x) {
     return x;
   }
 }
+// [[ include("vctrs.h") ]]
+SEXP vec_proxy_method(SEXP x) {
+  return s3_method(x, "vec_proxy");
+}
+// [[ include("vctrs.h") ]]
+SEXP vec_proxy_invoke(SEXP x, SEXP method) {
+  return vctrs_dispatch1(syms_vec_proxy, method,
+                         syms_x, x);
+}
 
 
 void vctrs_init_data(SEXP ns) {
+  syms_vec_proxy = Rf_install("vec_proxy");
+
   syms_vec_proxy_dispatch = Rf_install("vec_proxy_dispatch");
   fns_vec_proxy_dispatch = Rf_findVar(syms_vec_proxy_dispatch, ns);
 }

--- a/src/init.c
+++ b/src/init.c
@@ -37,7 +37,7 @@ extern SEXP vctrs_type2(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_typeof2(SEXP, SEXP);
 extern SEXP vec_cast(SEXP, SEXP);
 extern SEXP vec_as_index(SEXP, SEXP);
-extern SEXP vctrs_slice(SEXP, SEXP, SEXP);
+extern SEXP vctrs_slice(SEXP, SEXP);
 extern SEXP vec_restore(SEXP, SEXP, SEXP);
 extern SEXP vctrs_restore_default(SEXP, SEXP);
 extern SEXP vec_proxy(SEXP);
@@ -79,7 +79,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_typeof2",                    (DL_FUNC) &vctrs_typeof2, 2},
   {"vctrs_cast",                       (DL_FUNC) &vec_cast, 2},
   {"vctrs_as_index",                   (DL_FUNC) &vec_as_index, 2},
-  {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 3},
+  {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 2},
   {"vctrs_restore",                    (DL_FUNC) &vec_restore, 3},
   {"vctrs_restore_default",            (DL_FUNC) &vctrs_restore_default, 2},
   {"vctrs_proxy",                      (DL_FUNC) &vec_proxy, 1},

--- a/src/utils.c
+++ b/src/utils.c
@@ -480,7 +480,14 @@ bool r_has_name_at(SEXP names, R_len_t i) {
 }
 
 SEXP r_env_get(SEXP env, SEXP sym) {
-  return Rf_findVarInFrame3(env, sym, FALSE);
+  SEXP obj = Rf_findVarInFrame3(env, sym, FALSE);
+
+  // Force lazy loaded bindings
+  if (TYPEOF(obj) == PROMSXP) {
+    obj = Rf_eval(obj, R_BaseEnv);
+  }
+
+  return obj;
 }
 
 bool r_is_function(SEXP x) {
@@ -512,7 +519,7 @@ SEXP fns_quote = NULL;
 
 void vctrs_init_utils(SEXP ns) {
   vctrs_ns_env = ns;
-  vctrs_method_table = Rf_findVar(Rf_install(".__S3MethodsTable__."), ns);
+  vctrs_method_table = r_env_get(ns, Rf_install(".__S3MethodsTable__."));
 
   vctrs_shared_empty_str = Rf_mkString("");
   R_PreserveObject(vctrs_shared_empty_str);

--- a/src/utils.c
+++ b/src/utils.c
@@ -197,7 +197,7 @@ inline void never_reached(const char* fn) {
 
 static char s3_buf[200];
 
-static SEXP s3_sym(const char* generic, const char* class) {
+static SEXP s3_method_sym(const char* generic, const char* class) {
   int gen_len = strlen(generic);
   int class_len = strlen(class);
   int dot_len = 1;
@@ -216,8 +216,8 @@ static SEXP s3_sym(const char* generic, const char* class) {
 }
 
 // First check in global env, then in method table
-static SEXP get_s3_method(const char* generic, const char* class) {
-  SEXP sym = s3_sym(generic, class);
+static SEXP s3_get_method(const char* generic, const char* class) {
+  SEXP sym = s3_method_sym(generic, class);
 
   SEXP method = r_env_get(R_GlobalEnv, sym);
   if (r_is_function(method)) {
@@ -232,7 +232,7 @@ static SEXP get_s3_method(const char* generic, const char* class) {
   return R_NilValue;
 }
 
-SEXP s3_method(SEXP x, const char* generic) {
+SEXP s3_find_method(SEXP x, const char* generic) {
   if (!OBJECT(x)) {
     return R_NilValue;
   }
@@ -242,7 +242,7 @@ SEXP s3_method(SEXP x, const char* generic) {
   int n_class = Rf_length(class);
 
   for (int i = 0; i < n_class; ++i, ++class_ptr) {
-    SEXP method = get_s3_method(generic, CHAR(*class_ptr));
+    SEXP method = s3_get_method(generic, CHAR(*class_ptr));
     if (method != R_NilValue) {
       UNPROTECT(1);
       return method;

--- a/src/utils.c
+++ b/src/utils.c
@@ -232,7 +232,7 @@ static SEXP s3_get_method(const char* generic, const char* class) {
   return R_NilValue;
 }
 
-SEXP s3_find_method(SEXP x, const char* generic) {
+SEXP s3_find_method(const char* generic, SEXP x) {
   if (!OBJECT(x)) {
     return R_NilValue;
   }

--- a/src/utils.c
+++ b/src/utils.c
@@ -8,6 +8,7 @@ bool (*rlang_is_splice_box)(SEXP) = NULL;
 SEXP (*rlang_unbox)(SEXP) = NULL;
 SEXP (*rlang_env_dots_values)(SEXP) = NULL;
 SEXP (*rlang_env_dots_list)(SEXP) = NULL;
+SEXP vctrs_method_table = NULL;
 
 SEXP strings_tbl = NULL;
 SEXP strings_tbl_df = NULL;
@@ -191,6 +192,65 @@ static bool is_data_frame_class(SEXP class) {
 
 inline void never_reached(const char* fn) {
   Rf_error("Internal error in `%s()`: Never reached", fn);
+}
+
+
+static char s3_buf[200];
+
+static SEXP s3_sym(const char* generic, const char* class) {
+  int gen_len = strlen(generic);
+  int class_len = strlen(class);
+  int dot_len = 1;
+  if (gen_len + class_len + dot_len >= 200) {
+    Rf_error("Internal error: Generic or class name is too long.");
+  }
+
+  char* buf = s3_buf;
+
+  memcpy(buf, generic, gen_len); buf += gen_len;
+  *buf = '.'; ++buf;
+  memcpy(buf, class, class_len); buf += class_len;
+  *buf = '\0';
+
+  return Rf_install(s3_buf);
+}
+
+// First check in global env, then in method table
+static SEXP get_s3_method(const char* generic, const char* class) {
+  SEXP sym = s3_sym(generic, class);
+
+  SEXP method = r_env_get(R_GlobalEnv, sym);
+  if (r_is_function(method)) {
+    return method;
+  }
+
+  method = r_env_get(vctrs_method_table, sym);
+  if (r_is_function(method)) {
+    return method;
+  }
+
+  return R_NilValue;
+}
+
+SEXP s3_method(SEXP x, const char* generic) {
+  if (!OBJECT(x)) {
+    return R_NilValue;
+  }
+
+  SEXP class = PROTECT(Rf_getAttrib(x, R_ClassSymbol));
+  SEXP* class_ptr = STRING_PTR(class);
+  int n_class = Rf_length(class);
+
+  for (int i = 0; i < n_class; ++i, ++class_ptr) {
+    SEXP method = get_s3_method(generic, CHAR(*class_ptr));
+    if (method != R_NilValue) {
+      UNPROTECT(1);
+      return method;
+    }
+  }
+
+  UNPROTECT(1);
+  return R_NilValue;
 }
 
 
@@ -419,6 +479,21 @@ bool r_has_name_at(SEXP names, R_len_t i) {
   return elt != NA_STRING && elt != Rf_mkChar("");
 }
 
+SEXP r_env_get(SEXP env, SEXP sym) {
+  return Rf_findVarInFrame3(env, sym, FALSE);
+}
+
+bool r_is_function(SEXP x) {
+  switch (TYPEOF(x)) {
+  case CLOSXP:
+  case BUILTINSXP:
+  case SPECIALSXP:
+    return true;
+  default:
+    return false;
+  }
+}
+
 
 SEXP vctrs_ns_env = NULL;
 SEXP vctrs_shared_empty_str = NULL;
@@ -437,6 +512,7 @@ SEXP fns_quote = NULL;
 
 void vctrs_init_utils(SEXP ns) {
   vctrs_ns_env = ns;
+  vctrs_method_table = Rf_findVar(Rf_install(".__S3MethodsTable__."), ns);
 
   vctrs_shared_empty_str = Rf_mkString("");
   R_PreserveObject(vctrs_shared_empty_str);

--- a/src/utils.h
+++ b/src/utils.h
@@ -26,7 +26,7 @@ SEXP vctrs_dispatch3(SEXP fn_sym, SEXP fn,
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP));
 SEXP with_proxy(SEXP x, SEXP (*rec)(SEXP, bool), SEXP i);
 bool is_bare_tibble(SEXP x);
-SEXP s3_method(SEXP x, const char* generic);
+SEXP s3_find_method(SEXP x, const char* generic);
 
 struct vctrs_arg args_empty;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -29,7 +29,7 @@ bool is_bare_tibble(SEXP x);
 
 // Returns S3 method for `generic` suitable for the class of `x`. The
 // inheritance hierarchy is explored except for the default method.
-SEXP s3_find_method(SEXP x, const char* generic);
+SEXP s3_find_method(const char* generic, SEXP x);
 
 struct vctrs_arg args_empty;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -26,6 +26,9 @@ SEXP vctrs_dispatch3(SEXP fn_sym, SEXP fn,
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP));
 SEXP with_proxy(SEXP x, SEXP (*rec)(SEXP, bool), SEXP i);
 bool is_bare_tibble(SEXP x);
+
+// Returns S3 method for `generic` suitable for the class of `x`. The
+// inheritance hierarchy is explored except for the default method.
 SEXP s3_find_method(SEXP x, const char* generic);
 
 struct vctrs_arg args_empty;

--- a/src/utils.h
+++ b/src/utils.h
@@ -26,6 +26,7 @@ SEXP vctrs_dispatch3(SEXP fn_sym, SEXP fn,
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP));
 SEXP with_proxy(SEXP x, SEXP (*rec)(SEXP, bool), SEXP i);
 bool is_bare_tibble(SEXP x);
+SEXP s3_method(SEXP x, const char* generic);
 
 struct vctrs_arg args_empty;
 
@@ -67,6 +68,8 @@ SEXP r_call(SEXP fn, SEXP* tags, SEXP* cars);
 
 SEXP r_names(SEXP x);
 bool r_has_name_at(SEXP names, R_len_t i);
+SEXP r_env_get(SEXP env, SEXP sym);
+bool r_is_function(SEXP x);
 
 static inline const char* r_chr_get_c_string(SEXP chr, R_len_t i) {
   return CHAR(STRING_ELT(chr, i));

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -140,6 +140,8 @@ bool vec_is_unspecified(SEXP x);
 #include "arg.h"
 
 SEXP vec_proxy(SEXP x);
+SEXP vec_proxy_method(SEXP x);
+SEXP vec_proxy_invoke(SEXP x, SEXP method);
 R_len_t vec_size(SEXP x);
 SEXP vec_cast(SEXP x, SEXP to);
 SEXP vec_slice(SEXP x, SEXP index);

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -151,7 +151,7 @@ test_that("assertion is not applied on proxy", {
   scoped_global_bindings(
     vec_proxy.vctrs_foobar = unclass,
     vec_restore.vctrs_foobar = function(x, ...) foobar(x),
-    `[.vctrs_foobar` = function(x, i) vec_slice_native(x, i)
+    `[.vctrs_foobar` = function(x, i) vec_slice(x, i)
   )
   x <- foobar(list())
 

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -265,16 +265,14 @@ test_that("vec_slice() falls back to `[` with S3 objects", {
   scoped_global_bindings(
     vec_proxy.vctrs_foobar = function(x) unclass(x)
   )
-  expect_identical(vec_slice(foobar(list(NA)), 1), "dispatched")
+  expect_identical(vec_slice(foobar(list(NA)), 1), foobar(list(NA)))
 })
 
 test_that("vec_slice() doesn't call vec_restore() with S3 objects", {
   scoped_global_bindings(
-    vec_proxy.vctrs_foobar = function(x) unclass(x),
-    vec_restore.vctrs_foobar = function(x, to) stop("not called")
+    vec_restore.vctrs_foobar = function(...) stop("not called")
   )
   expect_error(vec_slice(foobar(NA), 1), NA)
-  expect_error(vec_slice(foobar(list(NA)), 1), NA)
 })
 
 test_that("can vec_slice() without inflooping when restore calls math generics", {

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -184,20 +184,21 @@ test_that("can `vec_slice()` records", {
   expect_size(out, 2)
 })
 
-test_that("vec_restore() is called after bare slicing", {
+test_that("vec_restore() is called after proxied slicing", {
   scoped_global_bindings(
+    vec_proxy.vctrs_foobar = identity,
     vec_restore.vctrs_foobar = function(x, to, ..., i) "dispatch"
   )
-  expect_identical(vec_slice_native(foobar(1:3), 2), "dispatch")
+  expect_identical(vec_slice(foobar(1:3), 2), "dispatch")
 })
 
-test_that("vec_slice_native() is proxied", {
+test_that("vec_slice() is proxied", {
   scoped_global_bindings(
     vec_restore.vctrs_proxy = function(x, to, ..., i) new_proxy(x),
     vec_proxy.vctrs_proxy = function(x) proxy_deref(x)
   )
 
-  x <- vec_slice_native(new_proxy(1:3), 2:3)
+  x <- vec_slice(new_proxy(1:3), 2:3)
   expect_identical(proxy_deref(x), 2:3)
 })
 
@@ -229,16 +230,17 @@ test_that("can slice shaped objects by name", {
   expect_error(vec_slice(x, "baz"), "non-existing")
 })
 
-test_that("vec_slice_native() unclasses input before calling `vec_restore()`", {
+test_that("vec_slice() unclasses input before calling `vec_restore()`", {
   class <- NULL
   scoped_global_bindings(
+    vec_proxy.vctrs_foobar = identity,
     vec_restore.vctrs_foobar = function(x, ...) class <<- class(x)
   )
 
   x <- foobar(1:4)
   dim(x) <- c(2, 2)
 
-  vec_slice_native(x, 1)
+  vec_slice(x, 1)
   expect_identical(class, "matrix")
 })
 


### PR DESCRIPTION
Currently the call graph looks like this when slicing S3 objects:

`vec_slice()` -> `[` -> `vec_slice_native()` -> `vec_proxy()` -> `vec_slice_impl()`

This PR adds a function to get S3 methods in the vctrs namespace or the global env. This is used to determine wether an object implements `vec_proxy()`, and avoid fallback to `[` in that case. The call graph then looks like:

`vec_slice()` -> `vec_proxy()` -> `vec_slice_impl()`