### PR TITLE
Default to `fixed = TRUE` in `expect_error_cnd()`

### DIFF
--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -80,11 +80,11 @@ expect_syntactic <- function(name, exp_syn_name) {
   expect_identical(syn_name, make.names(syn_name))
 }
 
-expect_error_cnd <- function(object, class, message, ...) {
-  cnd <- expect_error(object, regexp = message, class = class)
+expect_error_cnd <- function(object, class, message, ..., .fixed = TRUE) {
+  cnd <- expect_error(object, regexp = message, class = class, fixed = .fixed)
   expect_true(inherits_all(cnd, class))
 
-  exp_fields <- list(...)
+  exp_fields <- list2(...)
   expect_true(is_empty(setdiff(!!names(exp_fields), names(cnd))))
   expect_equal(cnd[names(exp_fields)], exp_fields)
 }

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -80,7 +80,7 @@ expect_syntactic <- function(name, exp_syn_name) {
   expect_identical(syn_name, make.names(syn_name))
 }
 
-expect_error_cnd <- function(object, class, message, ..., .fixed = TRUE) {
+expect_error_cnd <- function(object, class, message = NULL, ..., .fixed = TRUE) {
   cnd <- expect_error(object, regexp = message, class = class, fixed = .fixed)
   expect_true(inherits_all(cnd, class))
 


### PR DESCRIPTION
We shouldn't use regexp checking by default.