### PR TITLE
vec_compare_proxy() handles data frame with a POSIXlt column.

### DIFF
--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -76,7 +76,7 @@ vec_proxy.data.frame <- function(x, ...) {
 }
 #' @export
 vec_proxy_compare.data.frame <- function(x, ..., relax = FALSE) {
-  x[] <- lapply(x[], vec_proxy_compare_default, relax = TRUE)
+  x[] <- lapply(x[], vec_proxy_compare, relax = TRUE)
   x
 }
 

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -93,6 +93,18 @@ test_that("vec_proxy_compare() preserves data frames and vectors", {
   expect_identical(vec_proxy_compare(x), x)
 })
 
+test_that("vec_proxy_compare() handles data frame with a POSIXlt column", {
+  df <- data.frame(times = 1:5, x = 1:5)
+  df$times <- as.POSIXlt(seq.Date(Sys.Date(), length.out = 5, by = "day"))
+
+  df2 <- df
+  df2$times <- vec_proxy_compare(df$times)
+
+  expect_identical(
+    vec_proxy_compare(df),
+    vec_proxy_compare(df2)
+  )
+})
 
 # order/sort --------------------------------------------------------------
 


### PR DESCRIPTION
I'm not sure about this, but at least it does not break tests and now I can do something like: 

``` r
library(vctrs)

df <- data.frame(times = 1:5, x = 1:5)
df$times <- as.POSIXlt(seq.Date(Sys.Date(), length.out = 5, by = "day"))

vctrs:::vec_proxy_compare(df)
#>   times.sec times.min times.hour times.mday times.mon times.year
#> 1         0         0          0         26         6        119
#> 2         0         0          0         27         6        119
#> 3         0         0          0         28         6        119
#> 4         0         0          0         29         6        119
#> 5         0         0          0         30         6        119
#>   times.wday times.yday times.isdst x
#> 1          5        206           0 1
#> 2          6        207           0 2
#> 3          0        208           0 3
#> 4          1        209           0 4
#> 5          2        210           0 5
```

Needed for https://github.com/tidyverse/dplyr/pull/4504
