### PR TITLE
Fix protection issues

### DIFF
--- a/src/arg-counter.c
+++ b/src/arg-counter.c
@@ -40,11 +40,11 @@ void init_next_box_counters(struct counters* counters, SEXP names) {
 }
 
 // Stack-based protection, should be called after `init_counters()`
-int PROTECT_COUNTERS(struct counters* counters) {
+void PROTECT_COUNTERS(struct counters* counters, int* nprot) {
   PROTECT_WITH_INDEX(counters->names, &counters->names_pi);
   PROTECT_WITH_INDEX(R_NilValue, &counters->prev_box_counters->names_pi);
   PROTECT_WITH_INDEX(R_NilValue, &counters->next_box_counters->names_pi);
-  return 3;
+  *nprot += 3;
 }
 
 
@@ -98,11 +98,12 @@ SEXP reduce(SEXP current, struct vctrs_arg* current_arg,
                 current_arg,
                 &prev_box_counters,
                 &next_box_counters);
-  int n_protect = PROTECT_COUNTERS(&counters);
+  int nprot = 0;
+  PROTECT_COUNTERS(&counters, &nprot);
 
   SEXP out = reduce_impl(current, rest, &counters, false, impl);
 
-  UNPROTECT(n_protect);
+  UNPROTECT(nprot);
   return out;
 }
 

--- a/src/arg-counter.c
+++ b/src/arg-counter.c
@@ -40,12 +40,12 @@ void init_next_box_counters(struct counters* counters, SEXP names) {
 }
 
 // Stack-based protection, should be called after `init_counters()`
-void PROTECT_COUNTERS(struct counters* counters, int* nprot) {
-  PROTECT_WITH_INDEX(counters->names, &counters->names_pi);
-  PROTECT_WITH_INDEX(R_NilValue, &counters->prev_box_counters->names_pi);
-  PROTECT_WITH_INDEX(R_NilValue, &counters->next_box_counters->names_pi);
-  *nprot += 3;
-}
+#define PROTECT_COUNTERS(counters, nprot) do {                                \
+    PROTECT_WITH_INDEX((counters)->names, &(counters)->names_pi);             \
+    PROTECT_WITH_INDEX(R_NilValue, &(counters)->prev_box_counters->names_pi); \
+    PROTECT_WITH_INDEX(R_NilValue, &(counters)->next_box_counters->names_pi); \
+    *nprot += 3;                                                              \
+  } while(0)
 
 
 void counters_inc(struct counters* counters) {

--- a/src/c.c
+++ b/src/c.c
@@ -96,11 +96,11 @@ static SEXP vec_c(SEXP xs,
     if (has_names) {
       SEXP outer = xs_names == R_NilValue ? R_NilValue : STRING_ELT(xs_names, i);
       SEXP inner = PROTECT(vec_names(x));
-      SEXP x_nms = apply_name_spec(name_spec, outer, inner, size);
+      SEXP x_nms = PROTECT(apply_name_spec(name_spec, outer, inner, size));
       if (x_nms != R_NilValue) {
         vec_assign_impl(out_names, idx, x_nms, false);
       }
-      UNPROTECT(1);
+      UNPROTECT(2);
     }
 
     counter += size;

--- a/src/cast.c
+++ b/src/cast.c
@@ -377,14 +377,16 @@ SEXP vec_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg
     out = vec_cast_switch(x, to, &lossy, x_arg, to_arg);
   }
 
-  if (lossy || out == R_NilValue) {
-    return vctrs_dispatch4(syms_vec_cast_dispatch, fns_vec_cast_dispatch,
-                           syms_x, x,
-                           syms_to, to,
-                           syms_x_arg, vctrs_arg(x_arg),
-                           syms_to_arg, vctrs_arg(to_arg));
+  if (!lossy && out != R_NilValue) {
+    return out;
   }
 
+  out = vctrs_dispatch4(syms_vec_cast_dispatch, fns_vec_cast_dispatch,
+                        syms_x, x,
+                        syms_to, to,
+                        syms_x_arg, PROTECT(vctrs_arg(x_arg)),
+                        syms_to_arg, PROTECT(vctrs_arg(to_arg)));
+  UNPROTECT(2);
   return out;
 }
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -221,7 +221,6 @@ SEXP vctrs_match(SEXP needles, SEXP haystack) {
 
   needles = PROTECT(vec_proxy_equal(needles));
   haystack = PROTECT(vec_proxy_equal(haystack));
-  UNPROTECT(3);
 
   dictionary d;
   dict_init(&d, haystack);
@@ -253,7 +252,7 @@ SEXP vctrs_match(SEXP needles, SEXP haystack) {
     }
   }
 
-  UNPROTECT(3);
+  UNPROTECT(6);
   dict_free(&d);
   return out;
 }
