### PR TITLE
Teach `vec_slice()` about `compact_seq()`

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -194,6 +194,8 @@ vec_init <- function(x, n = 1L) {
 }
 
 # Exposed for testing
+# Sliced as `[from, to)`
+# `from` and `to` are 0-based
 vec_slice_seq <- function(x, from, to) {
-  .Call(vctrs_slice_seq, x, from - 1L, to - 1L)
+  .Call(vctrs_slice_seq, x, from, to)
 }

--- a/R/slice.R
+++ b/R/slice.R
@@ -194,8 +194,7 @@ vec_init <- function(x, n = 1L) {
 }
 
 # Exposed for testing
-# Sliced as `[from, to)`
-# `from` and `to` are 0-based
+# Used here like `vec_slice(x, from:to)`
 vec_slice_seq <- function(x, from, to) {
-  .Call(vctrs_slice_seq, x, from, to)
+  .Call(vctrs_slice_seq, x, from - 1L, to)
 }

--- a/R/slice.R
+++ b/R/slice.R
@@ -192,3 +192,8 @@ vec_index <- function(x, i, ...) {
 vec_init <- function(x, n = 1L) {
   vec_slice(x, rep_len(NA_integer_, n))
 }
+
+# Exposed for testing
+vec_slice_seq <- function(x, from, to) {
+  .Call(vctrs_slice_seq, x, from - 1L, to - 1L)
+}

--- a/src/init.c
+++ b/src/init.c
@@ -40,6 +40,7 @@ extern SEXP vctrs_typeof2(SEXP, SEXP);
 extern SEXP vctrs_cast(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_as_index(SEXP, SEXP, SEXP);
 extern SEXP vctrs_slice(SEXP, SEXP);
+extern SEXP vec_slice_seq(SEXP x, SEXP from, SEXP to);
 extern SEXP vec_restore(SEXP, SEXP, SEXP);
 extern SEXP vec_restore_default(SEXP, SEXP);
 extern SEXP vec_proxy(SEXP);
@@ -107,6 +108,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_cast",                       (DL_FUNC) &vctrs_cast, 4},
   {"vctrs_as_index",                   (DL_FUNC) &vctrs_as_index, 3},
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 2},
+  {"vctrs_slice_seq",            (DL_FUNC) &vec_slice_seq, 3},
   {"vctrs_restore",                    (DL_FUNC) &vec_restore, 3},
   {"vctrs_restore_default",            (DL_FUNC) &vec_restore_default, 2},
   {"vctrs_proxy",                      (DL_FUNC) &vec_proxy, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -108,7 +108,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_cast",                       (DL_FUNC) &vctrs_cast, 4},
   {"vctrs_as_index",                   (DL_FUNC) &vctrs_as_index, 3},
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 2},
-  {"vctrs_slice_seq",            (DL_FUNC) &vec_slice_seq, 3},
+  {"vctrs_slice_seq",                  (DL_FUNC) &vec_slice_seq, 3},
   {"vctrs_restore",                    (DL_FUNC) &vec_restore, 3},
   {"vctrs_restore_default",            (DL_FUNC) &vec_restore_default, 2},
   {"vctrs_proxy",                      (DL_FUNC) &vec_proxy, 1},

--- a/src/slice-array.c
+++ b/src/slice-array.c
@@ -234,6 +234,7 @@ static SEXP raw_slice_shaped(SEXP x, SEXP index, struct vec_slice_shaped_info in
 
 #undef SLICE_SHAPED
 #undef SLICE_SHAPED_COMPACT_REP
+#undef SLICE_SHAPED_COMPACT_SEQ
 #undef SLICE_SHAPED_INDEX
 
 #define SLICE_BARRIER_SHAPED_INDEX(RTYPE, GET, SET, NA_VALUE)  \

--- a/src/slice-array.c
+++ b/src/slice-array.c
@@ -169,39 +169,39 @@ struct vec_slice_shaped_info {
   UNPROTECT(1);                                                                \
   return out
 
-#define SLICE_SHAPED_COMPACT_SEQ(RTYPE, CTYPE, DEREF, CONST_DEREF)               \
-  SEXP out = PROTECT(Rf_allocArray(RTYPE, info.out_dim));                        \
-  CTYPE* out_data = DEREF(out);                                                  \
-                                                                                 \
-  int from = info.p_index[0];                                                    \
-  int to = info.p_index[1];                                                      \
-                                                                                 \
-  const CTYPE* x_data = CONST_DEREF(x);                                          \
-                                                                                 \
-  for (int i = 0; i < info.shape_elem_n; ++i) {                                  \
-                                                                                 \
-    /* Find and add the next `x` element */                                      \
-    for (int size_index = from; size_index < to; ++size_index, ++out_data) {     \
-      int loc = vec_strided_loc(                                                 \
-        size_index,                                                              \
-        info.p_shape_index,                                                      \
-        info.p_strides,                                                          \
-        info.shape_n                                                             \
-      );                                                                         \
-      *out_data = x_data[loc];                                                   \
-    }                                                                            \
-                                                                                 \
-    /* Update shape_index */                                                     \
-    for (int j = 0; j < info.shape_n; ++j) {                                     \
-      info.p_shape_index[j]++;                                                   \
-      if (info.p_shape_index[j] < info.p_dim[j + 1]) {                           \
-        break;                                                                   \
-      }                                                                          \
-      info.p_shape_index[j] = 0;                                                 \
-    }                                                                            \
-  }                                                                              \
-                                                                                 \
-  UNPROTECT(1);                                                                  \
+#define SLICE_SHAPED_COMPACT_SEQ(RTYPE, CTYPE, DEREF, CONST_DEREF)             \
+  SEXP out = PROTECT(Rf_allocArray(RTYPE, info.out_dim));                      \
+  CTYPE* out_data = DEREF(out);                                                \
+                                                                               \
+  int from = info.p_index[0];                                                  \
+  int to = info.p_index[1];                                                    \
+                                                                               \
+  const CTYPE* x_data = CONST_DEREF(x);                                        \
+                                                                               \
+  for (int i = 0; i < info.shape_elem_n; ++i) {                                \
+                                                                               \
+    /* Find and add the next `x` element */                                    \
+    for (int size_index = from; size_index < to; ++size_index, ++out_data) {   \
+      int loc = vec_strided_loc(                                               \
+        size_index,                                                            \
+        info.p_shape_index,                                                    \
+        info.p_strides,                                                        \
+        info.shape_n                                                           \
+      );                                                                       \
+      *out_data = x_data[loc];                                                 \
+    }                                                                          \
+                                                                               \
+    /* Update shape_index */                                                   \
+    for (int j = 0; j < info.shape_n; ++j) {                                   \
+      info.p_shape_index[j]++;                                                 \
+      if (info.p_shape_index[j] < info.p_dim[j + 1]) {                         \
+        break;                                                                 \
+      }                                                                        \
+      info.p_shape_index[j] = 0;                                               \
+    }                                                                          \
+  }                                                                            \
+                                                                               \
+  UNPROTECT(1);                                                                \
   return out
 
 #define SLICE_SHAPED(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE)          \

--- a/src/slice.c
+++ b/src/slice.c
@@ -143,22 +143,22 @@ static SEXP raw_slice(SEXP x, SEXP index) {
   UNPROTECT(1);                                                 \
   return out
 
-#define SLICE_BARRIER_COMPACT_SEQ(RTYPE, GET, SET)                      \
-  int* index_data = INTEGER(index);                                     \
-  R_len_t from = index_data[0];                                         \
-  R_len_t to = index_data[1];                                           \
-  R_len_t n = to - from;                                                \
-                                                                        \
-  SEXP out = PROTECT(Rf_allocVector(RTYPE, n));                         \
-                                                                        \
-  R_len_t j = from;                                                     \
-                                                                        \
-  for (R_len_t i = 0; i < n; ++i, ++j) {                                \
-    SEXP elt = GET(x, j);                                               \
-    SET(out, i, elt);                                                   \
-  }                                                                     \
-                                                                        \
-  UNPROTECT(1);                                                         \
+#define SLICE_BARRIER_COMPACT_SEQ(RTYPE, GET, SET)  \
+  int* index_data = INTEGER(index);                 \
+  R_len_t from = index_data[0];                     \
+  R_len_t to = index_data[1];                       \
+  R_len_t n = to - from;                            \
+                                                    \
+  SEXP out = PROTECT(Rf_allocVector(RTYPE, n));     \
+                                                    \
+  R_len_t j = from;                                 \
+                                                    \
+  for (R_len_t i = 0; i < n; ++i, ++j) {            \
+    SEXP elt = GET(x, j);                           \
+    SET(out, i, elt);                               \
+  }                                                 \
+                                                    \
+  UNPROTECT(1);                                     \
   return out
 
 #define SLICE_BARRIER(RTYPE, GET, SET, NA_VALUE)            \

--- a/src/slice.c
+++ b/src/slice.c
@@ -176,6 +176,7 @@ static SEXP list_slice(SEXP x, SEXP index) {
 
 #undef SLICE_BARRIER
 #undef SLICE_BARRIER_COMPACT_REP
+#undef SLICE_BARRIER_COMPACT_SEQ
 #undef SLICE_BARRIER_INDEX
 
 static SEXP df_slice(SEXP x, SEXP index) {

--- a/src/slice.c
+++ b/src/slice.c
@@ -382,9 +382,13 @@ SEXP vec_init(SEXP x, R_len_t n) {
   return out;
 }
 
+// Exported for testing
+// [[ register() ]]
 SEXP vec_slice_seq(SEXP x, SEXP from, SEXP to) {
-  SEXP index = PROTECT(compact_seq(INTEGER(from)[0], INTEGER(to)[0]));
+  R_len_t from_ = r_int_get(from, 0);
+  R_len_t to_ = r_int_get(to, 0);
 
+  SEXP index = PROTECT(compact_seq(from_, to_));
   SEXP out = vec_slice_impl(x, index);
 
   UNPROTECT(1);

--- a/src/slice.c
+++ b/src/slice.c
@@ -143,9 +143,29 @@ static SEXP raw_slice(SEXP x, SEXP index) {
   UNPROTECT(1);                                                 \
   return out
 
+#define SLICE_BARRIER_COMPACT_SEQ(RTYPE, GET, SET)                      \
+  int* index_data = INTEGER(index);                                     \
+  R_len_t from = index_data[0];                                         \
+  R_len_t to = index_data[1];                                           \
+  R_len_t n = to - from;                                                \
+                                                                        \
+  SEXP out = PROTECT(Rf_allocVector(RTYPE, n));                         \
+                                                                        \
+  R_len_t j = from;                                                     \
+                                                                        \
+  for (R_len_t i = 0; i < n; ++i, ++j) {                                \
+    SEXP elt = GET(x, j);                                               \
+    SET(out, i, elt);                                                   \
+  }                                                                     \
+                                                                        \
+  UNPROTECT(1);                                                         \
+  return out
+
 #define SLICE_BARRIER(RTYPE, GET, SET, NA_VALUE)            \
   if (is_compact_rep(index)) {                              \
     SLICE_BARRIER_COMPACT_REP(RTYPE, GET, SET, NA_VALUE);   \
+  } else if (is_compact_seq(index)) {                       \
+    SLICE_BARRIER_COMPACT_SEQ(RTYPE, GET, SET);             \
   } else {                                                  \
     SLICE_BARRIER_INDEX(RTYPE, GET, SET, NA_VALUE);         \
   }

--- a/src/utils.c
+++ b/src/utils.c
@@ -278,13 +278,14 @@ bool is_compact_seq(SEXP x) {
   return ATTRIB(x) == compact_seq_attrib;
 }
 
+// Materialize a 1-based sequence
 SEXP compact_seq_materialize(SEXP x) {
   R_len_t from = r_int_get(x, 0);
   R_len_t to = r_int_get(x, 1);
-  R_len_t n = from - to;
+  R_len_t n = to - from;
 
   SEXP out = PROTECT(Rf_allocVector(INTSXP, n));
-  r_int_fill_seq(out, from, n);
+  r_int_fill_seq(out, from + 1, n);
 
   UNPROTECT(1);
   return out;

--- a/src/utils.h
+++ b/src/utils.h
@@ -81,8 +81,9 @@ bool is_compact_seq(SEXP x);
 void init_compact_rep(int* p, R_len_t i, R_len_t n);
 SEXP compact_rep(R_len_t i, R_len_t n);
 bool is_compact_rep(SEXP x);
-SEXP compact_rep_materialize(SEXP x);
 
+bool is_compact(SEXP x);
+SEXP compact_materialize(SEXP x);
 R_len_t vec_index_size(SEXP x);
 
 SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -214,6 +214,7 @@ SEXP vec_cast_common(SEXP xs, SEXP to);
 SEXP vec_coercible_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_slice(SEXP x, SEXP index);
 SEXP vec_slice_shaped(enum vctrs_type type, SEXP x, SEXP index);
+SEXP vec_slice_seq(SEXP x, SEXP from, SEXP to);
 SEXP vec_assign(SEXP x, SEXP index, SEXP value);
 SEXP vec_init(SEXP x, R_len_t n);
 SEXP vec_type(SEXP x);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -214,7 +214,6 @@ SEXP vec_cast_common(SEXP xs, SEXP to);
 SEXP vec_coercible_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_slice(SEXP x, SEXP index);
 SEXP vec_slice_shaped(enum vctrs_type type, SEXP x, SEXP index);
-SEXP vec_slice_seq(SEXP x, SEXP from, SEXP to);
 SEXP vec_assign(SEXP x, SEXP index, SEXP value);
 SEXP vec_init(SEXP x, R_len_t n);
 SEXP vec_type(SEXP x);

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -425,3 +425,59 @@ test_that("na of list-array is 1d slice", {
 test_that("vec_init() asserts vectorness (#301)", {
   expect_error(vec_init(NULL), class = "vctrs_error_scalar_type")
 })
+
+# vec_slice + compact_seq -------------------------------------------------
+
+# Slices `[from, to)`
+# `from` and `to` are 0-based
+
+test_that("can subset base vectors with compact seqs", {
+  from <- 1L
+  to <- 3L
+  expect_identical(vec_slice_seq(lgl(1, 0, 1), from, to), lgl(0, 1))
+  expect_identical(vec_slice_seq(int(1, 2, 3), from, to), int(2, 3))
+  expect_identical(vec_slice_seq(dbl(1, 2, 3), from, to), dbl(2, 3))
+  expect_identical(vec_slice_seq(cpl(1, 2, 3), from, to), cpl(2, 3))
+  expect_identical(vec_slice_seq(chr("1", "2", "3"), from, to), chr("2", "3"))
+  expect_identical(vec_slice_seq(bytes(1, 2, 3), from, to), bytes(2, 3))
+  expect_identical(vec_slice_seq(list(1, 2, 3), from, to), list(2, 3))
+})
+
+test_that("can subset shaped base vectors with compact seqs", {
+  from <- 1L
+  to <- 3L
+  mat <- as.matrix
+  expect_identical(vec_slice_seq(mat(lgl(1, 0, 1)), from, to), mat(lgl(0, 1)))
+  expect_identical(vec_slice_seq(mat(int(1, 2, 3)), from, to), mat(int(2, 3)))
+  expect_identical(vec_slice_seq(mat(dbl(1, 2, 3)), from, to), mat(dbl(2, 3)))
+  expect_identical(vec_slice_seq(mat(cpl(1, 2, 3)), from, to), mat(cpl(2, 3)))
+  expect_identical(vec_slice_seq(mat(chr("1", "2", "3")), from, to), mat(chr("2", "3")))
+  expect_identical(vec_slice_seq(mat(bytes(1, 2, 3)), from, to), mat(bytes(2, 3)))
+  expect_identical(vec_slice_seq(mat(list(1, 2, 3)), from, to), mat(list(2, 3)))
+})
+
+test_that("can subset object of any dimensionality with compact seqs", {
+  x0 <- c(1, 1)
+  x1 <- ones(2)
+  x2 <- ones(2, 3)
+  x3 <- ones(2, 3, 4)
+  x4 <- ones(2, 3, 4, 5)
+
+  expect_equal(vec_slice_seq(x0, 0L, 1L), 1)
+  expect_identical(vec_slice_seq(x1, 0L, 1L), ones(1))
+  expect_identical(vec_slice_seq(x2, 0L, 1L), ones(1, 3))
+  expect_identical(vec_slice_seq(x3, 0L, 1L), ones(1, 3, 4))
+  expect_identical(vec_slice_seq(x4, 0L, 1L), ones(1, 3, 4, 5))
+})
+
+test_that("can subset data frames", {
+  df <- data_frame(x = 1:5, y = letters[1:5])
+  expect_equal(vec_slice_seq(df, 0L, 0L), vec_slice(df, integer()))
+  expect_equal(vec_slice_seq(df, 0L, 1L), vec_slice(df, 1L))
+  expect_equal(vec_slice_seq(df, 0L, 3L), vec_slice(df, 1:3))
+
+  df$df <- df
+  expect_equal(vec_slice_seq(df, 0L, 0L), vec_slice(df, integer()))
+  expect_equal(vec_slice_seq(df, 0L, 1L), vec_slice(df, 1L))
+  expect_equal(vec_slice_seq(df, 0L, 3L), vec_slice(df, 1:3))
+})

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -481,3 +481,9 @@ test_that("can subset data frames with compact seqs", {
   expect_equal(vec_slice_seq(df, 0L, 1L), vec_slice(df, 1L))
   expect_equal(vec_slice_seq(df, 0L, 3L), vec_slice(df, 1:3))
 })
+
+test_that("can subset S3 objects using the fallback method with compact seqs", {
+  x <- factor(c("a", "b", "c", "d"))
+  expect_equal(vec_slice_seq(x, 0L, 0L), vec_slice(x, integer()))
+  expect_equal(vec_slice_seq(x, 2L, 4L), vec_slice(x, 3:4))
+})

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -432,7 +432,7 @@ test_that("vec_init() asserts vectorness (#301)", {
 # `from` and `to` are 0-based
 
 test_that("can subset base vectors with compact seqs", {
-  from <- 1L
+  from <- 2L
   to <- 3L
   expect_identical(vec_slice_seq(lgl(1, 0, 1), from, to), lgl(0, 1))
   expect_identical(vec_slice_seq(int(1, 2, 3), from, to), int(2, 3))
@@ -444,7 +444,7 @@ test_that("can subset base vectors with compact seqs", {
 })
 
 test_that("can subset shaped base vectors with compact seqs", {
-  from <- 1L
+  from <- 2L
   to <- 3L
   mat <- as.matrix
   expect_identical(vec_slice_seq(mat(lgl(1, 0, 1)), from, to), mat(lgl(0, 1)))
@@ -463,27 +463,27 @@ test_that("can subset object of any dimensionality with compact seqs", {
   x3 <- ones(2, 3, 4)
   x4 <- ones(2, 3, 4, 5)
 
-  expect_equal(vec_slice_seq(x0, 0L, 1L), 1)
-  expect_identical(vec_slice_seq(x1, 0L, 1L), ones(1))
-  expect_identical(vec_slice_seq(x2, 0L, 1L), ones(1, 3))
-  expect_identical(vec_slice_seq(x3, 0L, 1L), ones(1, 3, 4))
-  expect_identical(vec_slice_seq(x4, 0L, 1L), ones(1, 3, 4, 5))
+  expect_equal(vec_slice_seq(x0, 1L, 1L), 1)
+  expect_identical(vec_slice_seq(x1, 1L, 1L), ones(1))
+  expect_identical(vec_slice_seq(x2, 1L, 1L), ones(1, 3))
+  expect_identical(vec_slice_seq(x3, 1L, 1L), ones(1, 3, 4))
+  expect_identical(vec_slice_seq(x4, 1L, 1L), ones(1, 3, 4, 5))
 })
 
 test_that("can subset data frames with compact seqs", {
   df <- data_frame(x = 1:5, y = letters[1:5])
-  expect_equal(vec_slice_seq(df, 0L, 0L), vec_slice(df, integer()))
-  expect_equal(vec_slice_seq(df, 0L, 1L), vec_slice(df, 1L))
-  expect_equal(vec_slice_seq(df, 0L, 3L), vec_slice(df, 1:3))
+  expect_equal(vec_slice_seq(df, 1L, 0L), vec_slice(df, integer()))
+  expect_equal(vec_slice_seq(df, 1L, 1L), vec_slice(df, 1L))
+  expect_equal(vec_slice_seq(df, 1L, 3L), vec_slice(df, 1:3))
 
   df$df <- df
-  expect_equal(vec_slice_seq(df, 0L, 0L), vec_slice(df, integer()))
-  expect_equal(vec_slice_seq(df, 0L, 1L), vec_slice(df, 1L))
-  expect_equal(vec_slice_seq(df, 0L, 3L), vec_slice(df, 1:3))
+  expect_equal(vec_slice_seq(df, 1L, 0L), vec_slice(df, integer()))
+  expect_equal(vec_slice_seq(df, 1L, 1L), vec_slice(df, 1L))
+  expect_equal(vec_slice_seq(df, 1L, 3L), vec_slice(df, 1:3))
 })
 
 test_that("can subset S3 objects using the fallback method with compact seqs", {
   x <- factor(c("a", "b", "c", "d"))
-  expect_equal(vec_slice_seq(x, 0L, 0L), vec_slice(x, integer()))
-  expect_equal(vec_slice_seq(x, 2L, 4L), vec_slice(x, 3:4))
+  expect_equal(vec_slice_seq(x, 1L, 0L), vec_slice(x, integer()))
+  expect_equal(vec_slice_seq(x, 3L, 4L), vec_slice(x, 3:4))
 })

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -470,7 +470,7 @@ test_that("can subset object of any dimensionality with compact seqs", {
   expect_identical(vec_slice_seq(x4, 0L, 1L), ones(1, 3, 4, 5))
 })
 
-test_that("can subset data frames", {
+test_that("can subset data frames with compact seqs", {
   df <- data_frame(x = 1:5, y = letters[1:5])
   expect_equal(vec_slice_seq(df, 0L, 0L), vec_slice(df, integer()))
   expect_equal(vec_slice_seq(df, 0L, 1L), vec_slice(df, 1L))


### PR DESCRIPTION
Update) Not sure this is quite ready yet. Still iterating on it.

Closes #489 

This PR teaches `vec_slice_impl()` how to work with `compact_seq()` objects.

We don't have a use case for this in vctrs, but I do have a potential use case for this in a C impl of `slide()` so I figured I would add it. I have exposed `vec_slice_seq()` to the R side for testing purposes.

Notes: 

- You can't have a seq with `NA` in it, so you'll see that `NA_VALUE` is not passed through in the macros.
- This does not solve #490, which will take some thinking and should be left to a different PR

Using `compact_seq()`s can have some nice performance improvements:

``` r
library(nycflights13)
library(vctrs)

x <- flights

nrow(x)
#> [1] 336776

vec_slice_seq <- vctrs:::vec_slice_seq

bench::mark(
  vec_slice_seq(x, 1L, 100000L),
  vec_slice(x, 1:100000),
  x[1:100000,],
  iterations = 1000
)
#> # A tibble: 3 x 6
#>   expression                        min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                    <bch:t> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 vec_slice_seq(x, 1L, 100000L)  1.68ms 2.37ms      379.    11.8MB    108. 
#> 2 vec_slice(x, 1:1e+05)          1.82ms 2.78ms      339.    11.8MB     91.7
#> 3 x[1:1e+05, ]                   4.81ms 6.28ms      156.    11.9MB     43.3

year <- x$year

bench::mark(
  vec_slice_seq(year, 1L, 100000L),
  vec_slice(year, 1:100000),
  year[1:100000],
  iterations = 5000
)
#> # A tibble: 3 x 6
#>   expression                           min  median `itr/sec` mem_alloc
#>   <bch:expr>                       <bch:t> <bch:t>     <dbl> <bch:byt>
#> 1 vec_slice_seq(year, 1L, 100000L)  29.6µs  53.4µs    18625.     391KB
#> 2 vec_slice(year, 1:1e+05)         132.9µs   189µs     5077.     781KB
#> 3 year[1:1e+05]                      188µs   286µs     3332.     781KB
#> # … with 1 more variable: `gc/sec` <dbl>
```