### PR TITLE
Implement `compact_rep()`

### DIFF
--- a/src/size.c
+++ b/src/size.c
@@ -3,6 +3,9 @@
 
 R_len_t rcrd_size(SEXP x);
 
+// From slice.c
+SEXP vec_slice_impl(SEXP x, SEXP index);
+
 // [[ register(); include("vctrs.h") ]]
 SEXP vec_dim(SEXP x) {
   SEXP dim = PROTECT(vec_bare_dim(x));
@@ -172,10 +175,8 @@ SEXP vec_recycle(SEXP x, R_len_t size) {
   }
 
   if (n_x == 1L) {
-    // FIXME: Replace with ALTREP repetition
-    SEXP i = PROTECT(Rf_allocVector(INTSXP, size));
-    r_int_fill(i, 1, size);
-    SEXP out = vec_slice(x, i);
+    SEXP i = PROTECT(compact_rep(1, size));
+    SEXP out = vec_slice_impl(x, i);
 
     UNPROTECT(1);
     return out;

--- a/src/slice-array.c
+++ b/src/slice-array.c
@@ -130,7 +130,8 @@ struct vec_slice_shaped_info {
                                                                                \
   int size_index = info.p_index[0];                                            \
   if (size_index == NA_INTEGER) {                                              \
-    for (int i = 0; i < info.shape_elem_n; ++i, ++out_data) {                  \
+    R_len_t out_n = info.shape_elem_n * info.index_n;                          \
+    for (int i = 0; i < out_n; ++i, ++out_data) {                              \
       *out_data = NA_VALUE;                                                    \
     }                                                                          \
     UNPROTECT(1);                                                              \
@@ -241,7 +242,8 @@ static SEXP raw_slice_shaped(SEXP x, SEXP index, struct vec_slice_shaped_info in
                                                                       \
   int size_index = info.p_index[0];                                   \
   if (size_index == NA_INTEGER) {                                     \
-    for (int i = 0; i < info.shape_elem_n; ++i) {                     \
+    R_len_t out_n = info.shape_elem_n * info.index_n;                 \
+    for (int i = 0; i < out_n; ++i) {                                 \
       SET(out, i, NA_VALUE);                                          \
     }                                                                 \
     UNPROTECT(1);                                                     \

--- a/src/slice-array.c
+++ b/src/slice-array.c
@@ -330,7 +330,7 @@ SEXP vec_slice_shaped(enum vctrs_type type, SEXP x, SEXP index) {
   info.p_index = INTEGER_RO(index);
   info.dim_n = Rf_length(dim);
   info.shape_n = info.dim_n - 1;
-  info.index_n = is_compact_rep(index) ? info.p_index[1] : Rf_length(index);
+  info.index_n = vec_index_size(index);
 
   SEXP strides = PROTECT(vec_strides(info.p_dim, info.shape_n));
   info.p_strides = INTEGER_RO(strides);

--- a/src/slice-array.c
+++ b/src/slice-array.c
@@ -87,46 +87,99 @@ struct vec_slice_shaped_info {
   SEXP out_dim;
 };
 
-#define SLICE_SHAPED(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE) \
-  SEXP out = PROTECT(Rf_allocArray(RTYPE, info.out_dim));        \
-  CTYPE* out_data = DEREF(out);                                  \
-  const CTYPE* x_data = CONST_DEREF(x);                          \
-                                                                 \
-  int out_loc = 0;                                               \
-                                                                 \
-  for (int i = 0; i < info.shape_elem_n; ++i) {                  \
-                                                                 \
-    /* Find and add the next `x` element */                      \
-    for (int j = 0; j < info.index_n; ++j) {                     \
-      int size_index = info.p_index[j];                          \
-                                                                 \
-      if (size_index == NA_INTEGER) {                            \
-        out_data[out_loc] = NA_VALUE;                            \
-      } else {                                                   \
-        int loc = vec_strided_loc(                               \
-          size_index - 1,                                        \
-          info.p_shape_index,                                    \
-          info.p_strides,                                        \
-          info.shape_n                                           \
-        );                                                       \
-        out_data[out_loc] = x_data[loc];                         \
-      }                                                          \
-                                                                 \
-      out_loc++;                                                 \
-    }                                                            \
-                                                                 \
-    /* Update shape_index */                                     \
-    for (int j = 0; j < info.shape_n; ++j) {                     \
-      info.p_shape_index[j]++;                                   \
-      if (info.p_shape_index[j] < info.p_dim[j + 1]) {           \
-        break;                                                   \
-      }                                                          \
-      info.p_shape_index[j] = 0;                                 \
-    }                                                            \
-  }                                                              \
-                                                                 \
-  UNPROTECT(1);                                                  \
+#define SLICE_SHAPED_INDEX(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE) \
+  SEXP out = PROTECT(Rf_allocArray(RTYPE, info.out_dim));              \
+  CTYPE* out_data = DEREF(out);                                        \
+  const CTYPE* x_data = CONST_DEREF(x);                                \
+                                                                       \
+  int out_loc = 0;                                                     \
+                                                                       \
+  for (int i = 0; i < info.shape_elem_n; ++i) {                        \
+                                                                       \
+    /* Find and add the next `x` element */                            \
+    for (int j = 0; j < info.index_n; ++j) {                           \
+      int size_index = info.p_index[j];                                \
+                                                                       \
+      if (size_index == NA_INTEGER) {                                  \
+        out_data[out_loc] = NA_VALUE;                                  \
+      } else {                                                         \
+        int loc = vec_strided_loc(                                     \
+          size_index - 1,                                              \
+          info.p_shape_index,                                          \
+          info.p_strides,                                              \
+          info.shape_n                                                 \
+        );                                                             \
+        out_data[out_loc] = x_data[loc];                               \
+      }                                                                \
+                                                                       \
+      out_loc++;                                                       \
+    }                                                                  \
+                                                                       \
+    /* Update shape_index */                                           \
+    for (int j = 0; j < info.shape_n; ++j) {                           \
+      info.p_shape_index[j]++;                                         \
+      if (info.p_shape_index[j] < info.p_dim[j + 1]) {                 \
+        break;                                                         \
+      }                                                                \
+      info.p_shape_index[j] = 0;                                       \
+    }                                                                  \
+  }                                                                    \
+                                                                       \
+  UNPROTECT(1);                                                        \
   return out
+
+#define SLICE_SHAPED_COMPACT_REP(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE)   \
+  SEXP out = PROTECT(Rf_allocArray(RTYPE, info.out_dim));                      \
+  CTYPE* out_data = DEREF(out);                                                \
+                                                                               \
+  int size_index = info.p_index[0];                                            \
+  if (size_index == NA_INTEGER) {                                              \
+    for (int i = 0; i < info.shape_elem_n; ++i, ++out_data) {                  \
+      *out_data = NA_VALUE;                                                    \
+    }                                                                          \
+    UNPROTECT(1);                                                              \
+    return(out);                                                               \
+  }                                                                            \
+                                                                               \
+  const CTYPE* x_data = CONST_DEREF(x);                                        \
+  int out_loc = 0;                                                             \
+                                                                               \
+  /* Convert to C index */                                                     \
+  size_index = size_index - 1;                                                 \
+                                                                               \
+  for (int i = 0; i < info.shape_elem_n; ++i) {                                \
+                                                                               \
+    /* Find and add the next `x` element */                                    \
+    for (int j = 0; j < info.index_n; ++j) {                                   \
+      int loc = vec_strided_loc(                                               \
+        size_index,                                                            \
+        info.p_shape_index,                                                    \
+        info.p_strides,                                                        \
+        info.shape_n                                                           \
+      );                                                                       \
+      out_data[out_loc] = x_data[loc];                                         \
+      out_loc++;                                                               \
+    }                                                                          \
+                                                                               \
+    /* Update shape_index */                                                   \
+    for (int j = 0; j < info.shape_n; ++j) {                                   \
+      info.p_shape_index[j]++;                                                 \
+      if (info.p_shape_index[j] < info.p_dim[j + 1]) {                         \
+        break;                                                                 \
+      }                                                                        \
+      info.p_shape_index[j] = 0;                                               \
+    }                                                                          \
+  }                                                                            \
+                                                                               \
+  UNPROTECT(1);                                                                \
+  return out
+
+#define SLICE_SHAPED(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE)          \
+  if (is_compact_rep(index)) {                                            \
+    SLICE_SHAPED_COMPACT_REP(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE); \
+  } else {                                                                \
+    SLICE_SHAPED_INDEX(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE);       \
+  }
 
 static SEXP lgl_slice_shaped(SEXP x, SEXP index, struct vec_slice_shaped_info info) {
   SLICE_SHAPED(LGLSXP, int, LOGICAL, LOGICAL_RO, NA_LOGICAL);
@@ -148,8 +201,10 @@ static SEXP raw_slice_shaped(SEXP x, SEXP index, struct vec_slice_shaped_info in
 }
 
 #undef SLICE_SHAPED
+#undef SLICE_SHAPED_COMPACT_REP
+#undef SLICE_SHAPED_INDEX
 
-#define SLICE_BARRIER_SHAPED(RTYPE, GET, SET, NA_VALUE)        \
+#define SLICE_BARRIER_SHAPED_INDEX(RTYPE, GET, SET, NA_VALUE)  \
   SEXP out = PROTECT(Rf_allocArray(RTYPE, info.out_dim));      \
                                                                \
   int out_loc = 0;                                             \
@@ -189,11 +244,65 @@ static SEXP raw_slice_shaped(SEXP x, SEXP index, struct vec_slice_shaped_info in
   UNPROTECT(1);                                                \
   return out
 
+#define SLICE_BARRIER_SHAPED_COMPACT_REP(RTYPE, GET, SET, NA_VALUE)   \
+  SEXP out = PROTECT(Rf_allocArray(RTYPE, info.out_dim));             \
+                                                                      \
+  int size_index = info.p_index[0];                                   \
+  if (size_index == NA_INTEGER) {                                     \
+    for (int i = 0; i < info.shape_elem_n; ++i) {                     \
+      SET(out, i, NA_VALUE);                                          \
+    }                                                                 \
+    UNPROTECT(1);                                                     \
+    return(out);                                                      \
+  }                                                                   \
+                                                                      \
+  int out_loc = 0;                                                    \
+                                                                      \
+  /* Convert to C index */                                            \
+  size_index = size_index - 1;                                        \
+                                                                      \
+  for (int i = 0; i < info.shape_elem_n; ++i) {                       \
+                                                                      \
+    /* Find and add the next `x` element */                           \
+    for (int j = 0; j < info.index_n; ++j) {                          \
+      int loc = vec_strided_loc(                                      \
+        size_index,                                                   \
+        info.p_shape_index,                                           \
+        info.p_strides,                                               \
+        info.shape_n                                                  \
+      );                                                              \
+      SEXP elt = GET(x, loc);                                         \
+      SET(out, out_loc, elt);                                         \
+      out_loc++;                                                      \
+    }                                                                 \
+                                                                      \
+    /* Update shape_index */                                          \
+    for (int j = 0; j < info.shape_n; ++j) {                          \
+      info.p_shape_index[j]++;                                        \
+      if (info.p_shape_index[j] < info.p_dim[j + 1]) {                \
+        break;                                                        \
+      }                                                               \
+      info.p_shape_index[j] = 0;                                      \
+    }                                                                 \
+  }                                                                   \
+                                                                      \
+  UNPROTECT(1);                                                       \
+  return out
+
+#define SLICE_BARRIER_SHAPED(RTYPE, GET, SET, NA_VALUE)          \
+  if (is_compact_rep(index)) {                                   \
+    SLICE_BARRIER_SHAPED_COMPACT_REP(RTYPE, GET, SET, NA_VALUE); \
+  } else {                                                       \
+    SLICE_BARRIER_SHAPED_INDEX(RTYPE, GET, SET, NA_VALUE);       \
+  }
+
 static SEXP list_slice_shaped(SEXP x, SEXP index, struct vec_slice_shaped_info info) {
   SLICE_BARRIER_SHAPED(VECSXP, VECTOR_ELT, SET_VECTOR_ELT, R_NilValue);
 }
 
 #undef SLICE_BARRIER_SHAPED
+#undef SLICE_BARRIER_SHAPED_COMPACT_REP
+#undef SLICE_BARRIER_SHAPED_INDEX
 
 SEXP vec_slice_shaped_base(enum vctrs_type type,
                            SEXP x,
@@ -221,7 +330,7 @@ SEXP vec_slice_shaped(enum vctrs_type type, SEXP x, SEXP index) {
   info.p_index = INTEGER_RO(index);
   info.dim_n = Rf_length(dim);
   info.shape_n = info.dim_n - 1;
-  info.index_n = Rf_length(index);
+  info.index_n = is_compact_rep(index) ? info.p_index[1] : Rf_length(index);
 
   SEXP strides = PROTECT(vec_strides(info.p_dim, info.shape_n));
   info.p_strides = INTEGER_RO(strides);

--- a/src/slice-array.c
+++ b/src/slice-array.c
@@ -92,16 +92,14 @@ struct vec_slice_shaped_info {
   CTYPE* out_data = DEREF(out);                                        \
   const CTYPE* x_data = CONST_DEREF(x);                                \
                                                                        \
-  int out_loc = 0;                                                     \
-                                                                       \
   for (int i = 0; i < info.shape_elem_n; ++i) {                        \
                                                                        \
     /* Find and add the next `x` element */                            \
-    for (int j = 0; j < info.index_n; ++j) {                           \
+    for (int j = 0; j < info.index_n; ++j, ++out_data) {               \
       int size_index = info.p_index[j];                                \
                                                                        \
       if (size_index == NA_INTEGER) {                                  \
-        out_data[out_loc] = NA_VALUE;                                  \
+        *out_data = NA_VALUE;                                          \
       } else {                                                         \
         int loc = vec_strided_loc(                                     \
           size_index - 1,                                              \
@@ -109,10 +107,8 @@ struct vec_slice_shaped_info {
           info.p_strides,                                              \
           info.shape_n                                                 \
         );                                                             \
-        out_data[out_loc] = x_data[loc];                               \
+        *out_data = x_data[loc];                                       \
       }                                                                \
-                                                                       \
-      out_loc++;                                                       \
     }                                                                  \
                                                                        \
     /* Update shape_index */                                           \
@@ -142,7 +138,6 @@ struct vec_slice_shaped_info {
   }                                                                            \
                                                                                \
   const CTYPE* x_data = CONST_DEREF(x);                                        \
-  int out_loc = 0;                                                             \
                                                                                \
   /* Convert to C index */                                                     \
   size_index = size_index - 1;                                                 \
@@ -150,15 +145,14 @@ struct vec_slice_shaped_info {
   for (int i = 0; i < info.shape_elem_n; ++i) {                                \
                                                                                \
     /* Find and add the next `x` element */                                    \
-    for (int j = 0; j < info.index_n; ++j) {                                   \
+    for (int j = 0; j < info.index_n; ++j, ++out_data) {                       \
       int loc = vec_strided_loc(                                               \
         size_index,                                                            \
         info.p_shape_index,                                                    \
         info.p_strides,                                                        \
         info.shape_n                                                           \
       );                                                                       \
-      out_data[out_loc] = x_data[loc];                                         \
-      out_loc++;                                                               \
+      *out_data = x_data[loc];                                                 \
     }                                                                          \
                                                                                \
     /* Update shape_index */                                                   \
@@ -212,7 +206,7 @@ static SEXP raw_slice_shaped(SEXP x, SEXP index, struct vec_slice_shaped_info in
   for (int i = 0; i < info.shape_elem_n; ++i) {                \
                                                                \
     /* Find and add the next `x` element */                    \
-    for (int j = 0; j < info.index_n; ++j) {                   \
+    for (int j = 0; j < info.index_n; ++j, ++out_loc) {        \
       int size_index = info.p_index[j];                        \
                                                                \
       if (size_index == NA_INTEGER) {                          \
@@ -227,8 +221,6 @@ static SEXP raw_slice_shaped(SEXP x, SEXP index, struct vec_slice_shaped_info in
         SEXP elt = GET(x, loc);                                \
         SET(out, out_loc, elt);                                \
       }                                                        \
-                                                               \
-      out_loc++;                                               \
     }                                                          \
                                                                \
     /* Update shape_index */                                   \
@@ -264,7 +256,7 @@ static SEXP raw_slice_shaped(SEXP x, SEXP index, struct vec_slice_shaped_info in
   for (int i = 0; i < info.shape_elem_n; ++i) {                       \
                                                                       \
     /* Find and add the next `x` element */                           \
-    for (int j = 0; j < info.index_n; ++j) {                          \
+    for (int j = 0; j < info.index_n; ++j, ++out_loc) {               \
       int loc = vec_strided_loc(                                      \
         size_index,                                                   \
         info.p_shape_index,                                           \
@@ -273,7 +265,6 @@ static SEXP raw_slice_shaped(SEXP x, SEXP index, struct vec_slice_shaped_info in
       );                                                              \
       SEXP elt = GET(x, loc);                                         \
       SET(out, out_loc, elt);                                         \
-      out_loc++;                                                      \
     }                                                                 \
                                                                       \
     /* Update shape_index */                                          \

--- a/src/slice.c
+++ b/src/slice.c
@@ -243,10 +243,7 @@ SEXP vec_slice_impl(SEXP x, SEXP index) {
     }
 
     if (is_compact_rep(index)) {
-      int i = r_int_get(index, 0);
-      int n = r_int_get(index, 1);
-      index = PROTECT_N(Rf_allocVector(INTSXP, n), &nprot);
-      r_int_fill(index, i, n);
+      index = PROTECT_N(compact_rep_materialize(index), &nprot);
     }
 
     SEXP out;

--- a/src/slice.c
+++ b/src/slice.c
@@ -227,8 +227,7 @@ static SEXP slice_rownames(SEXP names, SEXP index) {
 SEXP vec_slice_impl(SEXP x, SEXP index) {
   int nprot = 0;
 
-  int index_n = is_compact_rep(index) ? r_int_get(index, 1) : Rf_length(index);
-  SEXP restore_size = PROTECT_N(r_int(index_n), &nprot);
+  SEXP restore_size = PROTECT_N(r_int(vec_index_size(index)), &nprot);
 
   struct vctrs_proxy_info info = vec_proxy_info(x);
   PROTECT_PROXY_INFO(&info, &nprot);

--- a/src/slice.c
+++ b/src/slice.c
@@ -17,7 +17,7 @@ static SEXP slice_rownames(SEXP names, SEXP index);
  * @param dispatch When `true`, dispatches to `[` for compatibility
  *   with base R. When `false`, uses native implementations.
  */
-static SEXP vec_slice_impl(SEXP x, SEXP index);
+SEXP vec_slice_impl(SEXP x, SEXP index);
 
 
 static void stop_bad_index_length(R_len_t n, R_len_t i) {
@@ -27,21 +27,47 @@ static void stop_bad_index_length(R_len_t n, R_len_t i) {
                n, i);
 }
 
-#define SLICE(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE)       \
-  const CTYPE* data = CONST_DEREF(x);                           \
-  R_len_t n = Rf_length(index);                                 \
-  int* index_data = INTEGER(index);                             \
-                                                                \
-  SEXP out = PROTECT(Rf_allocVector(RTYPE, n));                 \
-  CTYPE* out_data = DEREF(out);                                 \
-                                                                \
-  for (R_len_t i = 0; i < n; ++i, ++index_data, ++out_data) {   \
-    int j = *index_data;                                        \
-    *out_data = (j == NA_INTEGER) ? NA_VALUE : data[j - 1];     \
-  }                                                             \
-                                                                \
-  UNPROTECT(1);                                                 \
+#define SLICE_INDEX(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE)   \
+  const CTYPE* data = CONST_DEREF(x);                             \
+  R_len_t n = Rf_length(index);                                   \
+  int* index_data = INTEGER(index);                               \
+                                                                  \
+  SEXP out = PROTECT(Rf_allocVector(RTYPE, n));                   \
+  CTYPE* out_data = DEREF(out);                                   \
+                                                                  \
+  for (R_len_t i = 0; i < n; ++i, ++index_data, ++out_data) {     \
+    int j = *index_data;                                          \
+    *out_data = (j == NA_INTEGER) ? NA_VALUE : data[j - 1];       \
+  }                                                               \
+                                                                  \
+  UNPROTECT(1);                                                   \
   return out
+
+#define SLICE_COMPACT_REP(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE) \
+  const CTYPE* data = CONST_DEREF(x);                                 \
+                                                                      \
+  int* index_data = INTEGER(index);                                   \
+  R_len_t j = index_data[0];                                          \
+  R_len_t n = index_data[1];                                          \
+                                                                      \
+  SEXP out = PROTECT(Rf_allocVector(RTYPE, n));                       \
+  CTYPE* out_data = DEREF(out);                                       \
+                                                                      \
+  CTYPE elt = (j == NA_INTEGER) ? NA_VALUE : data[j - 1];             \
+                                                                      \
+  for (R_len_t i = 0; i < n; ++i, ++out_data) {                       \
+    *out_data = elt;                                                  \
+  }                                                                   \
+                                                                      \
+  UNPROTECT(1);                                                       \
+  return out
+
+#define SLICE(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE)          \
+  if (is_compact_rep(index)) {                                     \
+    SLICE_COMPACT_REP(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE); \
+  } else {                                                         \
+    SLICE_INDEX(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE);       \
+  }
 
 static SEXP lgl_slice(SEXP x, SEXP index) {
   SLICE(LGLSXP, int, LOGICAL, LOGICAL_RO, NA_LOGICAL);
@@ -63,9 +89,10 @@ static SEXP raw_slice(SEXP x, SEXP index) {
 }
 
 #undef SLICE
+#undef SLICE_COMPACT_REP
+#undef SLICE_INDEX
 
-
-#define SLICE_BARRIER(RTYPE, GET, SET, NA_VALUE)                \
+#define SLICE_BARRIER_INDEX(RTYPE, GET, SET, NA_VALUE)          \
   R_len_t n = Rf_length(index);                                 \
   int* index_data = INTEGER(index);                             \
                                                                 \
@@ -80,11 +107,37 @@ static SEXP raw_slice(SEXP x, SEXP index) {
   UNPROTECT(1);                                                 \
   return out
 
+
+#define SLICE_BARRIER_COMPACT_REP(RTYPE, GET, SET, NA_VALUE)    \
+  int* index_data = INTEGER(index);                             \
+  R_len_t j = index_data[0];                                    \
+  R_len_t n = index_data[1];                                    \
+                                                                \
+  SEXP out = PROTECT(Rf_allocVector(RTYPE, n));                 \
+                                                                \
+  SEXP elt = (j == NA_INTEGER) ? NA_VALUE : GET(x, j - 1);      \
+                                                                \
+  for (R_len_t i = 0; i < n; ++i) {                             \
+    SET(out, i, elt);                                           \
+  }                                                             \
+                                                                \
+  UNPROTECT(1);                                                 \
+  return out
+
+#define SLICE_BARRIER(RTYPE, GET, SET, NA_VALUE)            \
+  if (is_compact_rep(index)) {                              \
+    SLICE_BARRIER_COMPACT_REP(RTYPE, GET, SET, NA_VALUE);   \
+  } else {                                                  \
+    SLICE_BARRIER_INDEX(RTYPE, GET, SET, NA_VALUE);         \
+  }
+
 static SEXP list_slice(SEXP x, SEXP index) {
   SLICE_BARRIER(VECSXP, VECTOR_ELT, SET_VECTOR_ELT, R_NilValue);
 }
 
 #undef SLICE_BARRIER
+#undef SLICE_BARRIER_COMPACT_REP
+#undef SLICE_BARRIER_INDEX
 
 static SEXP df_slice(SEXP x, SEXP index) {
   R_len_t n = Rf_length(x);
@@ -171,10 +224,11 @@ static SEXP slice_rownames(SEXP names, SEXP index) {
   return names;
 }
 
-static SEXP vec_slice_impl(SEXP x, SEXP index) {
+SEXP vec_slice_impl(SEXP x, SEXP index) {
   int nprot = 0;
 
-  SEXP restore_size = PROTECT_N(r_int(Rf_length(index)), &nprot);
+  int index_n = is_compact_rep(index) ? r_int_get(index, 1) : Rf_length(index);
+  SEXP restore_size = PROTECT_N(r_int(index_n), &nprot);
 
   struct vctrs_proxy_info info = vec_proxy_info(x);
   PROTECT_PROXY_INFO(&info, &nprot);
@@ -186,6 +240,13 @@ static SEXP vec_slice_impl(SEXP x, SEXP index) {
   if (OBJECT(x) && info.proxy_method == R_NilValue) {
     if (info.type == vctrs_type_scalar) {
       Rf_errorcall(R_NilValue, "Can't slice a scalar");
+    }
+
+    if (is_compact_rep(index)) {
+      int i = r_int_get(index, 0);
+      int n = r_int_get(index, 1);
+      index = PROTECT_N(Rf_allocVector(INTSXP, n), &nprot);
+      r_int_fill(index, i, n);
     }
 
     SEXP out;
@@ -239,7 +300,7 @@ static SEXP vec_slice_impl(SEXP x, SEXP index) {
       Rf_setAttrib(out, R_NamesSymbol, names);
     }
 
-    out = vec_restore(out, x, index);
+    out = vec_restore(out, x, restore_size);
 
     UNPROTECT(nprot);
     return out;
@@ -275,9 +336,7 @@ SEXP vec_slice(SEXP x, SEXP index) {
 
 // [[ include("vctrs.h") ]]
 SEXP vec_init(SEXP x, R_len_t n) {
-  // FIXME: Use ALTREP to avoid allocation of index vector
-  SEXP i = PROTECT(Rf_allocVector(INTSXP, n));
-  r_int_fill(i, NA_INTEGER, n);
+  SEXP i = PROTECT(compact_rep(NA_INTEGER, n));
 
   SEXP out = vec_slice_impl(x, i);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -317,6 +317,16 @@ SEXP compact_rep_materialize(SEXP x) {
   return out;
 }
 
+R_len_t vec_index_size(SEXP x) {
+  if (is_compact_rep(x)) {
+    return r_int_get(x, 1);
+  } else if (is_compact_seq(x)) {
+    return r_int_get(x, 1) - r_int_get(x, 0);
+  } else {
+    return vec_size(x);
+  }
+}
+
 static SEXP syms_colnames = NULL;
 static SEXP fns_colnames = NULL;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -276,6 +276,35 @@ bool is_compact_seq(SEXP x) {
   return ATTRIB(x) == compact_seq_attrib;
 }
 
+// Initialised at load time
+SEXP compact_rep_attrib = NULL;
+
+void init_compact_rep(int* p, R_len_t i, R_len_t n) {
+  p[0] = i;
+  p[1] = n;
+}
+
+// Returns a compact repetition that `vec_slice()` understands
+// `i` should be an R-based index
+SEXP compact_rep(R_len_t i, R_len_t n) {
+  if (n < 0) {
+    Rf_error("Internal error: Negative `n` in `compact_rep()`.");
+  }
+
+  SEXP rep = PROTECT(Rf_allocVector(INTSXP, 2));
+
+  int* p = INTEGER(rep);
+  init_compact_rep(p, i, n);
+
+  SET_ATTRIB(rep, compact_rep_attrib);
+
+  UNPROTECT(1);
+  return rep;
+}
+bool is_compact_rep(SEXP x) {
+  return ATTRIB(x) == compact_rep_attrib;
+}
+
 
 static SEXP syms_colnames = NULL;
 static SEXP fns_colnames = NULL;
@@ -1039,4 +1068,8 @@ void vctrs_init_utils(SEXP ns) {
   compact_seq_attrib = Rf_cons(R_NilValue, R_NilValue);
   R_PreserveObject(compact_seq_attrib);
   SET_TAG(compact_seq_attrib, Rf_install("vctrs_compact_seq"));
+
+  compact_rep_attrib = Rf_cons(R_NilValue, R_NilValue);
+  R_PreserveObject(compact_rep_attrib);
+  SET_TAG(compact_rep_attrib, Rf_install("vctrs_compact_rep"));
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -301,10 +301,21 @@ SEXP compact_rep(R_len_t i, R_len_t n) {
   UNPROTECT(1);
   return rep;
 }
+
 bool is_compact_rep(SEXP x) {
   return ATTRIB(x) == compact_rep_attrib;
 }
 
+SEXP compact_rep_materialize(SEXP x) {
+  int i = r_int_get(x, 0);
+  int n = r_int_get(x, 1);
+
+  SEXP out = PROTECT(Rf_allocVector(INTSXP, n));
+  r_int_fill(out, i, n);
+
+  UNPROTECT(1);
+  return out;
+}
 
 static SEXP syms_colnames = NULL;
 static SEXP fns_colnames = NULL;

--- a/src/utils.h
+++ b/src/utils.h
@@ -81,6 +81,7 @@ bool is_compact_seq(SEXP x);
 void init_compact_rep(int* p, R_len_t i, R_len_t n);
 SEXP compact_rep(R_len_t i, R_len_t n);
 bool is_compact_rep(SEXP x);
+SEXP compact_rep_materialize(SEXP x);
 
 SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n);
 SEXP outer_names(SEXP names, SEXP outer, R_len_t n);

--- a/src/utils.h
+++ b/src/utils.h
@@ -78,6 +78,10 @@ void init_compact_seq(int* p, R_len_t from, R_len_t to);
 SEXP compact_seq(R_len_t from, R_len_t to);
 bool is_compact_seq(SEXP x);
 
+void init_compact_rep(int* p, R_len_t i, R_len_t n);
+SEXP compact_rep(R_len_t i, R_len_t n);
+bool is_compact_rep(SEXP x);
+
 SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n);
 SEXP outer_names(SEXP names, SEXP outer, R_len_t n);
 SEXP set_rownames(SEXP x, SEXP names);

--- a/src/utils.h
+++ b/src/utils.h
@@ -83,6 +83,8 @@ SEXP compact_rep(R_len_t i, R_len_t n);
 bool is_compact_rep(SEXP x);
 SEXP compact_rep_materialize(SEXP x);
 
+R_len_t vec_index_size(SEXP x);
+
 SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n);
 SEXP outer_names(SEXP names, SEXP outer, R_len_t n);
 SEXP set_rownames(SEXP x, SEXP names);

--- a/tests/testthat/test-recycle.R
+++ b/tests/testthat/test-recycle.R
@@ -20,6 +20,26 @@ test_that("incompatible lengths get error messages", {
   expect_error(vec_recycle(x2, 3), "2, 3")
 })
 
+test_that("can recycle arrays", {
+  x <- matrix(1:2, 1)
+  x2 <- matrix(1:2, 2, 2, byrow = TRUE)
+  x0 <- matrix(integer(), 0, 2)
+
+  expect_equal(vec_recycle(x, 1), x)
+  expect_equal(vec_recycle(x, 0), x0)
+  expect_equal(vec_recycle(x, 2), x2)
+
+  # List arrays
+  data <- c(list(1), list(2))
+  x <- matrix(data, 1)
+  x2 <- matrix(data, 2, 2, byrow = TRUE)
+  x0 <- matrix(list(), 0, 2)
+
+  expect_equal(vec_recycle(x, 1), x)
+  expect_equal(vec_recycle(x, 0), x0)
+  expect_equal(vec_recycle(x, 2), x2)
+})
+
 # Empty -------------------------------------------------------------------
 
 test_that("empty input returns empty list", {


### PR DESCRIPTION
Closes #472 

This PR introduces `compact_rep()`. It is similar to `compact_seq()`, but takes a single value `i` and repeats it `n` times.

**With this PR we gain performance at the cost of more C defines**

`vec_slice()` has been made aware of `compact_rep` objects, and `vec_recycle()` and the C level `vec_init()` use it.

Because `vec_init()` and `vec_recycle()` are used in `vec_c()`, `vec_rbind()`, and `vec_cbind()`, these all inherit a little bit of the performance.

_It would be great if the R level `vec_init()` used the C level version of `vec_init()` so it could get these benefits too._

``` r
library(vctrs)
library(bench)
```

``` r
# old (recycling length 1 object)
mark(recycle = vec_recycle(1L, 10000L), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 recycle      14.4µs     23µs    41152.    80.6KB     56.0

# new (recycling length 1 object)
mark(recycle = vec_recycle(1L, 10000L), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 recycle       2.8µs   6.02µs   136939.    45.6KB     93.2
```

``` r
x <- 1:1000

# old (vec_init()'s the output container)
mark(c = vec_c(x, x, x, x, x), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 c            9.29µs     13µs    66621.    46.2KB     48.0

# new (vec_init()'s the output container)
mark(c = vec_c(x, x, x, x, x), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 c            5.39µs   7.71µs   116337.    30.5KB     40.7
```

``` r
x <- data.frame(x = 1:1000)

# old (vec_init()'s the output container)
mark(rbind = vec_rbind(x,x,x,x,x), iterations = 10000)
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 rbind        53.6µs   68.2µs    14374.    67.9KB     15.8

# new (vec_init()'s the output container)
mark(rbind = vec_rbind(x,x,x,x,x), iterations = 10000)
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 rbind        48.7µs   59.9µs    16786.    53.8KB     15.1
```

``` r
x <- data.frame(x = 1:100000)

# old (vec_init()'s the output container)
mark(rbind_big = vec_rbind(x,x,x,x,x), iterations = 10000)
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 rbind_big    2.38ms   3.39ms      289.     6.1MB     31.4

# new (vec_init()'s the output container)
mark(rbind_big = vec_rbind(x,x,x,x,x), iterations = 10000)
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 rbind_big     2.2ms   3.02ms      325.     4.2MB     22.4
```

``` r
x <- data.frame(x = 1:100000)
y <- data.frame(y = 1)

# old (vec_recycle()'s size 1 input)
mark(cbind = vec_cbind(x,y,y,y,y, .name_repair = "minimal"), iterations = 10000)
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 cbind         650µs    1.1ms      900.    4.58MB     120.

# new (vec_recycle()'s size 1 input)
mark(cbind = vec_cbind(x,y,y,y,y, .name_repair = "minimal"), iterations = 10000)
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 cbind         248µs    441µs     2253.    3.06MB     163.
```