### PR TITLE
Fix cast error messages

### DIFF
--- a/R/cast-list.R
+++ b/R/cast-list.R
@@ -10,9 +10,14 @@
 #'
 #' @param x A list
 #' @param to Type to coerce to
+#' @inheritParams ellipsis::dots_empty
+#'
 #' @export
 #' @keywords internal
-vec_list_cast <- function(x, to) {
+vec_list_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
+  if (!missing(...)) {
+    ellipsis::check_dots_empty()
+  }
   ns <- map_int(x, vec_size)
 
   n <- vec_size(x)
@@ -20,10 +25,12 @@ vec_list_cast <- function(x, to) {
 
   for (i in seq_len(n)) {
     val <- x[[i]]
-    if (length(val) == 0)
+    if (length(val) == 0) {
       next
+    }
 
-    vec_slice(out, i) <- vec_cast(vec_slice(val, 1L), to)
+    val <- vec_slice(val, 1L)
+    vec_slice(out, i) <- vec_cast(val, to, x_arg = x_arg, to_arg = to_arg)
   }
 
   if (!is.object(to)) {

--- a/R/cast.R
+++ b/R/cast.R
@@ -138,11 +138,11 @@ vec_cast_common <- function(..., .to = NULL) {
 }
 
 #' @export
-vec_cast.default <- function(x, to, ...) {
+vec_cast.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (has_same_type(x, to)) {
     return(x)
   }
-  stop_incompatible_cast(x, to)
+  stop_incompatible_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 # Cast `x` to `to` but only if they are coercible
@@ -168,11 +168,11 @@ vec_coercible_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
 #'
 #' @inheritParams vec_cast
 #' @export
-vec_default_cast <- function(x, to) {
+vec_default_cast <- function(x, to, x_arg = "", to_arg = "") {
   if (is_unspecified(x)) {
     vec_na(to, length(x))
   } else {
-    stop_incompatible_cast(x, to)
+    stop_incompatible_cast(x, to, x_arg = x_arg, to_arg = to_arg)
   }
 }
 

--- a/R/cast.R
+++ b/R/cast.R
@@ -87,6 +87,9 @@
 #'   can safely ignore that argument. This parameter should be
 #'   considered internal and experimental, it might change in the
 #'   future.
+#' @param x_arg,to_arg Argument names for `x` and `to`. These are used
+#'   in error messages to inform the user about the locations of
+#'   incompatible types (see [stop_incompatible_type()]).
 #' @return A vector the same length as `x` with the same type as `to`,
 #'   or an error if the cast is not possible. An error is generated if
 #'   information is lost when casting between compatible types (i.e. when
@@ -117,14 +120,14 @@
 #' # Cast to common type
 #' vec_cast_common(factor("a"), factor(c("a", "b")))
 #' vec_cast_common(factor("a"), Sys.Date(), .to = list())
-vec_cast <- function(x, to, ...) {
+vec_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
-  return(.Call(vctrs_cast, x, to))
+  return(.Call(vctrs_cast, x, to, x_arg, to_arg))
   UseMethod("vec_cast", to)
 }
-vec_cast_dispatch <- function(x, to) {
+vec_cast_dispatch <- function(x, to, ..., x_arg = "", to_arg = "") {
   UseMethod("vec_cast", to)
 }
 

--- a/R/cast.R
+++ b/R/cast.R
@@ -120,14 +120,14 @@
 #' # Cast to common type
 #' vec_cast_common(factor("a"), factor(c("a", "b")))
 #' vec_cast_common(factor("a"), Sys.Date(), .to = list())
-vec_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
   return(.Call(vctrs_cast, x, to, x_arg, to_arg))
   UseMethod("vec_cast", to)
 }
-vec_cast_dispatch <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast_dispatch <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   UseMethod("vec_cast", to)
 }
 
@@ -138,7 +138,7 @@ vec_cast_common <- function(..., .to = NULL) {
 }
 
 #' @export
-vec_cast.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   if (has_same_type(x, to)) {
     return(x)
   }
@@ -146,7 +146,7 @@ vec_cast.default <- function(x, to, ..., x_arg = "", to_arg = "") {
 }
 
 # Cast `x` to `to` but only if they are coercible
-vec_coercible_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_coercible_cast <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
@@ -168,7 +168,7 @@ vec_coercible_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
 #'
 #' @inheritParams vec_cast
 #' @export
-vec_default_cast <- function(x, to, x_arg = "", to_arg = "") {
+vec_default_cast <- function(x, to, x_arg = "x", to_arg = "to") {
   if (is_unspecified(x)) {
     vec_na(to, length(x))
   } else {

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -204,6 +204,8 @@ maybe_lossy_cast <- function(result, x, to,
                              locations = NULL,
                              details = NULL,
                              ...,
+                             x_arg = "",
+                             to_arg = "",
                              message = NULL,
                              .subclass = NULL,
                              .deprecation = FALSE) {

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -102,17 +102,30 @@ stop_incompatible_type <- function(x, y,
 
 #' @rdname vctrs-conditions
 #' @export
-stop_incompatible_cast <- function(x, y, details = NULL, ..., message = NULL, .subclass = NULL) {
+stop_incompatible_cast <- function(x,
+                                   y,
+                                   details = NULL,
+                                   ...,
+                                   x_arg = "",
+                                   to_arg = "",
+                                   message = NULL,
+                                   .subclass = NULL) {
+  if (is_null(message)) {
+    x_label <- format_arg_label(vec_ptype_full(x), x_arg)
+    to_label <- format_arg_label(vec_ptype_full(y), to_arg)
 
-  message <- message %||% glue_lines(
-    "Can't cast <{vec_ptype_full(x)}> to <{vec_ptype_full(y)}>",
-    details
-  )
+    message <- glue_lines(
+      "Can't cast {x_label} to {to_label}.",
+      details
+    )
+  }
 
   stop_incompatible(
     x, y,
     details = details,
     ...,
+    x_arg = x_arg,
+    y_arg = to_arg,
     message = message,
     .subclass = c(.subclass, "vctrs_error_incompatible_cast")
   )
@@ -213,7 +226,7 @@ maybe_lossy_cast <- function(result, x, to,
     return(result)
   }
   if (.deprecation) {
-    maybe_warn_deprecated_lossy_cast(x, to)
+    maybe_warn_deprecated_lossy_cast(x, to, x_arg, to_arg)
     return(result)
   }
 
@@ -228,8 +241,10 @@ maybe_lossy_cast <- function(result, x, to,
       locations = locations,
       details = details,
       ...,
+      x_arg = x_arg,
+      to_arg = to_arg,
       message = message,
-      .subclass = .subclass,
+      .subclass = .subclass
     )
   )
 }
@@ -237,16 +252,24 @@ stop_lossy_cast <- function(x, to, result,
                             locations = NULL,
                             details = NULL,
                             ...,
+                            x_arg = "",
+                            to_arg = "",
                             message = NULL,
                             .subclass = NULL) {
   if (length(locations)) {
     locations <- inline_list("Locations: ", locations)
   }
-  message <- message %||% glue_lines(
-    "Lossy cast from <{vec_ptype_full(x)}> to <{vec_ptype_full(to)}>.",
-    locations,
-    details
-  )
+
+  if (is_null(message)) {
+    x_label <- format_arg_label(vec_ptype_full(x), x_arg)
+    to_label <- format_arg_label(vec_ptype_full(to), to_arg)
+
+    message <- glue_lines(
+      "Lossy cast from {x_label} to {to_label}.",
+      locations,
+      details
+    )
+  }
 
   stop_vctrs(
     message,
@@ -280,7 +303,7 @@ allow_lossy_cast <- function(expr, x_ptype = NULL, to_ptype = NULL) {
   )
 }
 
-maybe_warn_deprecated_lossy_cast <- function(x, to) {
+maybe_warn_deprecated_lossy_cast <- function(x, to, x_arg, to_arg) {
   # Returns `TRUE` if `allow_lossy_cast()` is on the stack and accepts
   # to handle the condition
   handled <- withRestarts(
@@ -295,8 +318,9 @@ maybe_warn_deprecated_lossy_cast <- function(x, to) {
     return(invisible())
   }
 
-  from <- vec_ptype_abbr(x)
-  to <- vec_ptype_abbr(to)
+  from <- format_arg_label(vec_ptype_abbr(x), x_arg)
+  to <- format_arg_label(vec_ptype_abbr(to), to_arg)
+
   warn_deprecated(paste_line(
     glue::glue("We detected a lossy transformation from `{ from }` to `{ to }`."),
     "The result will contain lower-resolution values or missing values.",
@@ -386,4 +410,13 @@ glue_lines <- function(..., env = parent.frame()) {
   lines <- c(...)
   out <- map_chr(lines, glue::glue, .envir = env)
   paste(out, collapse = "\n")
+}
+
+format_arg_label <- function(type, arg = "") {
+  type <- paste0("<", type, ">")
+  if (nzchar(arg)) {
+    paste0("`", arg, "` ", type)
+  } else {
+    type
+  }
 }

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -16,7 +16,7 @@ vec_cast.logical.logical <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.logical integer
-vec_cast.logical.integer <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.logical.integer <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   out <- vec_coerce_bare(x, "logical")
   out <- shape_broadcast(out, to)
   lossy <- !x %in% c(0L, 1L)
@@ -24,7 +24,7 @@ vec_cast.logical.integer <- function(x, to, ..., x_arg = "", to_arg = "") {
 }
 #' @export
 #' @method vec_cast.logical double
-vec_cast.logical.double <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.logical.double <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   out <- vec_coerce_bare(x, "logical")
   out <- shape_broadcast(out, to)
   lossy <- !x %in% c(0, 1)
@@ -32,7 +32,7 @@ vec_cast.logical.double <- function(x, to, ..., x_arg = "", to_arg = "") {
 }
 #' @export
 #' @method vec_cast.logical character
-vec_cast.logical.character <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.logical.character <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   out <- vec_coerce_bare(x, "logical")
   out <- shape_broadcast(out, to)
   lossy <- !x %in% c("T", "F", "TRUE", "FALSE", "true", "false")
@@ -40,12 +40,12 @@ vec_cast.logical.character <- function(x, to, ..., x_arg = "", to_arg = "") {
 }
 #' @export
 #' @method vec_cast.logical list
-vec_cast.logical.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.logical.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.logical default
-vec_cast.logical.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.logical.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -69,7 +69,7 @@ vec_cast.integer.integer <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.integer double
-vec_cast.integer.double <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.integer.double <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   out <- suppressWarnings(vec_coerce_bare(x, "integer"))
   lossy <- (out != x) | xor(is.na(x), is.na(out))
   out <- shape_broadcast(out, to)
@@ -80,12 +80,12 @@ vec_cast.integer.double <- function(x, to, ..., x_arg = "", to_arg = "") {
 vec_cast.integer.character <- vec_cast.integer.double
 #' @export
 #' @method vec_cast.integer list
-vec_cast.integer.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.integer.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.integer default
-vec_cast.integer.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.integer.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -107,7 +107,7 @@ vec_cast.double.logical <- function(x, to, ...) {
 vec_cast.double.integer <- vec_cast.double.logical
 #' @export
 #' @method vec_cast.double character
-vec_cast.double.character <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.double.character <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   out <- suppressWarnings(vec_coerce_bare(x, "double"))
   lossy <- (out != x) | xor(is.na(x), is.na(out))
   out <- shape_broadcast(out, to)
@@ -120,12 +120,12 @@ vec_cast.double.double <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.double list
-vec_cast.double.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.double.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.double default
-vec_cast.double.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.double.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -155,12 +155,12 @@ vec_cast.complex.complex <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.complex list
-vec_cast.complex.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.complex.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.complex default
-vec_cast.complex.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.complex.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -178,12 +178,12 @@ vec_cast.raw.raw <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.raw list
-vec_cast.raw.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.raw.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.raw default
-vec_cast.raw.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.raw.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -219,12 +219,12 @@ vec_cast.character.difftime <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.character list
-vec_cast.character.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.character.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.character default
-vec_cast.character.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.character.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -259,7 +259,7 @@ vec_cast.list.default <- function(x, to, ...) {
 
 # Helpers -----------------------------------------------------------------
 
-lossy_floor <- function(x, to, x_arg = "", to_arg = "") {
+lossy_floor <- function(x, to, x_arg = "x", to_arg = "to") {
   x_floor <- floor(x)
   lossy <- x != x_floor
   maybe_lossy_cast(x_floor, x, to, lossy, x_arg = x_arg, to_arg = to_arg)

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -16,37 +16,37 @@ vec_cast.logical.logical <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.logical integer
-vec_cast.logical.integer <- function(x, to, ...) {
+vec_cast.logical.integer <- function(x, to, ..., x_arg = "", to_arg = "") {
   out <- vec_coerce_bare(x, "logical")
   out <- shape_broadcast(out, to)
   lossy <- !x %in% c(0L, 1L)
-  maybe_lossy_cast(out, x, to, lossy)
+  maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.logical double
-vec_cast.logical.double <- function(x, to, ...) {
+vec_cast.logical.double <- function(x, to, ..., x_arg = "", to_arg = "") {
   out <- vec_coerce_bare(x, "logical")
   out <- shape_broadcast(out, to)
   lossy <- !x %in% c(0, 1)
-  maybe_lossy_cast(out, x, to, lossy)
+  maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.logical character
-vec_cast.logical.character <- function(x, to, ...) {
+vec_cast.logical.character <- function(x, to, ..., x_arg = "", to_arg = "") {
   out <- vec_coerce_bare(x, "logical")
   out <- shape_broadcast(out, to)
   lossy <- !x %in% c("T", "F", "TRUE", "FALSE", "true", "false")
-  maybe_lossy_cast(out, x, to, lossy)
+  maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.logical list
-vec_cast.logical.list <- function(x, to, ...) {
-  vec_list_cast(x, to)
+vec_cast.logical.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.logical default
-vec_cast.logical.default <- function(x, to, ...) {
-  vec_default_cast(x, to)
+vec_cast.logical.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 #' @export
@@ -69,24 +69,24 @@ vec_cast.integer.integer <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.integer double
-vec_cast.integer.double <- function(x, to, ...) {
+vec_cast.integer.double <- function(x, to, ..., x_arg = "", to_arg = "") {
   out <- suppressWarnings(vec_coerce_bare(x, "integer"))
   lossy <- (out != x) | xor(is.na(x), is.na(out))
   out <- shape_broadcast(out, to)
-  maybe_lossy_cast(out, x, to, lossy)
+  maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.integer character
 vec_cast.integer.character <- vec_cast.integer.double
 #' @export
 #' @method vec_cast.integer list
-vec_cast.integer.list <- function(x, to, ...) {
-  vec_list_cast(x, to)
+vec_cast.integer.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.integer default
-vec_cast.integer.default <- function(x, to, ...) {
-  vec_default_cast(x, to)
+vec_cast.integer.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 #' @export
@@ -107,11 +107,11 @@ vec_cast.double.logical <- function(x, to, ...) {
 vec_cast.double.integer <- vec_cast.double.logical
 #' @export
 #' @method vec_cast.double character
-vec_cast.double.character <- function(x, to, ...) {
+vec_cast.double.character <- function(x, to, ..., x_arg = "", to_arg = "") {
   out <- suppressWarnings(vec_coerce_bare(x, "double"))
   lossy <- (out != x) | xor(is.na(x), is.na(out))
   out <- shape_broadcast(out, to)
-  maybe_lossy_cast(out, x, to, lossy)
+  maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.double double
@@ -120,13 +120,13 @@ vec_cast.double.double <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.double list
-vec_cast.double.list <- function(x, to, ...) {
-  vec_list_cast(x, to)
+vec_cast.double.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.double default
-vec_cast.double.default <- function(x, to, ...) {
-  vec_default_cast(x, to)
+vec_cast.double.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 #' @export
@@ -155,13 +155,13 @@ vec_cast.complex.complex <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.complex list
-vec_cast.complex.list <- function(x, to, ...) {
-  vec_list_cast(x, to)
+vec_cast.complex.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.complex default
-vec_cast.complex.default <- function(x, to, ...) {
-  vec_default_cast(x, to)
+vec_cast.complex.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 #' @export
@@ -178,13 +178,13 @@ vec_cast.raw.raw <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.raw list
-vec_cast.raw.list <- function(x, to, ...) {
-  vec_list_cast(x, to)
+vec_cast.raw.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.raw default
-vec_cast.raw.default <- function(x, to, ...) {
-  vec_default_cast(x, to)
+vec_cast.raw.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 #' @export
@@ -219,13 +219,13 @@ vec_cast.character.difftime <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.character list
-vec_cast.character.list <- function(x, to, ...) {
-  vec_list_cast(x, to)
+vec_cast.character.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.character default
-vec_cast.character.default <- function(x, to, ...) {
-  vec_default_cast(x, to)
+vec_cast.character.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 #' @rdname vec_cast
@@ -259,8 +259,8 @@ vec_cast.list.default <- function(x, to, ...) {
 
 # Helpers -----------------------------------------------------------------
 
-lossy_floor <- function(x, to) {
+lossy_floor <- function(x, to, x_arg = "", to_arg = "") {
   x_floor <- floor(x)
   lossy <- x != x_floor
-  maybe_lossy_cast(x_floor, x, to, lossy)
+  maybe_lossy_cast(x_floor, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -111,8 +111,8 @@ vec_cast.data.frame <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.data.frame data.frame
-vec_cast.data.frame.data.frame <- function(x, to, ...) {
-  .Call(vctrs_df_as_dataframe, x, to)
+vec_cast.data.frame.data.frame <- function(x, to, ..., x_arg = "", to_arg = "") {
+  .Call(vctrs_df_as_dataframe, x, to, x_arg, to_arg)
 }
 #' @export
 #' @method vec_cast.data.frame default

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -111,12 +111,12 @@ vec_cast.data.frame <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.data.frame data.frame
-vec_cast.data.frame.data.frame <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.data.frame.data.frame <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   .Call(vctrs_df_as_dataframe, x, to, x_arg, to_arg)
 }
 #' @export
 #' @method vec_cast.data.frame default
-vec_cast.data.frame.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.data.frame.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -90,12 +90,12 @@ vec_proxy_compare.data.frame <- function(x, ..., relax = FALSE) {
 vec_type2.data.frame <- function(x, y, ...) UseMethod("vec_type2.data.frame", y)
 #' @method vec_type2.data.frame data.frame
 #' @export
-vec_type2.data.frame.data.frame <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.data.frame.data.frame <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   .Call(vctrs_type2_df_df, x, y, x_arg, y_arg)
 }
 #' @method vec_type2.data.frame default
 #' @export
-vec_type2.data.frame.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.data.frame.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   vec_default_type2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -116,7 +116,9 @@ vec_cast.data.frame.data.frame <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.data.frame default
-vec_cast.data.frame.default <- function(x, to, ...) vec_default_cast(x, to)
+vec_cast.data.frame.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
+}
 
 #' @export
 vec_restore.data.frame <- function(x, to, ..., i = NULL) {

--- a/R/type-date-time.R
+++ b/R/type-date-time.R
@@ -185,19 +185,19 @@ vec_cast.Date.Date <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.Date POSIXt
-vec_cast.Date.POSIXt <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.Date.POSIXt <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   out <- as.Date(x)
   lossy <- abs(x - as.POSIXct(out)) > 1e-9
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.Date list
-vec_cast.Date.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.Date.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.Date default
-vec_cast.Date.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.Date.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -235,12 +235,12 @@ vec_cast.POSIXct.POSIXct <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.POSIXct list
-vec_cast.POSIXct.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.POSIXct.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.POSIXct default
-vec_cast.POSIXct.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.POSIXct.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -278,12 +278,12 @@ vec_cast.POSIXlt.POSIXct <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.POSIXlt list
-vec_cast.POSIXlt.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.POSIXlt.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.POSIXlt default
-vec_cast.POSIXlt.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.POSIXlt.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -313,12 +313,12 @@ vec_cast.difftime.difftime <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.difftime list
-vec_cast.difftime.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.difftime.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.difftime default
-vec_cast.difftime.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.difftime.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 

--- a/R/type-date-time.R
+++ b/R/type-date-time.R
@@ -118,7 +118,7 @@ vec_ptype_abbr.difftime <- function(x, ...) {
 vec_type2.Date <- function(x, y, ...) UseMethod("vec_type2.Date", y)
 #' @method vec_type2.Date default
 #' @export
-vec_type2.Date.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.Date.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_type2.Date Date
@@ -132,7 +132,7 @@ vec_type2.Date.Date <- function(x, y, ...) new_date()
 vec_type2.POSIXt <- function(x, y, ...) UseMethod("vec_type2.POSIXt", y)
 #' @method vec_type2.POSIXt default
 #' @export
-vec_type2.POSIXt.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.POSIXt.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_type2.POSIXt Date
@@ -152,7 +152,7 @@ vec_type2.POSIXt.POSIXt <- function(x, y, ...) new_datetime(tzone = tzone_union(
 vec_type2.difftime <- function(x, y, ...) UseMethod("vec_type2.difftime", y)
 #' @method vec_type2.difftime default
 #' @export
-vec_type2.difftime.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.difftime.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_type2.difftime difftime

--- a/R/type-date-time.R
+++ b/R/type-date-time.R
@@ -185,20 +185,20 @@ vec_cast.Date.Date <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.Date POSIXt
-vec_cast.Date.POSIXt <- function(x, to, ...) {
+vec_cast.Date.POSIXt <- function(x, to, ..., x_arg = "", to_arg = "") {
   out <- as.Date(x)
   lossy <- abs(x - as.POSIXct(out)) > 1e-9
-  maybe_lossy_cast(out, x, to, lossy)
+  maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.Date list
-vec_cast.Date.list <- function(x, to, ...) {
-  vec_list_cast(x, to)
+vec_cast.Date.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.Date default
-vec_cast.Date.default <- function(x, to, ...) {
-  vec_default_cast(x, to)
+vec_cast.Date.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 #' @rdname new_date
@@ -235,13 +235,13 @@ vec_cast.POSIXct.POSIXct <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.POSIXct list
-vec_cast.POSIXct.list <- function(x, to, ...) {
-  vec_list_cast(x, to)
+vec_cast.POSIXct.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.POSIXct default
-vec_cast.POSIXct.default <- function(x, to, ...) {
-  vec_default_cast(x, to)
+vec_cast.POSIXct.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 #' @rdname new_date
@@ -278,13 +278,13 @@ vec_cast.POSIXlt.POSIXct <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.POSIXlt list
-vec_cast.POSIXlt.list <- function(x, to, ...) {
-  vec_list_cast(x, to)
+vec_cast.POSIXlt.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.POSIXlt default
-vec_cast.POSIXlt.default <- function(x, to, ...) {
-  vec_default_cast(x, to)
+vec_cast.POSIXlt.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 
@@ -313,13 +313,13 @@ vec_cast.difftime.difftime <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.difftime list
-vec_cast.difftime.list <- function(x, to, ...) {
-  vec_list_cast(x, to)
+vec_cast.difftime.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.difftime default
-vec_cast.difftime.default <- function(x, to, ...) {
-  vec_default_cast(x, to)
+vec_cast.difftime.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 

--- a/R/type-factor.R
+++ b/R/type-factor.R
@@ -65,7 +65,7 @@ vec_ptype_abbr.ordered <- function(x, ...) {
 vec_type2.factor <- function(x, y, ...) UseMethod("vec_type2.factor", y)
 #' @method vec_type2.factor default
 #' @export
-vec_type2.factor.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.factor.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_type2.character factor
@@ -85,7 +85,7 @@ vec_type2.factor.factor <- function(x, y, ...) new_factor(levels = levels_union(
 vec_type2.ordered <- function(x, y, ...) UseMethod("vec_type2.ordered", y)
 #' @method vec_type2.ordered default
 #' @export
-vec_type2.ordered.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.ordered.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_type2.ordered character
@@ -96,12 +96,12 @@ vec_type2.ordered.character <- function(x, y, ...) character()
 vec_type2.character.ordered <- function(x, y, ...) character()
 #' @method vec_type2.ordered factor
 #' @export
-vec_type2.ordered.factor <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.ordered.factor <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_type2.factor ordered
 #' @export
-vec_type2.factor.ordered <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.factor.ordered <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_type2.ordered ordered

--- a/R/type-factor.R
+++ b/R/type-factor.R
@@ -120,13 +120,13 @@ vec_cast.factor <- function(x, to, ...) {
 
 #' @export
 #' @method vec_cast.factor factor
-vec_cast.factor.factor <- function(x, to, ...) {
+vec_cast.factor.factor <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (length(levels(to)) == 0L) {
     factor(as.character(x), levels = unique(x), ordered = is.ordered(to))
   } else {
     lossy <- !(x %in% levels(to) | is.na(x))
     out <- factor(x, levels = levels(to), ordered = is.ordered(to))
-    maybe_lossy_cast(out, x, to, lossy)
+    maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
   }
 }
 #' @export
@@ -137,13 +137,13 @@ vec_cast.factor.character <- vec_cast.factor.factor
 vec_cast.character.factor <- function(x, to, ...) as.character(x)
 #' @export
 #' @method vec_cast.factor list
-vec_cast.factor.list <- function(x, to, ...) {
-  vec_list_cast(x, to)
+vec_cast.factor.list <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.factor default
-vec_cast.factor.default <- function(x, to, ...) {
-  vec_default_cast(x, to)
+vec_cast.factor.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 # Math and arithmetic -----------------------------------------------------

--- a/R/type-integer64.R
+++ b/R/type-integer64.R
@@ -73,7 +73,7 @@ vec_cast.integer64 <- function(x, to, ...) UseMethod("vec_cast.integer64")
 
 #' @export
 #' @method vec_cast.integer64 default
-vec_cast.integer64.default <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.integer64.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   # Don't use `vec_default_cast()` because integer64 is not compatible
   # with `vec_na()`
   if (is_unspecified(x)) {

--- a/R/type-integer64.R
+++ b/R/type-integer64.R
@@ -73,13 +73,13 @@ vec_cast.integer64 <- function(x, to, ...) UseMethod("vec_cast.integer64")
 
 #' @export
 #' @method vec_cast.integer64 default
-vec_cast.integer64.default <- function(x, to, ...) {
+vec_cast.integer64.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   # Don't use `vec_default_cast()` because integer64 is not compatible
   # with `vec_na()`
   if (is_unspecified(x)) {
     bit64::as.integer64(unclass(x))
   } else {
-    stop_incompatible_cast(x, to)
+    stop_incompatible_cast(x, to, x_arg = x_arg, to_arg = to_arg)
   }
 }
 

--- a/R/type-integer64.R
+++ b/R/type-integer64.R
@@ -33,7 +33,7 @@ vec_type2.integer64 <- function(x, y, ...) {
 }
 #' @method vec_type2.integer64 default
 #' @export
-vec_type2.integer64.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.integer64.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 

--- a/R/type-list-of.R
+++ b/R/type-list-of.R
@@ -179,7 +179,7 @@ vec_type2.vctrs_list_of.vctrs_list_of <- function(x, y, ...) {
 }
 #' @method vec_type2.vctrs_list_of default
 #' @export
-vec_type2.vctrs_list_of.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.vctrs_list_of.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 

--- a/R/type-rcrd.R
+++ b/R/type-rcrd.R
@@ -101,9 +101,9 @@ vec_cast.vctrs_rcrd.vctrs_rcrd <- function(x, to, ...) {
 
 #' @method vec_cast.vctrs_rcrd default
 #' @export
-vec_cast.vctrs_rcrd.default <- function(x, to, ...) {
+vec_cast.vctrs_rcrd.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is_bare_list(x)) {
-    vec_list_cast(x, to)
+    vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
   } else {
     stop_incompatible_cast(x, to)
   }

--- a/R/type-tibble.R
+++ b/R/type-tibble.R
@@ -8,12 +8,12 @@ vec_type2.tbl_df <- function(x, y, ...) UseMethod("vec_type2.tbl_df", y)
 
 #' @method vec_type2.tbl_df data.frame
 #' @export
-vec_type2.tbl_df.data.frame <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.tbl_df.data.frame <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   .Call(vctrs_type2_df_df, x, y, x_arg, y_arg)
 }
 #' @method vec_type2.data.frame tbl_df
 #' @export
-vec_type2.data.frame.tbl_df <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.data.frame.tbl_df <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   .Call(vctrs_type2_df_df, x, y, x_arg, y_arg)
 }
 

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -606,9 +606,7 @@ format.hidden <- function(x, ...) rep("xxx", length(x))
 scoped_hidden <- function(frame = caller_env()) {
   scoped_bindings(.env = global_env(), .frame = frame,
     vec_type2.hidden         = function(x, y, ...) UseMethod("vec_type2.hidden", y),
-    vec_type2.hidden.default = function(x, y, ..., x_arg = "", y_arg = "") {
-      stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
-    },
+    vec_type2.hidden.default = function(x, y, ...) stop_incompatible_type(x, y, ...),
     vec_type2.hidden.hidden  = function(x, y, ...) new_hidden(),
     vec_type2.hidden.double  = function(x, y, ...) new_hidden(),
     vec_type2.double.hidden  = function(x, y, ...) new_hidden(),
@@ -616,7 +614,7 @@ scoped_hidden <- function(frame = caller_env()) {
     vec_type2.logical.hidden = function(x, y, ...) new_hidden(),
 
     vec_cast.hidden          = function(x, to, ...) UseMethod("vec_cast.hidden"),
-    vec_cast.hidden.default  = function(x, to, ...) stop_incompatible_cast(x, to),
+    vec_cast.hidden.default  = function(x, to, ...) stop_incompatible_cast(x, to, ...),
     vec_cast.hidden.hidden   = function(x, to, ...) x,
     vec_cast.hidden.double   = function(x, to, ...) new_hidden(vec_data(x)),
     vec_cast.double.hidden   = function(x, to, ...) vec_data(x),

--- a/R/type2.R
+++ b/R/type2.R
@@ -36,25 +36,25 @@
 #'   in error messages to inform the user about the locations of
 #'   incompatible types (see [stop_incompatible_type()]).
 #' @export
-vec_type2 <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2 <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
   return(.Call(vctrs_type2, x, y, x_arg, y_arg))
   UseMethod("vec_type2")
 }
-vec_type2_dispatch <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2_dispatch <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   UseMethod("vec_type2")
 }
 #' @export
-vec_type2.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   if (has_same_type(x, y)) {
     return(x)
   }
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 
-vec_default_type2 <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_default_type2 <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   if (is_unspecified(y)) {
     return(vec_type(x))
   }
@@ -129,22 +129,22 @@ vec_type2.raw.raw         <- function(x, y, ...) shape_match(raw(), x, y)
 
 #' @method vec_type2.logical default
 #' @export
-vec_type2.logical.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.logical.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_type2.integer default
 #' @export
-vec_type2.integer.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.integer.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_type2.double default
 #' @export
-vec_type2.double.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.double.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_type2.raw default
 #' @export
-vec_type2.raw.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.raw.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 
@@ -160,7 +160,7 @@ vec_type2.character <- function(x, y, ...) UseMethod("vec_type2.character", y)
 vec_type2.character.character <- function(x, y, ...) shape_match(character(), x, y)
 #' @method vec_type2.character default
 #' @export
-vec_type2.character.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.character.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 
@@ -176,6 +176,6 @@ vec_type2.list <- function(x, y, ...) UseMethod("vec_type2.list", y)
 vec_type2.list.list <- function(x, y, ...) shape_match(list(), x, y)
 #' @method vec_type2.list default
 #' @export
-vec_type2.list.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.list.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }

--- a/man/vctrs-conditions.Rd
+++ b/man/vctrs-conditions.Rd
@@ -23,8 +23,8 @@ stop_incompatible_size(x, y, x_size, y_size, x_arg = "", y_arg = "",
   details = NULL, ..., message = NULL, .subclass = NULL)
 
 maybe_lossy_cast(result, x, to, lossy = NULL, locations = NULL,
-  details = NULL, ..., message = NULL, .subclass = NULL,
-  .deprecation = FALSE)
+  details = NULL, ..., x_arg = "", to_arg = "", message = NULL,
+  .subclass = NULL, .deprecation = FALSE)
 
 allow_lossy_cast(expr, x_ptype = NULL, to_ptype = NULL)
 }

--- a/man/vctrs-conditions.Rd
+++ b/man/vctrs-conditions.Rd
@@ -13,8 +13,8 @@
 stop_incompatible_type(x, y, x_arg = "", y_arg = "", details = NULL,
   ..., message = NULL, .subclass = NULL)
 
-stop_incompatible_cast(x, y, details = NULL, ..., message = NULL,
-  .subclass = NULL)
+stop_incompatible_cast(x, y, details = NULL, ..., x_arg = "",
+  to_arg = "", message = NULL, .subclass = NULL)
 
 stop_incompatible_op(op, x, y, details = NULL, ..., message = NULL,
   .subclass = NULL)

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -13,7 +13,7 @@
 \alias{vec_cast.list}
 \title{Cast a vector to specified type}
 \usage{
-vec_cast(x, to, ...)
+vec_cast(x, to, ..., x_arg = "", to_arg = "")
 
 vec_cast_common(..., .to = NULL)
 
@@ -41,6 +41,10 @@ vec_restore(x, to, ..., n = NULL)
 \item{...}{For \code{vec_cast_common()}, vectors to cast. For
 \code{vec_cast()} and \code{vec_restore()}, these dots are only for future
 extensions and should be empty.}
+
+\item{x_arg, to_arg}{Argument names for \code{x} and \code{to}. These are used
+in error messages to inform the user about the locations of
+incompatible types (see \code{\link[=stop_incompatible_type]{stop_incompatible_type()}}).}
 
 \item{n}{\Sexpr[results=rd, stage=render]{vctrs:::lifecycle("experimental")}
 The total size to restore to. This is currently passed by

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -13,7 +13,7 @@
 \alias{vec_cast.list}
 \title{Cast a vector to specified type}
 \usage{
-vec_cast(x, to, ..., x_arg = "", to_arg = "")
+vec_cast(x, to, ..., x_arg = "x", to_arg = "to")
 
 vec_cast_common(..., .to = NULL)
 

--- a/man/vec_default_cast.Rd
+++ b/man/vec_default_cast.Rd
@@ -4,12 +4,20 @@
 \alias{vec_default_cast}
 \title{Default cast method}
 \usage{
-vec_default_cast(x, to)
+vec_default_cast(x, to, x_arg = "", to_arg = "")
 }
 \arguments{
 \item{x}{Vectors to cast.}
 
 \item{to}{Type to cast to. If \code{NULL}, \code{x} will be returned as is.}
+
+\item{x_arg}{Argument names for \code{x} and \code{to}. These are used
+in error messages to inform the user about the locations of
+incompatible types (see \code{\link[=stop_incompatible_type]{stop_incompatible_type()}}).}
+
+\item{to_arg}{Argument names for \code{x} and \code{to}. These are used
+in error messages to inform the user about the locations of
+incompatible types (see \code{\link[=stop_incompatible_type]{stop_incompatible_type()}}).}
 }
 \description{
 This function should typically be called from the default

--- a/man/vec_default_cast.Rd
+++ b/man/vec_default_cast.Rd
@@ -4,7 +4,7 @@
 \alias{vec_default_cast}
 \title{Default cast method}
 \usage{
-vec_default_cast(x, to, x_arg = "", to_arg = "")
+vec_default_cast(x, to, x_arg = "x", to_arg = "to")
 }
 \arguments{
 \item{x}{Vectors to cast.}

--- a/man/vec_list_cast.Rd
+++ b/man/vec_list_cast.Rd
@@ -4,12 +4,14 @@
 \alias{vec_list_cast}
 \title{Cast a list to vector of specific type}
 \usage{
-vec_list_cast(x, to)
+vec_list_cast(x, to, ..., x_arg = "", to_arg = "")
 }
 \arguments{
 \item{x}{A list}
 
 \item{to}{Type to coerce to}
+
+\item{...}{These dots are for future extensions and must be empty.}
 }
 \description{
 This is a function for developers to use when extending vctrs. It casts

--- a/src/bind.c
+++ b/src/bind.c
@@ -77,7 +77,8 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, enum name_repair_arg name_repair) {
       continue;
     }
 
-    SEXP tbl = PROTECT(vec_cast(VECTOR_ELT(xs, i), ptype));
+    // TODO
+    SEXP tbl = PROTECT(vec_cast(VECTOR_ELT(xs, i), ptype, args_empty, args_empty));
     init_compact_seq(idx_ptr, counter, counter + size);
     df_assign(out, idx, tbl, false);
 

--- a/src/c.c
+++ b/src/c.c
@@ -74,8 +74,9 @@ static SEXP vec_c(SEXP xs, SEXP ptype, enum name_repair_arg name_repair) {
       continue;
     }
 
+    // TODO
     SEXP x = VECTOR_ELT(xs, i);
-    SEXP elt = PROTECT(vec_cast(x, ptype));
+    SEXP elt = PROTECT(vec_cast(x, ptype, args_empty, args_empty));
 
     init_compact_seq(idx_ptr, counter, counter + size);
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -1,5 +1,6 @@
 #include "vctrs.h"
 #include "dictionary.h"
+#include "utils.h"
 
 // Initialised at load time
 struct vctrs_arg args_needles;
@@ -211,8 +212,8 @@ SEXP vctrs_match(SEXP needles, SEXP haystack) {
   int _;
   SEXP type = PROTECT(vec_type2(needles, haystack, &args_needles, &args_haystack, &_));
 
-  needles = PROTECT(vec_cast(needles, type));
-  haystack = PROTECT(vec_cast(haystack, type));
+  needles = PROTECT(vec_cast(needles, type, args_empty, args_empty));
+  haystack = PROTECT(vec_cast(haystack, type, args_empty, args_empty));
 
   needles = PROTECT(vec_proxy_equal(needles));
   haystack = PROTECT(vec_proxy_equal(haystack));
@@ -258,8 +259,8 @@ SEXP vctrs_in(SEXP needles, SEXP haystack) {
   int _;
   SEXP type = PROTECT(vec_type2(needles, haystack, &args_needles, &args_haystack, &_));
 
-  needles = PROTECT(vec_cast(needles, type));
-  haystack = PROTECT(vec_cast(haystack, type));
+  needles = PROTECT(vec_cast(needles, type, args_empty, args_empty));
+  haystack = PROTECT(vec_cast(haystack, type, args_empty, args_empty));
 
   needles = PROTECT(vec_proxy_equal(needles));
   haystack = PROTECT(vec_proxy_equal(haystack));

--- a/src/init.c
+++ b/src/init.c
@@ -37,7 +37,7 @@ extern SEXP vctrs_typeof(SEXP, SEXP);
 extern SEXP vctrs_is_vector(SEXP);
 extern SEXP vctrs_type2(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_typeof2(SEXP, SEXP);
-extern SEXP vec_cast(SEXP, SEXP);
+extern SEXP vctrs_cast(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_as_index(SEXP, SEXP, SEXP);
 extern SEXP vctrs_slice(SEXP, SEXP);
 extern SEXP vec_restore(SEXP, SEXP, SEXP);
@@ -101,7 +101,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_is_vector",                  (DL_FUNC) &vctrs_is_vector, 1},
   {"vctrs_type2",                      (DL_FUNC) &vctrs_type2, 4},
   {"vctrs_typeof2",                    (DL_FUNC) &vctrs_typeof2, 2},
-  {"vctrs_cast",                       (DL_FUNC) &vec_cast, 2},
+  {"vctrs_cast",                       (DL_FUNC) &vctrs_cast, 4},
   {"vctrs_as_index",                   (DL_FUNC) &vctrs_as_index, 3},
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 2},
   {"vctrs_restore",                    (DL_FUNC) &vec_restore, 3},

--- a/src/init.c
+++ b/src/init.c
@@ -52,7 +52,7 @@ extern SEXP vctrs_as_minimal_names(SEXP);
 extern SEXP vec_names(SEXP);
 extern SEXP vctrs_is_unique_names(SEXP);
 extern SEXP vctrs_as_unique_names(SEXP, SEXP);
-extern SEXP df_as_dataframe(SEXP, SEXP);
+extern SEXP vctrs_df_as_dataframe(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_type2_df_df(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_type_info(SEXP);
 extern SEXP vctrs_proxy_info(SEXP);
@@ -116,7 +116,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_names",                      (DL_FUNC) &vec_names, 1},
   {"vctrs_is_unique_names",            (DL_FUNC) &vctrs_is_unique_names, 1},
   {"vctrs_as_unique_names",            (DL_FUNC) &vctrs_as_unique_names, 2},
-  {"vctrs_df_as_dataframe",            (DL_FUNC) &df_as_dataframe, 2},
+  {"vctrs_df_as_dataframe",            (DL_FUNC) &vctrs_df_as_dataframe, 4},
   {"vctrs_type2_df_df",                (DL_FUNC) &vctrs_type2_df_df, 4},
   {"vctrs_type_info",                  (DL_FUNC) &vctrs_type_info, 1},
   {"vctrs_proxy_info",                 (DL_FUNC) &vctrs_proxy_info, 1},

--- a/src/size.c
+++ b/src/size.c
@@ -180,7 +180,7 @@ SEXP vctrs_recycle(SEXP x, SEXP size_obj) {
     return R_NilValue;
   }
 
-  size_obj = PROTECT(vec_cast(size_obj, vctrs_shared_empty_int));
+  size_obj = PROTECT(vec_cast(size_obj, vctrs_shared_empty_int, args_empty, args_empty));
   R_len_t size = r_int_get(size_obj, 0);
   UNPROTECT(1);
 
@@ -190,7 +190,7 @@ SEXP vctrs_recycle(SEXP x, SEXP size_obj) {
 
 // [[ include("utils.h") ]]
 R_len_t size_validate(SEXP size, const char* arg) {
-  size = vec_cast(size, vctrs_shared_empty_int);
+  size = vec_cast(size, vctrs_shared_empty_int, args_empty, args_empty);
 
   if (Rf_length(size) != 1) {
     Rf_errorcall(R_NilValue, "`%s` must be a single integer.", arg);

--- a/src/slice.c
+++ b/src/slice.c
@@ -355,7 +355,7 @@ static SEXP int_filter_zero(SEXP index, R_len_t n_zero) {
 }
 
 static SEXP dbl_as_index(SEXP i, R_len_t n) {
-  i = PROTECT(vec_cast(i, vctrs_shared_empty_int));
+  i = PROTECT(vec_cast(i, vctrs_shared_empty_int, args_empty, args_empty));
   i = int_as_index(i, n);
 
   UNPROTECT(1);

--- a/src/unspecified.c
+++ b/src/unspecified.c
@@ -24,7 +24,7 @@ SEXP vctrs_unspecified(SEXP n) {
     Rf_errorcall(R_NilValue, "`n` must be a single number");
   }
   if (TYPEOF(n) != INTSXP) {
-    n = vec_cast(n, vctrs_shared_empty_int);
+    n = vec_cast(n, vctrs_shared_empty_int, args_empty, args_empty);
   }
   int len = INTEGER(n)[0];
   return vec_unspecified(len);

--- a/src/utils.c
+++ b/src/utils.c
@@ -89,6 +89,15 @@ SEXP vctrs_dispatch3(SEXP fn_sym, SEXP fn,
   SEXP args[4] = { x, y, z, NULL };
   return vctrs_dispatch_n(fn_sym, fn, syms, args);
 }
+SEXP vctrs_dispatch4(SEXP fn_sym, SEXP fn,
+                     SEXP w_sym, SEXP w,
+                     SEXP x_sym, SEXP x,
+                     SEXP y_sym, SEXP y,
+                     SEXP z_sym, SEXP z) {
+  SEXP syms[5] = { w_sym, x_sym, y_sym, z_sym, NULL };
+  SEXP args[5] = { w, x, y, z, NULL };
+  return vctrs_dispatch_n(fn_sym, fn, syms, args);
+}
 
 // An alternative to `attributes(x) <- attrib`, which makes
 // two copies on R < 3.6.0
@@ -703,6 +712,7 @@ SEXP syms_dots = NULL;
 SEXP syms_bracket = NULL;
 SEXP syms_x_arg = NULL;
 SEXP syms_y_arg = NULL;
+SEXP syms_to_arg = NULL;
 SEXP syms_out = NULL;
 SEXP syms_value = NULL;
 SEXP syms_quiet = NULL;
@@ -841,6 +851,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_bracket = Rf_install("[");
   syms_x_arg = Rf_install("x_arg");
   syms_y_arg = Rf_install("y_arg");
+  syms_to_arg = Rf_install("to_arg");
   syms_out = Rf_install("out");
   syms_value = Rf_install("value");
   syms_quiet = Rf_install("quiet");

--- a/src/utils.h
+++ b/src/utils.h
@@ -36,6 +36,11 @@ SEXP vctrs_dispatch3(SEXP fn_sym, SEXP fn,
                      SEXP x_sym, SEXP x,
                      SEXP y_sym, SEXP y,
                      SEXP z_sym, SEXP z);
+SEXP vctrs_dispatch4(SEXP fn_sym, SEXP fn,
+                     SEXP w_sym, SEXP w,
+                     SEXP x_sym, SEXP x,
+                     SEXP y_sym, SEXP y,
+                     SEXP z_sym, SEXP z);
 
 SEXP map(SEXP x, SEXP (*fn)(SEXP));
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP));
@@ -191,6 +196,7 @@ extern SEXP syms_dots;
 extern SEXP syms_bracket;
 extern SEXP syms_x_arg;
 extern SEXP syms_y_arg;
+extern SEXP syms_to_arg;
 extern SEXP syms_out;
 extern SEXP syms_value;
 extern SEXP syms_quiet;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -198,7 +198,7 @@ R_len_t vec_size(SEXP x);
 R_len_t vec_size_common(SEXP xs, R_len_t absent);
 SEXP vec_dim(SEXP x);
 R_len_t vec_dim_n(SEXP x);
-SEXP vec_cast(SEXP x, SEXP to);
+SEXP vec_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_cast_common(SEXP xs, SEXP to);
 SEXP vec_coercible_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_slice(SEXP x, SEXP index);

--- a/tests/testthat/helper-rational.R
+++ b/tests/testthat/helper-rational.R
@@ -42,9 +42,7 @@ scoped_rational_class <- function(frame = caller_env()) {
     vec_ptype_full.vctrs_rational = function(x, ...) "rational",
 
     vec_type2.vctrs_rational = function(x, y, ...) UseMethod("vec_type2.vctrs_rational", y),
-    vec_type2.vctrs_rational.default = function(x, y, ..., x_arg = "", y_arg = "") {
-      stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
-    },
+    vec_type2.vctrs_rational.default = function(x, y, ...) stop_incompatible_type(x, y, ...),
     vec_type2.vctrs_rational.vctrs_unspecified = function(x, y, ...) x,
     vec_type2.vctrs_rational.vctrs_rational = function(x, y, ...) new_rational(),
     vec_type2.vctrs_rational.integer = function(x, y, ...) new_rational(),

--- a/tests/testthat/helper-types.R
+++ b/tests/testthat/helper-types.R
@@ -50,7 +50,7 @@ tuple_methods <- list(
   vec_type2.tuple = function(x, y, ...)  UseMethod("vec_type2.tuple", y),
   vec_type2.tuple.vctrs_unspecified = function(x, y, ...) tuple(),
   vec_type2.tuple.tuple = function(x, y, ...) tuple(),
-  vec_type2.tuple.default = function(x, y, ..., x_arg = "", y_arg = "") {
+  vec_type2.tuple.default = function(x, y, ..., x_arg = "x", y_arg = "y") {
     stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
   },
 

--- a/tests/testthat/test-cast-error-nested.txt
+++ b/tests/testthat/test-cast-error-nested.txt
@@ -1,13 +1,24 @@
 
+vec_cast("foo", 10):
+
+Lossy cast from `x` <character> to `to` <double>.
+Locations: 1 
+
+
+vec_cast(factor("foo"), 10):
+
+Can't cast `x` <factor<bd40e>> to `to` <double>. 
+
+
 vec_cast(x, y):
 
-Lossy cast from `a$b` <character> to `a$b` <double>.
+Lossy cast from `x$a$b` <character> to `to$a$b` <double>.
 Locations: 1 
 
 
 vec_cast(x, y):
 
-Can't cast `a$b` <factor<bd40e>> to `a$b` <double>. 
+Can't cast `x$a$b` <factor<bd40e>> to `to$a$b` <double>. 
 
 
 vec_cast_common(x, y):

--- a/tests/testthat/test-cast-error-nested.txt
+++ b/tests/testthat/test-cast-error-nested.txt
@@ -1,0 +1,16 @@
+
+vec_cast(x, y):
+
+Lossy cast from `a$b` <character> to `a$b` <double>.
+Locations: 1 
+
+
+vec_cast(x, y):
+
+Can't cast `a$b` <factor<bd40e>> to `a$b` <double>. 
+
+
+vec_cast_common(x, y):
+
+No common type for `..1$a$b` <factor<bd40e>> and `..2$a$b` <double>. 
+

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -37,6 +37,22 @@ test_that("cast common preserves names", {
   expect_identical(vec_cast_common(foo = 1, bar = 2L), list(foo = 1, bar = 2))
 })
 
+test_that("cast errors with nested data frames creates helpful messages (#57, #225)", {
+  expect_known_output(file = test_path("test-cast-error-nested.txt"), {
+    # Lossy cast
+    x <- tibble(a = tibble(b = "foo"))
+    y <- tibble(a = tibble(b = 10))
+    try2(vec_cast(x, y))
+
+    # Incompatible cast
+    x <- tibble(a = tibble(b = factor("foo")))
+    try2(vec_cast(x, y))
+
+    # Common cast error
+    try2(vec_cast_common(x, y))
+  })
+})
+
 
 # vec_restore -------------------------------------------------------------
 

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -37,8 +37,17 @@ test_that("cast common preserves names", {
   expect_identical(vec_cast_common(foo = 1, bar = 2L), list(foo = 1, bar = 2))
 })
 
-test_that("cast errors with nested data frames creates helpful messages (#57, #225)", {
+test_that("cast errors create helpful messages (#57, #225)", {
   expect_known_output(file = test_path("test-cast-error-nested.txt"), {
+    # Lossy cast
+    try2(vec_cast("foo", 10))
+
+    # Incompatible cast
+    try2(vec_cast(factor("foo"), 10))
+
+
+    ## Nested data frames
+
     # Lossy cast
     x <- tibble(a = tibble(b = "foo"))
     y <- tibble(a = tibble(b = 10))

--- a/tests/testthat/test-type2-error-messages.txt
+++ b/tests/testthat/test-type2-error-messages.txt
@@ -1,0 +1,12 @@
+Bare objects:
+
+vec_type2("foo", 10):
+
+No common type for `x` <character> and `y` <double>. 
+
+Nested dataframes:
+
+vec_type2(df1, df2):
+
+No common type for `x$x$y$z` <double> and `y$x$y$z` <character>. 
+

--- a/tests/testthat/test-type2-nested-data-frames-error.txt
+++ b/tests/testthat/test-type2-nested-data-frames-error.txt
@@ -1,1 +1,0 @@
-No common type for `x$y$z` <double> and `x$y$z` <character>. 

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -86,11 +86,14 @@ test_that("vec_type2() methods forward args to stop_incompatible_type()", {
 })
 
 test_that("vec_type2() data frame methods builds argument tags", {
-  df1 <- tibble(x = tibble(y = tibble(z = 1)))
-  df2 <- tibble(x = tibble(y = tibble(z = "a")))
-  expect_known_output(file = test_path("test-type2-nested-data-frames-error.txt"), {
-    err <- catch_cnd(vec_type2(df1, df2), classes = "error")
-    cat(err$message, "\n")
+  expect_known_output(file = test_path("test-type2-error-messages.txt"), {
+    cat_line("Bare objects:")
+    try2(vec_type2("foo", 10))
+
+    cat_line("Nested dataframes:")
+    df1 <- tibble(x = tibble(y = tibble(z = 1)))
+    df2 <- tibble(x = tibble(y = tibble(z = "a")))
+    try2(vec_type2(df1, df2))
   })
 })
 

--- a/vignettes/s3-vector.Rmd
+++ b/vignettes/s3-vector.Rmd
@@ -200,7 +200,7 @@ Both generics use __[double dispatch](https://en.wikipedia.org/wiki/Double_dispa
 
 ```{r}
 vec_type2.MYCLASS <- function(x, y, ...) UseMethod("vec_type2.MYCLASS", y)
-vec_type2.MYCLASS.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.MYCLASS.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 vec_type2.MYCLASS.vctrs_unspecified <- function(x, y, ...) x
@@ -217,7 +217,7 @@ We'll make our percent class coercible back and forth with double vectors. I'll 
 
 ```{r}
 vec_type2.vctrs_percent <- function(x, y, ...) UseMethod("vec_type2.vctrs_percent", y)
-vec_type2.vctrs_percent.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.vctrs_percent.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 vec_type2.vctrs_percent.vctrs_unspecified <- function(x, y, ...) x
@@ -379,7 +379,7 @@ Now consider `vec_cast()` and `vec_type2()`. I start with the standard recipes:
 
 ```{r}
 vec_type2.vctrs_decimal <- function(x, y, ...) UseMethod("vec_type2.vctrs_decimal")
-vec_type2.vctrs_decimal.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.vctrs_decimal.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 vec_type2.vctrs_decimal.vctrs_unspecified <- function(x, y, ...) x
@@ -575,7 +575,7 @@ For `rational`, `vec_type2()` and `vec_cast()` follow the same pattern as  `perc
 
 ```{r}
 vec_type2.vctrs_rational <- function(x, y, ...) UseMethod("vec_type2.vctrs_rational", y)
-vec_type2.vctrs_rational.default <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_type2.vctrs_rational.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 vec_type2.vctrs_rational.vctrs_unspecified <- function(x, y, ...) x


### PR DESCRIPTION
We now have:

```r
x <- tibble(a = tibble(b = "foo"))
y <- tibble(a = tibble(b = 10))

vec_cast(x, y)
#> Error: Lossy cast from `x$a$b` <character> to `to$a$b` <double>.
#> Locations: 1

x <- tibble(a = tibble(b = factor("foo")))

vec_cast(x, y)
#> Error: Can't cast `x$a$b` <factor<bd40e>> to `to$a$b` <double>.
#> Call `rlang::last_error()` to see a backtrace

vec_cast_common(x, y)
#> Error: No common type for `..1$a$b` <factor<bd40e>> and `..2$a$b` <double>.
```

I'm not sure about the last commit which adds default argument tags to `vec_cast()`. It improves the messages above (`to$a$b` instead of just `a$b`), but this looks slightly suboptimal in the non-nested case because of the repetition of "to":

```r
vec_cast("foo", 10.5)
#> Error: Lossy cast from `x` <character> to `to` <double>.
```

Closes #57 and #225. 
Case 1 in #225 isn't solved, but I don't think we can make it better for this release.