### PR TITLE
Construct fallback slice call with symbols, not values

### DIFF
--- a/src/slice.c
+++ b/src/slice.c
@@ -250,8 +250,10 @@ SEXP vec_slice_impl(SEXP x, SEXP index) {
     if (has_dim(x)) {
       out = PROTECT_N(vec_slice_fallback(x, index), &nprot);
     } else {
-      SEXP call = PROTECT_N(Rf_lang3(fns_bracket, x, index), &nprot);
-      out = PROTECT_N(Rf_eval(call, R_GlobalEnv), &nprot);
+      out = PROTECT_N(
+        vctrs_dispatch2(syms_bracket, fns_bracket, syms_x, x, syms_i, index),
+        &nprot
+      );
     }
 
     // Take over attribute restoration only if the `[` method did not


### PR DESCRIPTION
Closes #504 

This PR improves performance of slicing S3 objects that don't implement a proxy.

Even though @lionel- is sending [a patch](https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17588) to base R for this, it will be worth it to work around this on our end as well to prevent regressions on older versions of R.

``` r
library(vctrs)

x <- factor(rep(letters, 10000))

# before
bench::mark(vec_slice(x, 1L))
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_slice(x, 1L)   90.4µs    152µs     4704.    1.01MB     94.3

# after
bench::mark(vec_slice(x, 1L))
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_slice(x, 1L)   8.55µs   9.94µs    97981.    17.1KB     98.1
```
