### PR TITLE
Remove order related generics from `vec_math()` docs

### DIFF
--- a/R/numeric.R
+++ b/R/numeric.R
@@ -1,8 +1,8 @@
 #' Mathematical operations
 #'
 #' This generic provides a common dispatch mechanism for all regular unary
-#' mathematical functions. It is used as a common wrapper around the Summary
-#' group generics, the Math group generics, and a handful of other
+#' mathematical functions. It is used as a common wrapper around many of the
+#' Summary group generics, the Math group generics, and a handful of other
 #' mathematical functions like `mean()`.
 #'
 #' `vec_math_base()` is provided as a convenience for writing methods. It
@@ -11,7 +11,7 @@
 #' @section Included functions:
 #'
 #' * From the [Summary] group generic:
-#'   `max()`, `min()`, `range()`, `prod()`, `sum()`, `any()`, `all()`.
+#'   `prod()`, `sum()`, `any()`, `all()`.
 #'
 #' * From the [Math] group generic:
 #'   `abs()`, `sign()`, `sqrt()`, `ceiling()`, `floor()`, `trunc()`, `cummax()`,

--- a/R/numeric.R
+++ b/R/numeric.R
@@ -6,7 +6,7 @@
 #' mathematical functions like `mean()`.
 #'
 #' `vec_math_base()` is provided as a convenience for writing methods. It
-#' calls the base `fn` on the underlying [vec_data()].
+#' calls the base `.fn` on the underlying [vec_data()].
 #'
 #' @section Included functions:
 #'

--- a/R/numeric.R
+++ b/R/numeric.R
@@ -11,7 +11,7 @@
 #' @section Included functions:
 #'
 #' * From the [Summary] group generic:
-#'   `max()`, `min()`, `range()`, `prod`, `sum()`, `any()`, `all()`.
+#'   `max()`, `min()`, `range()`, `prod()`, `sum()`, `any()`, `all()`.
 #'
 #' * From the [Math] group generic:
 #'   `abs()`, `sign()`, `sqrt()`, `ceiling()`, `floor()`, `trunc()`, `cummax()`,

--- a/man/vec_math.Rd
+++ b/man/vec_math.Rd
@@ -18,8 +18,8 @@ vec_math_base(.fn, .x, ...)
 }
 \description{
 This generic provides a common dispatch mechanism for all regular unary
-mathematical functions. It is used as a common wrapper around the Summary
-group generics, the Math group generics, and a handful of other
+mathematical functions. It is used as a common wrapper around many of the
+Summary group generics, the Math group generics, and a handful of other
 mathematical functions like \code{mean()}.
 }
 \details{
@@ -30,7 +30,7 @@ calls the base \code{fn} on the underlying \code{\link[=vec_data]{vec_data()}}.
 
 \itemize{
 \item From the \link{Summary} group generic:
-\code{max()}, \code{min()}, \code{range()}, \code{prod()}, \code{sum()}, \code{any()}, \code{all()}.
+\code{prod()}, \code{sum()}, \code{any()}, \code{all()}.
 \item From the \link{Math} group generic:
 \code{abs()}, \code{sign()}, \code{sqrt()}, \code{ceiling()}, \code{floor()}, \code{trunc()}, \code{cummax()},
 \code{cummin()}, \code{cumprod()}, \code{cumsum()}, \code{log()}, \code{log10()}, \code{log2()},

--- a/man/vec_math.Rd
+++ b/man/vec_math.Rd
@@ -24,7 +24,7 @@ mathematical functions like \code{mean()}.
 }
 \details{
 \code{vec_math_base()} is provided as a convenience for writing methods. It
-calls the base \code{fn} on the underlying \code{\link[=vec_data]{vec_data()}}.
+calls the base \code{.fn} on the underlying \code{\link[=vec_data]{vec_data()}}.
 }
 \section{Included functions}{
 

--- a/man/vec_math.Rd
+++ b/man/vec_math.Rd
@@ -30,7 +30,7 @@ calls the base \code{fn} on the underlying \code{\link[=vec_data]{vec_data()}}.
 
 \itemize{
 \item From the \link{Summary} group generic:
-\code{max()}, \code{min()}, \code{range()}, \code{prod}, \code{sum()}, \code{any()}, \code{all()}.
+\code{max()}, \code{min()}, \code{range()}, \code{prod()}, \code{sum()}, \code{any()}, \code{all()}.
 \item From the \link{Math} group generic:
 \code{abs()}, \code{sign()}, \code{sqrt()}, \code{ceiling()}, \code{floor()}, \code{trunc()}, \code{cummax()},
 \code{cummin()}, \code{cumprod()}, \code{cumsum()}, \code{log()}, \code{log10()}, \code{log2()},


### PR DESCRIPTION
Closes #431 

- Removes `min()`, `max()` and `range()` from `vec_math()` docs
- I'm going to follow this up with a `range.vctrs_vctr` implementation