### PR TITLE
Remove performance note in unique/duplicate/match functions

### DIFF
--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -90,13 +90,6 @@ reset_rownames <- function(x) {
 #' so these functions consider all `NAs` to be equal. (Similarly,
 #' all `NaN` are also considered to be equal.)
 #'
-#' @section Performance:
-#' These functions are currently slightly slower than their base equivalents.
-#' This is primarily because they do a little more checking and coercion
-#' in R, which makes them both a little safer and more generic. Additionally,
-#' the C code underlying vctrs has not yet been implemented: we expect
-#' some performance improvements when that happens.
-#'
 #' @param x A vector (including a data frame).
 #' @return
 #'   * `vec_duplicate_any()`: a logical vector of length 1.

--- a/man/vec_duplicate.Rd
+++ b/man/vec_duplicate.Rd
@@ -43,15 +43,6 @@ so these functions consider all \code{NAs} to be equal. (Similarly,
 all \code{NaN} are also considered to be equal.)
 }
 
-\section{Performance}{
-
-These functions are currently slightly slower than their base equivalents.
-This is primarily because they do a little more checking and coercion
-in R, which makes them both a little safer and more generic. Additionally,
-the C code underlying vctrs has not yet been implemented: we expect
-some performance improvements when that happens.
-}
-
 \examples{
 vec_duplicate_any(1:10)
 vec_duplicate_any(c(1, 1:10))

--- a/man/vec_match.Rd
+++ b/man/vec_match.Rd
@@ -37,15 +37,6 @@ so these functions consider all \code{NAs} to be equal. (Similarly,
 all \code{NaN} are also considered to be equal.)
 }
 
-\section{Performance}{
-
-These functions are currently slightly slower than their base equivalents.
-This is primarily because they do a little more checking and coercion
-in R, which makes them both a little safer and more generic. Additionally,
-the C code underlying vctrs has not yet been implemented: we expect
-some performance improvements when that happens.
-}
-
 \examples{
 hadley <- strsplit("hadley", "")[[1]]
 vec_match(hadley, letters)

--- a/man/vec_unique.Rd
+++ b/man/vec_unique.Rd
@@ -39,15 +39,6 @@ so these functions consider all \code{NAs} to be equal. (Similarly,
 all \code{NaN} are also considered to be equal.)
 }
 
-\section{Performance}{
-
-These functions are currently slightly slower than their base equivalents.
-This is primarily because they do a little more checking and coercion
-in R, which makes them both a little safer and more generic. Additionally,
-the C code underlying vctrs has not yet been implemented: we expect
-some performance improvements when that happens.
-}
-
 \examples{
 x <- rpois(100, 8)
 vec_unique(x)


### PR DESCRIPTION
This performance section is outdated, as all of the referenced functions have C implementations.