### PR TITLE
Fix array hashing

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -23,7 +23,7 @@ vec_proxy_compare <- function(x, relax = FALSE) {
 
 #' @export
 vec_proxy_compare.data.frame <- function(x, relax = FALSE) {
-  x[] <- lapply(x[], vec_proxy_compare, relax = TRUE)
+  x[] <- lapply(x[], vec_proxy_compare_default, relax = TRUE)
   x
 }
 
@@ -34,6 +34,14 @@ vec_proxy_compare.POSIXlt <- function(x, relax = FALSE) {
 
 #' @export
 vec_proxy_compare.default <- function(x, relax = FALSE) {
+  if (vec_dims(x) > 1) {
+    as.data.frame(x)
+  } else {
+    vec_proxy_compare_default(x, relax)
+  }
+}
+
+vec_proxy_compare_default <- function(x, relax = FALSE) {
   if (is_bare_list(x)) {
     if (relax) {
       vec_seq_along(x)

--- a/R/compare.R
+++ b/R/compare.R
@@ -35,6 +35,9 @@ vec_proxy_compare.POSIXlt <- function(x, relax = FALSE) {
 #' @export
 vec_proxy_compare.default <- function(x, relax = FALSE) {
   if (vec_dims(x) > 1) {
+    # The conversion to data frame is only a stopgap, in the long
+    # term, we'll hash arrays natively. Note that hashing functions
+    # similarly convert to data frames.
     as.data.frame(x)
   } else {
     vec_proxy_compare_default(x, relax)

--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -45,11 +45,12 @@ vec_count <- function(x, sort = c("count", "key", "location", "none")) {
   kv <- .Call(vctrs_count, vec_proxy(x))
 
   # rep_along() to support zero-length vectors!
-  df <- data.frame(key = rep_along(kv$val, NA), count = kv$val)
+  df <- data_frame(key = rep_along(kv$val, NA), count = kv$val)
   df$key <- vec_slice(x, kv$key) # might be a dataframe
 
-  if (sort == "none")
+  if (sort == "none") {
     return(df)
+  }
 
   idx <- switch(sort,
     location = order(kv$key),

--- a/src/hash.c
+++ b/src/hash.c
@@ -123,7 +123,8 @@ static uint32_t list_hash_scalar(SEXP x, R_len_t i) {
 }
 
 // This is slow and matrices / arrays should be converted to data
-// frames ahead of time
+// frames ahead of time. The conversion to data frame is only a
+// stopgap, in the long term, we'll hash arrays natively.
 static uint32_t shaped_hash_scalar(SEXP x, R_len_t i) {
   x = PROTECT(r_as_data_frame(x));
   uint32_t out = hash_scalar(x, i);
@@ -250,6 +251,8 @@ static void df_hash_fill(uint32_t* p, R_len_t size, SEXP x);
 // [[ include("vctrs.h") ]]
 void hash_fill(uint32_t* p, R_len_t size, SEXP x) {
   if (has_dim(x)) {
+    // The conversion to data frame is only a stopgap, in the long
+    // term, we'll hash arrays natively
     x = PROTECT(r_as_data_frame(x));
     hash_fill(p, size, x);
     UNPROTECT(1);

--- a/src/utils.h
+++ b/src/utils.h
@@ -122,9 +122,8 @@ static inline double r_dbl_get(SEXP x, R_len_t i) {
   return REAL(x)[i];
 }
 
-static inline SEXP r_lgl(int x) {
-  return Rf_ScalarLogical(x);
-}
+#define r_lgl Rf_ScalarLogical
+#define r_int Rf_ScalarInteger
 
 SEXP r_as_list(SEXP x);
 SEXP r_as_data_frame(SEXP x);

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -81,6 +81,14 @@ test_that("vec_compare() calls vec_proxy_compare()", {
   expect_identical(vec_compare(1:3, foobar(1:3)), int(-1, 0, 1))
 })
 
+test_that("vec_proxy_compare() preserves data frames and vectors", {
+  df <- data_frame(x = 1:2, y = c("a", "b"))
+  expect_identical(vec_proxy_compare(df), df)
+
+  x <- c(NA, "a", "b", "c")
+  expect_identical(vec_proxy_compare(x), x)
+})
+
 
 # order/sort --------------------------------------------------------------
 

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -80,6 +80,16 @@ test_that("also works for data frames", {
   expect_identical(vec_unique(vec_slice(exp, c(1, 1, 2, 3))), exp)
 })
 
+test_that("vec_unique() handles matrices (#327)", {
+  x <- matrix(c(1, 2, 3, 4), c(2, 2))
+  y <- matrix(c(1, 2, 3, 5), c(2, 2))
+  expect_identical(vec_unique(list(x, x)), list(x))
+  expect_identical(vec_unique(list(x, y)), list(x, y))
+
+  x <- matrix(c(1, 2, 1, 1, 2, 1), nrow = 3)
+  expect_identical(vec_unique(x), vec_slice(x, 1:2))
+})
+
 
 # matching ----------------------------------------------------------------
 

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -8,6 +8,16 @@ test_that("vec_count counts number observations", {
   expect_equal(x, data.frame(key = 1:3, count = 1:3))
 })
 
+test_that("vec_count works with matrices", {
+  x <- matrix(c(1, 1, 1, 2, 2, 1), c(3, 2))
+
+  out <- vec_count(x)
+  exp <- data_frame(key = c(NA, NA), count = int(2L, 1L))
+  exp$key <- vec_slice(x, c(1, 3))
+
+  expect_identical(out, exp)
+})
+
 test_that("vec_count works with arrays", {
   x <- array(c(rep(1, 3), rep(2, 3)), dim = c(3, 2, 1))
   expect <- data.frame(key = NA, count = 3)

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -69,6 +69,20 @@ test_that("can hash list of non-vectors", {
   )
 })
 
+test_that("can hash matrices", {
+  x <- matrix(c(1, 2, 3, 4), c(2, 2))
+  y <- matrix(c(1, 2, 3, 5), c(2, 2))
+
+  expect_false(identical(
+    vec_hash(x, rowwise = TRUE),
+    vec_hash(y, rowwise = TRUE)
+  ))
+  expect_false(identical(
+    vec_hash(x, rowwise = FALSE),
+    vec_hash(y, rowwise = FALSE)
+  ))
+})
+
 
 # Object ------------------------------------------------------------------
 

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -69,18 +69,53 @@ test_that("can hash list of non-vectors", {
   )
 })
 
-test_that("can hash matrices", {
+test_that("can hash matrices rowwise", {
   x <- matrix(c(1, 2, 3, 4), c(2, 2))
-  y <- matrix(c(1, 2, 3, 5), c(2, 2))
+  expect_identical(
+    vec_hash(x, rowwise = TRUE),
+    vec_hash(x, rowwise = TRUE)
+  )
 
+  y <- matrix(c(1, 2, 3, 5), c(2, 2))
   expect_false(identical(
     vec_hash(x, rowwise = TRUE),
     vec_hash(y, rowwise = TRUE)
   ))
+})
+
+test_that("can hash matrices non-rowwise", {
+  x <- matrix(c(1, 1, 1, 2, 2, 1), c(3, 2))
+
+  expect_identical(
+    vec_hash(x, rowwise = FALSE),
+    vec_hash(x, rowwise = FALSE)
+  )
+
+  x <- matrix(c(1, 2, 3, 4), c(2, 2))
+
+  expect_identical(
+    vec_hash(x, rowwise = FALSE),
+    vec_hash(x, rowwise = FALSE)
+  )
+
+  expect_false(identical(
+    vec_hash(x, rowwise = FALSE),
+    vec_hash(c(1, 2), rowwise = FALSE)
+  ))
+
+  y <- matrix(c(1, 2, 3, 5), c(2, 2))
+
   expect_false(identical(
     vec_hash(x, rowwise = FALSE),
     vec_hash(y, rowwise = FALSE)
   ))
+})
+
+test_that("can hash with non-rowwise method", {
+  expect_identical(
+    vec_hash(NA, rowwise = FALSE),
+    vec_hash(NA, rowwise = FALSE),
+  )
 })
 
 


### PR DESCRIPTION
Closes #327.

`vec_hash()` and `vec_proxy_compare()` now transform matrices and arrays to data frames. This allows dictionary functions to behave properly.

cc @DavisVaughan 