### PR TITLE
vec_order() works recursively to handle data frame columns.

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -140,10 +140,10 @@ order_proxy <- function(proxy, direction = "asc", na_value = "largest") {
       return(integer(0L))
     }
     args <- map(unname(proxy), function(.x) {
-      if (is.data.frame(.x))
-        vec_order(.x, direction = direction, na_value = na_value)
-      else
-        .x
+      if (is.data.frame(.x)) {
+        .x <- vec_order(.x, direction = direction, na_value = na_value)
+      }
+      .x
     })
     exec("order", !!!args, decreasing = decreasing, na.last = na.last)
   } else if (is_character(proxy) || is_logical(proxy) || is_integer(proxy) || is_double(proxy)) {

--- a/R/compare.R
+++ b/R/compare.R
@@ -139,7 +139,12 @@ order_proxy <- function(proxy, direction = "asc", na_value = "largest") {
     if (vec_size(proxy) == 0L) {
       return(integer(0L))
     }
-    args <- unname(proxy)
+    args <- map(unname(proxy), function(.x) {
+      if (is.data.frame(.x))
+        vec_order(.x, direction = direction, na_value = na_value)
+      else
+        .x
+    })
     exec("order", !!!args, decreasing = decreasing, na.last = na.last)
   } else if (is_character(proxy) || is_logical(proxy) || is_integer(proxy) || is_double(proxy)) {
     order(proxy, decreasing = decreasing, na.last = na.last)

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -155,3 +155,13 @@ test_that("can order empty data frames (#356)", {
   df2 <- data.frame(x = numeric(), y = integer())
   expect_equal(vec_order(df2), integer())
 })
+
+test_that("can order data frames with data frame columns", {
+  df <- data.frame(x = 1:5, y = 1:5)
+  df$y <- data.frame(a = 1:5, b = 1:5)
+  expect_equal(
+    vec_order(df),
+    vec_order(data.frame(x = 1:5, a = 1:5, b = 1:5))
+  )
+})
+


### PR DESCRIPTION
closes #507

``` r
library(vctrs)
library(tibble)

df <- tibble(x = 1:5, d = tibble(y = 1:5, z = 1:5, a = letters[1:5]))
vec_order(df)
#> [1] 1 2 3 4 5

# follow up to https://github.com/r-lib/vctrs/pull/506
df <- data.frame(times = 1:5, x = 1:5)
df$times <- as.POSIXlt(seq.Date(Sys.Date(), length.out = 5, by = "day"))
vec_order(df)
#> [1] 1 2 3 4 5
```

