### PR TITLE
Implement `vec_c()` in C

### DIFF
--- a/R/bind.R
+++ b/R/bind.R
@@ -162,7 +162,7 @@ as_df_col <- function(x, outer_name) UseMethod("as_df_col")
 
 #' @export
 as_df_col.data.frame <- function(x, outer_name = NULL) {
-  names(x) <- outer_names(outer_name, names(x), length(x))
+  names(x) <- outer_names(names(x), outer_name, length(x))
   x
 }
 
@@ -172,7 +172,7 @@ as_df_col.default <- function(x, outer_name = NULL) {
     x <- stats::setNames(list(x), outer_name)
     new_data_frame(x)
   } else {
-    colnames(x) <- outer_names(outer_name, colnames(x), ncol(x))
+    colnames(x) <- outer_names(colnames(x), outer_name, ncol(x))
     as.data.frame(x)
   }
 }

--- a/R/c.R
+++ b/R/c.R
@@ -57,7 +57,7 @@ vec_c <- function(..., .ptype = NULL) {
 
     x <- vec_cast(args[[i]], to = ptype)
 
-    names[pos:(pos + n - 1)] <- outer_names(names(args)[[i]], vec_names(args[[i]]), length(x))
+    names[pos:(pos + n - 1)] <- outer_names(vec_names(args[[i]]), names(args)[[i]], length(x))
     vec_slice(out, pos:(pos + n - 1)) <- x
     pos <- pos + n
   }

--- a/R/c.R
+++ b/R/c.R
@@ -32,39 +32,5 @@
 #' c(factor("a"), factor("b"))
 #' vec_c(factor("a"), factor("b"))
 vec_c <- function(..., .ptype = NULL) {
-  args <- list2(...)
-
-  ptype <- vec_type_common(!!!args, .ptype = .ptype)
-  if (is.null(ptype))
-    return(NULL)
-
-  is_null <- map_lgl(args, is_null)
-  args <- args[!is_null]
-
-  ns <- map_int(args, vec_size)
-  out <- vec_na(ptype, sum(ns))
-  if (is.null(names(args)) && !has_inner_names(args)) {
-    names <- NULL
-  } else {
-    names <- vec_na(character(), sum(ns))
-  }
-
-  pos <- 1
-  for (i in seq_along(ns)) {
-    n <- ns[[i]]
-    if (n == 0L)
-      next
-
-    x <- vec_cast(args[[i]], to = ptype)
-
-    names[pos:(pos + n - 1)] <- outer_names(vec_names(args[[i]]), names(args)[[i]], length(x))
-    vec_slice(out, pos:(pos + n - 1)) <- x
-    pos <- pos + n
-  }
-
-  if (!is.null(names)) {
-    vec_names(out) <- names
-  }
-
-  out
+  .External2(vctrs_c, .ptype)
 }

--- a/R/names.R
+++ b/R/names.R
@@ -420,3 +420,9 @@ tick_if_needed <- function(x) {
   x[needs_ticks] <- tick(x[needs_ticks])
   x
 }
