### PR TITLE
Move back to fct and cpl

### DIFF
--- a/R/ptype-abbr-full.R
+++ b/R/ptype-abbr-full.R
@@ -57,7 +57,7 @@ vec_ptype_abbr.default <- function(x) {
       integer = "int",
       double = "dbl",
       character = "chr",
-      complex = "cplx",
+      complex = "cpl",
       list = "list",
       expression = "expr"
     )

--- a/R/type-factor.R
+++ b/R/type-factor.R
@@ -43,7 +43,7 @@ vec_ptype_full.factor <- function(x) {
 
 #' @export
 vec_ptype_abbr.factor <- function(x) {
-  "fctr"
+  "fct"
 }
 
 #' @export

--- a/tests/testthat/test-ptype-abbr-full.R
+++ b/tests/testthat/test-ptype-abbr-full.R
@@ -34,10 +34,15 @@ test_that("atomic vectors and arrays as expected", {
   expect_equal(vec_ptype_full(dbl_mat), "double[,3]")
 })
 
+test_that("complex and factor as expected (#323)", {
+  expect_equal(vec_ptype_abbr(0i), "cpl")
+  expect_equal(vec_ptype_abbr(factor()), "fct")
+})
+
 test_that("I() wraps contents", {
   f <- factor()
 
-  expect_equal(vec_ptype_abbr(I(f)), "I<fctr>")
+  expect_equal(vec_ptype_abbr(I(f)), "I<fct>")
   expect_equal(vec_ptype_full(I(f)), "I<factor<>>")
 })
 

--- a/tests/testthat/test-type-factor.R
+++ b/tests/testthat/test-type-factor.R
@@ -4,7 +4,7 @@ test_that("ptype methods are descriptive", {
   f <- factor()
   o <- ordered(character())
 
-  expect_equal(vec_ptype_abbr(f), "fctr")
+  expect_equal(vec_ptype_abbr(f), "fct")
   expect_equal(vec_ptype_abbr(o), "ord")
 
   expect_equal(vec_ptype_full(f), "factor<>")


### PR DESCRIPTION
for consistency with `type_sum()`.

Closes #323.