### PR TITLE
Add name repair parameter to `vec_cbind()`, `vec_rbind()`, and `vec_c()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # vctrs 0.1.0.9000
 
-* `vec_cbind()` gains a `.name_repair` argument.
+* `vec_c()` and `vec_cbind()` gain a `.name_repair` argument (#227).
 
 * `vec_dims()` has been replaced by `vec_dim_n()`. This name more clearly
   indicates the purpose of the function.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # vctrs 0.1.0.9000
 
-* `vec_c()` and `vec_cbind()` gain a `.name_repair` argument (#227).
+* `vec_c()`, `vec_rbind()`, and `vec_cbind()` gain a `.name_repair`
+  argument (#227, #229).
 
 * `vec_dims()` has been replaced by `vec_dim_n()`. This name more clearly
   indicates the purpose of the function.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
 # vctrs 0.1.0.9000
 
+* `vec_cbind()` gains a `.name_repair` argument.
+
 * `vec_dims()` has been replaced by `vec_dim_n()`. This name more clearly
   indicates the purpose of the function.
-  
+
 * New `stop_incompatible_size()` to signal a failure due to mismatched sizes.
 
 * `vec_empty()` has been renamed to `vec_is_empty()`.

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,0 +1,16 @@
+
+# nocov start
+
+# Useful for micro-optimising default arguments requiring evaluation,
+# such as `param = c("foo", "bar")`. Buys about 0.6us on my desktop.
+fn_inline_formals <- function(fn, names) {
+  stopifnot(typeof(fn) == "closure")
+
+  fmls <- formals(fn)
+  fmls[names] <- lapply(fmls[names], eval)
+
+  formals(fn) <- fmls
+  fn
+}
+
+# nocov end

--- a/R/bind.R
+++ b/R/bind.R
@@ -36,6 +36,9 @@
 #'
 #'   `NULL` inputs are silently ignored. Empty (e.g. zero row) inputs
 #'   will not appear in the output, but will affect the derived `.ptype`.
+#' @param .name_repair One of `"unique"`, `"universal"`, or
+#'   `"check_unique"`. See [vec_as_names()] for the meaning of these
+#'   options.
 #' @inheritParams vec_c
 #' @return A data frame, or subclass of data frame.
 #'
@@ -108,9 +111,12 @@ NULL
 
 #' @export
 #' @rdname vec_bind
-vec_rbind <- function(..., .ptype = NULL) {
-  .External2(vctrs_rbind, .ptype)
+vec_rbind <- function(...,
+                      .ptype = NULL,
+                      .name_repair = c("unique", "universal", "check_unique")) {
+  .External2(vctrs_rbind, .ptype, .name_repair)
 }
+vec_rbind <- fn_inline_formals(vec_rbind, ".name_repair")
 
 #' @export
 #' @rdname vec_bind
@@ -119,9 +125,6 @@ vec_rbind <- function(..., .ptype = NULL) {
 #'
 #'   Alternatively, specify the desired number of rows, and any inputs
 #'   of length 1 will be recycled appropriately.
-#' @param .name_repair One of `"unique"`, `"universal"`, or
-#'   `"check_unique"`. See [vec_as_names()] for the meaning of these
-#'   options.
 vec_cbind <- function(...,
                       .ptype = NULL,
                       .size = NULL,

--- a/R/bind.R
+++ b/R/bind.R
@@ -128,7 +128,7 @@ vec_rbind <- fn_inline_formals(vec_rbind, ".name_repair")
 vec_cbind <- function(...,
                       .ptype = NULL,
                       .size = NULL,
-                      .name_repair = c("unique", "universal", "check_unique")) {
+                      .name_repair = c("unique", "universal", "check_unique", "minimal")) {
   .External2(vctrs_cbind, .ptype, .size, .name_repair)
 }
 vec_cbind <- fn_inline_formals(vec_cbind, ".name_repair")

--- a/R/bind.R
+++ b/R/bind.R
@@ -39,6 +39,14 @@
 #' @param .name_repair One of `"unique"`, `"universal"`, or
 #'   `"check_unique"`. See [vec_as_names()] for the meaning of these
 #'   options.
+#'
+#'   With `vec_rbind()`, the repair function is applied to all inputs
+#'   separately. This is because `vec_rbind()` needs to align their
+#'   columns before binding the rows, and thus needs all inputs to
+#'   have unique names. On the other hand, `vec_cbind()` applies the
+#'   repair function after all inputs have been concatenated together
+#'   in a final data frame. Hence `vec_cbind()` allows the more
+#'   permissive minimal names repair.
 #' @inheritParams vec_c
 #' @return A data frame, or subclass of data frame.
 #'

--- a/R/bind.R
+++ b/R/bind.R
@@ -119,8 +119,14 @@ vec_rbind <- function(..., .ptype = NULL) {
 #'
 #'   Alternatively, specify the desired number of rows, and any inputs
 #'   of length 1 will be recycled appropriately.
-vec_cbind <- function(..., .ptype = NULL, .size = NULL) {
-  .External2(vctrs_cbind, .ptype, .size)
+#' @param .name_repair One of `"unique"`, `"universal"`, or
+#'   `"check_unique"`. See [vec_as_names()] for the meaning of these
+#'   options.
+vec_cbind <- function(...,
+                      .ptype = NULL,
+                      .size = NULL,
+                      .name_repair = c("unique", "universal", "check_unique")) {
+  .External2(vctrs_cbind, .ptype, .size, .name_repair)
 }
 
 as_df_row <- function(x, quiet = FALSE) {

--- a/R/bind.R
+++ b/R/bind.R
@@ -129,6 +129,14 @@ vec_cbind <- function(...,
   .External2(vctrs_cbind, .ptype, .size, .name_repair)
 }
 
+# Micro-optimisation: don't compute `.name_repair` at each invokation
+formals(vec_cbind) <- pairlist2(
+  ... = ,
+  .ptype = NULL,
+  .size = NULL,
+  .name_repair = c("unique", "universal", "check_unique")
+)
+
 as_df_row <- function(x, quiet = FALSE) {
   .Call(vctrs_as_df_row, x, quiet)
 }

--- a/R/bind.R
+++ b/R/bind.R
@@ -128,14 +128,7 @@ vec_cbind <- function(...,
                       .name_repair = c("unique", "universal", "check_unique")) {
   .External2(vctrs_cbind, .ptype, .size, .name_repair)
 }
-
-# Micro-optimisation: don't compute `.name_repair` at each invokation
-formals(vec_cbind) <- pairlist2(
-  ... = ,
-  .ptype = NULL,
-  .size = NULL,
-  .name_repair = c("unique", "universal", "check_unique")
-)
+vec_cbind <- fn_inline_formals(vec_cbind, ".name_repair")
 
 as_df_row <- function(x, quiet = FALSE) {
   .Call(vctrs_as_df_row, x, quiet)

--- a/R/c.R
+++ b/R/c.R
@@ -37,10 +37,4 @@ vec_c <- function(...,
                   .name_repair = c("minimal", "unique", "check_unique", "universal")) {
   .External2(vctrs_c, .ptype, .name_repair)
 }
-
-# Micro-optimisation: don't compute `.name_repair` at each invokation
-formals(vec_c) <- pairlist2(
-  ... = ,
-  .ptype = NULL,
-  .name_repair = c("minimal", "unique", "check_unique", "universal")
-)
+vec_c <- fn_inline_formals(vec_c, ".name_repair")

--- a/R/c.R
+++ b/R/c.R
@@ -7,6 +7,7 @@
 #' * `vec_type(vec_c(x, y)) == vec_type_common(x, y)`.
 #'
 #' @param ... Vectors to coerce.
+#' @param .name_repair How to repair names, see `repair` options in [vec_as_names()].
 #' @return A vector with class given by `.ptype`, and length equal to the
 #'   sum of the `vec_size()` of the contents of `...`.
 #'
@@ -31,6 +32,8 @@
 #' # Factors -----------------------------
 #' c(factor("a"), factor("b"))
 #' vec_c(factor("a"), factor("b"))
-vec_c <- function(..., .ptype = NULL) {
-  .External2(vctrs_c, .ptype)
+vec_c <- function(...,
+                  .ptype = NULL,
+                  .name_repair = c("minimal", "unique", "check_unique", "universal")) {
+  .External2(vctrs_c, .ptype, .name_repair)
 }

--- a/R/c.R
+++ b/R/c.R
@@ -37,3 +37,10 @@ vec_c <- function(...,
                   .name_repair = c("minimal", "unique", "check_unique", "universal")) {
   .External2(vctrs_c, .ptype, .name_repair)
 }
+
+# Micro-optimisation: don't compute `.name_repair` at each invokation
+formals(vec_c) <- pairlist2(
+  ... = ,
+  .ptype = NULL,
+  .name_repair = c("minimal", "unique", "check_unique", "universal")
+)

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -8,7 +8,8 @@
 \usage{
 vec_rbind(..., .ptype = NULL)
 
-vec_cbind(..., .ptype = NULL, .size = NULL)
+vec_cbind(..., .ptype = NULL, .size = NULL,
+  .name_repair = c("unique", "universal", "check_unique"))
 }
 \arguments{
 \item{...}{Data frames or vectors.
@@ -31,6 +32,10 @@ rows in \code{vec_cbind()} output by using the standard recycling rules.
 
 Alternatively, specify the desired number of rows, and any inputs
 of length 1 will be recycled appropriately.}
+
+\item{.name_repair}{One of \code{"unique"}, \code{"universal"}, or
+\code{"check_unique"}. See \code{\link[=vec_as_names]{vec_as_names()}} for the meaning of these
+options.}
 }
 \value{
 A data frame, or subclass of data frame.

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -6,7 +6,8 @@
 \alias{vec_cbind}
 \title{Combine many data frames into one data frame}
 \usage{
-vec_rbind(..., .ptype = NULL)
+vec_rbind(..., .ptype = NULL, .name_repair = c("unique", "universal",
+  "check_unique"))
 
 vec_cbind(..., .ptype = NULL, .size = NULL,
   .name_repair = c("unique", "universal", "check_unique"))
@@ -27,15 +28,15 @@ Alternatively, you can supply \code{.ptype} to give the output known type.
 If \code{getOption("vctrs.no_guessing")} is \code{TRUE} you must supply this value:
 this is a convenient way to make production code demand fixed types.}
 
+\item{.name_repair}{One of \code{"unique"}, \code{"universal"}, or
+\code{"check_unique"}. See \code{\link[=vec_as_names]{vec_as_names()}} for the meaning of these
+options.}
+
 \item{.size}{If, \code{NULL}, the default, will determine the number of
 rows in \code{vec_cbind()} output by using the standard recycling rules.
 
 Alternatively, specify the desired number of rows, and any inputs
 of length 1 will be recycled appropriately.}
-
-\item{.name_repair}{One of \code{"unique"}, \code{"universal"}, or
-\code{"check_unique"}. See \code{\link[=vec_as_names]{vec_as_names()}} for the meaning of these
-options.}
 }
 \value{
 A data frame, or subclass of data frame.

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -10,7 +10,7 @@ vec_rbind(..., .ptype = NULL, .name_repair = c("unique", "universal",
   "check_unique"))
 
 vec_cbind(..., .ptype = NULL, .size = NULL,
-  .name_repair = c("unique", "universal", "check_unique"))
+  .name_repair = c("unique", "universal", "check_unique", "minimal"))
 }
 \arguments{
 \item{...}{Data frames or vectors.

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -30,7 +30,15 @@ this is a convenient way to make production code demand fixed types.}
 
 \item{.name_repair}{One of \code{"unique"}, \code{"universal"}, or
 \code{"check_unique"}. See \code{\link[=vec_as_names]{vec_as_names()}} for the meaning of these
-options.}
+options.
+
+With \code{vec_rbind()}, the repair function is applied to all inputs
+separately. This is because \code{vec_rbind()} needs to align their
+columns before binding the rows, and thus needs all inputs to
+have unique names. On the other hand, \code{vec_cbind()} applies the
+repair function after all inputs have been concatenated together
+in a final data frame. Hence \code{vec_cbind()} allows the more
+permissive minimal names repair.}
 
 \item{.size}{If, \code{NULL}, the default, will determine the number of
 rows in \code{vec_cbind()} output by using the standard recycling rules.

--- a/man/vec_c.Rd
+++ b/man/vec_c.Rd
@@ -4,7 +4,8 @@
 \alias{vec_c}
 \title{Combine many vectors into one vector}
 \usage{
-vec_c(..., .ptype = NULL)
+vec_c(..., .ptype = NULL, .name_repair = c("minimal", "unique",
+  "check_unique", "universal"))
 }
 \arguments{
 \item{...}{Vectors to coerce.}
@@ -15,6 +16,8 @@ computing the common type across all elements of \code{...}.
 Alternatively, you can supply \code{.ptype} to give the output known type.
 If \code{getOption("vctrs.no_guessing")} is \code{TRUE} you must supply this value:
 this is a convenient way to make production code demand fixed types.}
+
+\item{.name_repair}{How to repair names, see \code{repair} options in \code{\link[=vec_as_names]{vec_as_names()}}.}
 }
 \value{
 A vector with class given by \code{.ptype}, and length equal to the

--- a/src/bind.c
+++ b/src/bind.c
@@ -217,7 +217,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size) {
     UNPROTECT(1);
   }
 
-  names = PROTECT(as_unique_names(names, false));
+  names = PROTECT(vec_as_unique_names(names, false));
   Rf_setAttrib(out, R_NamesSymbol, names);
 
   out = vec_restore(out, type, R_NilValue);

--- a/src/init.c
+++ b/src/init.c
@@ -145,7 +145,7 @@ static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_size_common",                (DL_FUNC) &vctrs_size_common, 2},
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 1},
   {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 1},
-  {"vctrs_cbind",                      (DL_FUNC) &vctrs_cbind, 2},
+  {"vctrs_cbind",                      (DL_FUNC) &vctrs_cbind, 3},
   {"vctrs_c",                          (DL_FUNC) &vctrs_c, 1},
   {NULL, NULL, 0}
 };

--- a/src/init.c
+++ b/src/init.c
@@ -144,7 +144,7 @@ static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_type_common",                (DL_FUNC) &vctrs_type_common, 1},
   {"vctrs_size_common",                (DL_FUNC) &vctrs_size_common, 2},
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 1},
-  {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 1},
+  {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 2},
   {"vctrs_cbind",                      (DL_FUNC) &vctrs_cbind, 3},
   {"vctrs_c",                          (DL_FUNC) &vctrs_c, 2},
   {NULL, NULL, 0}

--- a/src/init.c
+++ b/src/init.c
@@ -146,7 +146,7 @@ static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 1},
   {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 1},
   {"vctrs_cbind",                      (DL_FUNC) &vctrs_cbind, 3},
-  {"vctrs_c",                          (DL_FUNC) &vctrs_c, 1},
+  {"vctrs_c",                          (DL_FUNC) &vctrs_c, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/names.c
+++ b/src/names.c
@@ -93,7 +93,7 @@ static ptrdiff_t suffix_pos(const char* name);
 static bool needs_suffix(SEXP str);
 
 // [[ include("vctrs.h") ]]
-SEXP as_unique_names(SEXP names, bool quiet) {
+SEXP vec_as_unique_names(SEXP names, bool quiet) {
   if (is_unique_names(names) && !any_has_suffix(names)) {
     return names;
   } else {
@@ -208,7 +208,7 @@ SEXP as_unique_names_impl(SEXP names, bool quiet) {
 }
 
 SEXP vctrs_as_unique_names(SEXP names, SEXP quiet) {
-  SEXP out = PROTECT(as_unique_names(names, LOGICAL(quiet)[0]));
+  SEXP out = PROTECT(vec_as_unique_names(names, LOGICAL(quiet)[0]));
   UNPROTECT(1);
   return out;
 }
@@ -322,7 +322,7 @@ SEXP vec_unique_names(SEXP x, bool quiet) {
       describe_repair(names, out);
     }
   } else {
-    out = PROTECT(as_unique_names(names, quiet));
+    out = PROTECT(vec_as_unique_names(names, quiet));
   }
 
   UNPROTECT(2);

--- a/src/names.c
+++ b/src/names.c
@@ -523,6 +523,17 @@ enum name_repair_arg validate_name_repair(SEXP arg) {
   Rf_errorcall(R_NilValue, "`.name_repair` can't be \"%s\". See `?vctrs::vec_as_names`.", CHAR(arg));
 }
 
+// [[ include("vctrs.h") ]]
+const char* name_repair_arg_as_c_string(enum name_repair_arg arg) {
+  switch (arg) {
+  case name_repair_none: return "none";
+  case name_repair_minimal: return "minimal";
+  case name_repair_unique: return "unique";
+  case name_repair_universal: return "universal";
+  case name_repair_check_unique: return "check_unique";
+  }
+}
+
 
 void vctrs_init_names(SEXP ns) {
   syms_set_rownames = Rf_install("set_rownames");

--- a/src/names.c
+++ b/src/names.c
@@ -459,6 +459,33 @@ SEXP set_rownames(SEXP x, SEXP names) {
 }
 
 
+enum name_repair_arg validate_name_repair(SEXP arg) {
+  if (!Rf_length(arg)) {
+    Rf_errorcall(R_NilValue, "`.name_repair` must be a string. See `?vctrs::vec_as_names`.");
+  }
+
+  arg = r_chr_get(arg, 0);
+
+  if (arg == strings_none) {
+    return name_repair_none;
+  }
+  if (arg == strings_minimal) {
+    return name_repair_minimal;
+  }
+  if (arg == strings_unique) {
+    return name_repair_unique;
+  }
+  if (arg == strings_universal) {
+    return name_repair_universal;
+  }
+  if (arg == strings_check_unique) {
+    return name_repair_check_unique;
+  }
+
+  Rf_errorcall(R_NilValue, "`.name_repair` can't be \"%s\". See `?vctrs::vec_as_names`.", CHAR(arg));
+}
+
+
 void vctrs_init_names(SEXP ns) {
   syms_set_rownames = Rf_install("set_rownames");
   fns_set_rownames = r_env_get(ns, syms_set_rownames);

--- a/src/utils.c
+++ b/src/utils.c
@@ -705,6 +705,7 @@ SEXP syms_x_arg = NULL;
 SEXP syms_y_arg = NULL;
 SEXP syms_out = NULL;
 SEXP syms_value = NULL;
+SEXP syms_quiet = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -842,6 +843,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_y_arg = Rf_install("y_arg");
   syms_out = Rf_install("out");
   syms_value = Rf_install("value");
+  syms_quiet = Rf_install("quiet");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.c
+++ b/src/utils.c
@@ -688,6 +688,11 @@ SEXP vctrs_shared_na_lgl = NULL;
 SEXP strings = NULL;
 SEXP strings_empty = NULL;
 SEXP strings_dots = NULL;
+SEXP strings_none = NULL;
+SEXP strings_minimal = NULL;
+SEXP strings_unique = NULL;
+SEXP strings_universal = NULL;
+SEXP strings_check_unique = NULL;
 
 SEXP syms_i = NULL;
 SEXP syms_n = NULL;
@@ -718,7 +723,7 @@ void vctrs_init_utils(SEXP ns) {
 
   // Holds the CHARSXP objects because unlike symbols they can be
   // garbage collected
-  strings = Rf_allocVector(STRSXP, 6);
+  strings = Rf_allocVector(STRSXP, 11);
   R_PreserveObject(strings);
 
   strings_dots = Rf_mkChar("...");
@@ -738,6 +743,21 @@ void vctrs_init_utils(SEXP ns) {
 
   strings_vctrs_vctr = Rf_mkChar("vctrs_vctr");
   SET_STRING_ELT(strings, 5, strings_vctrs_vctr);
+
+  strings_none = Rf_mkChar("none");
+  SET_STRING_ELT(strings, 6, strings_none);
+
+  strings_minimal = Rf_mkChar("minimal");
+  SET_STRING_ELT(strings, 7, strings_minimal);
+
+  strings_unique = Rf_mkChar("unique");
+  SET_STRING_ELT(strings, 8, strings_unique);
+
+  strings_universal = Rf_mkChar("universal");
+  SET_STRING_ELT(strings, 9, strings_universal);
+
+  strings_check_unique = Rf_mkChar("check_unique");
+  SET_STRING_ELT(strings, 10, strings_check_unique);
 
 
   classes_data_frame = Rf_allocVector(STRSXP, 1);

--- a/src/utils.h
+++ b/src/utils.h
@@ -176,6 +176,11 @@ extern SEXP strings_vctrs_rcrd;
 extern SEXP strings_posixlt;
 extern SEXP strings_posixt;
 extern SEXP strings_vctrs_vctr;
+extern SEXP strings_none;
+extern SEXP strings_minimal;
+extern SEXP strings_unique;
+extern SEXP strings_universal;
+extern SEXP strings_check_unique;
 
 extern SEXP syms_i;
 extern SEXP syms_n;
@@ -188,6 +193,7 @@ extern SEXP syms_x_arg;
 extern SEXP syms_y_arg;
 extern SEXP syms_out;
 extern SEXP syms_value;
+extern SEXP syms_quiet;
 
 #define syms_names R_NamesSymbol
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -264,6 +264,7 @@ enum name_repair_arg {
 };
 
 enum name_repair_arg validate_name_repair(SEXP arg);
+SEXP vec_as_names(SEXP names, enum name_repair_arg type, bool quiet);
 bool is_unique_names(SEXP names);
 SEXP vec_as_unique_names(SEXP names, bool quiet);
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -250,13 +250,25 @@ uint32_t hash_object(SEXP x);
 uint32_t hash_scalar(SEXP x, R_len_t i);
 void hash_fill(uint32_t* p, R_len_t n, SEXP x);
 
-bool is_unique_names(SEXP names);
-
 bool duplicated_any(SEXP names);
 
 
-// Growable vector -----------------------------------------------
+// Names --------------------------------------------------------
+
+enum name_repair_arg {
+  name_repair_none,
+  name_repair_minimal,
+  name_repair_unique,
+  name_repair_universal,
+  name_repair_check_unique
+};
+
+enum name_repair_arg validate_name_repair(SEXP arg);
+bool is_unique_names(SEXP names);
 SEXP vec_as_unique_names(SEXP names, bool quiet);
+
+
+// Growable vector ----------------------------------------------
 
 struct growable {
   SEXP x;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -251,12 +251,12 @@ uint32_t hash_scalar(SEXP x, R_len_t i);
 void hash_fill(uint32_t* p, R_len_t n, SEXP x);
 
 bool is_unique_names(SEXP names);
-SEXP as_unique_names(SEXP names, bool quiet);
 
 bool duplicated_any(SEXP names);
 
 
 // Growable vector -----------------------------------------------
+SEXP vec_as_unique_names(SEXP names, bool quiet);
 
 struct growable {
   SEXP x;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -263,6 +263,7 @@ enum name_repair_arg {
   name_repair_check_unique
 };
 
+const char* name_repair_arg_as_c_string(enum name_repair_arg arg);
 enum name_repair_arg validate_name_repair(SEXP arg);
 SEXP vec_as_names(SEXP names, enum name_repair_arg type, bool quiet);
 bool is_unique_names(SEXP names);

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -126,6 +126,17 @@ test_that("vec_rbind() respects size invariants (#286)", {
   expect_identical(vec_rbind(int(), new_data_frame(n = 2L), int()), new_data_frame(n = 4L))
 })
 
+test_that("can repair names in `vec_rbind()` (#229)", {
+  expect_error(vec_rbind(.name_repair = "none"), "can't be `\"none\"`")
+  expect_error(vec_rbind(.name_repair = "minimal"), "can't be `\"minimal\"`")
+
+  expect_named(vec_rbind(list(a = 1, a = 2), .name_repair = "unique"), c("a...1", "a...2"))
+  expect_error(vec_rbind(list(a = 1, a = 2), .name_repair = "check_unique"), class = "vctrs_error_names_must_be_unique")
+
+  expect_named(vec_rbind(list(`_` = 1)), "_")
+  expect_named(vec_rbind(list(`_` = 1), .name_repair = "universal"), c("._"))
+})
+
 
 # cols --------------------------------------------------------------------
 

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -201,4 +201,12 @@ test_that("can override default .nrow", {
   expect_dim(vec_cbind(1, .size = 3), c(3, 1))
 })
 
