### PR TITLE
Tweak restore size parameter

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -80,10 +80,13 @@
 #'   `vec_cast()` and `vec_restore()`, these dots are only for future
 #'   extensions and should be empty.
 #' @param to,.to Type to cast to. If `NULL`, `x` will be returned as is.
-#' @param n The total size to restore to. This is currently passed by
-#'   `vec_slice()` to solve edge cases arising in data frame restoration.
-#'   In most cases you don't need this information and can safely
-#'   ignore that argument.
+#' @param n \Sexpr[results=rd, stage=render]{vctrs:::lifecycle("experimental")}
+#'   The total size to restore to. This is currently passed by
+#'   `vec_slice()` to solve edge cases arising in data frame
+#'   restoration. In most cases you don't need this information and
+#'   can safely ignore that argument. This parameter should be
+#'   considered internal and experimental, it might change in the
+#'   future.
 #' @return A vector the same length as `x` with the same type as `to`,
 #'   or an error if the cast is not possible. An error is generated if
 #'   information is lost when casting between compatible types (i.e. when

--- a/R/cast.R
+++ b/R/cast.R
@@ -80,9 +80,10 @@
 #'   `vec_cast()` and `vec_restore()`, these dots are only for future
 #'   extensions and should be empty.
 #' @param to,.to Type to cast to. If `NULL`, `x` will be returned as is.
-#' @param i The index vector used to slice `x` when restoration is
-#'   triggered by [vec_slice()]. In most cases you don't need this
-#'   information and can safely ignore that argument.
+#' @param n The total size to restore to. This is currently passed by
+#'   `vec_slice()` to solve edge cases arising in data frame restoration.
+#'   In most cases you don't need this information and can safely
+#'   ignore that argument.
 #' @return A vector the same length as `x` with the same type as `to`,
 #'   or an error if the cast is not possible. An error is generated if
 #'   information is lost when casting between compatible types (i.e. when
@@ -172,17 +173,17 @@ vec_default_cast <- function(x, to) {
 
 #' @export
 #' @rdname vec_cast
-vec_restore <- function(x, to, ..., i = NULL) {
+vec_restore <- function(x, to, ..., n = NULL) {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
-  return(.Call(vctrs_restore, x, to, i))
+  return(.Call(vctrs_restore, x, to, n))
   UseMethod("vec_restore", to)
 }
-vec_restore_dispatch <- function(x, to, ..., i = NULL) {
+vec_restore_dispatch <- function(x, to, ..., n = NULL) {
   UseMethod("vec_restore", to)
 }
 #' @export
-vec_restore.default <- function(x, to, ..., i = NULL) {
+vec_restore.default <- function(x, to, ..., n = NULL) {
   .Call(vctrs_restore_default, x, to)
 }

--- a/R/slice.R
+++ b/R/slice.R
@@ -177,7 +177,7 @@ vec_index <- function(x, i, ...) {
   vec_assert(out)
 
   i <- vec_as_index(i, vec_size(x), vec_names(x))
-  vec_restore(out[i, ..., drop = FALSE], x, i = i)
+  vec_restore(out[i, ..., drop = FALSE], x, n = length(i))
 }
 
 #' Create a missing vector

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -17,7 +17,7 @@ vec_cast(x, to, ...)
 
 vec_cast_common(..., .to = NULL)
 
-vec_restore(x, to, ..., i = NULL)
+vec_restore(x, to, ..., n = NULL)
 
 \method{vec_cast}{logical}(x, to, ...)
 
@@ -42,9 +42,10 @@ vec_restore(x, to, ..., i = NULL)
 \code{vec_cast()} and \code{vec_restore()}, these dots are only for future
 extensions and should be empty.}
 
-\item{i}{The index vector used to slice \code{x} when restoration is
-triggered by \code{\link[=vec_slice]{vec_slice()}}. In most cases you don't need this
-information and can safely ignore that argument.}
+\item{n}{The total size to restore to. This is currently passed by
+\code{vec_slice()} to solve edge cases arising in data frame restoration.
+In most cases you don't need this information and can safely
+ignore that argument.}
 }
 \value{
 A vector the same length as \code{x} with the same type as \code{to},

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -42,10 +42,13 @@ vec_restore(x, to, ..., n = NULL)
 \code{vec_cast()} and \code{vec_restore()}, these dots are only for future
 extensions and should be empty.}
 
-\item{n}{The total size to restore to. This is currently passed by
-\code{vec_slice()} to solve edge cases arising in data frame restoration.
-In most cases you don't need this information and can safely
-ignore that argument.}
+\item{n}{\Sexpr[results=rd, stage=render]{vctrs:::lifecycle("experimental")}
+The total size to restore to. This is currently passed by
+\code{vec_slice()} to solve edge cases arising in data frame
+restoration. In most cases you don't need this information and
+can safely ignore that argument. This parameter should be
+considered internal and experimental, it might change in the
+future.}
 }
 \value{
 A vector the same length as \code{x} with the same type as \code{to},

--- a/src/cast.c
+++ b/src/cast.c
@@ -406,13 +406,13 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
   return x;
 }
 
-SEXP vctrs_df_restore(SEXP x, SEXP to, SEXP i) {
+SEXP vctrs_df_restore(SEXP x, SEXP to, SEXP n) {
   if (TYPEOF(x) != VECSXP) {
     Rf_errorcall(R_NilValue, "Internal error: Attempt to restore data frame from a %s.",
                  Rf_type2char(TYPEOF(x)));
   }
 
-  R_len_t size = (i == R_NilValue) ? df_raw_size(x) : r_int_get(i, 0);
+  R_len_t size = (n == R_NilValue) ? df_raw_size(x) : r_int_get(n, 0);
   return df_restore_impl(x, to, size);
 }
 
@@ -436,30 +436,30 @@ SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size) {
 }
 
 
-static SEXP vec_restore_dispatch(SEXP x, SEXP to, SEXP i);
+static SEXP vec_restore_dispatch(SEXP x, SEXP to, SEXP n);
 
-SEXP vec_restore(SEXP x, SEXP to, SEXP i) {
+SEXP vec_restore(SEXP x, SEXP to, SEXP n) {
   switch (class_type(to)) {
-  default: return vec_restore_dispatch(x, to, i);
+  default: return vec_restore_dispatch(x, to, n);
   case vctrs_class_none: return vec_restore_default(x, to);
   case vctrs_class_bare_data_frame:
-  case vctrs_class_bare_tibble: return vctrs_df_restore(x, to, i);
+  case vctrs_class_bare_tibble: return vctrs_df_restore(x, to, n);
   case vctrs_class_data_frame: {
     // Restore methods are passed the original atomic type back, so we
     // first restore data frames as such before calling the restore
     // method, if any
-    SEXP out = PROTECT(vctrs_df_restore(x, to, i));
-    out = vec_restore_dispatch(x, to, i);
+    SEXP out = PROTECT(vctrs_df_restore(x, to, n));
+    out = vec_restore_dispatch(x, to, n);
     UNPROTECT(1);
     return out;
   }}
 }
 
-static SEXP vec_restore_dispatch(SEXP x, SEXP to, SEXP i) {
+static SEXP vec_restore_dispatch(SEXP x, SEXP to, SEXP n) {
   return vctrs_dispatch3(syms_vec_restore_dispatch, fns_vec_restore_dispatch,
                          syms_x, x,
                          syms_to, to,
-                         syms_i, i);
+                         syms_n, n);
 }
 
 

--- a/src/cast.c
+++ b/src/cast.c
@@ -412,7 +412,7 @@ SEXP vctrs_df_restore(SEXP x, SEXP to, SEXP i) {
                  Rf_type2char(TYPEOF(x)));
   }
 
-  R_len_t size = (i == R_NilValue) ? df_raw_size(x) : Rf_length(i);
+  R_len_t size = (i == R_NilValue) ? df_raw_size(x) : r_int_get(i, 0);
   return df_restore_impl(x, to, size);
 }
 

