### PR TITLE
Fix typos and standardize comma usage in vignettes

### DIFF
--- a/R/type.R
+++ b/R/type.R
@@ -3,7 +3,7 @@
 #' `vec_ptype()` finds the prototype of a single vector.
 #' `vec_ptype_common()` finds the common type of multiple vectors.
 #' `vec_ptype_show()` nicely prints the common type of any number of
-#' inputs, and is designed for interative exploration.
+#' inputs, and is designed for interactive exploration.
 #'
 #' `vec_ptype_common()` first finds the prototype of each input, then
 #' successively calls [vec_ptype2()] to find a common type.

--- a/README.Rmd
+++ b/README.Rmd
@@ -37,7 +37,7 @@ There are three main goals to the vctrs package, each described in a vignette:
   generics in terms of a few new vctrs generics, making implementation 
   considerably simpler and more robust.
   
-vctrs is a developer-focussed package. Understanding and extending vctrs requires some effort from developers, but should be invisible to most users. It's our hope that having an underlying theory will mean that users can build up an accurate mental model without explicitly learning the theory. vctrs will typically be used by other packages, making it easy for them to provide new classes of S3 vectors that are supported throughout the tidyverse (and beyond). For that reason, vctrs has few dependencies.
+vctrs is a developer-focussed package. Understanding and extending vctrs requires some effort from developers but should be invisible to most users. It's our hope that having an underlying theory will mean that users can build up an accurate mental model without explicitly learning the theory. vctrs will typically be used by other packages, making it easy for them to provide new classes of S3 vectors that are supported throughout the tidyverse (and beyond). For that reason, vctrs has few dependencies.
 
 ## Installation
 
@@ -47,7 +47,7 @@ Install vctrs from CRAN with:
 install.packages("vctrs")
 ```
 
-Alternatively, if you need to development version, install it with:
+Alternatively, if you need the development version, install it with:
 
 ```{r, eval = FALSE}
 # install.packages("devtools")
@@ -70,7 +70,7 @@ str(vec_recycle_common(1, 1:10))
 
 ## Motivation
 
-The original motivation for vctrs from two separate, but related problems. The first problem is that `base::c()` has rather undesirable behaviour when you mix different S3 vectors:
+The original motivation for vctrs from two separate but related problems. The first problem is that `base::c()` has rather undesirable behaviour when you mix different S3 vectors:
 
 ```{r}
 # combining factors makes integers
@@ -86,4 +86,4 @@ c(dttm, dt)
 
 This behaviour arises because `c()` has dual purposes: as well as its primary duty of combining vectors, it has a secondary duty of stripping attributes. For example, `?POSIXct` suggests that you should use `c()` if you want to reset the timezone. 
 
-The second problem is that `dplyr::bind_rows()` is not extensible by others. Currently, it handles arbitrary S3 classes using heuristics, but these often fail, and it feels like we really need to think through the problem in order to build a principled solution. This intersects with the need to cleanly support more types of data frame columns including lists of data frames, data frames, and matrices.
+The second problem is that `dplyr::bind_rows()` is not extensible by others. Currently, it handles arbitrary S3 classes using heuristics, but these often fail, and it feels like we really need to think through the problem in order to build a principled solution. This intersects with the need to cleanly support more types of data frame columns, including lists of data frames, data frames, and matrices.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ vignette:
     implementation considerably simpler and more robust.
 
 vctrs is a developer-focussed package. Understanding and extending vctrs
-requires some effort from developers, but should be invisible to most
+requires some effort from developers but should be invisible to most
 users. It’s our hope that having an underlying theory will mean that
 users can build up an accurate mental model without explicitly learning
 the theory. vctrs will typically be used by other packages, making it
@@ -48,7 +48,7 @@ Install vctrs from CRAN with:
 install.packages("vctrs")
 ```
 
-Alternatively, if you need to development version, install it with:
+Alternatively, if you need the development version, install it with:
 
 ``` r
 # install.packages("devtools")
@@ -80,7 +80,7 @@ str(vec_recycle_common(1, 1:10))
 
 ## Motivation
 
-The original motivation for vctrs from two separate, but related
+The original motivation for vctrs from two separate but related
 problems. The first problem is that `base::c()` has rather undesirable
 behaviour when you mix different S3 vectors:
 
@@ -96,7 +96,7 @@ dttm <- as.POSIXct(dt)
 c(dt, dttm)
 #> [1] "2020-01-01"    "4321940-06-07"
 c(dttm, dt)
-#> [1] "2020-01-01 01:00:00 CET" "1970-01-01 06:04:22 CET"
+#> [1] "2019-12-31 16:00:00 PST" "1969-12-31 21:04:22 PST"
 ```
 
 This behaviour arises because `c()` has dual purposes: as well as its
@@ -108,5 +108,5 @@ The second problem is that `dplyr::bind_rows()` is not extensible by
 others. Currently, it handles arbitrary S3 classes using heuristics, but
 these often fail, and it feels like we really need to think through the
 problem in order to build a principled solution. This intersects with
-the need to cleanly support more types of data frame columns including
+the need to cleanly support more types of data frame columns, including
 lists of data frames, data frames, and matrices.

--- a/man/vec_ptype.Rd
+++ b/man/vec_ptype.Rd
@@ -30,7 +30,7 @@ this is a convenient way to make production code demand fixed types.}
 \code{vec_ptype()} finds the prototype of a single vector.
 \code{vec_ptype_common()} finds the common type of multiple vectors.
 \code{vec_ptype_show()} nicely prints the common type of any number of
