### PR TITLE
Inline `can_s3_register_now()`

### DIFF
--- a/R/register-s3.R
+++ b/R/register-s3.R
@@ -64,7 +64,7 @@ s3_register <- function(generic, class, method = NULL) {
 
   # Avoid registration failures during loading (pkgload or regular)
   if (!isNamespaceLoaded(package)) {
-    return()
+    return(invisible())
   }
 
   envir <- asNamespace(package)
@@ -73,6 +73,8 @@ s3_register <- function(generic, class, method = NULL) {
   if (exists(generic, envir)) {
     registerS3method(generic, class, method, envir = envir)
   }
+
+  invisible()
 }
 
 # nocov end

--- a/R/register-s3.R
+++ b/R/register-s3.R
@@ -54,16 +54,6 @@ s3_register <- function(generic, class, method = NULL) {
   }
   stopifnot(is.function(method))
 
-  envir <- asNamespace(package)
-
-  # Avoid registration failures during loading (pkgload or regular),
-  # only register if generic can be accessed
-  can_register <- isNamespaceLoaded(package) && exists(generic, envir)
-
-  if (can_register) {
-    registerS3method(generic, class, method, envir = envir)
-  }
-
   # Always register hook in case package is later unloaded & reloaded
   setHook(
     packageEvent(package, "onLoad"),
@@ -71,6 +61,18 @@ s3_register <- function(generic, class, method = NULL) {
       registerS3method(generic, class, method, envir = asNamespace(package))
     }
   )
+
+  # Avoid registration failures during loading (pkgload or regular)
+  if (!isNamespaceLoaded(package)) {
+    return()
+  }
+
+  envir <- asNamespace(package)
+
+  # Only register if generic can be accessed
+  if (exists(generic, envir)) {
+    registerS3method(generic, class, method, envir = envir)
+  }
 }
 
 # nocov end


### PR DESCRIPTION
Closes #371 

- Inlines `can_s3_register_now()` so `s3_register()` stands alone
- Uses `isNamespaceLoaded()` which was added in R 3.2.0
- Stores `asNamespace(package)` as `envir` rather than calling it twice

I've reordered things a bit as well for maximal clarity. The hook is set first, and then we have a potential early exit if the namespace is not loaded. Then we only register if we can also find the generic in the namespace. I think this makes it a bit more readable, and the comments read in a nice order.