### PR TITLE
Improve `NA` casting between base types

### DIFF
--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -71,7 +71,8 @@ vec_cast.integer.integer <- function(x, to, ...) {
 #' @method vec_cast.integer double
 vec_cast.integer.double <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   out <- suppressWarnings(vec_coerce_bare(x, "integer"))
-  lossy <- (out != x) | xor(is.na(x), is.na(out))
+  x_na <- is.na(x)
+  lossy <- (out != x & !x_na) | xor(x_na, is.na(out))
   out <- shape_broadcast(out, to)
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -19,7 +19,7 @@ vec_cast.logical.logical <- function(x, to, ...) {
 vec_cast.logical.integer <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   out <- vec_coerce_bare(x, "logical")
   out <- shape_broadcast(out, to)
-  lossy <- !x %in% c(0L, 1L)
+  lossy <- !x %in% c(0L, 1L, NA_integer_)
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -109,7 +109,8 @@ vec_cast.double.integer <- vec_cast.double.logical
 #' @method vec_cast.double character
 vec_cast.double.character <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   out <- suppressWarnings(vec_coerce_bare(x, "double"))
-  lossy <- (out != x) | xor(is.na(x), is.na(out))
+  x_na <- is.na(x)
+  lossy <- (out != x & !x_na) | xor(x_na, is.na(out))
   out <- shape_broadcast(out, to)
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -27,7 +27,7 @@ vec_cast.logical.integer <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 vec_cast.logical.double <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   out <- vec_coerce_bare(x, "logical")
   out <- shape_broadcast(out, to)
-  lossy <- !x %in% c(0, 1)
+  lossy <- !x %in% c(0, 1, NA_real_)
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
@@ -35,7 +35,7 @@ vec_cast.logical.double <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 vec_cast.logical.character <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   out <- vec_coerce_bare(x, "logical")
   out <- shape_broadcast(out, to)
-  lossy <- !x %in% c("T", "F", "TRUE", "FALSE", "true", "false")
+  lossy <- !x %in% c("T", "F", "TRUE", "FALSE", "true", "false", NA_character_)
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export

--- a/src/cast.c
+++ b/src/cast.c
@@ -20,6 +20,11 @@ static SEXP int_as_logical(SEXP x, bool* lossy) {
   for (R_len_t i = 0; i < n; ++i, ++data, ++out_data) {
     int elt = *data;
 
+    if (elt == NA_INTEGER) {
+      *out_data = NA_LOGICAL;
+      continue;
+    }
+
     if (elt != 0 && elt != 1) {
       *lossy = true;
       UNPROTECT(1);

--- a/src/cast.c
+++ b/src/cast.c
@@ -48,13 +48,18 @@ static SEXP dbl_as_logical(SEXP x, bool* lossy) {
   for (R_len_t i = 0; i < n; ++i, ++data, ++out_data) {
     double elt = *data;
 
+    if (isnan(elt)) {
+      *out_data = NA_LOGICAL;
+      continue;
+    }
+
     if (elt != 0 && elt != 1) {
       *lossy = true;
       UNPROTECT(1);
       return R_NilValue;
     }
 
-    *out_data = isnan(elt) ? NA_LOGICAL : (int) elt;
+    *out_data = (int) elt;
   }
 
   UNPROTECT(1);
@@ -69,7 +74,13 @@ static SEXP chr_as_logical(SEXP x, bool* lossy) {
   int* out_data = LOGICAL(out);
 
   for (R_len_t i = 0; i < n; ++i, ++data, ++out_data) {
-    const char* elt = CHAR(*data);
+    SEXP str = *data;
+    if (str == NA_STRING) {
+      *out_data = NA_LOGICAL;
+      continue;
+    }
+
+    const char* elt = CHAR(str);
     switch (elt[0]) {
     case 'T':
       if (elt[1] == '\0' || strcmp(elt, "TRUE") == 0) {

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -29,9 +29,11 @@ test_that("NA casts work as expected", {
   exp <- lgl(NA)
   to <- lgl()
 
+  expect_equal(vec_cast(lgl(NA), to), exp)
   expect_equal(vec_cast(int(NA), to), exp)
   expect_equal(vec_cast(dbl(NA), to), exp)
   expect_equal(vec_cast(chr(NA), to), exp)
+  expect_equal(vec_cast(list(NA), to), exp)
 })
 
 test_that("Shaped NA casts work as expected", {
@@ -39,9 +41,11 @@ test_that("Shaped NA casts work as expected", {
   exp_mat <- mat(lgl(NA))
   to_mat <- matrix(lgl())
 
+  expect_equal(vec_cast(mat(lgl(NA)), to_mat), exp_mat)
   expect_equal(vec_cast(mat(int(NA)), to_mat), exp_mat)
   expect_equal(vec_cast(mat(dbl(NA)), to_mat), exp_mat)
   expect_equal(vec_cast(mat(chr(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(list(NA)), to_mat), exp_mat)
 })
 
 test_that("lossy casts generate warning", {
@@ -79,6 +83,29 @@ test_that("safe casts work as expected", {
   expect_equal(vec_cast(list(1L, 2L), integer()), int(1L, 2L))
 })
 
+test_that("NA casts work as expected", {
+  exp <- int(NA)
+  to <- int()
+
+  expect_equal(vec_cast(lgl(NA), to), exp)
+  expect_equal(vec_cast(int(NA), to), exp)
+  expect_equal(vec_cast(dbl(NA), to), exp)
+  expect_equal(vec_cast(chr(NA), to), exp)
+  expect_equal(vec_cast(list(NA), to), exp)
+})
+
+test_that("Shaped NA casts work as expected", {
+  mat <- matrix
+  exp_mat <- mat(int(NA))
+  to_mat <- matrix(int())
+
+  expect_equal(vec_cast(mat(lgl(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(int(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(dbl(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(chr(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(list(NA)), to_mat), exp_mat)
+})
+
 test_that("lossy casts generate error", {
   expect_lossy(vec_cast(c(2.5, 2), int()),     int(2, 2), x = dbl(), to = int())
   expect_lossy(vec_cast(c("2.5", "2"), int()), int(2, 2), x = chr(), to = int())
@@ -103,6 +130,29 @@ test_that("safe casts work as expected", {
   expect_equal(vec_cast(list(1, 1.5), double()), dbl(1, 1.5))
 })
 
+test_that("NA casts work as expected", {
+  exp <- dbl(NA)
+  to <- dbl()
+
+  expect_equal(vec_cast(lgl(NA), to), exp)
+  expect_equal(vec_cast(int(NA), to), exp)
+  expect_equal(vec_cast(dbl(NA), to), exp)
+  expect_equal(vec_cast(chr(NA), to), exp)
+  expect_equal(vec_cast(list(NA), to), exp)
+})
+
+test_that("Shaped NA casts work as expected", {
+  mat <- matrix
+  exp_mat <- mat(dbl(NA))
+  to_mat <- matrix(dbl())
+
+  expect_equal(vec_cast(mat(lgl(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(int(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(dbl(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(chr(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(list(NA)), to_mat), exp_mat)
+})
+
 test_that("lossy casts generate warning", {
   expect_lossy(vec_cast(c("2.5", "x"), dbl()), dbl(2.5, NA), x = chr(), to = dbl())
 })
@@ -122,6 +172,27 @@ test_that("safe casts to complex works", {
   expect_identical(vec_cast(list(1, 1.5), cpl()), cpl(1, 1.5))
 })
 
+test_that("NA casts work as expected", {
+  exp <- cpl(NA)
+  to <- cpl()
+
+  expect_equal(vec_cast(lgl(NA), to), exp)
+  expect_equal(vec_cast(int(NA), to), exp)
+  expect_equal(vec_cast(dbl(NA), to), exp)
+  expect_equal(vec_cast(list(NA), to), exp)
+})
+
+test_that("Shaped NA casts work as expected", {
+  mat <- matrix
+  exp_mat <- mat(cpl(NA))
+  to_mat <- matrix(cpl())
+
+  expect_equal(vec_cast(mat(lgl(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(int(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(dbl(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(list(NA)), to_mat), exp_mat)
+})
+
 
 # Character
 
@@ -130,6 +201,29 @@ test_that("safe casts work as expected", {
   expect_equal(vec_cast(NA, character()), NA_character_)
   expect_equal(vec_cast(lgl(TRUE, FALSE), character()), chr("TRUE", "FALSE"))
   expect_equal(vec_cast(list("x", "y"), character()), chr("x", "y"))
+})
+
+test_that("NA casts work as expected", {
+  exp <- chr(NA)
+  to <- chr()
+
+  expect_equal(vec_cast(lgl(NA), to), exp)
+  expect_equal(vec_cast(int(NA), to), exp)
+  expect_equal(vec_cast(dbl(NA), to), exp)
+  expect_equal(vec_cast(chr(NA), to), exp)
+  expect_equal(vec_cast(list(NA), to), exp)
+})
+
+test_that("Shaped NA casts work as expected", {
+  mat <- matrix
+  exp_mat <- mat(chr(NA))
+  to_mat <- matrix(chr())
+
+  expect_equal(vec_cast(mat(lgl(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(int(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(dbl(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(chr(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(list(NA)), to_mat), exp_mat)
 })
 
 test_that("difftime gets special treatment", {

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -30,6 +30,8 @@ test_that("NA casts work as expected", {
   to <- lgl()
 
   expect_equal(vec_cast(int(NA), to), exp)
+  expect_equal(vec_cast(dbl(NA), to), exp)
+  expect_equal(vec_cast(chr(NA), to), exp)
 })
 
 test_that("Shaped NA casts work as expected", {
@@ -38,6 +40,8 @@ test_that("Shaped NA casts work as expected", {
   to_mat <- matrix(lgl())
 
   expect_equal(vec_cast(mat(int(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(dbl(NA)), to_mat), exp_mat)
+  expect_equal(vec_cast(mat(chr(NA)), to_mat), exp_mat)
 })
 
 test_that("lossy casts generate warning", {

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -25,6 +25,21 @@ test_that("safe casts work as expected", {
   expect_equal(vec_cast(list(1, 0), logical()), exp)
 })
 
+test_that("NA casts work as expected", {
+  exp <- lgl(NA)
+  to <- lgl()
+
+  expect_equal(vec_cast(int(NA), to), exp)
+})
+
+test_that("Shaped NA casts work as expected", {
+  mat <- matrix
+  exp_mat <- mat(lgl(NA))
+  to_mat <- matrix(lgl())
+
+  expect_equal(vec_cast(mat(int(NA)), to_mat), exp_mat)
+})
+
 test_that("lossy casts generate warning", {
   expect_lossy(vec_cast(int(2L, 1L), lgl()),                lgl(TRUE, TRUE), x = int(),  to = lgl())
   expect_lossy(vec_cast(dbl(2, 1), lgl()),                  lgl(TRUE, TRUE), x = dbl(),  to = lgl())


### PR DESCRIPTION
Closes #451 

- Integer -> Logical `NA` casting is now supported
- Double -> Logical `NA` casting is now supported
- Character -> Logical `NA` casting is now supported
- A bug was fixed in detecting if a cast was `lossy` or not in the R level `vec_cast()` fallbacks. Before, you'd get this error due to `out != x` returning `NA`:

``` r
vctrs::vec_cast(matrix(NA_real_), matrix(NA_integer_))
#> Error in if (!any(lossy)) {: missing value where TRUE/FALSE needed
```

If you have suggestions on how to simplify the `lossy` condition, I'm all for it. It took me awhile to parse.

- I added tests for all relevant `NA` conversions, and shaped `NA` conversions. The latter have the nice side effect of testing the R level casting functions. Fleshing it out this way helped me find all of the locations where we might not be handling `NA` casts correctly.