### PR TITLE
Alter `r_as_data_frame()` to only extract column names of 2D objects

### DIFF
--- a/src/bind.c
+++ b/src/bind.c
@@ -147,7 +147,7 @@ static SEXP as_df_row_impl(SEXP x, enum name_repair_arg name_repair, bool quiet)
     Rf_errorcall(R_NilValue, "Can't bind arrays.");
   }
   if (ndim == 2) {
-    return r_as_data_frame(x);
+    return r_as_data_frame(x, false);
   }
 
   x = PROTECT(r_as_list(x));
@@ -202,7 +202,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, enum name_repair_arg name_
   if (type == R_NilValue) {
     type = new_data_frame(vctrs_shared_empty_list, 0);
   } else if (!is_data_frame(type)) {
-    type = r_as_data_frame(type);
+    type = r_as_data_frame(type, false);
   }
   UNPROTECT(1);
   PROTECT(type);
@@ -339,7 +339,7 @@ static SEXP shaped_as_df_col(SEXP x, SEXP outer) {
 
   // If unpacked, transform to data frame first. We repair names
   // after unpacking and concatenation.
-  SEXP out = PROTECT(r_as_data_frame(x));
+  SEXP out = PROTECT(r_as_data_frame(x, false));
 
   // Remove names if they were repaired by `as.data.frame()`
   if (colnames(x) == R_NilValue) {

--- a/src/hash.c
+++ b/src/hash.c
@@ -126,7 +126,7 @@ static uint32_t list_hash_scalar(SEXP x, R_len_t i) {
 // frames ahead of time. The conversion to data frame is only a
 // stopgap, in the long term, we'll hash arrays natively.
 static uint32_t shaped_hash_scalar(SEXP x, R_len_t i) {
-  x = PROTECT(r_as_data_frame(x));
+  x = PROTECT(r_as_data_frame(x, true));
   uint32_t out = hash_scalar(x, i);
 
   UNPROTECT(1);
@@ -265,7 +265,7 @@ void hash_fill(uint32_t* p, R_len_t size, SEXP x) {
   if (has_dim(x)) {
     // The conversion to data frame is only a stopgap, in the long
     // term, we'll hash arrays natively
-    x = PROTECT(r_as_data_frame(x));
+    x = PROTECT(r_as_data_frame(x, true));
     hash_fill(p, size, x);
     UNPROTECT(1);
     return;

--- a/src/names.c
+++ b/src/names.c
@@ -355,7 +355,7 @@ static bool needs_suffix(SEXP str) {
 
 
 static SEXP names_iota(R_len_t n);
-static SEXP vec_unique_names_impl(SEXP names, R_len_t n, bool quiet);
+SEXP vec_unique_names_impl(SEXP names, R_len_t n, bool quiet);
 
 // [[ register() ]]
 SEXP vctrs_unique_names(SEXP x, SEXP quiet) {
@@ -377,7 +377,8 @@ SEXP vec_unique_colnames(SEXP x, bool quiet) {
   return out;
 }
 
-static SEXP vec_unique_names_impl(SEXP names, R_len_t n, bool quiet) {
+// [[ include("utils.h") ]]
+SEXP vec_unique_names_impl(SEXP names, R_len_t n, bool quiet) {
   SEXP out;
   if (names == R_NilValue) {
     out = PROTECT(names_iota(n));

--- a/src/utils.c
+++ b/src/utils.c
@@ -772,14 +772,21 @@ SEXP r_as_list(SEXP x) {
     return Rf_coerceVector(x, VECSXP);
   }
 }
-SEXP r_as_data_frame(SEXP x) {
+
+SEXP r_as_data_frame(SEXP x, bool quiet) {
   if (is_bare_data_frame(x)) {
     return x;
   }
 
   SEXP out = PROTECT(vctrs_dispatch1(syms_as_data_frame2, fns_as_data_frame2, syms_x, x));
 
-  SEXP names = PROTECT(vec_unique_colnames(x, false));
+  SEXP names;
+  if (vec_dim_n(x) == 2) {
+    names = PROTECT(vec_unique_colnames(x, quiet));
+  } else {
+    names = PROTECT(vec_unique_names_impl(R_NilValue, Rf_length(out), quiet));
+  }
+
   r_poke_names(out, names);
 
   UNPROTECT(2);

--- a/src/utils.h
+++ b/src/utils.h
@@ -52,6 +52,7 @@ bool is_bare_tibble(SEXP x);
 bool is_record(SEXP x);
 
 SEXP vec_unique_names(SEXP x, bool quiet);
+SEXP vec_unique_names_impl(SEXP names, R_len_t n, bool quiet);
 SEXP vec_unique_colnames(SEXP x, bool quiet);
 
 // Returns S3 method for `generic` suitable for the class of `x`. The
@@ -174,7 +175,7 @@ static inline SEXP r_list(SEXP x) {
 #define r_str_as_character Rf_ScalarString
 
 SEXP r_as_list(SEXP x);
-SEXP r_as_data_frame(SEXP x);
+SEXP r_as_data_frame(SEXP x, bool quiet);
 
 static inline void r_dbg_save(SEXP x, const char* name) {
   Rf_defineVar(Rf_install(name), x, R_GlobalEnv);

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -108,6 +108,12 @@ test_that("vec_unique() works with 1D arrays with NULL dimnames (#461)", {
 
   expect_equal(vec_unique(x), exp)
 })
+
+test_that("vec_unique() does silent name repair with array to data frame conversion (#461)", {
+  x <- matrix(c(1, 2), 2, 2, byrow = TRUE)
+  expect_silent(vec_unique(x))
+})
+
 test_that("unique functions take the equality proxy (#375)", {
   scoped_comparable_tuple()
   x <- tuple(c(1, 2, 1), 1:3)

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -100,6 +100,14 @@ test_that("vec_unique() works with 1D arrays", {
   expect_identical(vec_unique(x), new_vctr(c(1, 1, 2, 1), dim = c(2, 2)))
 })
 
+test_that("vec_unique() works with 1D arrays with NULL dimnames (#461)", {
+  # Arrays are converted to data frames, and in that conversion colnames
+  # are detected only for 2D arrays, since colnames(x) here would be an error
+  x <- array(c(1, 1), dimnames = list(NULL))
+  exp <- array(1, dimnames = list(NULL))
+
+  expect_equal(vec_unique(x), exp)
+})
 test_that("unique functions take the equality proxy (#375)", {
   scoped_comparable_tuple()
   x <- tuple(c(1, 2, 1), 1:3)


### PR DESCRIPTION
Closes #461 

Here is one potential solution to #461.

- `r_as_data_frame()` gains a `quiet` argument to solve the noisiness issue when calling `vec_unique()` on an array without column names. It is now called quietly from the hashing functions.
- `r_as_data_frame()` now only attempts to extract column names from 2D objects. A 1D / 3D+ object has default names repaired (`...1`, `...2`, etc). 

This solves the problem of trying to extract `colnames()` from a 1D array with `NULL` dimnames, which is an error.

This also solves the problem of trying to extract column names from a 3D array, and then trying to assign those column names to the newly created data frame. This is problematic because the 3D array might have dimensions `(1, 2, 2)` resulting in 2 column names, but the corresponding data frame will have 4 columns.

_One thing to note is that `vec_unique_names_impl()` is now exposed in `util.h`_