### PR TITLE
Use `vctrs_error_scalar_type` class in `expect_error()`

### DIFF
--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -4,7 +4,7 @@ context("test-equal")
 # vectorised --------------------------------------------------------------
 
 test_that("throws error for unsuported type", {
-  expect_error(.Call(vctrs_equal, expression(x), expression(x), TRUE), "must be a vector")
+  expect_error(.Call(vctrs_equal, expression(x), expression(x), TRUE), class = "vctrs_error_scalar_type")
 })
 
 test_that("C wrapper throws error if length or type doesn't match", {

--- a/tests/testthat/test-size.R
+++ b/tests/testthat/test-size.R
@@ -3,7 +3,7 @@ context("test-size")
 # vec_size -----------------------------------------------------------------
 
 test_that("vec_size must be called with vector", {
-  expect_error(vec_size(mean), "must be a vector")
+  expect_error(vec_size(mean), class = "vctrs_error_scalar_type")
 })
 
 test_that("length is number of rows", {

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -1,7 +1,7 @@
 context("test-slice")
 
 test_that("vec_slice throws error with non-vector inputs", {
-  expect_error(vec_slice(environment(), 1L), "a vector")
+  expect_error(vec_slice(environment(), 1L), class = "vctrs_error_scalar_type")
 })
 
 test_that("can subset base vectors", {
@@ -259,7 +259,7 @@ test_that("vec_slice() falls back to `[` with S3 objects", {
   )
   expect_identical(vec_slice(foobar(NA), 1), foobar("dispatched"))
 
-  expect_error(vec_slice(foobar(list(NA)), 1), "must be a vector")
+  expect_error(vec_slice(foobar(list(NA)), 1), class = "vctrs_error_scalar_type")
   scoped_global_bindings(
     vec_proxy.vctrs_foobar = identity
   )
@@ -344,7 +344,7 @@ test_that("can't use names to vec_slice() an unnamed object", {
 # vec_na ------------------------------------------------------------------
 
 test_that("vec_slice throws error with non-vector inputs", {
-  expect_error(vec_slice(environment(), 1L), "a vector")
+  expect_error(vec_slice(environment(), 1L), class = "vctrs_error_scalar_type")
 })
 
 # vec_na ------------------------------------------------------------------


### PR DESCRIPTION
This was throwing warnings for me with the latest version of testthat