### PR TITLE
Add vctrs_ prefix to all C API functions

### DIFF
--- a/src/bind.c
+++ b/src/bind.c
@@ -230,7 +230,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, enum name_repair_arg name_
   names = PROTECT(vec_as_names(names, name_repair, false));
   Rf_setAttrib(out, R_NamesSymbol, names);
 
-  out = vec_restore(out, type, R_NilValue);
+  out = vctrs_vec_restore(out, type, R_NilValue);
 
   UNPROTECT(8);
   return out;

--- a/src/c.c
+++ b/src/c.c
@@ -52,7 +52,7 @@ static SEXP vec_c(SEXP xs, SEXP ptype, enum name_repair_arg name_repair) {
   PROTECT_INDEX out_pi;
   SEXP out = vec_na(ptype, out_size);
   PROTECT_WITH_INDEX(out, &out_pi);
-  out = vec_proxy(out);
+  out = vctrs_vec_proxy(out);
   REPROTECT(out, out_pi);
 
   SEXP idx = PROTECT(compact_seq(0, 0));
@@ -82,7 +82,7 @@ static SEXP vec_c(SEXP xs, SEXP ptype, enum name_repair_arg name_repair) {
 
     if (is_shaped) {
       SEXP idx = PROTECT(r_seq(counter + 1, counter + size + 1));
-      out = vec_assign(out, idx, elt);
+      out = vctrs_vec_assign(out, idx, elt);
       REPROTECT(out, out_pi);
       UNPROTECT(1);
     } else {
@@ -91,7 +91,7 @@ static SEXP vec_c(SEXP xs, SEXP ptype, enum name_repair_arg name_repair) {
 
     if (has_names) {
       SEXP outer = xs_names == R_NilValue ? R_NilValue : STRING_ELT(xs_names, i);
-      SEXP x_nms = outer_names(PROTECT(vec_names(x)), outer, size);
+      SEXP x_nms = outer_names(PROTECT(vctrs_vec_names(x)), outer, size);
       if (x_nms != R_NilValue) {
         vec_assign_impl(out_names, idx, x_nms, false);
       }
@@ -115,7 +115,7 @@ static SEXP vec_c(SEXP xs, SEXP ptype, enum name_repair_arg name_repair) {
     UNPROTECT(1);
   }
 
-  out = vec_restore(out, ptype, R_NilValue);
+  out = vctrs_vec_restore(out, ptype, R_NilValue);
 
   UNPROTECT(6);
   return out;
@@ -127,7 +127,7 @@ static bool list_has_inner_names(SEXP xs) {
 
   for (R_len_t i = 0; i < n; ++i) {
     SEXP elt = VECTOR_ELT(xs, i);
-    if (vec_names(elt) != R_NilValue) {
+    if (vctrs_vec_names(elt) != R_NilValue) {
       return true;
     }
   }

--- a/src/cast.c
+++ b/src/cast.c
@@ -238,11 +238,11 @@ static SEXP df_as_dataframe(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vct
     SET_VECTOR_ELT(out, i, col);
   }
 
-  // Restore data frame size before calling `vec_restore()`. `x` and
+  // Restore data frame size before calling `vctrs_vec_restore()`. `x` and
   // `to` might not have any columns to compute the original size.
   init_data_frame(out, size);
 
-  out = PROTECT(vec_restore(out, to, R_NilValue));
+  out = PROTECT(vctrs_vec_restore(out, to, R_NilValue));
 
   R_len_t extra_len = Rf_length(x) - common_len;
   if (extra_len) {
@@ -373,7 +373,7 @@ SEXP vec_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg
 }
 
 // Copy attributes except names and dim. This duplicates `x` if needed.
-SEXP vec_restore_default(SEXP x, SEXP to) {
+SEXP vctrs_vec_restore_default(SEXP x, SEXP to) {
   int n_protect = 0;
 
   SEXP attrib = PROTECT(Rf_shallow_duplicate(ATTRIB(to)));
@@ -459,7 +459,7 @@ SEXP vctrs_df_restore(SEXP x, SEXP to, SEXP n) {
 
 SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size) {
   x = PROTECT(r_maybe_duplicate(x));
-  x = PROTECT(vec_restore_default(x, to));
+  x = PROTECT(vctrs_vec_restore_default(x, to));
 
   if (Rf_getAttrib(x, R_NamesSymbol) == R_NilValue) {
     Rf_setAttrib(x, R_NamesSymbol, vctrs_shared_empty_chr);
@@ -479,10 +479,10 @@ SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size) {
 
 static SEXP vec_restore_dispatch(SEXP x, SEXP to, SEXP n);
 
-SEXP vec_restore(SEXP x, SEXP to, SEXP n) {
+SEXP vctrs_vec_restore(SEXP x, SEXP to, SEXP n) {
   switch (class_type(to)) {
   default: return vec_restore_dispatch(x, to, n);
-  case vctrs_class_none: return vec_restore_default(x, to);
+  case vctrs_class_none: return vctrs_vec_restore_default(x, to);
   case vctrs_class_bare_data_frame:
   case vctrs_class_bare_tibble: return vctrs_df_restore(x, to, n);
   case vctrs_class_data_frame: {

--- a/src/hash.c
+++ b/src/hash.c
@@ -335,7 +335,7 @@ static void df_hash_fill(uint32_t* p, R_len_t size, SEXP x) {
   R_len_t ncol = Rf_length(x);
 
   for (R_len_t i = 0; i < ncol; ++i) {
-    // FIXME: Call `vec_proxy()`?
+    // FIXME: Call `vctrs_vec_proxy()`?
     SEXP col = VECTOR_ELT(x, i);
     hash_fill(p, size, col);
   }
@@ -343,7 +343,7 @@ static void df_hash_fill(uint32_t* p, R_len_t size, SEXP x) {
 
 // [[ register() ]]
 SEXP vctrs_hash(SEXP x, SEXP rowwise) {
-  x = PROTECT(vec_proxy(x));
+  x = PROTECT(vctrs_vec_proxy(x));
 
   R_len_t n = vec_size(x);
   SEXP out = PROTECT(Rf_allocVector(RAWSXP, n * sizeof(uint32_t)));

--- a/src/init.c
+++ b/src/init.c
@@ -30,7 +30,7 @@ extern SEXP vctrs_compare(SEXP, SEXP, SEXP);
 extern SEXP vctrs_match(SEXP, SEXP);
 extern SEXP vctrs_duplicated_any(SEXP);
 extern SEXP vctrs_size(SEXP);
-extern SEXP vec_dim(SEXP x);
+extern SEXP vctrs_vec_dim(SEXP x);
 extern SEXP vctrs_dim_n(SEXP x);
 extern SEXP vctrs_is_unspecified(SEXP);
 extern SEXP vctrs_typeof(SEXP, SEXP);
@@ -40,16 +40,16 @@ extern SEXP vctrs_typeof2(SEXP, SEXP);
 extern SEXP vctrs_cast(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_as_index(SEXP, SEXP, SEXP);
 extern SEXP vctrs_slice(SEXP, SEXP);
-extern SEXP vec_restore(SEXP, SEXP, SEXP);
-extern SEXP vec_restore_default(SEXP, SEXP);
-extern SEXP vec_proxy(SEXP);
+extern SEXP vctrs_vec_restore(SEXP, SEXP, SEXP);
+extern SEXP vctrs_vec_restore_default(SEXP, SEXP);
+extern SEXP vctrs_vec_proxy(SEXP);
 extern SEXP vctrs_unspecified(SEXP);
-extern SEXP vec_type(SEXP);
-extern SEXP vec_type_finalise(SEXP);
+extern SEXP vctrs_vec_type(SEXP);
+extern SEXP vctrs_vec_type_finalise(SEXP);
 extern SEXP vctrs_minimal_names(SEXP);
 extern SEXP vctrs_unique_names(SEXP, SEXP);
 extern SEXP vctrs_as_minimal_names(SEXP);
-extern SEXP vec_names(SEXP);
+extern SEXP vctrs_vec_names(SEXP);
 extern SEXP vctrs_is_unique_names(SEXP);
 extern SEXP vctrs_as_unique_names(SEXP, SEXP);
 extern SEXP vctrs_df_as_dataframe(SEXP, SEXP, SEXP, SEXP);
@@ -60,7 +60,7 @@ extern SEXP vctrs_class_type(SEXP);
 extern SEXP vctrs_df_restore(SEXP, SEXP, SEXP);
 extern SEXP vctrs_recycle(SEXP, SEXP);
 extern SEXP vctrs_coercible_cast(SEXP, SEXP, SEXP, SEXP);
-extern SEXP vec_assign(SEXP, SEXP, SEXP);
+extern SEXP vctrs_vec_assign(SEXP, SEXP, SEXP);
 extern SEXP vctrs_set_attributes(SEXP, SEXP);
 extern SEXP vctrs_as_df_row(SEXP, SEXP);
 extern SEXP vctrs_outer_names(SEXP, SEXP, SEXP);
@@ -89,7 +89,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_id",                         (DL_FUNC) &vctrs_id, 1},
   {"vctrs_n_distinct",                 (DL_FUNC) &vctrs_n_distinct, 1},
   {"vctrs_size",                       (DL_FUNC) &vctrs_size, 1},
-  {"vctrs_dim",                        (DL_FUNC) &vec_dim, 1},
+  {"vctrs_dim",                        (DL_FUNC) &vctrs_vec_dim, 1},
   {"vctrs_dim_n",                      (DL_FUNC) &vctrs_dim_n, 1},
   {"vctrs_is_unspecified",             (DL_FUNC) &vctrs_is_unspecified, 1},
   {"vctrs_equal",                      (DL_FUNC) &vctrs_equal, 3},
@@ -104,16 +104,16 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_cast",                       (DL_FUNC) &vctrs_cast, 4},
   {"vctrs_as_index",                   (DL_FUNC) &vctrs_as_index, 3},
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 2},
-  {"vctrs_restore",                    (DL_FUNC) &vec_restore, 3},
-  {"vctrs_restore_default",            (DL_FUNC) &vec_restore_default, 2},
-  {"vctrs_proxy",                      (DL_FUNC) &vec_proxy, 1},
+  {"vctrs_restore",                    (DL_FUNC) &vctrs_vec_restore, 3},
+  {"vctrs_restore_default",            (DL_FUNC) &vctrs_vec_restore_default, 2},
+  {"vctrs_proxy",                      (DL_FUNC) &vctrs_vec_proxy, 1},
   {"vctrs_unspecified",                (DL_FUNC) &vctrs_unspecified, 1},
-  {"vctrs_type",                       (DL_FUNC) &vec_type, 1},
-  {"vctrs_type_finalise",              (DL_FUNC) &vec_type_finalise, 1},
+  {"vctrs_type",                       (DL_FUNC) &vctrs_vec_type, 1},
+  {"vctrs_type_finalise",              (DL_FUNC) &vctrs_vec_type_finalise, 1},
   {"vctrs_minimal_names",              (DL_FUNC) &vctrs_minimal_names, 1},
   {"vctrs_unique_names",               (DL_FUNC) &vctrs_unique_names, 2},
   {"vctrs_as_minimal_names",           (DL_FUNC) &vctrs_as_minimal_names, 1},
-  {"vctrs_names",                      (DL_FUNC) &vec_names, 1},
+  {"vctrs_names",                      (DL_FUNC) &vctrs_vec_names, 1},
   {"vctrs_is_unique_names",            (DL_FUNC) &vctrs_is_unique_names, 1},
   {"vctrs_as_unique_names",            (DL_FUNC) &vctrs_as_unique_names, 2},
   {"vctrs_df_as_dataframe",            (DL_FUNC) &vctrs_df_as_dataframe, 4},
@@ -124,7 +124,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_df_restore",                 (DL_FUNC) &vctrs_df_restore, 3},
   {"vctrs_recycle",                    (DL_FUNC) &vctrs_recycle, 2},
   {"vctrs_coercible_cast",             (DL_FUNC) &vctrs_coercible_cast, 4},
-  {"vctrs_assign",                     (DL_FUNC) &vec_assign, 3},
+  {"vctrs_assign",                     (DL_FUNC) &vctrs_vec_assign, 3},
   {"vctrs_set_attributes",             (DL_FUNC) &vctrs_set_attributes, 2},
   {"vctrs_as_df_row",                  (DL_FUNC) &vctrs_as_df_row, 2},
   {"vctrs_outer_names",                (DL_FUNC) &vctrs_outer_names, 3},

--- a/src/names.c
+++ b/src/names.c
@@ -48,7 +48,7 @@ SEXP vec_validate_unique_names(SEXP names) {
 
 
 // [[ register(); include("vctrs.h") ]]
-SEXP vec_names(SEXP x) {
+SEXP vctrs_vec_names(SEXP x) {
   if (OBJECT(x) && Rf_inherits(x, "data.frame")) {
     return R_NilValue;
   }
@@ -107,7 +107,7 @@ SEXP vctrs_as_minimal_names(SEXP names) {
 
 // [[ register() ]]
 SEXP vctrs_minimal_names(SEXP x) {
-  SEXP names = PROTECT(vec_names(x));
+  SEXP names = PROTECT(vctrs_vec_names(x));
 
   if (names == R_NilValue) {
     names = Rf_allocVector(STRSXP, vec_size(x));

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -12,7 +12,7 @@ SEXP vec_proxy_invoke(SEXP x, SEXP method);
 
 
 // [[ register(); include("vctrs.h") ]]
-SEXP vec_proxy(SEXP x) {
+SEXP vctrs_vec_proxy(SEXP x) {
   int nprot = 0;
   struct vctrs_type_info info = PROTECT_TYPE_INFO(vec_type_info(x), &nprot);
 

--- a/src/size.c
+++ b/src/size.c
@@ -4,7 +4,7 @@
 R_len_t rcrd_size(SEXP x);
 
 // [[ register(); include("vctrs.h") ]]
-SEXP vec_dim(SEXP x) {
+SEXP vctrs_vec_dim(SEXP x) {
   SEXP dim = PROTECT(Rf_getAttrib(x, R_DimSymbol));
 
   if (dim == R_NilValue) {
@@ -17,7 +17,7 @@ SEXP vec_dim(SEXP x) {
 
 // [[ include("vctrs.h") ]]
 R_len_t vec_dim_n(SEXP x) {
-  return Rf_length(vec_dim(x));
+  return Rf_length(vctrs_vec_dim(x));
 }
 
 // [[ register() ]]

--- a/src/slice-array.c
+++ b/src/slice-array.c
@@ -214,7 +214,7 @@ SEXP vec_slice_shaped_base(enum vctrs_type type,
 
 SEXP vec_slice_shaped(enum vctrs_type type, SEXP x, SEXP index) {
 
-  SEXP dim = PROTECT(vec_dim(x));
+  SEXP dim = PROTECT(vctrs_vec_dim(x));
 
   struct vec_slice_shaped_info info;
   info.p_dim = INTEGER_RO(dim);

--- a/src/slice.c
+++ b/src/slice.c
@@ -175,7 +175,7 @@ static SEXP vec_slice_impl(SEXP x, SEXP index) {
     // Take over attribute restoration only if the `[` method did not
     // restore itself
     if (ATTRIB(out) == R_NilValue) {
-      out = vec_restore(out, x, restore_size);
+      out = vctrs_vec_restore(out, x, restore_size);
     }
 
     UNPROTECT(nprot);
@@ -214,7 +214,7 @@ static SEXP vec_slice_impl(SEXP x, SEXP index) {
       Rf_setAttrib(out, R_NamesSymbol, names);
     }
 
-    out = vec_restore(out, x, index);
+    out = vctrs_vec_restore(out, x, index);
 
     UNPROTECT(nprot);
     return out;
@@ -222,7 +222,7 @@ static SEXP vec_slice_impl(SEXP x, SEXP index) {
 
   case vctrs_type_dataframe: {
     SEXP out = PROTECT_N(df_slice(data, index), &nprot);
-    out = vec_restore(out, x, restore_size);
+    out = vctrs_vec_restore(out, x, restore_size);
     UNPROTECT(nprot);
     return out;
   }
@@ -239,7 +239,7 @@ SEXP vctrs_slice(SEXP x, SEXP index) {
     return x;
   }
 
-  index = PROTECT(vec_as_index(index, vec_size(x), PROTECT(vec_names(x))));
+  index = PROTECT(vec_as_index(index, vec_size(x), PROTECT(vctrs_vec_names(x))));
   SEXP out = vec_slice_impl(x, index);
 
   UNPROTECT(2);

--- a/src/type2.c
+++ b/src/type2.c
@@ -133,7 +133,7 @@ SEXP df_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) 
 
     SEXP type;
     if (dup == NA_INTEGER) {
-      type = vec_type(VECTOR_ELT(x, i));
+      type = vctrs_vec_type(VECTOR_ELT(x, i));
     } else {
       --dup; // 1-based index
       struct arg_data_index x_arg_data = new_index_arg_data(r_chr_get_c_string(x_names, i), x_arg);
@@ -156,7 +156,7 @@ SEXP df_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) 
   for (R_len_t j = 0; i < out_len; ++j) {
     R_len_t dup = y_dups_pos_data[j];
     if (dup == NA_INTEGER) {
-      SET_VECTOR_ELT(out, i, vec_type(VECTOR_ELT(y, j)));
+      SET_VECTOR_ELT(out, i, vctrs_vec_type(VECTOR_ELT(y, j)));
       SET_STRING_ELT(nms, i, STRING_ELT(y_names, j));
       ++i;
     }

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -28,7 +28,7 @@ enum vctrs_type {
 
 /**
  * @member type The vector type of the original data.
- * @member proxy_method The function of the `vec_proxy()` method, if
+ * @member proxy_method The function of the `vctrs_vec_proxy()` method, if
  *   any. This method is looked up with [vec_proxy_method()].
  */
 struct vctrs_type_info {
@@ -191,25 +191,25 @@ bool vec_is_unspecified(SEXP x);
 
 #include "arg.h"
 
-SEXP vec_proxy(SEXP x);
+SEXP vctrs_vec_proxy(SEXP x);
 SEXP vec_proxy_equal(SEXP x);
-SEXP vec_restore(SEXP x, SEXP to, SEXP i);
+SEXP vctrs_vec_restore(SEXP x, SEXP to, SEXP i);
 R_len_t vec_size(SEXP x);
 R_len_t vec_size_common(SEXP xs, R_len_t absent);
-SEXP vec_dim(SEXP x);
+SEXP vctrs_vec_dim(SEXP x);
 R_len_t vec_dim_n(SEXP x);
 SEXP vec_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_cast_common(SEXP xs, SEXP to);
 SEXP vec_coercible_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_slice(SEXP x, SEXP index);
 SEXP vec_slice_shaped(enum vctrs_type type, SEXP x, SEXP index);
-SEXP vec_assign(SEXP x, SEXP index, SEXP value);
+SEXP vctrs_vec_assign(SEXP x, SEXP index, SEXP value);
 SEXP vec_na(SEXP x, R_len_t n);
-SEXP vec_type(SEXP x);
-SEXP vec_type_finalise(SEXP x);
+SEXP vctrs_vec_type(SEXP x);
+SEXP vctrs_vec_type_finalise(SEXP x);
 bool vec_is_unspecified(SEXP x);
 SEXP vec_recycle(SEXP x, R_len_t size);
-SEXP vec_names(SEXP x);
+SEXP vctrs_vec_names(SEXP x);
 
 SEXP vec_type2(SEXP x,
                SEXP y,


### PR DESCRIPTION
via:

```
sed -r -i 's/(vec_(dim|restore|restore_default|proxy|type|type_finalise|names|assign)[(,])/vctrs_\1/g' src/*
```

This makes these functions easier to search for in the C part of the codebase.