### PR TITLE
Fix casting of shaped `vctrs_vctr` to `data.frame`

### DIFF
--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -273,16 +273,33 @@ as.POSIXct.vctrs_vctr <- function(x, tz = "", ...) {
   vec_cast(x, new_datetime(tzone = tz))
 }
 
+# Work around inconsistencies in as.data.frame() for 1D arrays
+as.data.frame2 <- function(x) {
+  out <- as.data.frame(x)
+
+  if (vec_dims(x) == 1) {
+    # 1D arrays are not stripped from their dimensions
+    out[[1]] <- as.vector(out[[1]])
+
+    # 1D arrays are auto-labelled with substitute()
+    names(out) <- "V1"
+  }
+
+  out
+}
 
 #' @export
 as.data.frame.vctrs_vctr <- function(x,
-                               row.names = NULL,
-                               optional = FALSE,
-                               ...,
-                               nm = paste(deparse(substitute(x), width.cutoff = 500L), collapse = " ")
-                               ) {
-
+                                     row.names = NULL,
+                                     optional = FALSE,
+                                     ...,
+                                     nm = paste(deparse(substitute(x), width.cutoff = 500L), collapse = " ")) {
   force(nm)
+
+  if (has_dim(x)) {
+    return(as.data.frame2(vec_data(x)))
+  }
+
   cols <- list(x)
   if (!optional) {
     names(cols) <- nm

--- a/src/hash.c
+++ b/src/hash.c
@@ -54,21 +54,10 @@ static uint32_t df_hash_scalar(SEXP x, R_len_t i);
 static uint32_t list_hash_scalar(SEXP x, R_len_t i);
 static uint32_t shaped_hash_scalar(SEXP x, R_len_t i);
 
-static bool is_dimensional(SEXP x) {
-  if (!has_dim(x)) {
-    return false;
-  }
-
-  // Work around inconsistency with 1D arrays. These are dispatched
-  // to `as.data.frame.vector()` which currently does not strip
-  // dimensions. This caused an infinite recursion.
-  return vec_dims(x) > 1;
-}
-
 
 // [[ include("vctrs.h") ]]
 uint32_t hash_scalar(SEXP x, R_len_t i) {
-  if (is_dimensional(x)) {
+  if (has_dim(x)) {
     return shaped_hash_scalar(x, i);
   }
 
@@ -273,7 +262,7 @@ static void df_hash_fill(uint32_t* p, R_len_t size, SEXP x);
 // Not compatible with hash_scalar
 // [[ include("vctrs.h") ]]
 void hash_fill(uint32_t* p, R_len_t size, SEXP x) {
-  if (is_dimensional(x)) {
+  if (has_dim(x)) {
     // The conversion to data frame is only a stopgap, in the long
     // term, we'll hash arrays natively
     x = PROTECT(r_as_data_frame(x));

--- a/src/utils.c
+++ b/src/utils.c
@@ -22,9 +22,9 @@ SEXP classes_data_frame = NULL;
 SEXP classes_tibble = NULL;
 
 static SEXP syms_as_list = NULL;
-static SEXP syms_as_data_frame = NULL;
+static SEXP syms_as_data_frame2 = NULL;
 static SEXP fns_as_list = NULL;
-static SEXP fns_as_data_frame = NULL;
+static SEXP fns_as_data_frame2 = NULL;
 
 
 bool is_bool(SEXP x) {
@@ -644,7 +644,7 @@ SEXP r_as_data_frame(SEXP x) {
   if (is_bare_data_frame(x)) {
     return x;
   } else {
-    return vctrs_dispatch1(syms_as_data_frame, fns_as_data_frame, syms_x, x);
+    return vctrs_dispatch1(syms_as_data_frame2, fns_as_data_frame2, syms_x, x);
   }
 }
 
@@ -815,9 +815,9 @@ void vctrs_init_utils(SEXP ns) {
   rlang_env_dots_list = (SEXP (*)(SEXP)) R_GetCCallable("rlang", "rlang_env_dots_list");
 
   syms_as_list = Rf_install("as.list");
-  syms_as_data_frame = Rf_install("as.data.frame");
+  syms_as_data_frame2 = Rf_install("as.data.frame2");
   fns_as_list = r_env_get(R_BaseEnv, syms_as_list);
-  fns_as_data_frame = r_env_get(R_BaseEnv, syms_as_data_frame);
+  fns_as_data_frame2 = r_env_get(ns, syms_as_data_frame2);
 
 
   compact_seq_attrib = Rf_cons(R_NilValue, R_NilValue);

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -95,6 +95,9 @@ test_that("vec_unique() works with 1D arrays", {
   # currently does not strip dimensions. This caused an infinite
   # recursion.
   expect_identical(vec_unique(array(1:2)), array(1:2))
+
+  x <- new_vctr(c(1, 1, 1, 2, 1, 2), dim = c(3, 2))
+  expect_identical(vec_unique(x), new_vctr(c(1, 1, 2, 1), dim = c(2, 2)))
 })
 
 

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -122,7 +122,7 @@ test_that("can hash 1D arrays", {
   # 1D arrays are dispatched to `as.data.frame.vector()` which
   # currently does not strip dimensions. This caused an infinite
   # recursion.
-  expect_identical(vec_hash(array(1:2), TRUE), vec_hash(1:2, TRUE))
+  expect_length(vec_hash(array(1:2), TRUE), 8)
   expect_identical(vec_hash(array(1:2), FALSE), vec_hash(1:2, FALSE))
 })
 

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -406,6 +406,14 @@ test_that("can't transpose", {
   expect_error(t(h), class = "vctrs_error_unsupported")
 })
 
+test_that("shaped vctrs can be cast to data frames", {
+  x <- new_vctr(1:4, dim = 4)
+  expect_identical(as.data.frame(x), data.frame(V1 = 1:4))
+
+  x <- new_vctr(1:4, dim = c(2, 2))
+  expect_identical(as.data.frame(x), data.frame(V1 = 1:2, V2 = 3:4))
+})
+
 
 # slicing -----------------------------------------------------------------
 


### PR DESCRIPTION
@DavisVaughan This should fix `vec_unique()` with rrays and this way you don't have to override `as.data.frame()`.