### PR TITLE
used `vec_size()` instead of `Rf_length()` in `vec_dim()` (pillar #167)

### DIFF
--- a/src/size.c
+++ b/src/size.c
@@ -8,7 +8,7 @@ SEXP vec_dim(SEXP x) {
   SEXP dim = PROTECT(vec_bare_dim(x));
 
   if (dim == R_NilValue) {
-    dim = r_int(Rf_length(x));
+    dim = r_int(vec_size(x));
   }
 
   UNPROTECT(1);


### PR DESCRIPTION
This PR is related to my issue about `list_of()` size display in the list-columns (now transferred to https://github.com/r-lib/pillar/issues/167). After digging into the source code, I think this issue lies in the **vctrs**, not **pillar**. For robustness, `Rf_length()` is replaced by `vec_size()` in `vec_dim()`. It fixes the size issue.

``` r
library(vctrs)

new_rational <- function(n = integer(), d = integer()) {
  vec_assert(n, ptype = integer())
  vec_assert(d, ptype = integer())
  
  new_rcrd(list(n = n, d = d), class = "vctrs_rational")
}

rational <- function(n, d) {
  c(n, d) %<-% vec_cast_common(n, d, .to = integer())
  c(n, d) %<-% vec_recycle_common(n, d)
  
  new_rational(n, d)
}

format.vctrs_rational <- function(x, ...) {
  n <- field(x, "n")
  d <- field(x, "d")
  
  out <- paste0(n, "/", d)
  out[is.na(n) | is.na(d)] <- NA
  
  out
}

vec_ptype_abbr.vctrs_rational <- function(x, ...) "rtnl"
vec_ptype_full.vctrs_rational <- function(x, ...) "rational"

x <- rational(1, 1:10)
x
#> <rational[10]>
#>  [1] 1/1  1/2  1/3  1/4  1/5  1/6  1/7  1/8  1/9  1/10

library(dplyr, warn.conflicts = FALSE)
iris %>% 
  group_by(Species) %>% 
  summarise(
    ratio = list_of(rational(as.integer(Sepal.Length), as.integer(Sepal.Width)))
  )
#> # A tibble: 3 x 2
#>   Species           ratio
#>   <fct>      <list<rtnl>>
#> 1 setosa             [50]
#> 2 versicolor         [50]
#> 3 virginica          [50]
```

<sup>Created on 2019-06-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>