### PR TITLE
Return logical vectors from predicate methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # vctrs 0.1.0.9000
 
+* Predicate generics now consistently return logical vectors when
+  passed a `vctrs_vctr` class. They used to restore the output to
+  their input type (#251).
+
 * `vec_c()`, `vec_rbind()`, and `vec_cbind()` gain a `.name_repair`
   argument (#227, #229).
 

--- a/R/numeric.R
+++ b/R/numeric.R
@@ -42,15 +42,22 @@ vec_math <- function(fun, x, ...) {
 
 #' @export
 vec_math.default <- function(fun, x, ...) {
-  if (is_double(x)) {
-    vec_restore(vec_math_base(fun, x, ...), x)
-  } else if (fun %in% c("any", "all") && is_logical(x)) {
-    vec_restore(vec_math_base(fun, x, ...), x)
-  } else {
-    # nocov start
+  if (!is_double(x) && !is_logical_dispatch(fun, x)) {
     stop_unimplemented(x, "vec_math")
-    # nocov end
   }
+
+  out <- vec_math_base(fun, x, ...)
+
+  # Don't restore output of logical predicates like `any()`,
+  # `is.finite()`, or `is.nan()`
+  if (is_double(out)) {
+    out <- vec_restore(out, x)
+  }
+
+  out
+}
+is_logical_dispatch <- function(fun, x) {
+  is_logical(x) && fun %in% c("any", "all")
 }
 
 #' @export

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -438,8 +438,8 @@ test_that("na.rm is forwarded to summary generics", {
 
   x <- new_vctr(lgl(TRUE, NA))
 
-  expect_identical(all(x, na.rm = FALSE), new_vctr(lgl(NA)))
-  expect_identical(all(x, na.rm = TRUE), new_vctr(TRUE))
+  expect_identical(all(x, na.rm = FALSE), lgl(NA))
+  expect_identical(all(x, na.rm = TRUE), TRUE)
 })
 
 test_that("Summary generics behave identically to base for empty vctrs (#88)", {
@@ -462,16 +462,6 @@ test_that("Summary generics behave identically to base for empty vctrs (#88)", {
       new_vctr(range(numeric())),
       range(new_vctr(numeric()))
     )
-  )
-
-  expect_identical(
-    new_vctr(any(logical())),
-    any(new_vctr(logical()))
-  )
-
-  expect_identical(
-    new_vctr(all(logical())),
-    all(new_vctr(logical()))
   )
 
   expect_identical(
@@ -508,4 +498,15 @@ test_that("Summary generics behave identically to base for empty vctrs (#88)", {
     new_vctr(mean(numeric())),
     mean(new_vctr(numeric()))
   )
+})
+
+test_that("generic predicates return logical vectors (#251)", {
+  x <- new_vctr(c(1, 2))
+  expect_identical(is.finite(x), c(TRUE, TRUE))
+  expect_identical(is.infinite(x), c(FALSE, FALSE))
+  expect_identical(is.nan(x), c(FALSE, FALSE))
+
+  x <- new_vctr(TRUE)
+  expect_identical(any(x), TRUE)
+  expect_identical(all(x), TRUE)
 })


### PR DESCRIPTION
Closes #251

This still goes through `vec_math()` because a `vec_logical()` might not make sense for `is.finite()` or `is.nan()` which are defined on numeric data. Since we need to special-case them in `vec_math()`, a new generic just for `any()` and `all()` seems a bit overkill.