### PR TITLE
Only shallow duplicate attributes in `vec_restore()` if they are not `NULL`

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -392,15 +392,16 @@ SEXP vec_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg
 
 // Copy attributes except names and dim. This duplicates `x` if needed.
 SEXP vec_restore_default(SEXP x, SEXP to) {
-  int n_protect = 0;
-
-  SEXP attrib = PROTECT(Rf_shallow_duplicate(ATTRIB(to)));
-  ++n_protect;
+  SEXP attrib = ATTRIB(to);
 
   if (attrib == R_NilValue) {
-    UNPROTECT(n_protect);
     return x;
   }
+
+  int n_protect = 0;
+
+  attrib = PROTECT(Rf_shallow_duplicate(attrib));
+  ++n_protect;
 
   if (MAYBE_REFERENCED(x)) {
     x = PROTECT(Rf_shallow_duplicate(x));


### PR DESCRIPTION
Seemingly minor optimization, but this makes a difference in `vec_split_list()` with bare atomics where `vec_restore()` is called many times but shouldn't have to do anything.

``` r
library(vctrs)

x <- 1:500000 + 0L

vec_split_list <- vctrs:::vec_split_list

# before
bench::mark(vec_split_list(x), iterations = 1000)
#> # A tibble: 1 x 6
#>   expression             min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split_list(x)   24.2ms   25.7ms      37.9    3.81MB     184.

# after
bench::mark(vec_split_list(x), iterations = 1000)
#> # A tibble: 1 x 6
#>   expression             min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split_list(x)   19.8ms   20.9ms      46.3    3.81MB     225.
```