### PR TITLE
Custom name repair gives a message

### DIFF
--- a/R/names.R
+++ b/R/names.R
@@ -155,8 +155,13 @@ vec_as_names <- function(names,
 
   if (is_function(repair)) {
     names <- as_minimal_names(names)
-    names <- validate_minimal(repair(names), n = length(names))
-    return(names)
+    new_names <- validate_minimal(repair(names), n = length(names))
+
+    if (!quiet) {
+      describe_repair(names, new_names)
+    }
+
+    return(new_names)
   }
 
   switch(repair,
@@ -220,8 +225,13 @@ vec_names2 <- function(x,
 
   if (is_function(repair)) {
     names <- minimal_names(x)
-    names <- validate_minimal(repair(names), n = length(names))
-    return(names)
+    new_names <- validate_minimal(repair(names), n = length(names))
+
+    if (!quiet) {
+      describe_repair(names, new_names)
+    }
+
+    return(new_names)
   }
 
   switch(repair,

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -381,6 +381,12 @@ test_that("messages by default", {
     "New names:\n* `a:b` -> a.b\n",
     fixed = TRUE
   )
+
+  expect_message(
+    vec_repair_names(set_names(1, "a:b"), ~ make.names(.)),
+    "New names:\n* `a:b` -> a.b\n",
+    fixed = TRUE
+  )
 })
 
 test_that("quiet = TRUE", {


### PR DESCRIPTION
Closes tidyverse/tibble#595.

``` r
vctrs::vec_as_names(c(".", "."), repair = ~ make.names(., unique = TRUE))
```

<sup>Created on 2019-06-13 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>