### PR TITLE
Update `vec_type_common()` documentation to reflect C rewrite

### DIFF
--- a/R/type.R
+++ b/R/type.R
@@ -6,7 +6,7 @@
 #' inputs, and is designed for interative exploration.
 #'
 #' `vec_type_common()` first finds the prototype of each input, then
-#' finds the common type using [vec_type2()] and [Reduce()].
+#' successively calls [vec_type2()] to find a common type.
 #'
 #' @section Prototype:
 #' A prototype is [size](vec_size) 0 vector containing attributes, but no

--- a/man/vec_type.Rd
+++ b/man/vec_type.Rd
@@ -34,7 +34,7 @@ inputs, and is designed for interative exploration.
 }
 \details{
 \code{vec_type_common()} first finds the prototype of each input, then
-finds the common type using \code{\link[=vec_type2]{vec_type2()}} and \code{\link[=Reduce]{Reduce()}}.
+successively calls \code{\link[=vec_type2]{vec_type2()}} to find a common type.
 }
 \section{Prototype}{
 


### PR DESCRIPTION
`vec_type_common()` documentation still said we use `Reduce()`. I've changed it to say we just successively call `vec_type2()`.