### PR TITLE
Precache dictionary hashes

### DIFF
--- a/R/hash.R
+++ b/R/hash.R
@@ -1,6 +1,5 @@
-vec_hash <- function(x) {
-  x <- vec_proxy(x)
-  as.hexmode(.Call(vctrs_hash, x))
+vec_hash <- function(x, rowwise = TRUE) {
+  as.hexmode(.Call(vctrs_hash, x, rowwise))
 }
 
 obj_hash <- function(x) {

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -100,7 +100,7 @@ void dict_put(dictionary* d, uint32_t hash, R_len_t i) {
 
 SEXP vctrs_unique_loc(SEXP x) {
   dictionary d;
-  dict_init(&d, x, false);
+  dict_init(&d, x, true);
 
   growable g;
   growable_init(&g, INTSXP, 256);
@@ -145,7 +145,7 @@ SEXP vctrs_duplicated_any(SEXP x) {
 
 SEXP vctrs_n_distinct(SEXP x) {
   dictionary d;
-  dict_init(&d, x, false);
+  dict_init(&d, x, true);
 
   R_len_t n = vec_size(x);
   for (int i = 0; i < n; ++i) {
@@ -161,7 +161,7 @@ SEXP vctrs_n_distinct(SEXP x) {
 
 SEXP vctrs_id(SEXP x) {
   dictionary d;
-  dict_init(&d, x, false);
+  dict_init(&d, x, true);
 
   R_len_t n = vec_size(x);
   SEXP out = PROTECT(Rf_allocVector(INTSXP, n));
@@ -244,7 +244,7 @@ SEXP vctrs_in(SEXP needles, SEXP haystack) {
 
 SEXP vctrs_count(SEXP x) {
   dictionary d;
-  dict_init(&d, x, false);
+  dict_init(&d, x, true);
 
   SEXP val = PROTECT(Rf_allocVector(INTSXP, d.size));
   int* p_val = INTEGER(val);
@@ -291,7 +291,7 @@ SEXP vctrs_count(SEXP x) {
 
 SEXP vctrs_duplicated(SEXP x) {
   dictionary d;
-  dict_init(&d, x, false);
+  dict_init(&d, x, true);
 
   SEXP val = PROTECT(Rf_allocVector(INTSXP, d.size));
   int* p_val = INTEGER(val);
@@ -323,7 +323,7 @@ SEXP vctrs_duplicated(SEXP x) {
 
 SEXP vctrs_duplicate_split(SEXP x) {
   dictionary d;
-  dict_init(&d, x, false);
+  dict_init(&d, x, true);
 
   // Tracks the order in which keys are seen
   SEXP tracker = PROTECT(Rf_allocVector(INTSXP, d.size));

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -17,7 +17,7 @@ int32_t ceil2(int32_t x) {
 
 // Caller is responsible for PROTECTing x
 void dict_init_impl(dictionary* d, SEXP x, bool hashed, bool partial) {
-  d->x = x;
+  d->vec = x;
   d->used = 0;
 
   if (partial) {
@@ -62,7 +62,7 @@ uint32_t dict_hash_scalar(dictionary* d, SEXP y, R_len_t i) {
   uint32_t hash;
 
   if (d->hash) {
-    if (d->x != y) {
+    if (d->vec != y) {
       Rf_error("Internal error: Can't compare hashed vector "
                "with unhashed vector.");
     }
@@ -91,7 +91,7 @@ uint32_t dict_hash_scalar(dictionary* d, SEXP y, R_len_t i) {
     // Check for same value as there might be a collision. If there is
     // a collision, next iteration will find another spot using
     // quadratic probing.
-    if (equal_scalar(d->x, idx, y, i, true)) {
+    if (equal_scalar(d->vec, idx, y, i, true)) {
       return probe;
     }
   }

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -9,7 +9,7 @@
 // at the R-level).
 
 struct dictionary {
-  SEXP x;
+  SEXP vec;
   R_len_t* key;
   uint32_t* hash;
   uint32_t size;

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -11,12 +11,13 @@
 struct dictionary {
   SEXP x;
   R_len_t* key;
+  uint32_t* hash;
   uint32_t size;
   uint32_t used;
 };
 typedef struct dictionary dictionary;
 
-void dict_init(dictionary* d, SEXP x);
+void dict_init(dictionary* d, SEXP x, bool hashed);
 void dict_free(dictionary* d);
 uint32_t dict_hash_scalar(dictionary* d, SEXP y, R_len_t i);
 void dict_put(dictionary* d, uint32_t k, R_len_t i);

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -19,5 +19,5 @@ typedef struct dictionary dictionary;
 
 void dict_init(dictionary* d, SEXP x, bool hashed);
 void dict_free(dictionary* d);
-uint32_t dict_hash_scalar(dictionary* d, SEXP y, R_len_t i);
+uint32_t dict_hash_scalar(dictionary* d, dictionary* x, R_len_t i);
 void dict_put(dictionary* d, uint32_t k, R_len_t i);

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -17,9 +17,29 @@ struct dictionary {
 };
 typedef struct dictionary dictionary;
 
+/**
+ * Initialise a dictionary
+ *
+ * - `dict_init()` creates a dictionary and precaches the hashes for
+ *   each element of `x`.
+ *
+ * - `dict_init_partial()` creates a dictionary with precached hashes
+ *   as well, but does not allocate an array of keys. This is useful
+ *   for finding a key in another dictionary with `dict_hash_with()`.
+ */
 void dict_init(dictionary* d, SEXP x);
 void dict_init_partial(dictionary* d, SEXP x);
 void dict_free(dictionary* d);
-uint32_t dict_hash_with(dictionary* d, dictionary* x, R_len_t i);
+
+/**
+ * Find key hash for a vector element
+ *
+ * - `dict_hash_scalar()` returns the key hash for element `i`.
+ *
+ * - `dict_hash_with()` finds the hash for indexing into `d` with
+ *   element `i` of `x`.
+ */
 uint32_t dict_hash_scalar(dictionary* d, R_len_t i);
+uint32_t dict_hash_with(dictionary* d, dictionary* x, R_len_t i);
+
 void dict_put(dictionary* d, uint32_t k, R_len_t i);

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -18,6 +18,8 @@ struct dictionary {
 typedef struct dictionary dictionary;
 
 void dict_init(dictionary* d, SEXP x);
+void dict_init_partial(dictionary* d, SEXP x);
 void dict_free(dictionary* d);
-uint32_t dict_hash_scalar(dictionary* d, dictionary* x, R_len_t i);
+uint32_t dict_hash_with(dictionary* d, dictionary* x, R_len_t i);
+uint32_t dict_hash_scalar(dictionary* d, R_len_t i);
 void dict_put(dictionary* d, uint32_t k, R_len_t i);

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -17,7 +17,7 @@ struct dictionary {
 };
 typedef struct dictionary dictionary;
 
-void dict_init(dictionary* d, SEXP x, bool hashed);
+void dict_init(dictionary* d, SEXP x);
 void dict_free(dictionary* d);
 uint32_t dict_hash_scalar(dictionary* d, dictionary* x, R_len_t i);
 void dict_put(dictionary* d, uint32_t k, R_len_t i);

--- a/src/init.c
+++ b/src/init.c
@@ -14,7 +14,7 @@ extern SEXP vctrs_field_get(SEXP, SEXP);
 extern SEXP vctrs_field_set(SEXP, SEXP, SEXP);
 extern SEXP vctrs_fields(SEXP);
 extern SEXP vctrs_n_fields(SEXP);
-extern SEXP vctrs_hash(SEXP);
+extern SEXP vctrs_hash(SEXP, SEXP );
 extern SEXP vctrs_hash_object(SEXP);
 extern SEXP vctrs_equal_object(SEXP, SEXP, SEXP);
 extern SEXP vctrs_in(SEXP, SEXP);
@@ -69,7 +69,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_field_set",                  (DL_FUNC) &vctrs_field_set, 3},
   {"vctrs_fields",                     (DL_FUNC) &vctrs_fields, 1},
   {"vctrs_n_fields",                   (DL_FUNC) &vctrs_n_fields, 1},
-  {"vctrs_hash",                       (DL_FUNC) &vctrs_hash, 1},
+  {"vctrs_hash",                       (DL_FUNC) &vctrs_hash, 2},
   {"vctrs_hash_object",                (DL_FUNC) &vctrs_hash_object, 1},
   {"vctrs_equal_object",               (DL_FUNC) &vctrs_equal_object, 3},
   {"vctrs_in",                         (DL_FUNC) &vctrs_in, 2},

--- a/src/names.c
+++ b/src/names.c
@@ -106,7 +106,7 @@ static SEXP as_unique_names(SEXP names) {
       break;
     }
 
-    int32_t hash = dict_hash_scalar(&d, names, i);
+    int32_t hash = dict_hash_scalar(&d, &d, i);
 
     if (d.key[hash] == DICT_EMPTY) {
       dict_put(&d, hash, i);
@@ -151,7 +151,7 @@ static SEXP as_unique_names(SEXP names) {
     }
 
     // Duplicates need a `...n` suffix
-    int32_t hash = dict_hash_scalar(&d, names, i);
+    int32_t hash = dict_hash_scalar(&d, &d, i);
 
     if (d.key[hash] == DICT_EMPTY) {
       dict_put(&d, hash, i);
@@ -169,7 +169,7 @@ static SEXP as_unique_names(SEXP names) {
   char buf[100] = "";
 
   for (i = 0, ptr = STRING_PTR(names); i < n; ++i, ++ptr) {
-    int32_t hash = dict_hash_scalar(&d, names, i);
+    int32_t hash = dict_hash_scalar(&d, &d, i);
     if (dups_ptr[hash] != 1) {
       const char* name = CHAR(*ptr);
 

--- a/src/names.c
+++ b/src/names.c
@@ -133,7 +133,7 @@ static SEXP as_unique_names(SEXP names) {
     if (elt == NA_STRING || elt == strings_dots || is_dotdotint(CHAR(elt))) {
       elt = strings_empty;
       SET_STRING_ELT(names, i, elt);
-      SET_STRING_ELT(d.x, i, elt);
+      SET_STRING_ELT(d.vec, i, elt);
     }
 
     // Strip `...n` suffixes
@@ -147,7 +147,7 @@ static SEXP as_unique_names(SEXP names) {
 
       elt = Rf_mkChar(buf);
       SET_STRING_ELT(names, i, elt);
-      SET_STRING_ELT(d.x, i, elt);
+      SET_STRING_ELT(d.vec, i, elt);
     }
 
     // Duplicates need a `...n` suffix

--- a/src/names.c
+++ b/src/names.c
@@ -86,7 +86,7 @@ static SEXP as_unique_names(SEXP names) {
   }
 
   dictionary d;
-  dict_init(&d, names);
+  dict_init(&d, names, false);
   SEXP dups = PROTECT(Rf_allocVector(INTSXP, d.size));
   int* dups_ptr = INTEGER(dups);
 

--- a/src/names.c
+++ b/src/names.c
@@ -1,5 +1,4 @@
 #include "vctrs.h"
-#include "dictionary.h"
 #include "utils.h"
 
 static void describe_repair(SEXP old, SEXP new);
@@ -76,19 +75,18 @@ SEXP vctrs_minimal_names(SEXP x) {
 }
 
 
-void stop_large_name();
-bool is_dotdotint(const char* name);
-ptrdiff_t suffix_pos(const char* name);
+// From dictionary.c
+SEXP vctrs_duplicated(SEXP x);
+
+static void stop_large_name();
+static bool is_dotdotint(const char* name);
+static ptrdiff_t suffix_pos(const char* name);
+static bool needs_suffix(SEXP str);
 
 static SEXP as_unique_names(SEXP names) {
   if (TYPEOF(names) != STRSXP) {
     Rf_errorcall(R_NilValue, "`names` must be a character vector");
   }
-
-  dictionary d;
-  dict_init(&d, names, false);
-  SEXP dups = PROTECT(Rf_allocVector(INTSXP, d.size));
-  int* dups_ptr = INTEGER(dups);
 
   R_len_t i = 0;
   R_len_t n = Rf_length(names);
@@ -99,41 +97,26 @@ static SEXP as_unique_names(SEXP names) {
   for (; i < n; ++i, ++ptr) {
     SEXP elt = *ptr;
 
-    if (elt == NA_STRING || elt == strings_dots || elt == strings_empty || is_dotdotint(CHAR(elt))) {
-      break;
-    }
-    if (suffix_pos(CHAR(elt)) >= 0) {
-      break;
-    }
-
-    int32_t hash = dict_hash_scalar(&d, &d, i);
-
-    if (d.key[hash] == DICT_EMPTY) {
-      dict_put(&d, hash, i);
-      dups_ptr[hash] = 1;
-    } else {
+    if (needs_suffix(elt) || suffix_pos(CHAR(elt)) >= 0) {
       break;
     }
   }
-
-  // Return early when no repairs are needed
   if (i == n) {
-    UNPROTECT(1);
     return names;
   }
 
-
   names = PROTECT(r_maybe_duplicate(names));
-  ptr = STRING_PTR(names) + i;
+  ptr = STRING_PTR(names);
 
   for (; i < n; ++i, ++ptr) {
     SEXP elt = *ptr;
 
-    // Set `NA` and dots values to "" so they get replaced by `...n` later on
-    if (elt == NA_STRING || elt == strings_dots || is_dotdotint(CHAR(elt))) {
+    // Set `NA` and dots values to "" so they get replaced by `...n`
+    // later on
+    if (needs_suffix(elt)) {
       elt = strings_empty;
       SET_STRING_ELT(names, i, elt);
-      SET_STRING_ELT(d.vec, i, elt);
+      continue;
     }
 
     // Strip `...n` suffixes
@@ -147,48 +130,41 @@ static SEXP as_unique_names(SEXP names) {
 
       elt = Rf_mkChar(buf);
       SET_STRING_ELT(names, i, elt);
-      SET_STRING_ELT(d.vec, i, elt);
+      continue;
     }
-
-    // Duplicates need a `...n` suffix
-    int32_t hash = dict_hash_scalar(&d, &d, i);
-
-    if (d.key[hash] == DICT_EMPTY) {
-      dict_put(&d, hash, i);
-      dups_ptr[hash] = 0;
-
-      // Ensure "" is seen as a duplicate so it always gets a suffix
-      if (elt == strings_empty) {
-        dups_ptr[hash]++;
-      }
-    }
-    dups_ptr[hash]++;
   }
 
   // Append all duplicates with a suffix
   char buf[100] = "";
+  ptr = STRING_PTR(names);
 
-  for (i = 0, ptr = STRING_PTR(names); i < n; ++i, ++ptr) {
-    int32_t hash = dict_hash_scalar(&d, &d, i);
-    if (dups_ptr[hash] != 1) {
-      const char* name = CHAR(*ptr);
+  SEXP dups = PROTECT(vctrs_duplicated(names));
+  int* dups_ptr = LOGICAL(dups);
 
-      int remaining = 100;
-      int size = strlen(name);
-      if (size >= 100) {
-        stop_large_name();
-      }
+  for (R_len_t i = 0; i < n; ++i, ++ptr) {
+    SEXP elt = *ptr;
 
-      memcpy(buf, name, size + 1);
-      remaining -= size;
-
-      int needed = snprintf(buf + size, remaining, "...%d", i + 1);
-      if (needed >= remaining) {
-        stop_large_name();
-      }
-
-      SET_STRING_ELT(names, i, Rf_mkChar(buf));
+    if (elt != strings_empty && !dups_ptr[i]) {
+      continue;
     }
+
+    const char* name = CHAR(elt);
+
+    int remaining = 100;
+    int size = strlen(name);
+    if (size >= 100) {
+      stop_large_name();
+    }
+
+    memcpy(buf, name, size + 1);
+    remaining -= size;
+
+    int needed = snprintf(buf + size, remaining, "...%d", i + 1);
+    if (needed >= remaining) {
+      stop_large_name();
+    }
+
+    SET_STRING_ELT(names, i, Rf_mkChar(buf));
   }
 
   UNPROTECT(2);
@@ -206,7 +182,7 @@ SEXP vctrs_as_unique_names(SEXP names, SEXP quiet) {
   return out;
 }
 
-bool is_dotdotint(const char* name) {
+static bool is_dotdotint(const char* name) {
   int n = strlen(name);
 
   if (n < 3) {
@@ -243,7 +219,7 @@ static bool is_digit(const char c) {
   }
 }
 
-ptrdiff_t suffix_pos(const char* name) {
+static ptrdiff_t suffix_pos(const char* name) {
   int n = strlen(name);
 
   const char* suffix_end = NULL;
@@ -302,9 +278,18 @@ ptrdiff_t suffix_pos(const char* name) {
   }
 }
 
-void stop_large_name() {
+static void stop_large_name() {
   Rf_errorcall(R_NilValue, "Can't tidy up name because it is too large");
 }
+
+static bool needs_suffix(SEXP str) {
+  return
+    str == NA_STRING ||
+    str == strings_dots ||
+    str == strings_empty ||
+    is_dotdotint(CHAR(str));
+}
+
 
 static SEXP names_iota(R_len_t n);
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -237,6 +237,8 @@ int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal);
 
 int32_t hash_object(SEXP x);
 int32_t hash_scalar(SEXP x, R_len_t i);
+void hash_fill(uint32_t* p, R_len_t n, SEXP x);
+
 
 // Growable vector -----------------------------------------------
 


### PR DESCRIPTION
This way the hashes can be computed with the vectorised method.

```r
x <- 1:1000

bench::mark(
  before = vec_hash(x, rowwise = TRUE),
  after = vec_hash(x, rowwise = FALSE),
  check = FALSE
)[1:6]
#>   expression      min     mean   median      max `itr/sec`
#>   <chr>      <bch:tm> <bch:tm> <bch:tm> <bch:tm>     <dbl>
#> 1 before       22.8µs   37.2µs   33.8µs   1.16ms    26851.
#> 2 after        11.7µs   17.7µs   13.8µs  888.9µs    56583.


df <- tibble(x = 1:1000, y = 1000:1)

bench::mark(
  before = vec_hash(df, rowwise = TRUE),
  after = vec_hash(df, rowwise = FALSE),
  check = FALSE
)[1:6]
#>   expression      min     mean   median      max `itr/sec`
#>   <chr>      <bch:tm> <bch:tm> <bch:tm> <bch:tm>     <dbl>
#> 1 before       83.6µs  103.7µs   87.3µs    736µs     9645.
#> 2 after        18.8µs   25.7µs   21.6µs    690µs    38915.


nested_df <- tibble(x = 1:1000, y = tibble(z = 1:1000))

bench::mark(
  before = vec_hash(nested_df, rowwise = TRUE),
  after = vec_hash(nested_df, rowwise = FALSE),
  check = FALSE
)[1:6]
#>   expression      min     mean   median      max `itr/sec`
#>   <chr>      <bch:tm> <bch:tm> <bch:tm> <bch:tm>     <dbl>
#> 1 before      140.1µs  174.4µs  149.8µs    998µs     5733.
#> 2 after        18.8µs   28.2µs   22.1µs    701µs    35450.
```

The hashes are also always precomputed, even in `_any` functions that could be short-circuited. This makes the code simpler and the best case performance gain of not prehashing doesn't seem to outweigh the other costs:

```r
worst <- 1:1000
mid <- c(1:500, 500L, 502:1000)
best <- c(1L, 1L, 3:1000)

bench::mark(
  before_worst = vec_duplicate_any(worst),
  before_mid = vec_duplicate_any(mid),
  before_best = vec_duplicate_any(best),
  check = FALSE
)[1:6]
#>   expression        min     mean   median      max `itr/sec`
#>   <chr>        <bch:tm> <bch:tm> <bch:tm> <bch:tm>     <dbl>
#> 1 before_worst  40.27µs  48.21µs  41.06µs    903µs    20742.
#> 2 before_mid    12.37µs  14.96µs  13.02µs    711µs    66861.
#> 3 before_best    2.36µs   4.21µs   3.19µs    845µs   237600.


bench::mark(
  after_worst = vec_duplicate_any(worst),
  after_mid = vec_duplicate_any(mid),
  after_best = vec_duplicate_any(best),
  check = FALSE
)[1:6]
#>   expression       min     mean   median      max `itr/sec`
#>   <chr>       <bch:tm> <bch:tm> <bch:tm> <bch:tm>     <dbl>
#> 1 after_worst     28µs   34.1µs  28.86µs    633µs    29350.
#> 2 after_mid      9.7µs   13.1µs  10.61µs    969µs    76379.
#> 3 after_best    3.48µs    5.5µs   4.23µs    788µs   181721.
```