+
+# Used in names.c
+set_rownames <- function(x, names) {
+  rownames(x) <- names
+  x
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,21 +16,8 @@ vec_coerce_bare <- function(x, type) {
 
 # Matches the semantics of c() - based on experimenting with the output
 # of c(), not reading the source code.
-outer_names <- function(outer, names, n) {
-  has_outer <- !is.null(outer) && !outer %in% c("", NA)
-  if (!has_outer)
-    return(names)
-
-  has_inner <- !is.null(names)
-  if (has_inner) {
-    paste0(outer, "..", names)
-  } else {
-    if (n == 1) {
-      outer
-    } else {
-      paste0(outer, seq_len(n))
-    }
-  }
+outer_names <- function(names, outer, n) {
+  .Call(vctrs_outer_names, names, outer, vec_cast(n, int()))
 }
 
 has_inner_names <- function(x) {

--- a/src/c.c
+++ b/src/c.c
@@ -47,9 +47,11 @@ static SEXP vec_c(SEXP xs, SEXP ptype) {
     ns[i] = size;
   }
 
-  SEXP out = vec_na(ptype, out_size);
   PROTECT_INDEX out_pi;
+  SEXP out = vec_na(ptype, out_size);
   PROTECT_WITH_INDEX(out, &out_pi);
+  out = vec_proxy(out);
+  REPROTECT(out, out_pi);
 
   SEXP idx = PROTECT(compact_seq(0, 0));
   int* idx_ptr = INTEGER(idx);
@@ -98,6 +100,8 @@ static SEXP vec_c(SEXP xs, SEXP ptype) {
   if (has_names) {
     Rf_setAttrib(out, R_NamesSymbol, out_names);
   }
+
+  out = vec_restore(out, ptype, R_NilValue);
 
   UNPROTECT(6);
   return out;

--- a/src/c.c
+++ b/src/c.c
@@ -1,0 +1,118 @@
+#include "vctrs.h"
+#include "utils.h"
+
+// From type.c
+SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype);
+
+// From slice-assign.c
+SEXP vec_assign_impl(SEXP proxy, SEXP index, SEXP value, bool clone);
+
+static SEXP vec_c(SEXP xs, SEXP ptype);
+static bool list_has_inner_names(SEXP xs);
+
+
+// [[ register(external = TRUE) ]]
+SEXP vctrs_c(SEXP call, SEXP op, SEXP args, SEXP env) {
+  args = CDR(args);
+
+  SEXP xs = PROTECT(rlang_env_dots_list(env));
+  SEXP ptype = PROTECT(Rf_eval(CAR(args), env));
+
+  SEXP out = vec_c(xs, ptype);
+
+  UNPROTECT(2);
+  return out;
+}
+
+static SEXP vec_c(SEXP xs, SEXP ptype) {
+  R_len_t n = Rf_length(xs);
+
+  ptype = PROTECT(vctrs_type_common_impl(xs, ptype));
+
+  if (ptype == R_NilValue) {
+    UNPROTECT(1);
+    return R_NilValue;
+  }
+
+  // Find individual input sizes and total size of output
+  R_len_t out_size = 0;
+
+  SEXP ns_placeholder = PROTECT(Rf_allocVector(INTSXP, n));
+  int* ns = INTEGER(ns_placeholder);
+
+  for (R_len_t i = 0; i < n; ++i) {
+    SEXP elt = VECTOR_ELT(xs, i);
+    R_len_t size = (elt == R_NilValue) ? 0 : vec_size(elt);
+    out_size += size;
+    ns[i] = size;
+  }
+
+  SEXP out = vec_na(ptype, out_size);
+  PROTECT_INDEX out_pi;
+  PROTECT_WITH_INDEX(out, &out_pi);
+
+  SEXP idx = PROTECT(compact_seq(0, 0));
+  int* idx_ptr = INTEGER(idx);
+
+  SEXP xs_names = PROTECT(r_names(xs));
+  bool has_names = xs_names != R_NilValue || list_has_inner_names(xs);
+  SEXP out_names = has_names ? Rf_allocVector(STRSXP, out_size) : R_NilValue;
+  PROTECT(out_names);
+
+  bool is_shaped = has_dim(ptype);
+
+  // Compact sequences use 0-based counters
+  R_len_t counter = 0;
+
+  for (R_len_t i = 0; i < n; ++i) {
+    R_len_t size = ns[i];
+    if (!size) {
+      continue;
+    }
+
+    SEXP x = VECTOR_ELT(xs, i);
+    SEXP elt = PROTECT(vec_cast(x, ptype));
+
+    if (is_shaped) {
+      SEXP idx = PROTECT(r_seq(counter + 1, counter + size + 1));
+      out = vec_assign(out, idx, elt);
+      REPROTECT(out, out_pi);
+      UNPROTECT(1);
+    } else {
+      idx_ptr[0] = counter;
+      idx_ptr[1] = counter + size;
+      vec_assign_impl(out, idx, elt, false);
+    }
+
+    if (has_names) {
+      SEXP outer = xs_names == R_NilValue ? R_NilValue : STRING_ELT(xs_names, i);
+      SEXP x_nms = outer_names(PROTECT(vec_names(x)), outer, size);
+      vec_assign_impl(out_names, idx, x_nms, false);
+      UNPROTECT(1);
+    }
+
+    counter += size;
+    UNPROTECT(1);
+  }
+
+  if (has_names) {
+    Rf_setAttrib(out, R_NamesSymbol, out_names);
+  }
+
+  UNPROTECT(6);
+  return out;
+}
+
+
+static bool list_has_inner_names(SEXP xs) {
+  R_len_t n = Rf_length(xs);
+
+  for (R_len_t i = 0; i < n; ++i) {
+    SEXP elt = VECTOR_ELT(xs, i);
+    if (vec_names(elt) != R_NilValue) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/c.c
+++ b/src/c.c
@@ -75,14 +75,15 @@ static SEXP vec_c(SEXP xs, SEXP ptype) {
     SEXP x = VECTOR_ELT(xs, i);
     SEXP elt = PROTECT(vec_cast(x, ptype));
 
+    idx_ptr[0] = counter;
+    idx_ptr[1] = counter + size;
+
     if (is_shaped) {
       SEXP idx = PROTECT(r_seq(counter + 1, counter + size + 1));
       out = vec_assign(out, idx, elt);
       REPROTECT(out, out_pi);
       UNPROTECT(1);
     } else {
-      idx_ptr[0] = counter;
-      idx_ptr[1] = counter + size;
       vec_assign_impl(out, idx, elt, false);
     }
 
@@ -98,7 +99,12 @@ static SEXP vec_c(SEXP xs, SEXP ptype) {
   }
 
   if (has_names) {
-    Rf_setAttrib(out, R_NamesSymbol, out_names);
+    if (is_shaped) {
+      out = set_rownames(out, out_names);
+      REPROTECT(out, out_pi);
+    } else {
+      Rf_setAttrib(out, R_NamesSymbol, out_names);
+    }
   }
 
   out = vec_restore(out, ptype, R_NilValue);

--- a/src/init.c
+++ b/src/init.c
@@ -146,6 +146,7 @@ void R_init_vctrs(DllInfo *dll)
 void vctrs_init_cast(SEXP ns);
 void vctrs_init_data(SEXP ns);
 void vctrs_init_dictionary(SEXP ns);
+void vctrs_init_names(SEXP ns);
 void vctrs_init_slice(SEXP ns);
 void vctrs_init_slice_assign(SEXP ns);
 void vctrs_init_type2(SEXP ns);
@@ -158,6 +159,7 @@ SEXP vctrs_init(SEXP ns) {
   vctrs_init_cast(ns);
   vctrs_init_data(ns);
   vctrs_init_dictionary(ns);
+  vctrs_init_names(ns);
   vctrs_init_slice(ns);
   vctrs_init_slice_assign(ns);
   vctrs_init_type2(ns);

--- a/src/init.c
+++ b/src/init.c
@@ -60,6 +60,7 @@ extern SEXP vctrs_coercible_cast(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_assign(SEXP, SEXP, SEXP);
 extern SEXP vctrs_set_attributes(SEXP, SEXP);
 extern SEXP vctrs_as_df_row(SEXP, SEXP);
+extern SEXP vctrs_outer_names(SEXP, SEXP, SEXP);
 
 // Defined below
 SEXP vctrs_init(SEXP);
@@ -118,6 +119,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_assign",                     (DL_FUNC) &vec_assign, 3},
   {"vctrs_set_attributes",             (DL_FUNC) &vctrs_set_attributes, 2},
   {"vctrs_as_df_row",                  (DL_FUNC) &vctrs_as_df_row, 2},
+  {"vctrs_outer_names",                (DL_FUNC) &vctrs_outer_names, 3},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -126,11 +126,13 @@ static const R_CallMethodDef CallEntries[] = {
 extern SEXP vctrs_type_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cast_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_rbind(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_c(SEXP, SEXP, SEXP, SEXP);
 
 static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_type_common",                (DL_FUNC) &vctrs_type_common, 1},
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 1},
   {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 1},
+  {"vctrs_c",                          (DL_FUNC) &vctrs_c, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/names.c
+++ b/src/names.c
@@ -450,3 +450,21 @@ static SEXP outer_names_seq(const char* outer, R_len_t n) {
 
   return r_chr_iota(n, buf, total_len, outer);
 }
+
+
+// Initialised at load time
+SEXP syms_set_rownames = NULL;
+SEXP fns_set_rownames = NULL;
+
+// [[ include("utils.h") ]]
+SEXP set_rownames(SEXP x, SEXP names) {
+  return vctrs_dispatch2(syms_set_rownames, fns_set_rownames,
+                         syms_x, x,
+                         syms_names, names);
+}
+
+
+void vctrs_init_names(SEXP ns) {
+  syms_set_rownames = Rf_install("set_rownames");
+  fns_set_rownames = r_env_get(ns, syms_set_rownames);
+}

--- a/src/names.c
+++ b/src/names.c
@@ -4,7 +4,7 @@
 static void describe_repair(SEXP old, SEXP new);
 
 
-// [[ register() ]]
+// [[ register(); include("vctrs.h") ]]
 SEXP vec_names(SEXP x) {
   if (OBJECT(x) && Rf_inherits(x, "data.frame")) {
     return R_NilValue;

--- a/src/names.c
+++ b/src/names.c
@@ -323,25 +323,15 @@ SEXP vctrs_unique_names(SEXP x, SEXP quiet) {
 
 // 3 leading '.' + 1 trailing '\0' + 24 characters
 #define TOTAL_BUF_SIZE 28
-#define FREE_BUF_SIZE 25
 
 static SEXP names_iota(R_len_t n) {
-  SEXP nms = PROTECT(Rf_allocVector(STRSXP, n));
+  char buf[TOTAL_BUF_SIZE];
+  SEXP nms = r_chr_iota(n, buf, TOTAL_BUF_SIZE, "...");
 
-  char buf[TOTAL_BUF_SIZE] = "...";
-  char* beg = buf + 3;
-
-  for (R_len_t i = 0; i < n; ++i) {
-    int written = snprintf(beg, FREE_BUF_SIZE, "%d", i + 1);
-
-    if (written >= FREE_BUF_SIZE) {
-      Rf_errorcall(R_NilValue, "Can't write repaired names as there are too many.");
-    }
-
-    SET_STRING_ELT(nms, i, Rf_mkChar(buf));
+  if (nms == R_NilValue) {
+    Rf_errorcall(R_NilValue, "Too many names to repair.");
   }
 
-  UNPROTECT(1);
   return nms;
 }
 

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -9,7 +9,7 @@ SEXP fns_vec_assign_fallback = NULL;
 SEXP vec_as_index(SEXP i, SEXP x);
 
 static SEXP vec_assign_fallback(SEXP x, SEXP index, SEXP value);
-static SEXP vec_assign_impl(SEXP x, SEXP index, SEXP value, bool clone);
+SEXP vec_assign_impl(SEXP x, SEXP index, SEXP value, bool clone);
 static SEXP lgl_assign(SEXP x, SEXP index, SEXP value, bool clone);
 static SEXP int_assign(SEXP x, SEXP index, SEXP value, bool clone);
 static SEXP dbl_assign(SEXP x, SEXP index, SEXP value, bool clone);
@@ -20,6 +20,7 @@ static SEXP list_assign(SEXP x, SEXP index, SEXP value, bool clone);
 SEXP df_assign(SEXP x, SEXP index, SEXP value, bool clone);
 
 
+// [[ register(); include("vctrs.h") ]]
 SEXP vec_assign(SEXP x, SEXP index, SEXP value) {
   if (x == R_NilValue) {
     return R_NilValue;
@@ -60,7 +61,7 @@ SEXP vec_assign(SEXP x, SEXP index, SEXP value) {
  *   own the relevant parts of the vector structure (data frame
  *   columns in particular).
  */
-static SEXP vec_assign_impl(SEXP proxy, SEXP index, SEXP value, bool clone) {
+SEXP vec_assign_impl(SEXP proxy, SEXP index, SEXP value, bool clone) {
   switch (vec_proxy_typeof(proxy)) {
   case vctrs_type_logical:   return lgl_assign(proxy, index, value, clone);
   case vctrs_type_integer:   return int_assign(proxy, index, value, clone);

--- a/src/utils.c
+++ b/src/utils.c
@@ -353,7 +353,6 @@ SEXP r_seq(R_len_t from, R_len_t to) {
   return seq;
 }
 
-
 bool r_int_any_na(SEXP x) {
   int* data = INTEGER(x);
   R_len_t n = Rf_length(x);
@@ -367,6 +366,19 @@ bool r_int_any_na(SEXP x) {
   return false;
 }
 
+
+int r_chr_max_len(SEXP x) {
+  R_len_t n = Rf_length(x);
+  SEXP* p = STRING_PTR(x);
+
+  int max = 0;
+  for (R_len_t i = 0; i < n; ++i, ++p) {
+    int len = strlen(CHAR(*p));
+    max = len > max ? len : max;
+  }
+
+  return max;
+}
 
 /**
  * Create a character vector of sequential integers
@@ -473,6 +485,11 @@ bool r_is_string(SEXP x) {
     Rf_length(x) == 1 &&
     STRING_ELT(x, 0) != NA_STRING;
 }
+bool r_is_number(SEXP x) {
+  return TYPEOF(x) == INTSXP &&
+    Rf_length(x) == 1 &&
+    INTEGER(x)[0] != NA_INTEGER;
+}
 
 SEXP r_peek_option(const char* option) {
   return Rf_GetOption1(Rf_install(option));
@@ -530,7 +547,47 @@ bool r_has_name_at(SEXP names, R_len_t i) {
   }
 
   SEXP elt = STRING_ELT(names, i);
-  return elt != NA_STRING && elt != Rf_mkChar("");
+  return elt != NA_STRING && elt != strings_empty;
+}
+
+bool r_is_minimal_names(SEXP x) {
+  if (TYPEOF(x) != STRSXP) {
+    return false;
+  }
+
+  R_len_t n = Rf_length(x);
+  const SEXP* p = STRING_PTR_RO(x);
+
+  for (R_len_t i = 0; i < n; ++i, ++p) {
+    SEXP elt = *p;
+    if (elt == NA_STRING || elt == strings_empty) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool r_is_empty_names(SEXP x) {
+  if (TYPEOF(x) != STRSXP) {
+    if (x == R_NilValue) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  R_len_t n = Rf_length(x);
+  const SEXP* p = STRING_PTR_RO(x);
+
+  for (R_len_t i = 0; i < n; ++i, ++p) {
+    SEXP elt = *p;
+    if (elt != NA_STRING && elt != strings_empty) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 SEXP r_env_get(SEXP env, SEXP sym) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -368,6 +368,41 @@ bool r_int_any_na(SEXP x) {
 }
 
 
+/**
+ * Create a character vector of sequential integers
+ *
+ * @param n The sequence is from 1 to `n`.
+ * @param buf,len A memory buffer of size `len`.
+ * @param prefix A null-terminated string that is prefixed to the
+ *   sequence.
+ */
+SEXP r_chr_iota(R_len_t n, char* buf, int len, const char* prefix) {
+  int prefix_len = strlen(prefix);
+  if (len - 1 < prefix_len) {
+    Rf_errorcall(R_NilValue, "Internal error: Prefix is larger than iota buffer.");
+  }
+
+  memcpy(buf, prefix, prefix_len);
+  len -= prefix_len;
+  char* beg = buf + prefix_len;
+
+  SEXP out = PROTECT(Rf_allocVector(STRSXP, n));
+
+  for (R_len_t i = 0; i < n; ++i) {
+    int written = snprintf(beg, len, "%d", i + 1);
+
+    if (written >= len) {
+      return R_NilValue;
+    }
+
+    SET_STRING_ELT(out, i, Rf_mkChar(buf));
+  }
+
+  UNPROTECT(1);
+  return out;
+}
+
+
 #include <R_ext/Parse.h>
 
 static void abort_parse(SEXP code, const char* why) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -67,6 +67,7 @@ SEXP compact_seq(R_len_t from, R_len_t to);
 bool is_compact_seq(SEXP x);
 
 SEXP outer_names(SEXP names, SEXP outer, R_len_t n);
+SEXP set_rownames(SEXP x, SEXP names);
 
 bool (*rlang_is_splice_box)(SEXP);
 SEXP (*rlang_unbox)(SEXP);

--- a/src/utils.h
+++ b/src/utils.h
@@ -82,6 +82,8 @@ SEXP r_seq(R_len_t from, R_len_t to);
 
 bool r_int_any_na(SEXP x);
 
+SEXP r_chr_iota(R_len_t n, char* buf, int len, const char* prefix);
+
 SEXP r_new_environment(SEXP parent, R_len_t size);
 
 SEXP r_protect(SEXP x);

--- a/src/utils.h
+++ b/src/utils.h
@@ -66,6 +66,8 @@ R_len_t compact_rownames_length(SEXP x);
 SEXP compact_seq(R_len_t from, R_len_t to);
 bool is_compact_seq(SEXP x);
 
+SEXP outer_names(SEXP names, SEXP outer, R_len_t n);
+
 bool (*rlang_is_splice_box)(SEXP);
 SEXP (*rlang_unbox)(SEXP);
 SEXP (*rlang_env_dots_values)(SEXP);
@@ -79,9 +81,9 @@ void r_int_fill(SEXP x, int value);
 
 void r_int_fill_seq(SEXP x, int start);
 SEXP r_seq(R_len_t from, R_len_t to);
-
 bool r_int_any_na(SEXP x);
 
+int r_chr_max_len(SEXP x);
 SEXP r_chr_iota(R_len_t n, char* buf, int len, const char* prefix);
 
 SEXP r_new_environment(SEXP parent, R_len_t size);
@@ -89,6 +91,7 @@ SEXP r_new_environment(SEXP parent, R_len_t size);
 SEXP r_protect(SEXP x);
 bool r_is_true(SEXP x);
 bool r_is_string(SEXP x);
+bool r_is_number(SEXP x);
 SEXP r_peek_option(const char* option);
 SEXP r_names(SEXP x);
 SEXP r_maybe_duplicate(SEXP x);
@@ -98,6 +101,8 @@ SEXP r_call(SEXP fn, SEXP* tags, SEXP* cars);
 
 SEXP r_names(SEXP x);
 bool r_has_name_at(SEXP names, R_len_t i);
+bool r_is_minimal_names(SEXP x);
+bool r_is_empty_names(SEXP x);
 SEXP r_env_get(SEXP env, SEXP sym);
 bool r_is_function(SEXP x);
 bool r_chr_has_string(SEXP x, SEXP str);
@@ -123,9 +128,11 @@ static inline double r_dbl_get(SEXP x, R_len_t i) {
   r__vec_get_check(x, i, "r_dbl_get");
   return REAL(x)[i];
 }
+#define r_chr_get STRING_ELT
 
 #define r_lgl Rf_ScalarLogical
 #define r_int Rf_ScalarInteger
+#define r_str Rf_mkChar
 
 SEXP r_as_list(SEXP x);
 SEXP r_as_data_frame(SEXP x);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -200,6 +200,7 @@ SEXP vec_cast(SEXP x, SEXP to);
 SEXP vec_cast_common(SEXP xs, SEXP to);
 SEXP vec_coercible_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_slice(SEXP x, SEXP index);
+SEXP vec_assign(SEXP x, SEXP index, SEXP value);
 SEXP vec_na(SEXP x, R_len_t n);
 SEXP vec_type(SEXP x);
 SEXP vec_type_finalise(SEXP x);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -205,6 +205,7 @@ SEXP vec_type(SEXP x);
 SEXP vec_type_finalise(SEXP x);
 bool vec_is_unspecified(SEXP x);
 SEXP vec_recycle(SEXP x, R_len_t size);
+SEXP vec_names(SEXP x);
 
 SEXP vec_type2(SEXP x,
                SEXP y,

--- a/tests/testthat/helper-rational.R
+++ b/tests/testthat/helper-rational.R
@@ -1,0 +1,44 @@
+
+# Rational record class from the S3 vector vignette
+
+new_rational <- function(n = integer(), d = integer()) {
+  vec_assert(n, ptype = integer())
+  vec_assert(d, ptype = integer())
+  new_rcrd(list(n = n, d = d), class = "vctrs_rational")
+}
+
+rational <- function(n, d) {
+  c(n, d) %<-% vec_cast_common(n, d, .to = integer())
+  c(n, d) %<-% vec_recycle_common(n, d)
+  new_rational(n, d)
+}
+
+format.vctrs_rational <- function(x, ...) {
+  n <- field(x, "n")
+  d <- field(x, "d")
+  out <- paste0(n, "/", d)
+  out[is.na(n) | is.na(d)] <- NA
+  out
+}
+
+scoped_rational_class <- function(frame = caller_env()) {
+  scoped_global_bindings(.frame = frame,
+    vec_ptype_abbr.vctrs_rational = function(x) "rtnl",
+    vec_ptype_full.vctrs_rational = function(x) "rational",
+
+    vec_type2.vctrs_rational = function(x, y, ...) UseMethod("vec_type2.vctrs_rational", y),
+    vec_type2.vctrs_rational.default = function(x, y, ..., x_arg = "", y_arg = "") {
+      stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
+    },
+    vec_type2.vctrs_rational.vctrs_unspecified = function(x, y, ...) x,
+    vec_type2.vctrs_rational.vctrs_rational = function(x, y, ...) new_rational(),
+    vec_type2.vctrs_rational.integer = function(x, y, ...) new_rational(),
+    vec_type2.integer.vctrs_rational = function(x, y, ...) new_rational(),
+
+    vec_cast.vctrs_rational = function(x, to) UseMethod("vec_cast.vctrs_rational"),
+    vec_cast.vctrs_rational.default = function(x, to) vec_default_cast(x, to),
+    vec_cast.vctrs_rational.vctrs_rational = function(x, to) x,
+    vec_cast.double.vctrs_rational = function(x, to) field(x, "n") / field(x, "d"),
+    vec_cast.vctrs_rational.integer = function(x, to) rational(x, 1)
+  )
+}

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -56,8 +56,14 @@ test_that("can bind data.frame columns", {
 })
 
 test_that("vec_c() handles matrices", {
-    m <- matrix(1:4, nrow = 2)
-    expect_identical(vec_c(m, m), matrix(c(1:2, 1:2, 3:4, 3:4), nrow = 4))
+  m <- matrix(1:4, nrow = 2)
+  dimnames(m) <- list(c("foo", "bar"), c("baz", "quux"))
+
+  # FIXME: `vec_type_common(m, m)` doesn't return dimension names
+  exp <- matrix(c(1:2, 1:2, 3:4, 3:4), nrow = 4)
+  rownames(exp) <- c("foo", "bar", "foo", "bar")
+
+  expect_identical(vec_c(m, m), exp)
 })
 
 test_that("vec_c() includes index in argument tag", {

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -70,3 +70,13 @@ test_that("vec_c() includes index in argument tag", {
     try2(vec_c(foo = df1, bar = df2))
   })
 })
+
+test_that("vec_c() handles record classes", {
+  scoped_rational_class()
+
+  out <- vec_c(rational(1, 2), 1L, NA)
+
+  expect_true(vec_is(out, rational(1, 2)))
+  expect_size(out, 3)
+  expect_identical(vec_proxy(out), data.frame(n = c(1L, 1L, NA), d = c(2L, 1L, NA)))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -5,16 +5,16 @@ context("test-utils")
 test_that("names preserved if outer name is missing", {
   x <- c("a", "z", "")
 
-  expect_equal(outer_names(NULL, x, 3), x)
-  expect_equal(outer_names("", x, 3), x)
-  expect_equal(outer_names(NA, x, 3), x)
+  expect_equal(outer_names(x, NULL, 3), x)
+  expect_equal(outer_names(x, "", 3), x)
+  expect_equal(outer_names(x, na_chr, 3), x)
 })
 
 test_that("outer name vectorised if needed", {
-  expect_equal(outer_names("x", NULL, 1L), c("x"))
-  expect_equal(outer_names("x", NULL, 2L), c("x1", "x2"))
+  expect_equal(outer_names(NULL, "x", 1L), c("x"))
+  expect_equal(outer_names(NULL, "x", 2L), c("x1", "x2"))
 })
 
 test_that("outer and inner names are combined", {
-  expect_equal(outer_names("y", "x", 1), c("y..x"))
+  expect_equal(outer_names("x", "y", 1), c("y..x"))
 })


### PR DESCRIPTION
The before marks are for current master. We should expect `vec_c()` to be 10 times slower as `c()` with types handled natively.

```r
bench <- function(..., base = c) {
  bench::mark(
    base = base(...),
    vctrs = vec_c(...),
    before = vec_c_old(...),
    check = FALSE
  )[1:6]
}

bench(1, 2, 3)
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 base          347ns    456ns  2023612.        0B      0
#> 2 vctrs        4.16µs   4.95µs   195711.        0B      0
#> 3 before       43.9µs  51.55µs    18969.        0B     17.5

bench(1, FALSE, 3L)
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 base          351ns    469ns  1930289.        0B      0
#> 2 vctrs        4.13µs   5.11µs   189542.        0B     19.0
#> 3 before      45.01µs  51.25µs    18739.        0B     15.0

bench(mtcars, mtcars, base = rbind)
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 base        195.6µs  219.1µs     4504.      12KB    13.2
#> 2 vctrs        29.7µs   40.3µs    24631.    13.4KB     9.86
#> 3 before      100.6µs  120.7µs     8285.    25.5KB     8.82


# Base S3 types and shaped vectors still need some work:

bench(factor("a"), factor("b"))
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 base          1.4µs   1.84µs   515996.        0B      0
#> 2 vctrs         149µs 169.32µs     5625.        0B     12.8
#> 3 before      493.7µs  547.1µs     1744.        0B     10.6

bench(as.matrix(mtcars), as.matrix(mtcars), base = rbind)
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 base         2.91µs   3.94µs   203508.    11.7KB    20.4
#> 2 vctrs      309.95µs  356.9µs     2696.    63.2KB    10.5
#> 3 before     383.21µs 424.81µs     2281.   276.1KB     8.36
```