### PR TITLE
Issue 486

### DIFF
--- a/R/bind.R
+++ b/R/bind.R
@@ -39,8 +39,8 @@
 #'   will not appear in the output, but will affect the derived `.ptype`.
 #' @param .names_to Optionally, the name of a column where the names
 #'   of `...` arguments are copied. These names are useful to identify
-#'   which row comes from which input. If supplied, `...` must be
-#'   named.
+#'   which row comes from which input. If supplied and `...` is not named,
+#'   an integer column is used to identify the rows.
 #' @param .name_repair One of `"unique"`, `"universal"`, or
 #'   `"check_unique"`. See [vec_as_names()] for the meaning of these
 #'   options.

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -31,8 +31,8 @@ this is a convenient way to make production code demand fixed types.}
 
 \item{.names_to}{Optionally, the name of a column where the names
 of \code{...} arguments are copied. These names are useful to identify
-which row comes from which input. If supplied, \code{...} must be
-named.}
+which row comes from which input. If supplied and \code{...} is not named,
+an integer column is used to identify the rows.}
 
 \item{.name_repair}{One of \code{"unique"}, \code{"universal"}, or
 \code{"check_unique"}. See \code{\link[=vec_as_names]{vec_as_names()}} for the meaning of these

--- a/src/utils.c
+++ b/src/utils.c
@@ -363,7 +363,7 @@ void r_vec_ptr_inc(SEXPTYPE type, void** p, R_len_t i) {
 #define FILL(CTYPE, PTR, VAL_PTR, VAL_I, N)             \
   do {                                                  \
     CTYPE* data = (CTYPE*) PTR;                         \
-    CTYPE* end = data + N + 1;                          \
+    CTYPE* end = data + N;                              \
     CTYPE value = ((const CTYPE*) VAL_PTR)[VAL_I];      \
                                                         \
     while (data != end) {                               \

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -137,6 +137,17 @@ test_that("can repair names in `vec_rbind()` (#229)", {
   expect_named(vec_rbind(list(`_` = 1), .name_repair = "universal"), c("._"))
 })
 
+test_that("can construct an id column", {
+  df <- data.frame(x = 1)
+
+  expect_named(vec_rbind(df, df, .names_to = "id"), c("x", "id"))
+  expect_equal(vec_rbind(df, df, .names_to = "id")$id, c(1L, 2L))
+
+  expect_equal(vec_rbind(a = df, b = df, .names_to = "id")$id, c("a", "b"))
+
+  expect_equal(vec_rbind(a = df, df, .names_to = "id")$id, c("a", ""))
+})
+
 test_that("vec_rbind() fails with arrays of dimensionality > 3", {
   expect_error(vec_rbind(array(NA, c(1, 1, 1))), "Can't bind arrays")
 })


### PR DESCRIPTION
Closes #486 

- Fixes off by one error in `FILL` macro, which is only used by `vec_rbind()`.
- Added tests for the `.names_to` argument to `vec_rbind()`. Some of these would segfault previously.
- Tweaked the `.names_to` documentation.