### PR TITLE
Fix performance of data frames containing objects

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -95,3 +95,7 @@ vec_proxy_dispatch <- function(x, ...) {
 vec_proxy.default <- function(x, ...) {
   x
 }
+
+vec_proxy_recursive <- function(x, kind = "default") {
+  .Call(vctrs_proxy_recursive, x, sym(kind))
+}

--- a/R/equal.R
+++ b/R/equal.R
@@ -56,18 +56,12 @@ vec_proxy_equal.default <- function(x, ...) {
 vec_equal <- function(x, y, na_equal = FALSE, .ptype = NULL) {
   args <- vec_recycle_common(x, y)
   args <- vec_cast_common(!!!args, .to = .ptype)
-  .Call(
-    vctrs_equal,
-    vec_proxy_equal(args[[1]]),
-    vec_proxy_equal(args[[2]]),
-    na_equal
-  )
+  .Call(vctrs_equal, args[[1]], args[[2]], na_equal)
 }
 
 #' @export
 #' @rdname vec_equal
 vec_equal_na <- function(x) {
-  x <- vec_proxy_equal(x)
   .Call(vctrs_equal_na, x)
 }
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -33,7 +33,7 @@ void dict_init_partial(dictionary* d, SEXP x) {
 }
 
 static void dict_init_impl(dictionary* d, SEXP x, bool partial) {
-  d->vec = x;
+  d->vec = PROTECT(vec_proxy_recursive(x));
   d->used = 0;
 
   if (partial) {
@@ -60,6 +60,8 @@ static void dict_init_impl(dictionary* d, SEXP x, bool partial) {
     memset(d->hash, 0, n * sizeof(R_len_t));
     hash_fill(d->hash, n, x);
   }
+
+  UNPROTECT(1);
 }
 
 uint32_t dict_hash_with(dictionary* d, dictionary* x, R_len_t i) {

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -33,7 +33,7 @@ void dict_init_partial(dictionary* d, SEXP x) {
 }
 
 static void dict_init_impl(dictionary* d, SEXP x, bool partial) {
-  d->vec = PROTECT(vec_proxy_recursive(x));
+  d->vec = PROTECT(vec_proxy_recursive(x, vctrs_proxy_equal));
   d->used = 0;
 
   if (partial) {

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -29,7 +29,10 @@ typedef struct dictionary dictionary;
  */
 void dict_init(dictionary* d, SEXP x);
 void dict_init_partial(dictionary* d, SEXP x);
-void dict_free(dictionary* d);
+
+#define PROTECT_DICT(d, n) do {                 \
+  } while(0)
+
 
 /**
  * Find key hash for a vector element

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -31,6 +31,8 @@ void dict_init(dictionary* d, SEXP x);
 void dict_init_partial(dictionary* d, SEXP x);
 
 #define PROTECT_DICT(d, n) do {                 \
+    PROTECT((d)->vec);                          \
+    *(n) += 1;                                  \
   } while(0)
 
 

--- a/src/init.c
+++ b/src/init.c
@@ -67,6 +67,8 @@ extern SEXP vctrs_outer_names(SEXP, SEXP, SEXP);
 extern SEXP vctrs_df_size(SEXP);
 extern SEXP vctrs_as_df_col(SEXP, SEXP);
 extern SEXP vctrs_apply_name_spec(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_proxy_recursive(SEXP, SEXP);
+
 
 // Defined below
 SEXP vctrs_init(SEXP);
@@ -132,6 +134,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_df_size",                    (DL_FUNC) &vctrs_df_size, 1},
   {"vctrs_as_df_col",                  (DL_FUNC) &vctrs_as_df_col, 2},
   {"vctrs_apply_name_spec",            (DL_FUNC) &vctrs_apply_name_spec, 4},
+  {"vctrs_proxy_recursive",            (DL_FUNC) &vctrs_proxy_recursive, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -28,6 +28,26 @@ SEXP vec_proxy(SEXP x) {
   return out;
 }
 
+// [[ include("vctrs.h") ]]
+SEXP vec_proxy_recursive(SEXP x) {
+  x = PROTECT(vec_proxy(x));
+
+  if (is_data_frame(x)) {
+    x = PROTECT(r_maybe_duplicate(x));
+    R_len_t n = Rf_length(x);
+
+    for (R_len_t i = 0; i < n; ++i) {
+      SEXP col = vec_proxy_recursive(VECTOR_ELT(x, i));
+      SET_VECTOR_ELT(x, i, col);
+    }
+
+    UNPROTECT(1);
+  }
+
+  UNPROTECT(1);
+  return x;
+}
+
 SEXP vec_proxy_method(SEXP x) {
   return s3_find_method("vec_proxy", x);
 }

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -52,6 +52,22 @@ SEXP vec_proxy_recursive(SEXP x, enum vctrs_proxy_kind kind) {
   return x;
 }
 
+// [[ register() ]]
+SEXP vctrs_proxy_recursive(SEXP x, SEXP kind_) {
+  enum vctrs_proxy_kind kind;
+  if (kind_ == Rf_install("default")) {
+    kind = vctrs_proxy_default;
+  } else if (kind_ == Rf_install("equal")) {
+    kind = vctrs_proxy_equal;
+  } else if (kind_ == Rf_install("compare")) {
+    kind = vctrs_proxy_compare;
+  } else {
+    Rf_error("Internal error: Unexpected proxy kind `%s`.", CHAR(PRINTNAME(kind_)));
+  }
+
+  return vec_proxy_recursive(x, kind);
+}
+
 SEXP vec_proxy_method(SEXP x) {
   return s3_find_method("vec_proxy", x);
 }

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -29,15 +29,19 @@ SEXP vec_proxy(SEXP x) {
 }
 
 // [[ include("vctrs.h") ]]
-SEXP vec_proxy_recursive(SEXP x) {
-  x = PROTECT(vec_proxy(x));
+SEXP vec_proxy_recursive(SEXP x, enum vctrs_proxy_kind kind) {
+  switch (kind) {
+  case vctrs_proxy_default: x = PROTECT(vec_proxy(x)); break;
+  case vctrs_proxy_equal: x = PROTECT(vec_proxy_equal(x)); break;
+  case vctrs_proxy_compare: Rf_error("Internal error: Unimplemented proxy kind");
+  }
 
   if (is_data_frame(x)) {
     x = PROTECT(r_maybe_duplicate(x));
     R_len_t n = Rf_length(x);
 
     for (R_len_t i = 0; i < n; ++i) {
-      SEXP col = vec_proxy_recursive(VECTOR_ELT(x, i));
+      SEXP col = vec_proxy_recursive(VECTOR_ELT(x, i), kind);
       SET_VECTOR_ELT(x, i, col);
     }
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -193,9 +193,15 @@ bool vec_is_unspecified(SEXP x);
 
 #include "arg.h"
 
+enum vctrs_proxy_kind {
+  vctrs_proxy_default,
+  vctrs_proxy_equal,
+  vctrs_proxy_compare
+};
+
 SEXP vec_proxy(SEXP x);
 SEXP vec_proxy_equal(SEXP x);
-SEXP vec_proxy_recursive(SEXP x);
+SEXP vec_proxy_recursive(SEXP x, enum vctrs_proxy_kind kind);
 SEXP vec_restore(SEXP x, SEXP to, SEXP i);
 R_len_t vec_size(SEXP x);
 R_len_t vec_size_common(SEXP xs, R_len_t absent);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -195,6 +195,7 @@ bool vec_is_unspecified(SEXP x);
 
 SEXP vec_proxy(SEXP x);
 SEXP vec_proxy_equal(SEXP x);
+SEXP vec_proxy_recursive(SEXP x);
 SEXP vec_restore(SEXP x, SEXP to, SEXP i);
 R_len_t vec_size(SEXP x);
 R_len_t vec_size_common(SEXP xs, R_len_t absent);


### PR DESCRIPTION
- Take equality proxy recursively before making equality comparisons. This way we only dispatch once on `vec_proxy()`, instead of once per comparison. Closes #498.

- Dictionaries must now be protected because they contain the proxied data as reference. The patch removes `dict_free()` and introduces `PROTECT_DICT()` to make the semantics clearer. The former makes it seem like dictionaries can be freed at any point in the lifetime of the program. For compatibility with rchk, `PROTECT_DICT()` is a macro that takes a protection counter. `UNPROTECT()` can then be called the normal way.