### PR TITLE
Construct `base::order()` call with `expr()`

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -144,7 +144,7 @@ order_proxy <- function(proxy, direction = "asc", na_value = "largest") {
   if (is.data.frame(proxy)) {
     args <- unname(proxy)
     order_expr <- expr(
-      base::order(!!! args, decreasing = decreasing, na.last = na.last)
+      base::order(!!!args, decreasing = decreasing, na.last = na.last)
     )
     eval_bare(order_expr)
   } else if (is_character(proxy) || is_logical(proxy) || is_integer(proxy) || is_double(proxy)) {

--- a/R/compare.R
+++ b/R/compare.R
@@ -142,6 +142,11 @@ order_proxy <- function(proxy, direction = "asc", na_value = "largest") {
   }
 
   if (is.data.frame(proxy)) {
+    # Avoid empty data frames getting a `NULL` order
+    if (vec_size(proxy) == 0L) {
+      return(integer(0L))
+    }
+
     args <- unname(proxy)
     order_expr <- expr(
       base::order(!!!args, decreasing = decreasing, na.last = na.last)

--- a/R/compare.R
+++ b/R/compare.R
@@ -143,10 +143,10 @@ order_proxy <- function(proxy, direction = "asc", na_value = "largest") {
 
   if (is.data.frame(proxy)) {
     args <- unname(proxy)
-    args$decreasing <- decreasing
-    args$na.last <- na.last
-
-    do.call(base::order, args)
+    order_expr <- expr(
+      base::order(!!! args, decreasing = decreasing, na.last = na.last)
+    )
+    eval_bare(order_expr)
   } else if (is_character(proxy) || is_logical(proxy) || is_integer(proxy) || is_double(proxy)) {
     order(proxy, decreasing = decreasing, na.last = na.last)
   } else {

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -114,6 +114,14 @@ test_that("can sort data frames", {
   expect_equal(out2, data.frame(x = c(2, 1, 1), y = c(2, 2, 1)))
 })
 
+test_that("can sort empty data frames (#356)", {
+  df1 <- data.frame()
+  expect_equal(vec_sort(df1), df1)
+
+  df2 <- data.frame(x = numeric(), y = integer())
+  expect_equal(vec_sort(df2), df2)
+})
+
 test_that("can order tibbles that contain non-comparable objects", {
   expect_equal(vec_order(data_frame(list(10, 2, 1))), 1:3)
 })
@@ -126,4 +134,12 @@ test_that("can order matrices and arrays (#306)", {
   x[2] <- 1
   x[3] <- 5
   expect_identical(vec_order(x), 2:1)
+})
+
+test_that("can order empty data frames (#356)", {
+  df1 <- data.frame()
+  expect_equal(vec_order(df1), NULL)
+
+  df2 <- data.frame(x = numeric(), y = integer())
+  expect_equal(vec_order(df2), integer())
 })

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -138,7 +138,7 @@ test_that("can order matrices and arrays (#306)", {
 
 test_that("can order empty data frames (#356)", {
   df1 <- data.frame()
-  expect_equal(vec_order(df1), NULL)
+  expect_equal(vec_order(df1), integer())
 
   df2 <- data.frame(x = numeric(), y = integer())
   expect_equal(vec_order(df2), integer())


### PR DESCRIPTION
Closes #356 

This failed because we were trying to attach the `base::order()` arguments to the unnamed data frame, which had 0 rows.

```
> vec_sort(data.frame())
Error in `$<-.data.frame`(`*tmp*`, "decreasing", value = FALSE) : 
  replacement has 1 row, data has 0
```

Instead, I now construct the `base::order()` expression with `expr()`, using `!!!` for the unnamed data frame.

This results in the following behavior:

``` r
library(vctrs)

vec_order(data.frame())
#> NULL

# consistent with order() called with no `...` args
# because that is essentially what happens, but maybe we want something
# different?
order()
#> NULL

vec_sort(data.frame())
#> data frame with 0 columns and 0 rows

vec_order(data.frame(x = numeric()))
#> integer(0)

vec_sort(data.frame(x = numeric()))
#> [1] x
#> <0 rows> (or 0-length row.names)
```

I feel like it might be appropriate for `vec_order(data.frame())` to return `integer(0)`, but I think the only way to do that is an early exit if `vec_size(x) == 0`