### PR TITLE
Use `vec_size()` for field size comparison

### DIFF
--- a/src/fields.c
+++ b/src/fields.c
@@ -122,7 +122,7 @@ SEXP vctrs_field_set(SEXP x, SEXP index, SEXP value) {
 
   if (!Rf_isVector(value))
     Rf_errorcall(R_NilValue, "Invalid value: not a vector");
-  if (Rf_length(value) != Rf_length(VECTOR_ELT(x, 0)))
+  if (vec_size(value) != vec_size(x))
     Rf_errorcall(R_NilValue, "Invalid value: incorrect length");
 
   return vctrs_list_set(x, index, value);

--- a/src/fields.c
+++ b/src/fields.c
@@ -120,10 +120,13 @@ SEXP vctrs_field_get(SEXP x, SEXP index) {
 SEXP vctrs_field_set(SEXP x, SEXP index, SEXP value) {
   check_rcrd(x);
 
-  if (!vec_is_vector(value))
-    Rf_errorcall(R_NilValue, "Invalid value: not a vector");
-  if (vec_size(value) != vec_size(x))
-    Rf_errorcall(R_NilValue, "Invalid value: incorrect length");
+  if (!vec_is_vector(value)) {
+    Rf_errorcall(R_NilValue, "Invalid value: not a vector.");
+  }
+
+  if (vec_size(value) != vec_size(x)) {
+    Rf_errorcall(R_NilValue, "Invalid value: incorrect length.");
+  }
 
   return vctrs_list_set(x, index, value);
 }

--- a/src/fields.c
+++ b/src/fields.c
@@ -120,7 +120,7 @@ SEXP vctrs_field_get(SEXP x, SEXP index) {
 SEXP vctrs_field_set(SEXP x, SEXP index, SEXP value) {
   check_rcrd(x);
 
-  if (!Rf_isVector(value))
+  if (!vec_is_vector(value))
     Rf_errorcall(R_NilValue, "Invalid value: not a vector");
   if (vec_size(value) != vec_size(x))
     Rf_errorcall(R_NilValue, "Invalid value: incorrect length");

--- a/tests/testthat/test-fields.R
+++ b/tests/testthat/test-fields.R
@@ -76,3 +76,13 @@ test_that("field<- checks inputs", {
   expect_error(field(r, "x") <- 1:3, "Invalid value")
   expect_error(field(r, "x") <- environment(), "Invalid value")
 })
+
+test_that("field<- respects size, not length (#450)", {
+  r1 <- new_rcrd(list(df = new_data_frame(n = 2L)))
+  new_df <- data.frame(x = 1:2)
+
+  field(r1, 'df') <- new_df
+  expect_equal(field(r1, "df"), new_df)
+
+  expect_error(field(r1, 'df') <- new_data_frame(n = 3L), "Invalid value")
+})


### PR DESCRIPTION
Closes #450 

`vctrs_field_set()` used `Rf_length()` to determine if `value` had the correct size. Since these fields can be any type of vector (including a data frame or another record), I think `vec_size()` is more correct, which will correctly ask for a proxy of the vector and take the size of that.

While I was there, I cleaned up some formatting and changed `Rf_isVector()` -> `vec_is_vector()`.