### PR TITLE
Use vctrs primitives in `vec_data()`

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -68,11 +68,9 @@
 #' @export
 vec_data <- function(x) {
   vec_assert(x)
+  x <- vec_proxy(x)
 
-  # TODO: implement with ALTREP to avoid making a copy
-  if (is_record(x)) {
-    x <- vec_set_attributes(x, list(names = fields(x)))
-  } else if (has_dim(x)) {
+  if (has_dim(x)) {
     x <- vec_set_attributes(x, list(dim = dim(x), dimnames = dimnames(x)))
   } else {
     x <- vec_set_attributes(x, list(names = names(x)))
@@ -109,10 +107,3 @@ vec_proxy_equal <- function(x) {
     "Please use `vec_proxy()` instead (if needed)."
   ))
 }
-
-is_record <- function(x) {
-  UseMethod("is_record")
-}
-is_record.POSIXlt <- function(x) TRUE
-is_record.vctrs_rcrd <- function(x) TRUE
-is_record.default <- function(x) FALSE

--- a/R/data.R
+++ b/R/data.R
@@ -67,9 +67,7 @@
 #'   `vec_restore(vec_data(x), x)` will always yield `x`.
 #' @export
 vec_data <- function(x) {
-  if (!is_vector(x)) {
-    return(x)
-  }
+  vec_assert(x)
 
   # TODO: implement with ALTREP to avoid making a copy
   if (is_record(x)) {

--- a/R/type-sclr.R
+++ b/R/type-sclr.R
@@ -40,7 +40,7 @@ print.vctrs_sclr <- function(x, ...) {
 
 #' @export
 as.list.vctrs_sclr <- function(x, ...) {
-  vec_data(x)
+  vec_set_attributes(x, list(names = names(x)))
 }
 
 #' @export

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -38,3 +38,8 @@ test_that("can take the proxy of non-vector objects", {
   scoped_env_proxy()
   expect_identical(vec_proxy(new_proxy(1:3)), 1:3)
 })
+
+test_that("vec_data() asserts vectorness", {
+  expect_error(vec_data(new_sclr()), class = "vctrs_error_scalar_type")
+  expect_error(vec_data(~foo), class = "vctrs_error_scalar_type")
+})

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -43,3 +43,9 @@ test_that("vec_data() asserts vectorness", {
   expect_error(vec_data(new_sclr()), class = "vctrs_error_scalar_type")
   expect_error(vec_data(~foo), class = "vctrs_error_scalar_type")
 })
+
+test_that("vec_data() is proxied", {
+  scoped_env_proxy()
+  x <- new_proxy(mtcars)
+  expect_identical(vec_data(x), vec_data(mtcars))
+})


### PR DESCRIPTION
* Assert input is a vector.
* Take the proxy.

I'm unsure of the original intent for allowing scalars, but it seems safer to restrict inputs to vector types at first. I think it makes the result of `vec_data()` more defined since the data in a scalar object like a model fit is unlikely to be vectorised data like you would find in a record or atomic.