### PR TITLE
Fix hash test results on big-endian systems.

### DIFF
--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -57,6 +57,17 @@ test_that("hashes are consistent from run to run", {
   )
   hash <- lapply(df, vec_hash)
 
+  # Big-endian results are byte-swapped, but otherwise equivalent.
+  # Swap results so that there's no need to save results twice.
+  if (.Platform$endian == "big") {
+    hash <- lapply(
+      hash,
+      function(x) {
+        writeBin(readBin(x, "int", 100, endian = "big"), x, endian = "little")
+      }
+    )
+  }
+
   scoped_options(max.print = 99999)
   expect_known_output(print(hash), file = test_path("test-hash-hash.txt"))
 })


### PR DESCRIPTION
The result is the same, but looking at the *raw* bytes, the results are
byte swapped. So comparing against a list of bytes from a little-endian
system won't work.

Just swap the byte order before comparing against the ground truth
values. This means there's no need to save two copies of the ground
truth.

Fixes #492.