### PR TITLE
Implement `vec_cast_common()`, `vec_match()` and `vec_in()` in C

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -123,9 +123,7 @@ vec_cast_dispatch <- function(x, to) {
 #' @export
 #' @rdname vec_cast
 vec_cast_common <- function(..., .to = NULL) {
-  args <- list2(...)
-  type <- vec_type_common(!!!args, .ptype = .to)
-  map(args, vec_cast, to = type)
+  .External2(vctrs_cast_common, .to)
 }
 
 #' @export

--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -126,21 +126,18 @@ NULL
 #' @rdname vec_duplicate
 #' @export
 vec_duplicate_any <- function(x) {
-  x <- vec_proxy(x)
   .Call(vctrs_duplicated_any, x)
 }
 
 #' @rdname vec_duplicate
 #' @export
 vec_duplicate_detect <- function(x) {
-  x <- vec_proxy(x)
   .Call(vctrs_duplicated, x)
 }
 
 #' @rdname vec_duplicate
 #' @export
 vec_duplicate_id <- function(x) {
-  x <- vec_proxy(x)
   .Call(vctrs_id, x)
 }
 
@@ -186,14 +183,12 @@ vec_unique <- function(x) {
 #' @rdname vec_unique
 #' @export
 vec_unique_loc <- function(x) {
-  x <- vec_proxy(x)
   .Call(vctrs_unique_loc, x)
 }
 
 #' @rdname vec_unique
 #' @export
 vec_unique_count <- function(x) {
-  x <- vec_proxy(x)
   .Call(vctrs_n_distinct, x)
 }
 
@@ -282,6 +277,5 @@ vec_split <- function(x, by) {
 # Returns key-index pair giving the index of first key occurence and
 # a list containing the locations of each key
 vec_duplicate_split <- function(x) {
-  x <- vec_proxy(x)
   .Call(vctrs_duplicate_split, x)
 }

--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -229,15 +229,13 @@ vec_unique_count <- function(x) {
 #' # Only the first index of duplicates is returned
 #' vec_match(c("a", "b"), c("a", "b", "a", "b"))
 vec_match <- function(needles, haystack) {
-  v <- vec_cast_common(needles = needles, haystack = haystack)
-  .Call(vctrs_match, vec_proxy(v$needles), vec_proxy(v$haystack))
+  .Call(vctrs_match, needles, haystack)
 }
 
 #' @export
 #' @rdname vec_match
 vec_in <- function(needles, haystack) {
-  v <- vec_cast_common(needles = needles, haystack = haystack)
-  .Call(vctrs_in, vec_proxy(v$needles), vec_proxy(v$haystack))
+  .Call(vctrs_in, needles, haystack)
 }
 
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -105,6 +105,8 @@ void dict_put(dictionary* d, uint32_t hash, R_len_t i) {
 // TODO: separate out into individual files
 
 SEXP vctrs_unique_loc(SEXP x) {
+  x = PROTECT(vec_proxy(x));
+
   dictionary d;
   dict_init(&d, x);
 
@@ -122,12 +124,16 @@ SEXP vctrs_unique_loc(SEXP x) {
   }
 
   SEXP out = growable_values(&g);
+
   dict_free(&d);
   growable_free(&g);
+  UNPROTECT(1);
   return out;
 }
 
 SEXP vctrs_duplicated_any(SEXP x) {
+  x = PROTECT(vec_proxy(x));
+
   dictionary d;
   dict_init(&d, x);
 
@@ -146,10 +152,14 @@ SEXP vctrs_duplicated_any(SEXP x) {
   }
 
   dict_free(&d);
+  UNPROTECT(1);
+
   return Rf_ScalarLogical(out);
 }
 
 SEXP vctrs_n_distinct(SEXP x) {
+  x = PROTECT(vec_proxy(x));
+
   dictionary d;
   dict_init(&d, x);
 
@@ -162,10 +172,13 @@ SEXP vctrs_n_distinct(SEXP x) {
   }
 
   dict_free(&d);
+  UNPROTECT(1);
   return Rf_ScalarInteger(d.used);
 }
 
 SEXP vctrs_id(SEXP x) {
+  x = PROTECT(vec_proxy(x));
+
   dictionary d;
   dict_init(&d, x);
 
@@ -182,7 +195,7 @@ SEXP vctrs_id(SEXP x) {
     p_out[i] = d.key[hash] + 1;
   }
 
-  UNPROTECT(1);
+  UNPROTECT(2);
   dict_free(&d);
   return out;
 }
@@ -325,6 +338,8 @@ SEXP vctrs_count(SEXP x) {
 }
 
 SEXP vctrs_duplicated(SEXP x) {
+  x = PROTECT(vec_proxy(x));
+
   dictionary d;
   dict_init(&d, x);
 
@@ -351,12 +366,14 @@ SEXP vctrs_duplicated(SEXP x) {
     p_out[i] = p_val[hash] != 1;
   }
 
-  UNPROTECT(2);
+  UNPROTECT(3);
   dict_free(&d);
   return out;
 }
 
 SEXP vctrs_duplicate_split(SEXP x) {
+  x = PROTECT(vec_proxy(x));
+
   dictionary d;
   dict_init(&d, x);
 
@@ -423,12 +440,14 @@ SEXP vctrs_duplicate_split(SEXP x) {
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
   SET_VECTOR_ELT(out, 0, out_key);
   SET_VECTOR_ELT(out, 1, out_idx);
+
   SEXP names = PROTECT(Rf_allocVector(STRSXP, 2));
   SET_STRING_ELT(names, 0, Rf_mkChar("key"));
   SET_STRING_ELT(names, 1, Rf_mkChar("idx"));
+
   Rf_setAttrib(out, R_NamesSymbol, names);
 
-  UNPROTECT(8);
+  UNPROTECT(9);
   dict_free(&d);
   return out;
 }

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -1,6 +1,11 @@
 #include "vctrs.h"
 #include "dictionary.h"
 
+// Initialised at load time
+struct vctrs_arg args_needles;
+struct vctrs_arg args_haystack;
+
+
 // http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
 int32_t ceil2(int32_t x) {
   x--;
@@ -182,7 +187,18 @@ SEXP vctrs_id(SEXP x) {
   return out;
 }
 
+// [[ register() ]]
 SEXP vctrs_match(SEXP needles, SEXP haystack) {
+  int _;
+  SEXP type = PROTECT(vec_type2(needles, haystack, &args_needles, &args_haystack, &_));
+
+  needles = PROTECT(vec_cast(needles, type));
+  haystack = PROTECT(vec_cast(haystack, type));
+
+  needles = PROTECT(vec_proxy(needles));
+  haystack = PROTECT(vec_proxy(haystack));
+  UNPROTECT(3);
+
   dictionary d;
   dict_init(&d, haystack);
 
@@ -213,13 +229,23 @@ SEXP vctrs_match(SEXP needles, SEXP haystack) {
     }
   }
 
-  UNPROTECT(1);
+  UNPROTECT(3);
   dict_free(&d);
   return out;
 }
 
-
+// [[ register() ]]
 SEXP vctrs_in(SEXP needles, SEXP haystack) {
+  int _;
+  SEXP type = PROTECT(vec_type2(needles, haystack, &args_needles, &args_haystack, &_));
+
+  needles = PROTECT(vec_cast(needles, type));
+  haystack = PROTECT(vec_cast(haystack, type));
+
+  needles = PROTECT(vec_proxy(needles));
+  haystack = PROTECT(vec_proxy(haystack));
+  UNPROTECT(3);
+
   dictionary d;
   dict_init(&d, haystack);
 
@@ -246,7 +272,7 @@ SEXP vctrs_in(SEXP needles, SEXP haystack) {
     p_out[i] = (d.key[hash] != DICT_EMPTY);
   }
 
-  UNPROTECT(1);
+  UNPROTECT(3);
   dict_free(&d);
   return out;
 }
@@ -405,4 +431,10 @@ SEXP vctrs_duplicate_split(SEXP x) {
   UNPROTECT(8);
   dict_free(&d);
   return out;
+}
+
+
+void vctrs_init_dictionary(SEXP ns) {
+  args_needles = new_wrapper_arg(NULL, "needles");
+  args_haystack = new_wrapper_arg(NULL, "haystack");
 }

--- a/src/init.c
+++ b/src/init.c
@@ -120,9 +120,11 @@ static const R_CallMethodDef CallEntries[] = {
 };
 
 extern SEXP vctrs_type_common(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_cast_common(SEXP, SEXP, SEXP, SEXP);
 
 static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_type_common",                (DL_FUNC) &vctrs_type_common, 1},
+  {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -137,6 +137,7 @@ void R_init_vctrs(DllInfo *dll)
 
 void vctrs_init_cast(SEXP ns);
 void vctrs_init_data(SEXP ns);
+void vctrs_init_dictionary(SEXP ns);
 void vctrs_init_slice(SEXP ns);
 void vctrs_init_slice_assign(SEXP ns);
 void vctrs_init_type2(SEXP ns);
@@ -148,6 +149,7 @@ void vctrs_init_utils(SEXP ns);
 SEXP vctrs_init(SEXP ns) {
   vctrs_init_cast(ns);
   vctrs_init_data(ns);
+  vctrs_init_dictionary(ns);
   vctrs_init_slice(ns);
   vctrs_init_slice_assign(ns);
   vctrs_init_type2(ns);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -196,6 +196,7 @@ SEXP vec_restore(SEXP x, SEXP to, SEXP i);
 R_len_t vec_size(SEXP x);
 R_len_t vec_dim(SEXP x);
 SEXP vec_cast(SEXP x, SEXP to);
+SEXP vec_cast_common(SEXP xs, SEXP to);
 SEXP vec_coercible_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_slice(SEXP x, SEXP index);
 SEXP vec_na(SEXP x, R_len_t n);

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -33,6 +33,10 @@ test_that("inputs to vec_coercible_cast() are checked", {
   expect_error(vec_coercible_cast("", "", to_arg = chr()), "must be a string")
 })
 
+test_that("cast common preserves names", {
+  expect_identical(vec_cast_common(foo = 1, bar = 2L), list(foo = 1, bar = 2))
+})
+
 
 # vec_restore -------------------------------------------------------------
 


### PR DESCRIPTION
This finishes the C implementation of dictionary functions.

The remaining bottleneck is the type2 and cast methods which are still implemented in R with S3 dispatch for types like factors.