### PR TITLE
Fix `min()` and `max()` methods

### DIFF
--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -422,7 +422,7 @@ min.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
   rank <- xtfrm(x)
 
   idx <- if (isTRUE(na.rm)) {
-    which.max(rank)
+    which.min(rank)
   } else {
     which(vec_equal(rank, min(rank), na_equal = TRUE))
   }

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -421,10 +421,10 @@ min.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
   # TODO: implement to do vec_arg_min()
   rank <- xtfrm(x)
 
-  idx <- if (isTRUE(na.rm)) {
-    which.min(rank)
+  if (isTRUE(na.rm)) {
+    idx <- which.min(rank)
   } else {
-    which(vec_equal(rank, min(rank), na_equal = TRUE))
+    idx <- which(vec_equal(rank, min(rank), na_equal = TRUE))
   }
 
   x[[idx[[1]]]]
@@ -435,10 +435,10 @@ max.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
   # TODO: implement to do vec_arg_max()
   rank <- xtfrm(x)
 
-  idx <- if (isTRUE(na.rm)) {
-    which.max(rank)
+  if (isTRUE(na.rm)) {
+    idx <- which.max(rank)
   } else {
-    which(vec_equal(rank, max(rank), na_equal = TRUE))
+    idx <- which(vec_equal(rank, max(rank), na_equal = TRUE))
   }
 
   x[[idx[[1]]]]

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -420,7 +420,13 @@ quantile.vctrs_vctr <- function(x, ..., type = 1, na.rm = FALSE) {
 min.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
   # TODO: implement to do vec_arg_min()
   rank <- xtfrm(x)
-  idx <- if (isTRUE(na.rm)) which.max(rank) else which(rank == min(rank))
+
+  idx <- if (isTRUE(na.rm)) {
+    which.max(rank)
+  } else {
+    which(vec_equal(rank, min(rank), na_equal = TRUE))
+  }
+
   x[[idx[[1]]]]
 }
 
@@ -428,7 +434,13 @@ min.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
 max.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
   # TODO: implement to do vec_arg_max()
   rank <- xtfrm(x)
-  idx <- if (isTRUE(na.rm)) which.max(rank) else which(rank == max(rank))
+
+  idx <- if (isTRUE(na.rm)) {
+    which.max(rank)
+  } else {
+    which(vec_equal(rank, max(rank), na_equal = TRUE))
+  }
+
   x[[idx[[1]]]]
 }
 

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -330,14 +330,21 @@ test_that("summaries preserve class", {
 
 test_that("methods using vec_proxy_compare agree with base", {
   h <- new_hidden(c(1:10))
+  h_na <- new_hidden(c(NA, 1:10))
 
-  expect_agree <- function(f, x) {
+  expect_agree <- function(f, x, na.rm = FALSE) {
     f <- enexpr(f)
-    expect_equal(vec_data((!!f)(x)), (!!f)(vec_data(x)))
+    expect_equal(vec_data((!!f)(x, na.rm = na.rm)), (!!f)(vec_data(x), na.rm = na.rm))
   }
 
   expect_agree(min, h)
   expect_agree(max, h)
+
+  expect_agree(min, h_na)
+  expect_agree(max, h_na)
+
+  expect_agree(min, h_na, na.rm = TRUE)
+  expect_agree(max, h_na, na.rm = TRUE)
 })
 
 test_that("can put in data frame", {


### PR DESCRIPTION
`min.vctrs_vctr()` and `max.vctrs_vctr()` have small bugs.

- Both break with missing values when `na.rm = FALSE`
- `min()` is using `which.max()` when `na.rm = TRUE`

``` r
library(vctrs)

x <- c(NA, 1, 2)
x_vctr <- new_vctr(x)

# not working 
min(x)
#> [1] NA
min(x_vctr)
#> Error in idx[[1]]: subscript out of bounds

max(x)
#> [1] NA
max(x_vctr)
#> Error in idx[[1]]: subscript out of bounds

# typo in min.vctrs_vctr()! woops!
min(x, na.rm = TRUE)
#> [1] 1
min(x_vctr, na.rm = TRUE)
#> <vctrs_vctr[1]>
#> [1] 2

# all good here
max(x, na.rm = TRUE)
#> [1] 2
max(x_vctr, na.rm = TRUE)
#> <vctrs_vctr[1]>
#> [1] 2
```

<sup>Created on 2019-05-10 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>

I fixed the error by using `vec_equal(na_equal = TRUE)`. It went past the 80 chr line limit so I took the chance to refactor a bit.