### PR TITLE
Implement `vec_cast()` method for tibble in C

### DIFF
--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -126,25 +126,8 @@ df_length <- function(x) {
   }
 }
 
-df_col_cast <- function(x, to) {
-  # Avoid expensive [.data.frame method
-  out <- vec_data(x)
-
-  # Coerce common columns
-  common <- intersect(names(x), names(to))
-  out[common] <- map2(out[common], to[common], vec_cast)
-
-  # Add new columns
-  from_type <- setdiff(names(to), names(x))
-  out[from_type] <- map(to[from_type], vec_na, n = vec_size(x))
-
-  # Drop extra columns
-  out <- out[names(to)]
+df_lossy_cast <- function(out, x, to) {
   extra <- setdiff(names(x), names(to))
-
-  # Casting doesn't affect number of rows
-  attr(out, "row.names") <- attr(x, "row.names")
-  out <- vec_restore(out, to)
 
   maybe_lossy_cast(
     result = out,

--- a/src/slice.c
+++ b/src/slice.c
@@ -221,6 +221,19 @@ SEXP vec_slice(SEXP x, SEXP index) {
   return vctrs_slice(x, index);
 }
 
+// [[ include("vctrs.h") ]]
+SEXP vec_na(SEXP x, R_len_t n) {
+  // FIXME: Use ALTREP to avoid allocation of index vector
+  SEXP i = PROTECT(Rf_allocVector(INTSXP, n));
+  r_int_fill(i, NA_INTEGER);
+
+  SEXP out = vec_slice_impl(x, i, x, true);
+
+  UNPROTECT(1);
+  return out;
+}
+
+
 static SEXP int_invert_index(SEXP index, SEXP x);
 static SEXP int_filter_zero(SEXP index, R_len_t x);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -525,6 +525,7 @@ SEXP syms_dots = NULL;
 SEXP syms_bracket = NULL;
 SEXP syms_x_arg = NULL;
 SEXP syms_y_arg = NULL;
+SEXP syms_out = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -577,6 +578,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_bracket = Rf_install("[");
   syms_x_arg = Rf_install("x_arg");
   syms_y_arg = Rf_install("y_arg");
+  syms_out = Rf_install("out");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.h
+++ b/src/utils.h
@@ -114,6 +114,8 @@ extern SEXP syms_dots;
 extern SEXP syms_bracket;
 extern SEXP syms_x_arg;
 extern SEXP syms_y_arg;
+extern SEXP syms_out;
+
 #define syms_names R_NamesSymbol
 
 extern SEXP fns_bracket;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -146,6 +146,7 @@ R_len_t vec_size(SEXP x);
 R_len_t vec_dim(SEXP x);
 SEXP vec_cast(SEXP x, SEXP to);
 SEXP vec_slice(SEXP x, SEXP index);
+SEXP vec_na(SEXP x, R_len_t n);
 SEXP vec_restore(SEXP x, SEXP to, SEXP i);
 SEXP vec_type(SEXP x);
 SEXP vec_type_finalise(SEXP x);


### PR DESCRIPTION

```r
df1 <- tibble(x = tibble(y = tibble(z = 0)))
df2 <- tibble(x = tibble(y = tibble(z = TRUE)))

bench::mark(
  before = vec_cast_before(df1, df2),
  after = vec_cast(df1, df2)
)[1:6]
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 before        308µs    346µs     2736.    65.1KB     12.7
#> 2 after        16.2µs   19.6µs    46870.        0B     14.1
```