### PR TITLE
Extract is_unique_names() and duplicated_any()

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -132,6 +132,12 @@ SEXP vctrs_unique_loc(SEXP x) {
 }
 
 SEXP vctrs_duplicated_any(SEXP x) {
+  bool out = duplicated_any(x);
+  return Rf_ScalarLogical(out);
+}
+
+// [[ include("vctrs.h") ]]
+bool duplicated_any(SEXP x) {
   x = PROTECT(vec_proxy_equal(x));
 
   dictionary d;
@@ -154,7 +160,7 @@ SEXP vctrs_duplicated_any(SEXP x) {
   dict_free(&d);
   UNPROTECT(1);
 
-  return Rf_ScalarLogical(out);
+  return out;
 }
 
 SEXP vctrs_n_distinct(SEXP x) {

--- a/src/init.c
+++ b/src/init.c
@@ -48,6 +48,7 @@ extern SEXP vctrs_minimal_names(SEXP);
 extern SEXP vctrs_unique_names(SEXP, SEXP);
 extern SEXP vctrs_as_minimal_names(SEXP);
 extern SEXP vec_names(SEXP);
+extern SEXP vctrs_is_unique_names(SEXP);
 extern SEXP vctrs_as_unique_names(SEXP, SEXP);
 extern SEXP df_as_dataframe(SEXP, SEXP);
 extern SEXP vctrs_type2_df_df(SEXP, SEXP, SEXP, SEXP);
@@ -109,6 +110,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_unique_names",               (DL_FUNC) &vctrs_unique_names, 2},
   {"vctrs_as_minimal_names",           (DL_FUNC) &vctrs_as_minimal_names, 1},
   {"vctrs_names",                      (DL_FUNC) &vec_names, 1},
+  {"vctrs_is_unique_names",            (DL_FUNC) &vctrs_is_unique_names, 1},
   {"vctrs_as_unique_names",            (DL_FUNC) &vctrs_as_unique_names, 2},
   {"vctrs_df_as_dataframe",            (DL_FUNC) &df_as_dataframe, 2},
   {"vctrs_type2_df_df",                (DL_FUNC) &vctrs_type2_df_df, 4},

--- a/src/names.c
+++ b/src/names.c
@@ -108,17 +108,17 @@ bool is_unique_names(SEXP names) {
   R_len_t n = Rf_length(names);
   const SEXP* names_ptr = STRING_PTR_RO(names);
 
-  SEXP dups = PROTECT(vctrs_duplicated(names));
-  const int* dups_ptr = LOGICAL_RO(dups);
+  if (duplicated_any(names)) {
+    return false;
+  }
 
   for (R_len_t i = 0; i < n; ++i) {
     SEXP elt = names_ptr[i];
 
-    if (needs_suffix(elt) || suffix_pos(CHAR(elt)) >= 0 || dups_ptr[i]) {
+    if (needs_suffix(elt) || suffix_pos(CHAR(elt)) >= 0) {
       return false;
     }
   }
-  UNPROTECT(1);
 
   return true;
 }

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -253,6 +253,8 @@ void hash_fill(uint32_t* p, R_len_t n, SEXP x);
 bool is_unique_names(SEXP names);
 SEXP as_unique_names(SEXP names, bool quiet);
 
+bool duplicated_any(SEXP names);
+
 // Experimental:
 SEXP vec_restore_container(SEXP x, SEXP to, R_len_t n);
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -250,6 +250,7 @@ uint32_t hash_object(SEXP x);
 uint32_t hash_scalar(SEXP x, R_len_t i);
 void hash_fill(uint32_t* p, R_len_t n, SEXP x);
 
+bool is_unique_names(SEXP names);
 SEXP as_unique_names(SEXP names, bool quiet);
 
 // Experimental:


### PR DESCRIPTION
to further simplify name repair and to prepare for `"check_unique"`.