--- a/src/slice.c
+++ b/src/slice.c
@@ -157,6 +157,8 @@ static SEXP vec_slice_impl(SEXP x, SEXP index) {
 
   int nprot = 0;
 
+  SEXP restore_size = PROTECT_N(r_int(Rf_length(index)), &nprot);
+
   struct vctrs_proxy_info info = PROTECT_PROXY_INFO(vec_proxy_info(x), &nprot);
   SEXP data = info.proxy;
 
@@ -173,7 +175,7 @@ static SEXP vec_slice_impl(SEXP x, SEXP index) {
     // Take over attribute restoration only if the `[` method did not
     // restore itself
     if (ATTRIB(out) == R_NilValue) {
-      out = vec_restore(out, x, index);
+      out = vec_restore(out, x, restore_size);
     }
 
     UNPROTECT(nprot);
@@ -194,7 +196,7 @@ static SEXP vec_slice_impl(SEXP x, SEXP index) {
     SEXP out = PROTECT_N(vec_slice_base(info.type, data, index), &nprot);
 
     slice_names(out, x, index);
-    out = vec_restore(out, x, index);
+    out = vec_restore(out, x, restore_size);
 
     UNPROTECT(nprot);
     return out;
@@ -202,7 +204,7 @@ static SEXP vec_slice_impl(SEXP x, SEXP index) {
 
   case vctrs_type_dataframe: {
     SEXP out = PROTECT_N(df_slice(data, index), &nprot);
-    out = vec_restore(out, x, index);
+    out = vec_restore(out, x, restore_size);
     UNPROTECT(nprot);
     return out;
   }

--- a/src/utils.c
+++ b/src/utils.c
@@ -690,6 +690,7 @@ SEXP strings_empty = NULL;
 SEXP strings_dots = NULL;
 
 SEXP syms_i = NULL;
+SEXP syms_n = NULL;
 SEXP syms_x = NULL;
 SEXP syms_y = NULL;
 SEXP syms_to = NULL;
@@ -811,6 +812,7 @@ void vctrs_init_utils(SEXP ns) {
 
 
   syms_i = Rf_install("i");
+  syms_n = Rf_install("n");
   syms_x = Rf_install("x");
   syms_y = Rf_install("y");
   syms_to = Rf_install("to");

--- a/src/utils.c
+++ b/src/utils.c
@@ -169,7 +169,7 @@ SEXP map(SEXP x, SEXP (*fn)(SEXP)) {
 
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
-  out = vctrs_df_restore(out, df, vctrs_shared_empty_int);
+  out = vctrs_df_restore(out, df, vctrs_shared_zero_int);
 
   UNPROTECT(1);
   return out;
@@ -682,6 +682,7 @@ SEXP vctrs_shared_true = NULL;
 SEXP vctrs_shared_false = NULL;
 Rcomplex vctrs_shared_na_cpl;
 
+SEXP vctrs_shared_zero_int = NULL;
 SEXP vctrs_shared_na_lgl = NULL;
 
 SEXP strings = NULL;
@@ -802,6 +803,11 @@ void vctrs_init_utils(SEXP ns) {
   vctrs_shared_na_lgl = r_lgl(NA_LOGICAL);
   R_PreserveObject(vctrs_shared_na_lgl);
   MARK_NOT_MUTABLE(vctrs_shared_na_lgl);
+
+  vctrs_shared_zero_int = Rf_allocVector(INTSXP, 1);
+  INTEGER(vctrs_shared_zero_int)[0] = 0;
+  R_PreserveObject(vctrs_shared_zero_int);
+  MARK_NOT_MUTABLE(vctrs_shared_zero_int);
 
 
   syms_i = Rf_install("i");

--- a/src/utils.h
+++ b/src/utils.h
@@ -162,6 +162,7 @@ static inline void r_dbg_save(SEXP x, const char* name) {
 extern SEXP vctrs_ns_env;
 extern SEXP vctrs_shared_empty_str;
 extern SEXP vctrs_shared_na_lgl;
+extern SEXP vctrs_shared_zero_int;
 
 extern SEXP classes_data_frame;
 extern SEXP classes_tibble;

--- a/src/utils.h
+++ b/src/utils.h
@@ -178,6 +178,7 @@ extern SEXP strings_posixt;
 extern SEXP strings_vctrs_vctr;
 
 extern SEXP syms_i;
+extern SEXP syms_n;
 extern SEXP syms_x;
 extern SEXP syms_y;
 extern SEXP syms_to;

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -84,7 +84,7 @@ test_that("vec_restore() passes `i` argument to methods", {
   scoped_global_bindings(
     vec_restore.vctrs_foobar = function(x, to, ..., i) i
   )
-  expect_identical(vec_slice(foobar(1:3), 2), 2L)
+  expect_identical(vec_slice(foobar(1:3), 2), 1L)
 })
 
 test_that("dimensions are preserved by default restore method", {

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -80,9 +80,9 @@ test_that("can use vctrs primitives from vec_restore() without inflooping", {
   expect_identical(vec_slice(foobar, 2), "woot")
 })
 
-test_that("vec_restore() passes `i` argument to methods", {
+test_that("vec_restore() passes `n` argument to methods", {
   scoped_global_bindings(
-    vec_restore.vctrs_foobar = function(x, to, ..., i) i
+    vec_restore.vctrs_foobar = function(x, to, ..., n) n
   )
   expect_identical(vec_slice(foobar(1:3), 2), 1L)
 })
@@ -114,11 +114,11 @@ test_that("names attribute isn't set when restoring 1D arrays using 2D+ objects"
 
 test_that("arguments are not inlined in the dispatch call (#300)", {
   scoped_global_bindings(
-    vec_restore.vctrs_foobar = function(x, to, ..., i) sys.call(),
+    vec_restore.vctrs_foobar = function(x, to, ..., n) sys.call(),
     vec_proxy.vctrs_foobar = unclass
   )
   call <- vec_restore(foobar(list(1)), foobar(list(1)))
-  expect_equal(call, quote(vec_restore.vctrs_foobar(x = x, to = to, i = i)))
+  expect_equal(call, quote(vec_restore.vctrs_foobar(x = x, to = to, n = n)))
 })
 
 

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -189,7 +189,7 @@ test_that("can `vec_slice()` records", {
 test_that("vec_restore() is called after proxied slicing", {
   scoped_global_bindings(
     vec_proxy.vctrs_foobar = identity,
-    vec_restore.vctrs_foobar = function(x, to, ..., i) "dispatch"
+    vec_restore.vctrs_foobar = function(x, to, ...) "dispatch"
   )
   expect_identical(vec_slice(foobar(1:3), 2), "dispatch")
 })


### PR DESCRIPTION
We're now being a little more conservative.

* Pass the total size instead of an index vector. Renamed from `i` to `n`.
* Marked as internal and experimental.

Closes #398