+test_that("can repair names in `vec_cbind()` (#227)", {
+  expect_error(vec_cbind(a = 1, a = 2, .name_repair = "none"), "can't be `\"none\"`")
+  expect_error(vec_cbind(a = 1, a = 2, .name_repair = "minimal"), "can't be `\"minimal\"`")
 
+  expect_named(vec_cbind(a = 1, a = 2, .name_repair = "unique"), c("a...1", "a...2"))
+  expect_error(vec_cbind(a = 1, a = 2, .name_repair = "check_unique"), class = "vctrs_error_names_must_be_unique")
+
+  expect_named(vec_cbind(`_` = 1, .name_repair = "universal"), "._")
+})

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -214,10 +214,11 @@ test_that("can override default .nrow", {
 
 test_that("can repair names in `vec_cbind()` (#227)", {
   expect_error(vec_cbind(a = 1, a = 2, .name_repair = "none"), "can't be `\"none\"`")
-  expect_error(vec_cbind(a = 1, a = 2, .name_repair = "minimal"), "can't be `\"minimal\"`")
 
   expect_named(vec_cbind(a = 1, a = 2, .name_repair = "unique"), c("a...1", "a...2"))
   expect_error(vec_cbind(a = 1, a = 2, .name_repair = "check_unique"), class = "vctrs_error_names_must_be_unique")
 
   expect_named(vec_cbind(`_` = 1, .name_repair = "universal"), "._")
+
+  expect_named(vec_cbind(a = 1, a = 2, .name_repair = "minimal"), c("a", "a"))
 })

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -91,3 +91,15 @@ test_that("can mix named and unnamed vectors (#271)", {
   expect_identical(vec_c(c(a = 1), 2), c(a = 1, 2))
   expect_identical(vec_c(0, c(a = 1), 2, b = 3), c(0, a = 1, 2, b =3))
 })
+
+test_that("vec_c() repairs names", {
+  # Default minimal repair
+  expect_named(vec_c(a = 1, a = 2, `_` = 3), c("a", "a", "_"))
+  out <- vec_c(!!!set_names(1, NA))
+  expect_named(out, "")
+
+  expect_named(vec_c(a = 1, a = 2, `_` = 3, .name_repair = "unique"), c("a...1", "a...2", "_"))
+  expect_error(vec_c(a = 1, a = 2, `_` = 3, .name_repair = "check_unique"), class = "vctrs_error_names_must_be_unique")
+
+  expect_named(vec_c(a = 1, a = 2, `_` = 3, .name_repair = "universal"), c("a...1", "a...2", "._"))
+})


### PR DESCRIPTION
Closes #227.

The micro-optimisation of inlining `.name_repair` in the formals list buys 0.6us:

```r
bench::mark(
  before = vec_c_old(),
  after = vec_c()
)[1:8]
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 before       2.48µs    3.1µs   303418.        0B      0   10000     0
#> 2 after         1.9µs   2.49µs   389138.        0B      0   10000     0
```