@@ -268,7 +267,6 @@ SEXP vctrs_in(SEXP needles, SEXP haystack) {
 
   needles = PROTECT(vec_proxy_equal(needles));
   haystack = PROTECT(vec_proxy_equal(haystack));
-  UNPROTECT(3);
 
   dictionary d;
   dict_init(&d, haystack);
@@ -296,7 +294,7 @@ SEXP vctrs_in(SEXP needles, SEXP haystack) {
     p_out[i] = (d.key[hash] != DICT_EMPTY);
   }
 
-  UNPROTECT(3);
+  UNPROTECT(6);
   dict_free(&d);
   return out;
 }

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -109,13 +109,15 @@ void dict_put(dictionary* d, uint32_t hash, R_len_t i) {
 // TODO: separate out into individual files
 
 SEXP vctrs_unique_loc(SEXP x) {
-  x = PROTECT(vec_proxy_equal(x));
+  int nprot = 0;
+  x = PROTECT_N(vec_proxy_equal(x), &nprot);
 
   dictionary d;
   dict_init(&d, x);
 
   growable g;
   growable_init(&g, INTSXP, 256);
+  PROTECT_GROWABLE(&g, &nprot);
 
   R_len_t n = vec_size(x);
   for (int i = 0; i < n; ++i) {
@@ -130,8 +132,7 @@ SEXP vctrs_unique_loc(SEXP x) {
   SEXP out = growable_values(&g);
 
   dict_free(&d);
-  growable_free(&g);
-  UNPROTECT(1);
+  UNPROTECT(nprot);
   return out;
 }
 

--- a/src/equal.c
+++ b/src/equal.c
@@ -316,10 +316,13 @@ static inline int vec_equal_attrib(SEXP x, SEXP y, bool na_equal) {
 
 // [[ include("vctrs.h") ]]
 bool equal_names(SEXP x, SEXP y) {
-  SEXP x_names = Rf_getAttrib(x, R_NamesSymbol);
-  SEXP y_names = Rf_getAttrib(y, R_NamesSymbol);
+  SEXP x_names = PROTECT(Rf_getAttrib(x, R_NamesSymbol));
+  SEXP y_names = PROTECT(Rf_getAttrib(y, R_NamesSymbol));
 
-  return equal_object(x_names, y_names, true);
+  bool out = equal_object(x_names, y_names, true);
+
+  UNPROTECT(2);
+  return out;
 }
 
 

--- a/src/fields.c
+++ b/src/fields.c
@@ -51,7 +51,7 @@ int find_offset(SEXP x, SEXP index) {
 
     return (int) val;
   } else if (TYPEOF(index) == STRSXP) {
-    SEXP names = Rf_getAttrib(x, R_NamesSymbol);
+    SEXP names = PROTECT(Rf_getAttrib(x, R_NamesSymbol));
     if (names == R_NilValue)
       Rf_errorcall(R_NilValue, "Corrupt x: no names");
 
@@ -68,8 +68,10 @@ int find_offset(SEXP x, SEXP index) {
       if (name_j == NA_STRING)
         Rf_errorcall(R_NilValue, "Corrupt x: element %i is unnamed", j + 1);
 
-      if (equal_string(val_0, &val_0_chr, name_j))
+      if (equal_string(val_0, &val_0_chr, name_j)) {
+        UNPROTECT(1);
         return j;
+      }
     }
     Rf_errorcall(R_NilValue, "Invalid index: field name '%s' not found", val_0_chr);
   } else {

--- a/src/growable.c
+++ b/src/growable.c
@@ -2,14 +2,8 @@
 
 void growable_init(growable* g, SEXPTYPE type, int capacity) {
   g->x = Rf_allocVector(type, capacity);
-  PROTECT_WITH_INDEX(g->x, &g->idx);
-
   g->n = 0;
   g->capacity = capacity;
-}
-
-void growable_free(growable* g) {
-  UNPROTECT(1);
 }
 
 void growable_push_int(growable* g, int i) {

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -14,7 +14,8 @@ SEXP vec_proxy_invoke(SEXP x, SEXP method);
 // [[ register(); include("vctrs.h") ]]
 SEXP vec_proxy(SEXP x) {
   int nprot = 0;
-  struct vctrs_type_info info = PROTECT_TYPE_INFO(vec_type_info(x), &nprot);
+  struct vctrs_type_info info = vec_type_info(x);
+  PROTECT_TYPE_INFO(&info, &nprot);
 
   SEXP out;
   if (info.type == vctrs_type_s3) {

--- a/src/size.c
+++ b/src/size.c
@@ -41,7 +41,9 @@ R_len_t vec_bare_dim_n(SEXP x) {
 R_len_t vec_size(SEXP x) {
   int nprot = 0;
 
-  struct vctrs_proxy_info info = PROTECT_PROXY_INFO(vec_proxy_info(x), &nprot);
+  struct vctrs_proxy_info info = vec_proxy_info(x);
+  PROTECT_PROXY_INFO(&info, &nprot);
+
   SEXP data = info.proxy;
 
   R_len_t size;

--- a/src/slice.c
+++ b/src/slice.c
@@ -176,7 +176,9 @@ static SEXP vec_slice_impl(SEXP x, SEXP index) {
 
   SEXP restore_size = PROTECT_N(r_int(Rf_length(index)), &nprot);
 
-  struct vctrs_proxy_info info = PROTECT_PROXY_INFO(vec_proxy_info(x), &nprot);
+  struct vctrs_proxy_info info = vec_proxy_info(x);
+  PROTECT_PROXY_INFO(&info, &nprot);
+
   SEXP data = info.proxy;
 
   // Fallback to `[` if the class doesn't implement a proxy. This is

--- a/src/utils.c
+++ b/src/utils.c
@@ -705,13 +705,14 @@ bool r_is_empty_names(SEXP x) {
 }
 
 SEXP r_env_get(SEXP env, SEXP sym) {
-  SEXP obj = Rf_findVarInFrame3(env, sym, FALSE);
+  SEXP obj = PROTECT(Rf_findVarInFrame3(env, sym, FALSE));
 
   // Force lazy loaded bindings
   if (TYPEOF(obj) == PROMSXP) {
     obj = Rf_eval(obj, R_BaseEnv);
   }
 
+  UNPROTECT(1);
   return obj;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -494,6 +494,7 @@ SEXP r_chr_iota(R_len_t n, char* buf, int len, const char* prefix) {
     int written = snprintf(beg, len, "%d", i + 1);
 
     if (written >= len) {
+      UNPROTECT(1);
       return R_NilValue;
     }
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -279,16 +279,23 @@ SEXP vec_as_unique_names(SEXP names, bool quiet);
 
 struct growable {
   SEXP x;
-  int32_t idx;
+  PROTECT_INDEX idx;
   int n;
   int capacity;
 };
 typedef struct growable growable;
 
 void growable_init(growable* g, SEXPTYPE type, int capacity);
-void growable_free(growable* g);
 void growable_push_int(growable* g, int i);
 SEXP growable_values(growable* g);
+
+#define PROTECT_GROWABLE(g, n) do {             \
+    PROTECT_WITH_INDEX((g)->x, &((g)->idx));    \
+    *n += 1;                                    \
+  } while(0)
+
+#define UNPROTECT_GROWABLE(g) do { UNPROTECT(1);} while(0)
+
 
 // Shape --------------------------------------------------------
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -70,14 +70,16 @@ struct vctrs_proxy_info {
 struct vctrs_type_info vec_type_info(SEXP x);
 struct vctrs_proxy_info vec_proxy_info(SEXP x);
 
-static inline struct vctrs_proxy_info PROTECT_PROXY_INFO(struct vctrs_proxy_info info, int* n) {
-  *n += 2; PROTECT(info.proxy); PROTECT(info.proxy_method);
-  return info;
-}
-static inline struct vctrs_type_info PROTECT_TYPE_INFO(struct vctrs_type_info info, int* n) {
-  ++(*n); PROTECT(info.proxy_method);
-  return info;
-}
+#define PROTECT_PROXY_INFO(info, n) do {        \
+    PROTECT((info)->proxy);                     \
+    PROTECT((info)->proxy_method);              \
+    *n += 2;                                    \
+  } while (0)
+
+#define PROTECT_TYPE_INFO(info, n) do {         \
+    PROTECT((info)->proxy_method);              \
+    *n += 1;                                    \
+  } while (0)
 
 enum vctrs_type vec_typeof(SEXP x);
 enum vctrs_type vec_proxy_typeof(SEXP x);


### PR DESCRIPTION
Thanks to rchk.

The compound protecters had to be rewritten as macros, as rchk couldn't analyse the functions properly.