### PR TITLE
Recursive reset_rownames()

### DIFF
--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -66,7 +66,7 @@ reset_rownames <- function(x) {
   rownames(x) <- NULL
 
   is_df <- map_lgl(x, is.data.frame)
-  x[is_df] <- lapply(x[is_df], `rownames<-`, NULL)
+  x[is_df] <- lapply(x[is_df], reset_rownames)
 
   x
 }


### PR DESCRIPTION
to support deeply nested data frames.

Probably harmless now, but perhaps this function will be used later in other contexts.