### PR TITLE
Implement `vec_type2()` data frame methods in C

### DIFF
--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -79,8 +79,8 @@ vec_ptype_abbr.data.frame <- function(x) {
 vec_type2.data.frame <- function(x, y, ...) UseMethod("vec_type2.data.frame", y)
 #' @method vec_type2.data.frame data.frame
 #' @export
-vec_type2.data.frame.data.frame <- function(x, y, ..., x_arg = "", y_arg = "") {
-  df_col_type2(x, y, x_arg, y_arg)
+vec_type2.data.frame.data.frame <- function(x, y, ...) {
+  abort("Never called: Native implementation")
 }
 #' @method vec_type2.data.frame default
 #' @export
@@ -124,36 +124,6 @@ df_length <- function(x) {
   } else {
     0L
   }
-}
-
-df_col_type2 <- function(x, y, x_arg, y_arg) {
-  # Avoid expensive [.data.frame
-  x_raw <- vec_data(vec_type(x))
-  y_raw <- vec_data(vec_type(y))
-
-  # Find types
-  names <- set_partition(names(x), names(y))
-  if (length(names$both) > 0) {
-    both <- names$both
-    x_args <- tag_push(x_arg, "$", both)
-    y_args <- tag_push(y_arg, "$", both)
-    common_types <- pmap(list(x_raw[both], y_raw[both], x_arg = x_args, y_arg = y_args), vec_type2)
-    common_types <- set_names(common_types, both)
-  } else {
-    common_types <- list()
-  }
-  only_x_types <- x_raw[names$only_x]
-  only_y_types <- y_raw[names$only_y]
-
-  # Combine and restore order and type
-  out <- c(common_types, only_x_types, only_y_types)
-  out <- out[c(names(x), names$only_y)]
-
-  if (length(out) == 0) {
-    names(out) <- character()
-  }
-
-  vec_restore(out, x)
 }
 
 df_col_cast <- function(x, to) {

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -79,7 +79,9 @@ vec_ptype_abbr.data.frame <- function(x) {
 vec_type2.data.frame <- function(x, y, ...) UseMethod("vec_type2.data.frame", y)
 #' @method vec_type2.data.frame data.frame
 #' @export
-vec_type2.data.frame.data.frame <- function(x, y, ...) df_col_type2(x, y, ...)
+vec_type2.data.frame.data.frame <- function(x, y, ..., x_arg = "", y_arg = "") {
+  df_col_type2(x, y, x_arg, y_arg)
+}
 #' @method vec_type2.data.frame default
 #' @export
 vec_type2.data.frame.default <- function(x, y, ..., x_arg = "", y_arg = "") {
@@ -124,7 +126,7 @@ df_length <- function(x) {
   }
 }
 
-df_col_type2 <- function(x, y, ..., x_arg = "", y_arg = "") {
+df_col_type2 <- function(x, y, x_arg, y_arg) {
   # Avoid expensive [.data.frame
   x_raw <- vec_data(vec_type(x))
   y_raw <- vec_data(vec_type(y))

--- a/R/type-tibble.R
+++ b/R/type-tibble.R
@@ -8,14 +8,13 @@ vec_type2.tbl_df <- function(x, y, ...) UseMethod("vec_type2.tbl_df", y)
 
 #' @method vec_type2.tbl_df data.frame
 #' @export
-vec_type2.tbl_df.data.frame <- function(x, y, ..., x_arg = "", y_arg = "") {
-  df_col_type2(x, y, x_arg, y_arg)
+vec_type2.tbl_df.data.frame <- function(x, y, ...) {
+  abort("Never called: Native implementation")
 }
-
 #' @method vec_type2.data.frame tbl_df
 #' @export
-vec_type2.data.frame.tbl_df <- function(x, y, ..., x_arg = "", y_arg = "") {
-  vec_restore(df_col_type2(x, y, x_arg, y_arg), y)
+vec_type2.data.frame.tbl_df <- function(x, y, ...) {
+  abort("Never called: Native implementation")
 }
 
 #' @method vec_type2.tbl_df default

--- a/R/type-tibble.R
+++ b/R/type-tibble.R
@@ -8,11 +8,15 @@ vec_type2.tbl_df <- function(x, y, ...) UseMethod("vec_type2.tbl_df", y)
 
 #' @method vec_type2.tbl_df data.frame
 #' @export
-vec_type2.tbl_df.data.frame <- function(x, y, ...) df_col_type2(x, y, ...)
+vec_type2.tbl_df.data.frame <- function(x, y, ..., x_arg = "", y_arg = "") {
+  df_col_type2(x, y, x_arg, y_arg)
+}
 
 #' @method vec_type2.data.frame tbl_df
 #' @export
-vec_type2.data.frame.tbl_df <- function(x, y, ...) vec_restore(df_col_type2(x, y, ...), y)
+vec_type2.data.frame.tbl_df <- function(x, y, ..., x_arg = "", y_arg = "") {
+  vec_restore(df_col_type2(x, y, x_arg, y_arg), y)
+}
 
 #' @method vec_type2.tbl_df default
 #' @export

--- a/src/arg.h
+++ b/src/arg.h
@@ -55,6 +55,8 @@ struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
                                          R_len_t* i,
                                          SEXP* names,
                                          R_len_t* names_i);
+struct vctrs_arg_wrapper new_index_arg(struct vctrs_arg* parent,
+                                       const char* arg);
 
 /**
  * Materialise an argument tag. Returns a CHARSXP.

--- a/src/type2.c
+++ b/src/type2.c
@@ -160,8 +160,8 @@ SEXP df_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) 
     }
   }
 
-  if ((is_tibble(x) && is_native_df(y)) ||
-      (is_tibble(y) && is_native_df(x))) {
+  if ((is_bare_tibble(x) && is_native_df(y)) ||
+      (is_bare_tibble(y) && is_native_df(x))) {
     init_tibble(out, 0);
   } else {
     init_data_frame(out, 0);

--- a/src/type2.c
+++ b/src/type2.c
@@ -23,6 +23,9 @@ static SEXP vctrs_type2_dispatch(SEXP x,
   return out;
 }
 
+
+static SEXP df_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
+
 // [[ include("vctrs.h") ]]
 SEXP vec_type2(SEXP x, SEXP y,
                struct vctrs_arg* x_arg,
@@ -84,10 +87,90 @@ SEXP vec_type2(SEXP x, SEXP y,
   case vctrs_type2_list_list:
     return vctrs_shared_empty_list;
 
+  case vctrs_type2_dataframe_dataframe:
+    return df_type2(x, y, x_arg, y_arg);
+
   default:
     return vctrs_type2_dispatch(x, y, x_arg, y_arg);
   }
 }
+
+
+// From dictionary.c
+SEXP vctrs_match(SEXP needles, SEXP haystack);
+
+SEXP df_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) {
+  SEXP x_names = PROTECT(r_names(x));
+  SEXP y_names = PROTECT(r_names(y));
+
+  SEXP x_dups_pos = PROTECT(vctrs_match(x_names, y_names));
+  SEXP y_dups_pos = PROTECT(vctrs_match(y_names, x_names));
+
+  int* x_dups_pos_data = INTEGER(x_dups_pos);
+  int* y_dups_pos_data = INTEGER(y_dups_pos);
+
+  R_len_t x_len = Rf_length(x_dups_pos);
+  R_len_t y_len = Rf_length(y_dups_pos);
+
+  // Count columns that are only in `y`
+  R_len_t rest_len = 0;
+  for (R_len_t i = 0; i < y_len; ++i) {
+    if (y_dups_pos_data[i] == NA_INTEGER) {
+      ++rest_len;
+    }
+  }
+
+  R_len_t out_len = x_len + rest_len;
+  SEXP out = PROTECT(Rf_allocVector(VECSXP, out_len));
+  SEXP nms = PROTECT(Rf_allocVector(STRSXP, out_len));
+  Rf_setAttrib(out, R_NamesSymbol, nms);
+
+  R_len_t i = 0;
+
+  // Fill in prototypes of all the columns that are in `x`, in order
+  for (; i < x_len; ++i) {
+    R_len_t dup = x_dups_pos_data[i];
+
+    SEXP type;
+    if (dup == NA_INTEGER) {
+      type = vec_type(VECTOR_ELT(x, i));
+    } else {
+      --dup; // 1-based index
+      struct vctrs_arg_wrapper named_x_arg = new_index_arg(x_arg, r_chr_get_c_string(x_names, i));
+      struct vctrs_arg_wrapper named_y_arg = new_index_arg(y_arg, r_chr_get_c_string(y_names, dup));
+      int _left;
+      type = vec_type2(VECTOR_ELT(x, i),
+                       VECTOR_ELT(y, dup),
+                       (struct vctrs_arg*) &named_x_arg,
+                       (struct vctrs_arg*) &named_y_arg,
+                       &_left);
+    }
+
+    SET_VECTOR_ELT(out, i, type);
+    SET_STRING_ELT(nms, i, STRING_ELT(x_names, i));
+  }
+
+  // Fill in prototypes of the columns that are only in `y`
+  for (R_len_t j = 0; i < out_len; ++j) {
+    R_len_t dup = y_dups_pos_data[j];
+    if (dup == NA_INTEGER) {
+      SET_VECTOR_ELT(out, i, vec_type(VECTOR_ELT(y, j)));
+      SET_STRING_ELT(nms, i, STRING_ELT(y_names, j));
+      ++i;
+    }
+  }
+
+  if ((is_tibble(x) && is_native_df(y)) ||
+      (is_tibble(y) && is_native_df(x))) {
+    init_tibble(out, 0);
+  } else {
+    init_data_frame(out, 0);
+  }
+
+  UNPROTECT(6);
+  return out;
+}
+
 
 // [[ register() ]]
 SEXP vctrs_type2(SEXP x, SEXP y, SEXP x_arg, SEXP y_arg) {

--- a/src/type2.c
+++ b/src/type2.c
@@ -91,15 +91,10 @@ SEXP vec_type2(SEXP x, SEXP y,
 
 // [[ register() ]]
 SEXP vctrs_type2(SEXP x, SEXP y, SEXP x_arg, SEXP y_arg) {
-  if (x_arg == R_NilValue) {
-    x_arg = vctrs_shared_empty_str;
-  } else if (!r_is_string(x_arg)) {
+  if (!r_is_string(x_arg)) {
     Rf_errorcall(R_NilValue, "`x_arg` must be a string");
   }
-
-  if (y_arg == R_NilValue) {
-    y_arg = vctrs_shared_empty_str;
-  } else if (!r_is_string(y_arg)) {
+  if (!r_is_string(y_arg)) {
     Rf_errorcall(R_NilValue, "`y_arg` must be a string");
   }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -148,7 +148,7 @@ static SEXP new_compact_rownames(R_len_t n) {
 static bool is_tibble_class(SEXP class);
 static bool is_data_frame_class(SEXP class);
 
-bool is_tibble(SEXP x) {
+bool is_bare_tibble(SEXP x) {
   SEXP class = PROTECT(Rf_getAttrib(x, R_ClassSymbol));
   bool out = is_tibble_class(class);
   UNPROTECT(1);

--- a/src/utils.h
+++ b/src/utils.h
@@ -25,7 +25,7 @@ SEXP vctrs_dispatch3(SEXP fn_sym, SEXP fn,
 
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP));
 SEXP with_proxy(SEXP x, SEXP (*rec)(SEXP, bool), SEXP i);
-bool is_tibble(SEXP x);
+bool is_bare_tibble(SEXP x);
 
 struct vctrs_arg args_empty;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -25,6 +25,7 @@ SEXP vctrs_dispatch3(SEXP fn_sym, SEXP fn,
 
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP));
 SEXP with_proxy(SEXP x, SEXP (*rec)(SEXP, bool), SEXP i);
+bool is_tibble(SEXP x);
 
 struct vctrs_arg args_empty;
 
@@ -34,6 +35,9 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x, enum vctrs_type type_y
 
 bool is_compact_rownames(SEXP x);
 R_len_t compact_rownames_length(SEXP x);
+void init_data_frame(SEXP x, R_len_t n);
+void init_tibble(SEXP x, R_len_t n);
+bool is_native_df(SEXP x);
 
 bool (*rlang_is_splice_box)(SEXP);
 SEXP (*rlang_unbox)(SEXP);
@@ -56,6 +60,7 @@ SEXP r_protect(SEXP x);
 bool r_is_true(SEXP x);
 bool r_is_string(SEXP x);
 SEXP r_peek_option(const char* option);
+SEXP r_names(SEXP x);
 
 SEXP r_pairlist(SEXP* tags, SEXP* cars);
 SEXP r_call(SEXP fn, SEXP* tags, SEXP* cars);
@@ -88,6 +93,8 @@ static inline double r_dbl_get(SEXP x, R_len_t i) {
 
 extern SEXP vctrs_ns_env;
 extern SEXP vctrs_shared_empty_str;
+
+extern SEXP classes_data_frame;
 
 extern SEXP syms_i;
 extern SEXP syms_x;


### PR DESCRIPTION
```r
df1 <- tibble(x = tibble(y = tibble(z = 1)))
df2 <- tibble(x = tibble(y = tibble(Z = "a")))

bench::mark(
  before = vec_type_common_before(df1, df2),
  after = vec_type_common(df1, df2)
)[1:6]
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 before        379µs    412µs     2342.    88.9KB     26.9
#> 2 after        11.1µs   13.3µs    72223.        0B     21.7

bench::mark(
  before = vec_type_common_before(df1, df2, df1),
  after = vec_type_common(df1, df2, df1)
)[1:6]
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 before        877µs    971µs      980.        0B     13.3
#> 2 after        15.2µs   18.4µs    50660.        0B     15.2
```

type2.c

* Implements `df_type2()` in C. Partitions the columns of the two data frames by calling `vec_match()` twice.

* Tibbles are special-cased so we don't need to add them to our type enums.

arg.c:

* New `struct vctrs_arg` derived from `struct vctrs_arg_wrapper`. It adds a `$` prefix to the argument tag, but only if there's no parent tag so it looks like `x$y$z` instead of `$x$y$z` (only a problem for `vec_type2()` since `vec_type_common()` leads with the position/name of dots).

utils.c:

* Predicates for data frames and tibbles that compare the class elements to cached strings.
* Constructors `init_data_frame()` and `init_tibble()`.