-inputs, and is designed for interative exploration.
+inputs, and is designed for interactive exploration.
 }
 \details{
 \code{vec_ptype_common()} first finds the prototype of each input, then

--- a/vignettes/s3-vector.Rmd
+++ b/vignettes/s3-vector.Rmd
@@ -69,19 +69,19 @@ In this section you'll learn how to create a new vctrs class by calling `new_vct
 * You can immediately put your new vector class in a data frame because 
   `as.data.frame.vctrs_vctr()` does the right thing.
 
-* Subsetting (`[`, `[[`, `$`), `length<-`, and `rep()` methods automatically
+* Subsetting (`[`, `[[`, and `$`), `length<-`, and `rep()` methods automatically
   preserve attributes because they use `vec_restore()`. A default 
   `vec_restore()` works for all classes where the attributes are 
   data-independent, and can easily be customised when the attributes do 
   depend on the data.
 
-* Default subset-assignment methods (`[<-`, `[[<-`, `$<-`) follow the principle 
+* Default subset-assignment methods (`[<-`, `[[<-`, and `$<-`) follow the principle 
   that the new values should be coerced to match the existing vector. This 
   gives predictable behaviour and clear error messages.
 
 ### Percent class
 
-In this section, I'll show you how to make a `percent` class, i.e. a double vector that is printed as a percentage. We start by defining a low-level [constructor](https://adv-r.hadley.nz/s3.html#s3-constrcutor) that uses `vec_assert()` to checks types and/or sizes then calls `new_vctr()`. 
+In this section, I'll show you how to make a `percent` class, i.e., a double vector that is printed as a percentage. We start by defining a low-level [constructor](https://adv-r.hadley.nz/s3.html#s3-constrcutor) that uses `vec_assert()` to checks types and/or sizes then calls `new_vctr()`. 
 
 `percent` is built on a double vector of any length and doesn't have any attributes.
 
@@ -225,7 +225,7 @@ vec_ptype2.vctrs_percent.default <- function(x, y, ..., x_arg = "x", y_arg = "y"
 s3_register("vctrs::vec_ptype2", "vctrs_percent")
 ```
 
-The default method provides a user friendly error message if the coercion doesn't exist, and makes sure `NA` is handled in a standard way. `NA` is technically a logical vector, but we want to stand in for a missing value of any type.
+The default method provides a user friendly error message if the coercion doesn't exist and makes sure `NA` is handled in a standard way. `NA` is technically a logical vector, but we want to stand in for a missing value of any type.
 
 ```{r, error = TRUE}
 vec_ptype2("bogus", percent())
@@ -239,7 +239,7 @@ Next, start by saying that a `vctrs_percent` combined with a `vctrs_percent` yie
 vec_ptype2.vctrs_percent.vctrs_percent <- function(x, y, ...) new_percent()
 ```
 
-Next we define methods that say that combining a `percent` and double should yield a `double`. We avoid returning a `percent` here, because errors in the scale (1 vs. 0.01) are more obvious with raw numbers.
+Next we define methods that say that combining a `percent` and double should yield a `double`. We avoid returning a `percent` here because errors in the scale (1 vs. 0.01) are more obvious with raw numbers.
 
 Because double dispatch is a bit of a hack, we need to provide two methods. It's your responsibility to ensure that each pair return the same result: if they don't you will get weird and unpredictable behaviour.
 
@@ -284,7 +284,7 @@ vec_cast(0.5, percent())
 vec_cast(percent(0.5), double())
 ```
 
-Once you've implemented `vec_ptype2()` and `vec_cast()` you get `vec_c()`, `[<-` and `[[<-` implementations for free.
+Once you've implemented `vec_ptype2()` and `vec_cast()` you get `vec_c()`, `[<-`, and `[[<-` implementations for free.
 
 ```{r, error = TRUE}
 vec_c(percent(0.5), 1)
@@ -355,16 +355,16 @@ x <- decimal(runif(10), 1L)
 x
 ```
 
-Note that I provide a little helper to extract the `digits` attribute. This makes the code a little easier to read, and should not be exported.
+Note that I provide a little helper to extract the `digits` attribute. This makes the code a little easier to read and should not be exported.
 
-By default, vctrs assumes that attributes are independent of the data, and so are automatically preserved. You'll see what to do if the attributes are data dependent in the next section.
+By default, vctrs assumes that attributes are independent of the data and so are automatically preserved. You'll see what to do if the attributes are data dependent in the next section.
 
 ```{r}
 x[1:2]
 x[[1]]
 ```
 
-For the sake of exposition, we'll assume that `digits` is an important attribute of the class, and should be included in the full type:
+For the sake of exposition, we'll assume that `digits` is an important attribute of the class and should be included in the full type:
 
 ```{r}
 vec_ptype_full.vctrs_decimal <- function(x, ...) {
@@ -386,7 +386,7 @@ vec_cast.vctrs_decimal <- function(x, to, ...) UseMethod("vec_cast.vctrs_decimal
 vec_cast.vctrs_decimal.default <- function(x, to, ...) vec_default_cast(x, to)
 ```
 
-Casting and coercing from one decimal to another requires a little thought as the values of the `digits` attribute might be different, and we need some way to reconcile them. Here I've chosen to chose the maximum of the two; other reasonable options are to take the value from the left-hand side or throw an error.
+Casting and coercing from one decimal to another requires a little thought as the values of the `digits` attribute might be different, and we need some way to reconcile them. Here I've decided to chose the maximum of the two; other reasonable options are to take the value from the left-hand side or throw an error.
 
 ```{r}
 vec_ptype2.vctrs_decimal.vctrs_decimal <- function(x, y, ...) {
@@ -399,7 +399,7 @@ vec_cast.vctrs_decimal.vctrs_decimal <- function(x, to, ...) {
 vec_c(decimal(1/100, digits = 3), decimal(2/100, digits = 2))
 ```
 
-Finally, I can implement coercion to and from other types, like doubles. When automatically coercing, I choose the richer type (i.e. the decimal).
+Finally, I can implement coercion to and from other types, like doubles. When automatically coercing, I choose the richer type (i.e., the decimal).
 
 ```{r}
 vec_ptype2.vctrs_decimal.double <- function(x, y, ...) x
@@ -480,7 +480,7 @@ vec_restore.vctrs_cached_sum <- function(x, to, ..., i = NULL) {
 x[1]
 ```
 
-This works because most of the vctrs methods dispatch to the underlying base function, by first stripping off extra attributes with `vec_data()` and then reapplying them again with `vec_restore()`. The default `vec_restore()` method copies over all attributes, which is not appropriate when the attributes depend on the data.
+This works because most of the vctrs methods dispatch to the underlying base function by first stripping off extra attributes with `vec_data()` and then reapplying them again with `vec_restore()`. The default `vec_restore()` method copies over all attributes, which is not appropriate when the attributes depend on the data.
 
 Note that `vec_restore.class` is subtly different from `vec_cast.class.class()`. `vec_restore()` is used when restoring attributes that have been lost; `vec_cast()` is used for coercions. This is easier to understand with a concrete example. Imagine factors were implemented with `new_vctr()`. `vec_restore.factor()` would restore attributes back to an integer vector, but you would not want to allow manually casting an integer to a factor with `vec_cast()`. 
 
@@ -504,9 +504,9 @@ vctrs makes it easy to create new record-style classes using `new_rcrd()`, which
 
 ### Rational class
 
-A fraction, or rational number can be represented by a pair of integer vectors representing the numerator (the number on top) and the denominator (the number on bottom), where the length of each vector must be the same. To represent such a data structure we turn to a new base data type: the record (or rcrd for short).
+A fraction, or rational number, can be represented by a pair of integer vectors representing the numerator (the number on top) and the denominator (the number on bottom), where the length of each vector must be the same. To represent such a data structure we turn to a new base data type: the record (or rcrd for short).
 
-As usual we start with low-level and user-friendly constructors. The low-level constructor calls `new_rcrd()` which needs a named list of equal-length vectors.
+As usual we start with low-level and user-friendly constructors. The low-level constructor calls `new_rcrd()`, which needs a named list of equal-length vectors.
 
 ```{r}
 new_rational <- function(n = integer(), d = integer()) {
@@ -591,9 +591,9 @@ vec_c(rational(1, 2), 1L, NA)
 
 ### Decimal2 class
 
-The previous implementation of `decimal` was built on top of doubles. This is a bad idea because decimal vectors are typically used when you care about precise values (i.e. dollars and cents in a bank account), and double values suffer from floating point problems. 
+The previous implementation of `decimal` was built on top of doubles. This is a bad idea because decimal vectors are typically used when you care about precise values (i.e., dollars and cents in a bank account), and double values suffer from floating point problems. 
 
-A better implementation of a decimal class would be to use pair of integers, one for the value to the left of the decimal point, and the other for the value to the right (divided by a `scale`). The code is a very quick sketch of how you might start creating such a class:
+A better implementation of a decimal class would be to use pair of integers, one for the value to the left of the decimal point, and the other for the value to the right (divided by a `scale`). The following code is a very quick sketch of how you might start creating such a class:
 
 ```{r}
 new_decimal2 <- function(l, r, scale = 2L) {
@@ -624,9 +624,9 @@ decimal2(10, c(0, 5, 99))
 
 ## Equality and comparison
 
-vctrs provides three "proxy" generics. Two of those let you control how your class determines equality and ordering:
+vctrs provides three "proxy" generics. Two of these let you control how your class determines equality and ordering:
 
-* `vec_proxy_equal()` returns a data vector suitable for comparison. It underpins `==`, `!=`, `unique()`, `anyDuplicated()`, and `is.na()`. By default, it just calls `vec_proxy()`.
+* `vec_proxy_equal()` returns a data vector suitable for comparison. It underpins `==`, `!=`, `unique()`, `anyDuplicated()`, and `is.na()`.
 
 * `vec_proxy_compare()` specifies how to compare the elements of your vector.
   This proxy is used in `<`, `<=`, `>=`, `>`, `min()`, `max()`, `median()`, 
@@ -638,7 +638,7 @@ By default, `vec_proxy_equal()` and `vec_proxy_compare()` just call `vec_proxy()
 
 You should only implement these proxies when some preprocessing on the data is needed to make elements comparable. In that case, defining these methods will get you a lot of behaviour for relatively little work.
 
-These proxy functions should always return a simple object (either a bare vector or a data frame), that possesses the same properties as your class. This permits efficient implementation of the vctrs internals because it allows dispatch to happen once in R, and then efficient computations can be written in C.
+These proxy functions should always return a simple object (either a bare vector or a data frame) that possesses the same properties as your class. This permits efficient implementation of the vctrs internals because it allows dispatch to happen once in R, and then efficient computations can be written in C.
 
 ### Rational class
 
@@ -653,7 +653,7 @@ vec_proxy(x)
 x == rational(1, 1)
 ```
 
-This makes sense as a default, but isn't correct here because `rational(1, 1)` represents the same number as `rational(2, 2)` so they should be equal. We can fix that by implementing a `vec_proxy_equal()` method that by divides `n` and `d` by their greatest common divisor:
+This makes sense as a default but isn't correct here because `rational(1, 1)` represents the same number as `rational(2, 2)`, so they should be equal. We can fix that by implementing a `vec_proxy_equal()` method that divides `n` and `d` by their greatest common divisor:
 
 ```{r}
 # Thanks to Matthew Lundberg: https://stackoverflow.com/a/21504113/16632 
@@ -757,7 +757,7 @@ Equality works out of the box because we can tell if two integer vectors are equ
 p == poly(c(1, 0, 1))
 ```
 
-But we can't order them, because lists are not comparable:
+But we can't order them because lists are not comparable:
 
 ```{r, error = TRUE}
 sort(p)
@@ -796,7 +796,7 @@ vctrs also provides two mathematical generics that allow you to define a broad s
 Both generics define the behaviour for multiple functions because `sum.vctrs_vctr(x)` calls `vec_math.vctrs_vctr("sum", x)`, and `x + y` calls
 `vec_math.x_class.y_class("+", x, y)`. They're accompanied by `vec_math_base()` and `vec_arith_base()` which make it easy to call the underlying base R functions.
 
-`vec_arith()` uses double dispatch, and needs the following standard boilerplate:
+`vec_arith()` uses double dispatch and needs the following standard boilerplate:
 
 ```{r}
 vec_arith.MYCLASS <- function(op, x, y, ...) {
@@ -809,7 +809,7 @@ vec_arith.MYCLASS.default <- function(op, x, y, ...) {
 
 ### Cached sum class
 
-I showed an example of `vec_math()` to define `sum()` and `mean()` methods `cached_sum`. Now let's talk about exactly how it works. Most `vec_math()` functions will have a similar form. You use a switch statement to handle the methods that you care about, and fall back to `vec_math_base()` for those that you don't care about.
+I showed an example of `vec_math()` to define `sum()` and `mean()` methods for `cached_sum`. Now let's talk about exactly how it works. Most `vec_math()` functions will have a similar form. You use a switch statement to handle the methods that you care about and fall back to `vec_math_base()` for those that you don't care about.
 
 ```{r}
 vec_math.vctrs_cached_sum <- function(.fn, .x, ...) {
@@ -863,7 +863,7 @@ To allow these infix functions to work, we'll need to provide `vec_arith()` gene
 
 * It makes sense to add and subtract meters: that yields another meter.
   We can divide a meter by another meter (yielding a unitless number), but
-  we can't multiply meters (because that would yield an area.)
+  we can't multiply meters (because that would yield an area).
   
 * For a combination of meter and number multiplication and division by a number
   are acceptable. Addition and subtraction don't make much sense as we, strictly
@@ -880,7 +880,7 @@ vec_arith.vctrs_meter.default <- function(op, x, y, ...) {
 }
 ```
 
-Then write the method for two meter objects. We use a switch statement to cover the cases we care about, and `stop_incompatible_op()` to throw an informative error message for everything else.
+Then write the method for two meter objects. We use a switch statement to cover the cases we care about and `stop_incompatible_op()` to throw an informative error message for everything else.
 
 ```{r, error = TRUE}
 vec_arith.vctrs_meter.vctrs_meter <- function(op, x, y, ...) {
@@ -899,7 +899,7 @@ meter(10) / meter(1)
 meter(10) * meter(1)
 ```
 
-Next we write the pair of methods for arithmetic with a meter and a number. These are almost identical, but while `meter(10) / 2` makes sense, `2 / meter(10)` does not (as addition and subtraction).
+Next we write the pair of methods for arithmetic with a meter and a number. These are almost identical, but while `meter(10) / 2` makes sense, `2 / meter(10)` does not (and neither do addition and subtraction).
 
 ```{r, error = TRUE}
 vec_arith.vctrs_meter.numeric <- function(op, x, y, ...) {

--- a/vignettes/stability.Rmd
+++ b/vignettes/stability.Rmd
@@ -14,9 +14,9 @@ knitr::opts_chunk$set(
 )
 ```
 
-This vignette introduces the ideas of type-stability and size-stability. If a function possesses these properties it is substantially easier to reason about because to predict the "shape" of the output, you only need to know the "shape"s of the inputs.
+This vignette introduces the ideas of type-stability and size-stability. If a function possesses these properties, it is substantially easier to reason about because to predict the "shape" of the output you only need to know the "shape"s of the inputs.
 
-This work is partly motivated by a common pattern that I noticed when reviewing code: if I read the code (without running it!) and I can't predict the type of each variable, I feel very uneasy about the code. This sense is important because most unit tests explore typical inputs, rather than exhaustively testing the strange and unusual. Analysing the types (and size) of variables makes it possible to spot unpleasant edge cases.
+This work is partly motivated by a common pattern that I noticed when reviewing code: if I read the code (without running it!), and I can't predict the type of each variable, I feel very uneasy about the code. This sense is important because most unit tests explore typical inputs, rather than exhaustively testing the strange and unusual. Analysing the types (and size) of variables makes it possible to spot unpleasant edge cases.
 
 ```{r setup}
 library(vctrs)
@@ -43,7 +43,7 @@ Very few base R functions are size-stable, so I'll also define a slightly weaker
 
 We'll call functions that don't obey these principles __type-unstable__ and __size-unstable__ respectively.
 
-On top of type- and size-stability, it's also desirable to have a single set of rules that are applied consistently. We want one set of type-coercion and size-recycling rules that apply everywhere, not many sets of rules that apply to different functions.
+On top of type- and size-stability it's also desirable to have a single set of rules that are applied consistently. We want one set of type-coercion and size-recycling rules that apply everywhere, not many sets of rules that apply to different functions.
 
 The goal of these principles is to minimise cognitive overhead. Rather than having to memorise many special cases, you should be able to learn one set of principles and apply them again and again.
 
@@ -71,15 +71,15 @@ To make these ideas concrete, let's apply them to a few base functions:
     vec_ptype_show(sapply(integer(), function(x) c(x, x)))
     ```
     
-    It's not quite size-stable, `vec_size(sapply(x, f))` is `vec_size(x)`
-    for vectors, but not for matrices (the output is transposed) or 
+    It's not quite size-stable; `vec_size(sapply(x, f))` is `vec_size(x)`
+    for vectors but not for matrices (the output is transposed) or 
     data frames (it iterates over the columns).
     
-1.  `vapply()` is type-stable version of `sapply()` because 
+1.  `vapply()` is a type-stable version of `sapply()` because 
     `vec_ptype_show(vapply(x, fn, template))` is always `vec_ptype_show(template)`.  
     It is size-unstable for the same reasons as `sapply()`.
 
-1.  `c()` is type-unstable because `c(x, y)` doesn't always the same type 
+1.  `c()` is type-unstable because `c(x, y)` doesn't always output the same type 
     as `c(y, x)`.
     
     ```{r}
@@ -89,7 +89,7 @@ To make these ideas concrete, let's apply them to a few base functions:
     
     `c()` is *almost always* length-stable because `length(c(x, y))`
     *almost always* equals `length(x) + length(y)`. One common source of
-    instability here is dealing with non-vectors (see also later section
+    instability here is dealing with non-vectors (see the later section
     "Non-vectors"):
     
     ```{r}
@@ -113,13 +113,13 @@ To make these ideas concrete, let's apply them to a few base functions:
     vec_ptype_show(ifelse(FALSE, 1L, 1L))
     ```
 
-1.  `read.csv(file)` is type-unstable and size-unstable because while you know 
-    it will return a data frame, you don't know what columns it will return, or
+1.  `read.csv(file)` is type-unstable and size-unstable because, while you know 
+    it will return a data frame, you don't know what columns it will return or
     how many rows it will have. Similarly, `df[[i]]` is not type-stable because 
     the result depends on the _value_ of `i`. There are very many important 
     functions that can not be made type-stable or size-stable!
 
-With this understand of type- and size-stability in hand, we'll use them to analyse some base R functions in greater depth and then propose alternatives with better properties.
+With this understanding of type- and size-stability in hand, we'll use them to analyse some base R functions in greater depth and then propose alternatives with better properties.
 
 ## `c()` and `vctrs::vec_c()`
 
@@ -128,7 +128,7 @@ In this section we'll compare and contrast `c()` and `vec_c()`. `vec_c()` is bot
 * `vec_ptype(vec_c(x, y))` equals `vec_ptype_common(x, y)`.
 * `vec_size(vec_c(x, y))` equals `vec_size(x) + vec_size(y)`.
 
-`c()` has another undesirable property in that it's not consistent with `unlist()`, i.e. `unlist(list(x, y))` does not always equal `c(x, y)`; i.e. base R has multiple sets of type-coercion rules. I won't consider this problem further here.
+`c()` has another undesirable property in that it's not consistent with `unlist()`; i.e., `unlist(list(x, y))` does not always equal `c(x, y)`; i.e., base R has multiple sets of type-coercion rules. I won't consider this problem further here.
 
 I have two goals here: 
 
@@ -151,7 +151,7 @@ c(FALSE, 1L, 2.5)
 vec_c(FALSE, 1L, 2.5)
 ```
 
-But does not automatically coerce to character vectors or lists:
+But it does not automatically coerce to character vectors or lists:
 
 ```{r, error = TRUE}
 c(FALSE, "x")
@@ -163,7 +163,7 @@ vec_c(FALSE, list(1))
 
 ### Non-vectors
 
-As far as I can tell `c()` never throws an error. No matter how bizarre the inputs, it always returns something:
+As far as I can tell, `c()` never throws an error. No matter how bizarre the inputs, it always returns something:
 
 ```{r}
 c(Sys.Date(), factor("x"), "x")
@@ -175,7 +175,7 @@ If the inputs aren't vectors, `c()` automatically puts them in a list:
 c(mean, globalenv())
 ```
 
-`vec_c()` throws an error if the inputs are not vectors, or not automatically coercible:
+`vec_c()` throws an error if the inputs are not vectors or not automatically coercible:
 
 ```{r, error = TRUE}
 vec_c(mean, globalenv())
@@ -194,9 +194,9 @@ fb <- factor("b")
 c(fa, fb)
 ```
 
-(this is documented in `c()` but is still undesirable.)
+(This is documented in `c()` but is still undesirable.)
 
-`vec_c()` returns a factor taking the union of the levels. This behaviour is motivated by pragmatics: there are many places in base R that automatically convert character vectors to factors, so enforcing stricter behaviour would be unnecessarily onerous. (This is backed up by experience with `dplyr::bind_rows()` which is stricter, and is a common source of user difficulty.) 
+`vec_c()` returns a factor taking the union of the levels. This behaviour is motivated by pragmatics: there are many places in base R that automatically convert character vectors to factors, so enforcing stricter behaviour would be unnecessarily onerous. (This is backed up by experience with `dplyr::bind_rows()`, which is stricter and is a common source of user difficulty.) 
 
 ```{r}
 vec_c(fa, fb)
@@ -212,7 +212,7 @@ datetime_nz <- as.POSIXct("2020-01-01 09:00", tz = "Pacific/Auckland")
 c(datetime_nz)
 ```
 
-This behaviour is documented in `?DateTimeClasses`, but is the source of considerable user pain.
+This behaviour is documented in `?DateTimeClasses` but is the source of considerable user pain.
 
 `vec_c()` preserves time zones:
 
@@ -220,7 +220,7 @@ This behaviour is documented in `?DateTimeClasses`, but is the source of conside
 vec_c(datetime_nz)
 ```
 
-What time zone should the output have if inputs have different time zones? One option would be to strict and force the user to manually align all the time zones. However, this is onerous (particularly because there's no easy way to change the time zone in base R), so vctrs chooses to use the first non-local time zone:
+What time zone should the output have if inputs have different time zones? One option would be to be strict and force the user to manually align all the time zones. However, this is onerous (particularly because there's no easy way to change the time zone in base R), so vctrs chooses to use the first non-local time zone:
 
 ```{r}
 datetime_local <- as.POSIXct("2020-01-01 09:00")
@@ -245,7 +245,7 @@ c(datetime, date)
 
 This behaviour arises because neither `c.Date()` nor `c.POSIXct()` check that all inputs are of the same type.
 
-`vec_c()` uses a standard set of rules to avoid this problem. When you mix dates and date-times, vctrs returns a date-time, and converts dates to date-times at midnight (in the timezone of the date-time).
+`vec_c()` uses a standard set of rules to avoid this problem. When you mix dates and date-times, vctrs returns a date-time and converts dates to date-times at midnight (in the timezone of the date-time).
 
 ```{r}
 vec_c(date, datetime)
@@ -254,7 +254,7 @@ vec_c(date, datetime_nz)
 
 ### Missing values
 
-If a missing value comes at the beginning of the inputs, `c()` falls back to the internal behaviour which strips all attributes:
+If a missing value comes at the beginning of the inputs, `c()` falls back to the internal behaviour, which strips all attributes:
 
 ```{r}
 c(NA, fa)
@@ -280,7 +280,7 @@ df2 <- data.frame(x = 2)
 str(c(df1, df1))
 ```
 
-`vec_c()` is size-stable which implies it will row-bind data frames:
+`vec_c()` is size-stable, which implies it will row-bind data frames:
 
 ```{r}
 vec_c(df1, df2)
@@ -296,7 +296,7 @@ c(m, m)
 vec_c(m, m)
 ```
 
-One difference is that `vec_c()` will "broadcast" a vector to match the dimensions of an matrix:
+One difference is that `vec_c()` will "broadcast" a vector to match the dimensions of a matrix:
 
 ```{r}
 c(m, 1)
@@ -336,9 +336,9 @@ vec_c <- function(...) {
 
 ## `ifelse()`
 
-One of the functions that motivate the development of vctrs is `ifelse`. It has the surprising property that the result value is "A vector of the same length and attributes (including dimensions and class) as `test`". To me, it seems more reasonable for type of the output to be controlled by the type of the `yes` and `no` arguments.
+One of the functions that motivate the development of vctrs is `ifelse`. It has the surprising property that the result value is "A vector of the same length and attributes (including dimensions and class) as `test`". To me, it seems more reasonable for the type of the output to be controlled by the type of the `yes` and `no` arguments.
 
-In `dplyr::if_else()`, I swung too far towards strictness: it throws an error if `yes` and `no` are not the same type. This is annoying in practice because requires typed missing values (`NA_character_` etc), and because the checks are only on the class (not the full prototype), it's easy to create invalid output.
+In `dplyr::if_else()` I swung too far towards strictness: it throws an error if `yes` and `no` are not the same type. This is annoying in practice because it requires typed missing values (`NA_character_` etc), and because the checks are only on the class (not the full prototype), it's easy to create invalid output.
 
 I found it much easier understand what `ifelse()` _should_ do once I internalised the ideas of type- and size-stability:
 
@@ -347,13 +347,13 @@ I found it much easier understand what `ifelse()` _should_ do once I internalise
 * `vec_ptype(if_else(test, yes, no))` equals 
   `vec_ptype_common(yes, no)`. Unlike `ifelse()` this implies
   that `if_else()` must always evaluate both `yes` and `no` in order
-  to figure out the correct type. I think this consistent with `&&` (scalar
+  to figure out the correct type. I think this is consistent with `&&` (scalar
   operation, short circuits) and `&` (vectorised, evaluates both sides).
 
 * `vec_size(if_else(test, yes, no))` equals 
   `vec_size_common(test, yes, no)`. I think the output could have the same 
-  size as `test` (i.e. the same behaviour as `ifelse`), but I _think_
-  as a general rule that you inputs should either be mutually recycling,
+  size as `test` (i.e., the same behaviour as `ifelse`), but I _think_
+  as a general rule that your inputs should either be mutually recycling
   or not.
 
 This leads to the following implementation:
@@ -377,7 +377,7 @@ if_else(x > 2, factor("small"), factor("big"))
 if_else(x > 2, Sys.Date(), Sys.Date() + 7)
 ```
 
-By using `vec_size()` and `vec_slice()` this definition of `if_else()` automatically works with data.frames and matrices:
+By using `vec_size()` and `vec_slice()`, this definition of `if_else()` automatically works with data.frames and matrices:
 
 ```{r}
 if_else(x > 2, data.frame(x = 1), data.frame(y = 2))

--- a/vignettes/type-size.Rmd
+++ b/vignettes/type-size.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-Rather than using `class()` and `length()`, vctrs has notions of prototype (`vec_ptype_show()`) and size (`vec_size()`). This vignette motivates why these alternatives are necessary, and connects their definitions to type coercion and the recycling rules.
+Rather than using `class()` and `length()`, vctrs has notions of prototype (`vec_ptype_show()`) and size (`vec_size()`). This vignette discusses the motivation for why these alternatives are necessary and connects their definitions to type coercion and the recycling rules.
 
 Size and prototype are motivated by thinking about the optimal behaviour for `c()` and `rbind()`, particularly inspired by data frames with columns that are matrices or data frames.
 
@@ -24,27 +24,27 @@ library(vctrs)
 
 ## Prototype
 
-The idea of a prototype is to capture the metadata associated with a vector, without capturing any data. Unfortunately, the `class()` of an object is inadequate for this purpose:
+The idea of a prototype is to capture the metadata associated with a vector without capturing any data. Unfortunately, the `class()` of an object is inadequate for this purpose:
 
 * The `class()` doesn't include attributes. Attributes are important because,
-  for example, they store the levels of a factor, and the timezone of a 
-  `POSIXct`. You can not combine two factors or two `POSIXct`s without
-  thinking about the attribute.
+  for example, they store the levels of a factor and the timezone of a 
+  `POSIXct`. You cannot combine two factors or two `POSIXct`s without
+  thinking about the attributes.
   
-* The `class()` of a matrix is "matrix", and doesn't include the type of the
-  underlying vector, or the dimensionality.
+* The `class()` of a matrix is "matrix" and doesn't include the type of the
+  underlying vector or the dimensionality.
   
-Instead vctrs takes advantage of R's vectorised nature and uses a __prototype__, a 0-observation slice of the vector (this is basically `x[0]` but with some subtleties we'll come back to later) . This is a miniature version of the vector that contains all of the attributes but none of the data. 
+Instead, vctrs takes advantage of R's vectorised nature and uses a __prototype__, a 0-observation slice of the vector (this is basically `x[0]` but with some subtleties we'll come back to later). This is a miniature version of the vector that contains all of the attributes but none of the data. 
 
-Conveniently, you can create many prototypes using existing base functions (e.g, `double()`, `factor(levels = c("a", "b"))`). vctrs provides a few helpers (e.g. `new_date()`, `new_datetime()`, `new_duration()`) where the equivalents in base R are missing.
+Conveniently, you can create many prototypes using existing base functions (e.g, `double()` and `factor(levels = c("a", "b"))`). vctrs provides a few helpers (e.g. `new_date()`, `new_datetime()`, and `new_duration()`) where the equivalents in base R are missing.
 
 ### Base prototypes
 
 `vec_ptype()` creates a prototype from an existing object. However, many base vectors have uninformative printing methods for 0-length subsets, so vctrs also provides `vec_ptype_show()`, which prints the prototype in a friendly way (and returns nothing).
 
-Using `vec_ptype_show()` allows us to see the prototypes base R classes:.
+Using `vec_ptype_show()` allows us to see the prototypes base R classes:
 
-*  Atomic vectors have no attributes, and just display the underlying `typeof()`:
+*  Atomic vectors have no attributes and just display the underlying `typeof()`:
 
     ```{r}
     vec_ptype_show(FALSE)
@@ -54,7 +54,7 @@ Using `vec_ptype_show()` allows us to see the prototypes base R classes:.
     vec_ptype_show(list(1, 2, 3))
     ```
 
-*  The prototype of matrices and arrays include the base type, and the 
+*  The prototype of matrices and arrays include the base type and the 
    dimensions after the first:
 
     ```{r}
@@ -65,7 +65,7 @@ Using `vec_ptype_show()` allows us to see the prototypes base R classes:.
 
 *  The prototype of a factor includes its levels. Levels are a character vector,
    which can be arbitrarily long, so the prototype just shows a hash. If the 
-   hash of two factors is equal it's highly likely that their levels are also 
+   hash of two factors is equal, it's highly likely that their levels are also 
    equal.
 
     ```{r}
@@ -117,11 +117,11 @@ It's often important to combine vectors with multiple types. vctrs provides a co
   
 * `vec_ptype_common(x, NULL) == vec_ptype(x)`.
 
-i.e. `vec_ptype_common()` is both commutative and associative (with respect to class), and has an identity element, `NULL`, i.e. it's a __commutative monoid__. This means the underlying implementation is quite simple: we can find the common type of any number of objects by progressively finding the common type of pairs of objects.
+i.e., `vec_ptype_common()` is both commutative and associative (with respect to class) and has an identity element, `NULL`; i.e., it's a __commutative monoid__. This means the underlying implementation is quite simple: we can find the common type of any number of objects by progressively finding the common type of pairs of objects.
 
 Like with `vec_ptype()`, the easiest way to explore `vec_ptype_common()` is with `vec_ptype_show()`: when given multiple inputs, it will print their common prototype. (In other words: program with `vec_ptype_common()` but play with `vec_ptype_show()`.)
 
-*   The common type of atomic vectors is computed very similar to rules of base 
+*   The common type of atomic vectors is computed very similar to the rules of base 
     R, except that we do not coerce to character automatically:
     
     ```{r, error = TRUE}
@@ -243,7 +243,7 @@ vec_cast(c(1, 2), integer())
 vec_cast(c(1.5, 2.5), factor("a"))
 ```
 
-If a cast is possible in general (i.e. double -> integer), but information is lost for a specific input (e.g. 1.5 -> 1), it will generate an error.
+If a cast is possible in general (i.e., double -> integer), but information is lost for a specific input (e.g. 1.5 -> 1), it will generate an error.
 
 ```{r, error = TRUE}
 vec_cast(c(1.5, 2), integer())
@@ -275,12 +275,12 @@ knitr::include_graphics("../man/figures/combined.png", dpi = 300)
 
 ## Size
 
-`vec_size()` was motivated by the need to have an invariant that describes the number of "observations" in a data structure. This is particularly important for data frames as it's useful to have some function such that `f(data.frame(x))` equals `f(x)`. No base function has this property:
+`vec_size()` was motivated by the need to have an invariant that describes the number of "observations" in a data structure. This is particularly important for data frames, as it's useful to have some function such that `f(data.frame(x))` equals `f(x)`. No base function has this property:
 
-* `length(data.frame(x))` equals `1`, because the length of a data frame 
+* `length(data.frame(x))` equals `1` because the length of a data frame 
    is the number of columns.
 
-* `nrow(data.frame(x))` does not equal `nrow(x)`, because `nrow()` of a 
+* `nrow(data.frame(x))` does not equal `nrow(x)` because `nrow()` of a 
   vector is `NULL`.
 
 * `NROW(data.frame(x))` equals `NROW(x)` for vector `x`, so is almost what
@@ -290,7 +290,7 @@ knitr::include_graphics("../man/figures/combined.png", dpi = 300)
 
 We define `vec_size()` as follows:
 
-* It is the length of 1d vectors
+* It is the length of 1d vectors.
 * It is the number of rows of data frames, matrices, and arrays.
 * It throws error for non vectors.
 
@@ -298,7 +298,7 @@ Given `vec_size()`, we can give a precise definition of a data frame: a data fra
 
 ### Slicing
 
-`vec_slice()` is to `vec_size()` as `[` is to `length()`; i.e. it allows you to select observations, regardless of the dimensionality of the underlying object. `vec_slice(x, i)` is equivalent to:
+`vec_slice()` is to `vec_size()` as `[` is to `length()`; i.e., it allows you to select observations regardless of the dimensionality of the underlying object. `vec_slice(x, i)` is equivalent to:
 
 * `x[i]` when `x` is a vector.
 * `x[i, , drop = FALSE]` when `x` is a data frame.
@@ -318,7 +318,7 @@ Prototypes are generated with `vec_slice(x, 0L)`; given a prototype, you can ini
 
 ### Common sizes: recycling rules
 
-Closely related to the definition of size are the __recycling rules__. The recycling rules determine the size of the output when two vectors of different sizes are combined. In vctrs, the recycling rules are encoded in `vec_size_common()` which give the common size of a set of vectors:
+Closely related to the definition of size are the __recycling rules__. The recycling rules determine the size of the output when two vectors of different sizes are combined. In vctrs, the recycling rules are encoded in `vec_size_common()`, which gives the common size of a set of vectors:
 
 ```{r}
 vec_size_common(1:3, 1:3, 1:3)
@@ -351,7 +351,7 @@ You can apply the recycling rules in two ways:
 
 ## Appendix: recycling in base R
 
-The recycling rules in base R are described in [The R Language Definition](https://cran.r-project.org/doc/manuals/r-release/R-lang.html#Recycling-rules) but are not implemented in a single function, and thus are not applied consistently. Here I give a brief overview of their most common realisation, as well as showing some of the exceptions.
+The recycling rules in base R are described in [The R Language Definition](https://cran.r-project.org/doc/manuals/r-release/R-lang.html#Recycling-rules) but are not implemented in a single function and thus are not applied consistently. Here, I give a brief overview of their most common realisation, as well as showing some of the exceptions.
 
 Generally, in base R, when a pair of vectors is not the same length, the shorter vector is recycled to the same length as the longer:
 


### PR DESCRIPTION
Found a couple of typos in the documentation. Also worked to standardize the comma usage in the vignettes to clean up the grammar a bit.