### PR TITLE
Assert that `vec_assign()`'s `value` argument must be a vector

### DIFF
--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -29,6 +29,7 @@ SEXP vec_assign(SEXP x, SEXP index, SEXP value) {
   struct vctrs_arg x_arg = new_wrapper_arg(NULL, "x");
   struct vctrs_arg value_arg = new_wrapper_arg(NULL, "value");
   vec_assert(x, &x_arg);
+  vec_assert(value, &value_arg);
 
   // Take the proxy of the RHS before coercing and recycling
   value = PROTECT(vec_coercible_cast(value, x, &value_arg, &x_arg));

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -5,6 +5,12 @@ test_that("slice-assign throws error with non-vector inputs", {
   expect_error(vec_slice(x, 1L) <- 1L, class = "vctrs_error_scalar_type")
 })
 
+test_that("slice-assign throws error with non-vector `value`", {
+  x <- 1L
+  expect_error(vec_slice(x, 1L) <- NULL, class = "vctrs_error_scalar_type")
+  expect_error(vec_slice(x, 1L) <- environment(), class = "vctrs_error_scalar_type")
+})
+
 test_that("can slice-assign NULL", {
   x <- NULL
   vec_slice(x, 1L) <- 1


### PR DESCRIPTION
Closes #285 

Rather than special casing `NULL`, this felt more appropriate. Since we already `vec_assert()` that `x` is a vector, it makes sense that `value` must be one too.

``` r
library(vctrs)
x <- 1
vec_slice(x, 1L) <- NULL
#> `value` must be a vector, not NULL
vec_slice(x, 1L) <- environment()
#> `value` must be a vector, not an environment
```

<sup>Created on 2019-06-04 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>