### PR TITLE
Simplify `struct vctrs_arg`

### DIFF
--- a/src/arg-counter.c
+++ b/src/arg-counter.c
@@ -16,8 +16,11 @@ void init_counters(struct counters* counters,
   counters->names_curr = 0;
   counters->names_next = 0;
 
-  counters->curr_counter = new_counter_arg(NULL, &counters->curr, &counters->names, &counters->names_curr);
-  counters->next_counter = new_counter_arg(NULL, &counters->next, &counters->names, &counters->names_next);
+  counters->curr_counter_data = new_counter_arg_data(&counters->curr, &counters->names, &counters->names_curr);
+  counters->next_counter_data = new_counter_arg_data(&counters->next, &counters->names, &counters->names_next);
+
+  counters->curr_counter = new_counter_arg(NULL, (void*) &counters->curr_counter_data);
+  counters->next_counter = new_counter_arg(NULL, (void*) &counters->next_counter_data);
 
   counters->curr_arg = curr_arg;
   counters->next_arg = (struct vctrs_arg*) &counters->next_counter;
@@ -60,9 +63,9 @@ void counters_inc(struct counters* counters) {
  */
 void counters_shift(struct counters* counters) {
   // Swap the counters data
-  SWAP(struct vctrs_arg_counter, counters->curr_counter, counters->next_counter);
-  SWAP(R_len_t*, counters->curr_counter.i, counters->next_counter.i);
-  SWAP(R_len_t*, counters->curr_counter.names_i, counters->next_counter.names_i);
+  SWAP(void*, counters->curr_counter.data, counters->next_counter.data);
+  SWAP(R_len_t*, counters->curr_counter_data.i, counters->next_counter_data.i);
+  SWAP(R_len_t*, counters->curr_counter_data.names_i, counters->next_counter_data.names_i);
 
   // Update the handles to `vctrs_arg`
   counters->curr_arg = (struct vctrs_arg*) &counters->curr_counter;

--- a/src/arg-counter.h
+++ b/src/arg-counter.h
@@ -33,8 +33,10 @@ struct counters {
   struct counters* prev_box_counters;
 
   // Actual counter args are stored here
-  struct vctrs_arg_counter curr_counter;
-  struct vctrs_arg_counter next_counter;
+  struct arg_data_counter curr_counter_data;
+  struct arg_data_counter next_counter_data;
+  struct vctrs_arg curr_counter;
+  struct vctrs_arg next_counter;
 };
 
 /**

--- a/src/arg.h
+++ b/src/arg.h
@@ -10,57 +10,55 @@
  * fail to match a given type. They are generated lazily by the `fill`
  * method in order to avoid any cost when there is no error.
  *
- * `vctrs_arg` is meant to be used with C-style inheritance. It should
- * be stored as the first member of derived structs. See
- * <https://www.python.org/dev/peps/pep-3123/>.
- *
  * @member parent The previously active argument tag.
- * @member fill Takes a pointer to self, which can be cast back to the
- *   original type containing the data, and a buffer to fill. If the
+ * @member fill Takes a pointer to data, and a buffer to fill. If the
  *   buffer is too small according to the `remaining` argument,
  *   `fill()` must return a negative error value.
  */
 struct vctrs_arg {
   struct vctrs_arg* parent;
-  r_ssize_t (*fill)(struct vctrs_arg* self, char* buf, r_ssize_t remaining);
+  r_ssize_t (*fill)(void* data, char* buf, r_ssize_t remaining);
+  void* data;
 };
 
 
-/**
- * Derived classes of `vctrs_arg`.
- *
- * - `vctrs_arg_wrapper` is a simple wrapper around a string.
- * - `vctrs_arg_counter` wraps a counter representing the current
- *   position of the argument.
- */
-struct vctrs_arg_wrapper {
-  struct vctrs_arg iface;
-  const char* arg;
-};
-struct vctrs_arg_counter {
-  struct vctrs_arg iface;
+// Simple wrapper around a string
+struct vctrs_arg new_wrapper_arg(struct vctrs_arg* parent,
+                                 const char* arg);
+
+
+// Wrapper around a counter representing the current position of the
+// argument
+struct arg_data_counter {
   R_len_t* i;
-  int offset;
   SEXP* names;
   R_len_t* names_i;
 };
 
+struct vctrs_arg new_counter_arg(struct vctrs_arg* parent,
+                                 struct arg_data_counter* data);
 
-/**
- * Constructors for argument wrapper and counters.
- */
-struct vctrs_arg_wrapper new_wrapper_arg(struct vctrs_arg* parent,
-                                         const char* arg);
-struct vctrs_arg_counter new_counter_arg(struct vctrs_arg* parent,
-                                         R_len_t* i,
-                                         SEXP* names,
-                                         R_len_t* names_i);
-struct vctrs_arg_wrapper new_index_arg(struct vctrs_arg* parent,
-                                       const char* arg);
+struct arg_data_counter new_counter_arg_data(R_len_t* i,
+                                             SEXP* names,
+                                             R_len_t* names_i);
 
-/**
- * Materialise an argument tag. Returns a CHARSXP.
- */
+
+// Wrapper around a string that should be prefixed with `$`, unless
+// that's the first argument of the chain
+
+struct arg_data_index {
+  const char* arg;
+  struct vctrs_arg* parent;
+};
+
+struct vctrs_arg new_index_arg(struct vctrs_arg* parent,
+                               struct arg_data_index* data);
+
+struct arg_data_index new_index_arg_data(const char* arg,
+                                         struct vctrs_arg* parent);
+
+
+// Materialise an argument tag as a CHARSXP.
 SEXP vctrs_arg(struct vctrs_arg* arg);
 
 

--- a/src/cast.c
+++ b/src/cast.c
@@ -488,10 +488,10 @@ SEXP vctrs_coercible_cast(SEXP x, SEXP to, SEXP x_arg_, SEXP to_arg_) {
     Rf_errorcall(R_NilValue, "`to_arg` must be a string");
   }
 
-  struct vctrs_arg_wrapper x_arg = new_wrapper_arg(NULL, r_chr_get_c_string(x_arg_, 0));
-  struct vctrs_arg_wrapper to_arg = new_wrapper_arg(NULL, r_chr_get_c_string(to_arg_, 0));
+  struct vctrs_arg x_arg = new_wrapper_arg(NULL, r_chr_get_c_string(x_arg_, 0));
+  struct vctrs_arg to_arg = new_wrapper_arg(NULL, r_chr_get_c_string(to_arg_, 0));
 
-  return vec_coercible_cast(x, to, (struct vctrs_arg*) &x_arg, (struct vctrs_arg*) &to_arg);
+  return vec_coercible_cast(x, to, &x_arg, &to_arg);
 }
 
 

--- a/src/size.c
+++ b/src/size.c
@@ -51,8 +51,8 @@ R_len_t vec_size(SEXP x) {
     break;
 
   default: {
-    struct vctrs_arg_wrapper arg = new_wrapper_arg(NULL, "x");
-    stop_scalar_type(x, (struct vctrs_arg*) &arg);
+    struct vctrs_arg arg = new_wrapper_arg(NULL, "x");
+    stop_scalar_type(x, &arg);
   }}
 
   UNPROTECT(nprot);

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -26,14 +26,12 @@ SEXP vec_assign(SEXP x, SEXP index, SEXP value) {
     return R_NilValue;
   }
 
-  struct vctrs_arg_wrapper x_arg = new_wrapper_arg(NULL, "x");
-  struct vctrs_arg_wrapper value_arg = new_wrapper_arg(NULL, "value");
-  vec_assert(x, (struct vctrs_arg*) &x_arg);
+  struct vctrs_arg x_arg = new_wrapper_arg(NULL, "x");
+  struct vctrs_arg value_arg = new_wrapper_arg(NULL, "value");
+  vec_assert(x, &x_arg);
 
   // Take the proxy of the RHS before coercing and recycling
-  value = PROTECT(vec_coercible_cast(value, x,
-                                     (struct vctrs_arg*) &value_arg,
-                                     (struct vctrs_arg*) &x_arg));
+  value = PROTECT(vec_coercible_cast(value, x, &value_arg, &x_arg));
   SEXP value_proxy = PROTECT(vec_proxy(value));
 
   index = PROTECT(vec_as_index(index, x));

--- a/src/type.c
+++ b/src/type.c
@@ -90,11 +90,9 @@ SEXP vctrs_type_common(SEXP call, SEXP op, SEXP args, SEXP env) {
   SEXP types = PROTECT(rlang_env_dots_values(env));
 
   // Start reduction with the `.ptype` argument
-  struct vctrs_arg_wrapper ptype_arg = new_wrapper_arg(NULL, ".ptype");
+  struct vctrs_arg ptype_arg = new_wrapper_arg(NULL, ".ptype");
 
-  SEXP type = PROTECT(reduce(ptype, (struct vctrs_arg*) &ptype_arg,
-                             types,
-                             &vctrs_type2_common));
+  SEXP type = PROTECT(reduce(ptype, &ptype_arg, types, &vctrs_type2_common));
   type = vec_type_finalise(type);
 
   UNPROTECT(3);

--- a/src/type2.c
+++ b/src/type2.c
@@ -136,13 +136,15 @@ SEXP df_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) 
       type = vec_type(VECTOR_ELT(x, i));
     } else {
       --dup; // 1-based index
-      struct vctrs_arg_wrapper named_x_arg = new_index_arg(x_arg, r_chr_get_c_string(x_names, i));
-      struct vctrs_arg_wrapper named_y_arg = new_index_arg(y_arg, r_chr_get_c_string(y_names, dup));
+      struct arg_data_index x_arg_data = new_index_arg_data(r_chr_get_c_string(x_names, i), x_arg);
+      struct arg_data_index y_arg_data = new_index_arg_data(r_chr_get_c_string(y_names, dup), y_arg);
+      struct vctrs_arg named_x_arg = new_index_arg(x_arg, &x_arg_data);
+      struct vctrs_arg named_y_arg = new_index_arg(y_arg, &y_arg_data);
       int _left;
       type = vec_type2(VECTOR_ELT(x, i),
                        VECTOR_ELT(y, dup),
-                       (struct vctrs_arg*) &named_x_arg,
-                       (struct vctrs_arg*) &named_y_arg,
+                       &named_x_arg,
+                       &named_y_arg,
                        &_left);
     }
 
@@ -180,11 +182,11 @@ SEXP vctrs_type2(SEXP x, SEXP y, SEXP x_arg, SEXP y_arg) {
     Rf_errorcall(R_NilValue, "`y_arg` must be a string");
   }
 
-  struct vctrs_arg_wrapper x_arg_ = new_wrapper_arg(NULL, r_chr_get_c_string(x_arg, 0));
-  struct vctrs_arg_wrapper y_arg_ = new_wrapper_arg(NULL, r_chr_get_c_string(y_arg, 0));
+  struct vctrs_arg x_arg_ = new_wrapper_arg(NULL, r_chr_get_c_string(x_arg, 0));
+  struct vctrs_arg y_arg_ = new_wrapper_arg(NULL, r_chr_get_c_string(y_arg, 0));
 
   int _left;
-  return vec_type2(x, y, (struct vctrs_arg*) &x_arg_, (struct vctrs_arg*) &y_arg_, &_left);
+  return vec_type2(x, y, &x_arg_, &y_arg_, &_left);
 }
 
 // [[ register() ]]
@@ -196,10 +198,10 @@ SEXP vctrs_type2_df_df(SEXP x, SEXP y, SEXP x_arg, SEXP y_arg) {
     Rf_errorcall(R_NilValue, "`y_arg` must be a string");
   }
 
-  struct vctrs_arg_wrapper x_arg_ = new_wrapper_arg(NULL, r_chr_get_c_string(x_arg, 0));
-  struct vctrs_arg_wrapper y_arg_ = new_wrapper_arg(NULL, r_chr_get_c_string(y_arg, 0));
+  struct vctrs_arg x_arg_ = new_wrapper_arg(NULL, r_chr_get_c_string(x_arg, 0));
+  struct vctrs_arg y_arg_ = new_wrapper_arg(NULL, r_chr_get_c_string(y_arg, 0));
 
-  return df_type2(x, y, (struct vctrs_arg*) &x_arg_, (struct vctrs_arg*) &y_arg_);
+  return df_type2(x, y, &x_arg_, &y_arg_);
 }
 
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -505,7 +505,7 @@ SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
 SEXP fns_names = NULL;
 
-struct vctrs_arg_wrapper args_empty_;
+struct vctrs_arg args_empty_;
 struct vctrs_arg* args_empty = NULL;
 
 void vctrs_init_utils(SEXP ns) {
@@ -623,7 +623,7 @@ void vctrs_init_utils(SEXP ns) {
   new_env__size_node = CDR(new_env__parent_node);
 
   args_empty_ = new_wrapper_arg(NULL, "");
-  args_empty = (struct vctrs_arg*) &args_empty_;
+  args_empty = &args_empty_;
 
   rlang_is_splice_box = (bool (*)(SEXP)) R_GetCCallable("rlang", "rlang_is_splice_box");
   rlang_unbox = (SEXP (*)(SEXP)) R_GetCCallable("rlang", "rlang_unbox");


### PR DESCRIPTION
- No longer uses C-style inheritance
- `fill()` method now takes `void*` data

This simplifies the call sites because the pointers to structs no longer need to be cast to their parent type. On the other hand the data needs to be explicitly allocated on the stack, for instance with `new_index_arg_data()`.