### PR TITLE
Add `vec_structure()` for use in `new_vctr()`

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -73,11 +73,11 @@ vec_data <- function(x) {
 
   # TODO: implement with ALTREP to avoid making a copy
   if (is_record(x)) {
-    attributes(x) <- list(names = fields(x))
+    x <- vec_set_attributes(x, list(names = fields(x)))
   } else if (has_dim(x)) {
-    attributes(x) <- list(dim = dim(x), dimnames = dimnames(x))
+    x <- vec_set_attributes(x, list(dim = dim(x), dimnames = dimnames(x)))
   } else {
-    attributes(x) <- list(names = names(x))
+    x <- vec_set_attributes(x, list(names = names(x)))
   }
 
   x

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -56,27 +56,11 @@ new_vctr <- function(.data, ..., class = character()) {
   if (!is_vector(.data)) {
     abort("`.data` must be a vector type.")
   }
+
   nms <- validate_names(.data)
+  attrib <- list(names = nms, ..., class = c(class, "vctrs_vctr"))
 
-  restructure(.data, names = nms, ..., class = c(class, "vctrs_vctr"))
-}
-
-restructure <- function(.data, ...) {
-  if (r_version_at_least_3.6.0) {
-    attributes(.data) <- NULL
-    structure(.data, ...)
-  } else {
-    vec_set_attributes(.data, list(...))
-  }
-}
-
-vec_set_attributes <- function(x, attrib) {
-  if (r_version_at_least_3.6.0) {
-    attributes(x) <- attrib
-    x
-  } else {
-    .Call(vctrs_set_attributes, x, attrib)
-  }
+  vec_set_attributes(.data, attrib)
 }
 
 validate_names <- function(.data) {

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -62,7 +62,7 @@ new_vctr <- function(.data, ..., class = character()) {
 }
 
 vec_structure <- function(.data, ...) {
-  if (r_version >= '3.6.0') {
+  if (r_version_at_least_3.6.0) {
     attributes(.data) <- NULL
     structure(.data, ...)
   } else {
@@ -71,7 +71,7 @@ vec_structure <- function(.data, ...) {
 }
 
 vec_set_attributes <- function(x, attrib) {
-  if (r_version >= '3.6.0') {
+  if (r_version_at_least_3.6.0) {
     attributes(x) <- attrib
     x
   } else {

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -65,8 +65,7 @@ vec_structure <- function(.data, ...) {
   if (r_version >= '3.6.0') {
     attributes(.data) <- NULL
     structure(.data, ...)
-  }
-  else {
+  } else {
     vec_set_attributes(.data, list(...))
   }
 }

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -67,12 +67,17 @@ vec_structure <- function(.data, ...) {
     structure(.data, ...)
   }
   else {
-    vec_set_attributes(.data, ...)
+    vec_set_attributes(.data, list(...))
   }
 }
 
-vec_set_attributes <- function(.x, ...) {
-  .Call(vctrs_set_attributes, .x, list(...))
+vec_set_attributes <- function(x, attrib) {
+  if (r_version >= '3.6.0') {
+    attributes(x) <- attrib
+    x
+  } else {
+    .Call(vctrs_set_attributes, x, attrib)
+  }
 }
 
 validate_names <- function(.data) {

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -56,20 +56,33 @@ new_vctr <- function(.data, ..., class = character()) {
   if (!is_vector(.data)) {
     abort("`.data` must be a vector type.")
   }
-  .data <- validate_attr(.data)
+  nms <- validate_names(.data)
 
-  structure(.data, ..., class = c(class, "vctrs_vctr"))
+  vec_structure(.data, names = nms, ..., class = c(class, "vctrs_vctr"))
 }
 
-validate_attr <- function(.data) {
+vec_structure <- function(.data, ...) {
+  if (r_version >= '3.6.0') {
+    attributes(.data) <- NULL
+    structure(.data, ...)
+  }
+  else {
+    vec_set_attributes(.data, ...)
+  }
+}
+
+vec_set_attributes <- function(.x, ...) {
+  .Call(vctrs_set_attributes, .x, list(...))
+}
+
+validate_names <- function(.data) {
   nms <- names(.data)
 
   if (!names_all_or_nothing(nms)) {
     stop("If any elements of `.data` are named, all must be named", call. = FALSE)
   }
 
-  attributes(.data) <- list(names = nms)
-  .data
+  nms
 }
 names_all_or_nothing <- function(names) {
   if (is.null(names)) {

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -58,10 +58,10 @@ new_vctr <- function(.data, ..., class = character()) {
   }
   nms <- validate_names(.data)
 
-  vec_structure(.data, names = nms, ..., class = c(class, "vctrs_vctr"))
+  restructure(.data, names = nms, ..., class = c(class, "vctrs_vctr"))
 }
 
-vec_structure <- function(.data, ...) {
+restructure <- function(.data, ...) {
   if (r_version_at_least_3.6.0) {
     attributes(.data) <- NULL
     structure(.data, ...)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,10 +1,14 @@
 # nocov start
+r_version <- NULL
+
 .onLoad <- function(libname, pkgname) {
   backports::import(pkgname, "strrep")
 
   s3_register("generics::as.factor", "vctrs_vctr")
   s3_register("generics::as.ordered", "vctrs_vctr")
   s3_register("generics::as.difftime", "vctrs_vctr")
+
+  r_version <<- as.character(getRversion())
 
   .Call(vctrs_init, ns_env())
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,5 @@
 # nocov start
-r_version <- NULL
+r_version_at_least_3.6.0 <- NULL
 
 .onLoad <- function(libname, pkgname) {
   backports::import(pkgname, "strrep")
@@ -8,7 +8,7 @@ r_version <- NULL
   s3_register("generics::as.ordered", "vctrs_vctr")
   s3_register("generics::as.difftime", "vctrs_vctr")
 
-  r_version <<- as.character(getRversion())
+  r_version_at_least_3.6.0 <<- getRversion() >= '3.6.0'
 
   .Call(vctrs_init, ns_env())
 }

--- a/src/init.c
+++ b/src/init.c
@@ -58,6 +58,7 @@ extern SEXP df_restore(SEXP, SEXP, SEXP);
 extern SEXP vctrs_recycle(SEXP, SEXP);
 extern SEXP vctrs_coercible_cast(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_assign(SEXP, SEXP, SEXP);
+extern SEXP vctrs_set_attributes(SEXP, SEXP);
 
 // Defined below
 SEXP vctrs_init(SEXP);
@@ -114,6 +115,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_recycle",                    (DL_FUNC) &vctrs_recycle, 2},
   {"vctrs_coercible_cast",             (DL_FUNC) &vctrs_coercible_cast, 4},
   {"vctrs_assign",                     (DL_FUNC) &vec_assign, 3},
+  {"vctrs_set_attributes",             (DL_FUNC) &vctrs_set_attributes, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/type.c
+++ b/src/type.c
@@ -7,6 +7,7 @@ static SEXP syms_vec_type_finalise_dispatch = NULL;
 static SEXP fns_vec_is_vector_dispatch = NULL;
 static SEXP fns_vec_type_finalise_dispatch = NULL;
 
+
 static SEXP vec_type_slice(SEXP x, SEXP empty) {
   if (ATTRIB(x) == R_NilValue) {
     return empty;

--- a/src/type.c
+++ b/src/type.c
@@ -7,66 +7,6 @@ static SEXP syms_vec_type_finalise_dispatch = NULL;
 static SEXP fns_vec_is_vector_dispatch = NULL;
 static SEXP fns_vec_type_finalise_dispatch = NULL;
 
-// [[ register() ]]
-SEXP vctrs_set_attributes(SEXP x, SEXP attrib) {
-  R_len_t n_attrib = Rf_length(attrib);
-  int n_protect = 0;
-
-  if (MAYBE_REFERENCED(x)) {
-    x = PROTECT(Rf_shallow_duplicate(x));
-    ++n_protect;
-  }
-
-  // Remove existing attributes, and unset the object bit
-  SET_ATTRIB(x, R_NilValue);
-  SET_OBJECT(x, 0);
-
-  // Possible early exit after removing attributes
-  if (n_attrib == 0) {
-    UNPROTECT(n_protect);
-    return x;
-  }
-
-  SEXP names = Rf_getAttrib(attrib, R_NamesSymbol);
-
-  if (Rf_isNull(names)) {
-    Rf_errorcall(R_NilValue, "Attributes must have names.");
-  }
-
-  // Check that each element of `names` is named.
-  for (R_len_t i = 0; i < n_attrib; ++i) {
-    SEXP name = STRING_ELT(names, i);
-
-    if (name == NA_STRING || name == R_BlankString) {
-      const char* msg = "All attributes must have names. Attribute %i does not.";
-      Rf_errorcall(R_NilValue, msg, i + 1);
-    }
-  }
-
-  // Always set `dim` first, if it exists. This way it is set before `dimnames`.
-  int dim_pos = -1;
-  for (R_len_t i = 0; i < n_attrib; ++i) {
-    if (!strcmp(CHAR(STRING_ELT(names, i)), "dim")) {
-      dim_pos = i;
-      break;
-    }
-  }
-
-  if (dim_pos != -1) {
-    Rf_setAttrib(x, R_DimSymbol, VECTOR_ELT(attrib, dim_pos));
-  }
-
-  for (R_len_t i = 0; i < n_attrib; ++i) {
-    if (i == dim_pos) {
-      continue;
-    }
-    Rf_setAttrib(x, Rf_installChar(STRING_ELT(names, i)), VECTOR_ELT(attrib, i));
-  }
-
-  UNPROTECT(n_protect);
-  return x;
-}
-
 static SEXP vec_type_slice(SEXP x, SEXP empty) {
   if (ATTRIB(x) == R_NilValue) {
     return empty;

--- a/src/utils.c
+++ b/src/utils.c
@@ -108,7 +108,7 @@ SEXP vctrs_set_attributes(SEXP x, SEXP attrib) {
   SEXP names = Rf_getAttrib(attrib, R_NamesSymbol);
 
   if (Rf_isNull(names)) {
-    Rf_errorcall(R_NilValue, "Attributes must have names.");
+    Rf_errorcall(R_NilValue, "Attributes must be named.");
   }
 
   // Check that each element of `names` is named.

--- a/src/utils.c
+++ b/src/utils.c
@@ -85,6 +85,8 @@ SEXP vctrs_dispatch3(SEXP fn_sym, SEXP fn,
   return vctrs_dispatch_n(fn_sym, fn, syms, args);
 }
 
+// An alternative to `attributes(x) <- attrib`, which makes
+// two copies on R < 3.6.0
 // [[ register() ]]
 SEXP vctrs_set_attributes(SEXP x, SEXP attrib) {
   R_len_t n_attrib = Rf_length(attrib);

--- a/src/utils.c
+++ b/src/utils.c
@@ -85,6 +85,66 @@ SEXP vctrs_dispatch3(SEXP fn_sym, SEXP fn,
   return vctrs_dispatch_n(fn_sym, fn, syms, args);
 }
 
+// [[ register() ]]
+SEXP vctrs_set_attributes(SEXP x, SEXP attrib) {
+  R_len_t n_attrib = Rf_length(attrib);
+  int n_protect = 0;
+
+  if (MAYBE_REFERENCED(x)) {
+    x = PROTECT(Rf_shallow_duplicate(x));
+    ++n_protect;
+  }
+
+  // Remove existing attributes, and unset the object bit
+  SET_ATTRIB(x, R_NilValue);
+  SET_OBJECT(x, 0);
+
+  // Possible early exit after removing attributes
+  if (n_attrib == 0) {
+    UNPROTECT(n_protect);
+    return x;
+  }
+
+  SEXP names = Rf_getAttrib(attrib, R_NamesSymbol);
+
+  if (Rf_isNull(names)) {
+    Rf_errorcall(R_NilValue, "Attributes must have names.");
+  }
+
+  // Check that each element of `names` is named.
+  for (R_len_t i = 0; i < n_attrib; ++i) {
+    SEXP name = STRING_ELT(names, i);
+
+    if (name == NA_STRING || name == R_BlankString) {
+      const char* msg = "All attributes must have names. Attribute %i does not.";
+      Rf_errorcall(R_NilValue, msg, i + 1);
+    }
+  }
+
+  // Always set `dim` first, if it exists. This way it is set before `dimnames`.
+  int dim_pos = -1;
+  for (R_len_t i = 0; i < n_attrib; ++i) {
+    if (!strcmp(CHAR(STRING_ELT(names, i)), "dim")) {
+      dim_pos = i;
+      break;
+    }
+  }
+
+  if (dim_pos != -1) {
+    Rf_setAttrib(x, R_DimSymbol, VECTOR_ELT(attrib, dim_pos));
+  }
+
+  for (R_len_t i = 0; i < n_attrib; ++i) {
+    if (i == dim_pos) {
+      continue;
+    }
+    Rf_setAttrib(x, Rf_installChar(STRING_ELT(names, i)), VECTOR_ELT(attrib, i));
+  }
+
+  UNPROTECT(n_protect);
+  return x;
+}
+
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
   R_len_t n = Rf_length(df);
   SEXP out = PROTECT(Rf_allocVector(VECSXP, n));

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -25,6 +25,14 @@ test_that("vctr class is proxied", {
   expect_true(vec_is(new_vctr(as.list(1:3))))
 })
 
+test_that("attributes must be named", {
+  expect_error(vec_set_attributes(1, list(1)), "must be named")
+  expect_error(vec_set_attributes(1, list(y = 1, 2)), "2 does not")
+})
+
+test_that("can strip all attributes without adding new ones", {
+  expect_equal(vec_set_attributes(structure(1, a = 1), NULL), 1)
+})
 
 # Cast/restore ------------------------------------------------------------
 


### PR DESCRIPTION
Closes #341 

- New `vctrs_set_attributes()`, inspired heavily from `do_attributesgets()`, which removes all attributes from `x` and then adds the `attrib`.
   - All attributes must be named.
   - `dim` is always set first, consistent with `do_attributesget()` to avoid an issue of attempting to set dim names on a non-array object if the user does `vec_structure(x, dimnames = list(...), dim = c(...))`
   - Exposed as `vec_set_attributes()`

- New `vec_structure()` that tries to do the same thing no matter what R version you are on. Both versions try to first remove attributes of `.data`, then add the new ones.

- `new_vctr()` now uses `vec_structure()` and just passes `names` through rather than calling `attributes(.data) <- list(names = nms)` separately.

- `vec_data()` now uses `vec_set_attributes()`.

Questions)

- I'm setting `r_version` in the `.onLoad()` because it's actually quite slow to call `getRVersion()`. Is this right?
- Does `vctrs_set_attributes()` do what you were intending?
- Is there a better way to avoid having to switch off the r version? Maybe register these in `.onLoad()` rather than storing the R version?
- I can add tests, I guess specifically for `vec_set_attributes()`?