### PR TITLE
support for hashing raw and complex vectors

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -97,13 +97,16 @@ static uint32_t dbl_hash_scalar(const double* x) {
   return hash_double(val);
 }
 static uint32_t cpl_hash_scalar(const Rcomplex* x) {
-  Rf_error("Hashing is not implemented for complex vectors.");
+  uint32_t hash = 0;
+  hash = hash_combine(hash, dbl_hash_scalar(&x->r));
+  hash = hash_combine(hash, dbl_hash_scalar(&x->i));
+  return hash;
 }
 static uint32_t chr_hash_scalar(const SEXP* x) {
   return hash_object(*x);
 }
 static uint32_t raw_hash_scalar(const Rbyte* x) {
-  Rf_error("Hashing is not implemented for raw vectors.");
+  return hash_int32(*x);
 }
 
 static uint32_t df_hash_scalar(SEXP x, R_len_t i) {

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -138,6 +138,16 @@ test_that("can hash 1D arrays", {
   expect_identical(vec_hash(array(1:2), FALSE), vec_hash(1:2, FALSE))
 })
 
+test_that("can hash raw vectors", {
+  expect_identical(vec_hash(0:255), vec_hash(as.raw(0:255)))
+})
+
+test_that("can hash complex vectors", {
+  expect_identical(
+    vec_hash(c(1, 2) + 0i),
+    vec_hash(matrix(c(1, 2, 0, 0), ncol = 2))
+  )
+})
 
 # Object ------------------------------------------------------------------
 


### PR DESCRIPTION
Need for https://github.com/tidyverse/dplyr/pull/4504

For raw vectors, just using the `int32` hasher, for complex, just using a combine of real and imaginary parts. 

``` r
library(vctrs)
vec_hash <- vctrs:::vec_hash

identical(
  vec_hash(0:255), 
  vec_hash(as.raw(0:255))
)
#> [1] TRUE

identical(
  vec_hash(c(1, 2) + 0i),
  vec_hash(matrix(c(1, 2, 0, 0), ncol = 2))
)
#> [1] TRUE
```
