### PR TITLE
Teach `vec_slice_impl()` about `compact_seq()` + implement decreasing `compact_seq()`s

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -197,3 +197,8 @@ vec_init <- function(x, n = 1L) {
 vec_split_along <- function(x) {
   .Call(vctrs_split_along, x)
 }
+
+# Exposed for testing (`start` is 0-based)
+vec_slice_seq <- function(x, start, size, increasing = TRUE) {
+  .Call(vctrs_slice_seq, x, start, size, increasing)
+}

--- a/src/bind.c
+++ b/src/bind.c
@@ -73,7 +73,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, enum name_repair_arg n
   }
 
   SEXP out = PROTECT_N(vec_init(ptype, nrow), &nprot);
-  SEXP idx = PROTECT_N(compact_seq(0, 0), &nprot);
+  SEXP idx = PROTECT_N(compact_seq(0, 0, true), &nprot);
   int* idx_ptr = INTEGER(idx);
 
   SEXP names_to_col = R_NilValue;
@@ -104,7 +104,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, enum name_repair_arg n
     }
 
     SEXP tbl = PROTECT(vec_cast(VECTOR_ELT(xs, i), ptype, args_empty, args_empty));
-    init_compact_seq(idx_ptr, counter, counter + size);
+    init_compact_seq(idx_ptr, counter, size, true);
     df_assign(out, idx, tbl, false);
 
     // Assign current name to group vector, if supplied
@@ -266,7 +266,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, enum name_repair_arg name_
   SEXP out = PROTECT(Rf_allocVector(VECSXP, ncol));
   SEXP names = PROTECT(Rf_allocVector(STRSXP, ncol));
 
-  SEXP idx = PROTECT(compact_seq(0, 0));
+  SEXP idx = PROTECT(compact_seq(0, 0, true));
   int* idx_ptr = INTEGER(idx);
 
   R_len_t counter = 0;
@@ -287,7 +287,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, enum name_repair_arg name_
     }
 
     R_len_t xn = Rf_length(x);
-    init_compact_seq(idx_ptr, counter, counter + xn);
+    init_compact_seq(idx_ptr, counter, xn, true);
     list_assign(out, idx, x, false);
 
     SEXP xnms = PROTECT(r_names(x));

--- a/src/c.c
+++ b/src/c.c
@@ -59,7 +59,7 @@ static SEXP vec_c(SEXP xs,
   out = vec_proxy(out);
   REPROTECT(out, out_pi);
 
-  SEXP idx = PROTECT(compact_seq(0, 0));
+  SEXP idx = PROTECT(compact_seq(0, 0, true));
   int* idx_ptr = INTEGER(idx);
 
   SEXP xs_names = PROTECT(r_names(xs));
@@ -82,7 +82,7 @@ static SEXP vec_c(SEXP xs,
     SEXP x = VECTOR_ELT(xs, i);
     SEXP elt = PROTECT(vec_cast(x, ptype, args_empty, args_empty));
 
-    init_compact_seq(idx_ptr, counter, counter + size);
+    init_compact_seq(idx_ptr, counter, size, true);
 
     if (is_shaped) {
       SEXP idx = PROTECT(r_seq(counter + 1, counter + size + 1));

--- a/src/init.c
+++ b/src/init.c
@@ -41,6 +41,7 @@ extern SEXP vctrs_cast(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_as_index(SEXP, SEXP, SEXP);
 extern SEXP vctrs_slice(SEXP, SEXP);
 extern SEXP vec_split_along(SEXP);
+extern SEXP vec_slice_seq(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_restore(SEXP, SEXP, SEXP);
 extern SEXP vec_restore_default(SEXP, SEXP);
 extern SEXP vec_proxy(SEXP);
@@ -109,6 +110,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_as_index",                   (DL_FUNC) &vctrs_as_index, 3},
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 2},
   {"vctrs_split_along",                (DL_FUNC) &vec_split_along, 1},
+  {"vctrs_slice_seq",                  (DL_FUNC) &vec_slice_seq, 4},
   {"vctrs_restore",                    (DL_FUNC) &vec_restore, 3},
   {"vctrs_restore_default",            (DL_FUNC) &vec_restore_default, 2},
   {"vctrs_proxy",                      (DL_FUNC) &vec_proxy, 1},

--- a/src/utils.c
+++ b/src/utils.c
@@ -253,7 +253,7 @@ SEXP compact_seq_attrib = NULL;
 
 // p[0] = Start value
 // p[1] = Sequence size. Always >= 1.
-// p[2] = Increasing step if `from <= to`, decreasing step if `from > to`
+// p[2] = Step size to increment/decrement `start` with
 void init_compact_seq(int* p, R_len_t start, R_len_t size, bool increasing) {
   int step = increasing ? 1 : -1;
 
@@ -263,8 +263,9 @@ void init_compact_seq(int* p, R_len_t start, R_len_t size, bool increasing) {
 }
 
 // Returns a compact sequence that `vec_slice()` understands
+// The sequence is generally generated as `[start, start +/- size)`
+// If `size == 0` a 0-length sequence is generated
 // `start` is 0-based
-// The sequence is generated as `[start, start +/- size]`
 SEXP compact_seq(R_len_t start, R_len_t size, bool increasing) {
   if (start < 0) {
     Rf_error("Internal error: `start` must not be negative in `compact_seq()`.");

--- a/src/utils.h
+++ b/src/utils.h
@@ -74,15 +74,16 @@ SEXP df_container_type(SEXP x);
 SEXP df_poke(SEXP x, R_len_t i, SEXP value);
 SEXP df_poke_at(SEXP x, SEXP name, SEXP value);
 
-void init_compact_seq(int* p, R_len_t from, R_len_t to);
-SEXP compact_seq(R_len_t from, R_len_t to);
+void init_compact_seq(int* p, R_len_t start, R_len_t size, bool increasing);
+SEXP compact_seq(R_len_t start, R_len_t size, bool increasing);
 bool is_compact_seq(SEXP x);
 
 void init_compact_rep(int* p, R_len_t i, R_len_t n);
 SEXP compact_rep(R_len_t i, R_len_t n);
 bool is_compact_rep(SEXP x);
-SEXP compact_rep_materialize(SEXP x);
 
+bool is_compact(SEXP x);
+SEXP compact_materialize(SEXP x);
 R_len_t vec_index_size(SEXP x);
 
 SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n);

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -511,3 +511,124 @@ test_that("vec_split_along() falls back to `[` for shaped objects with no proxy"
   dim(x) <- c(1, 1)
   expect_equal(vec_split_along(x), list(x))
 })
+
+# vec_slice + compact_seq -------------------------------------------------
+
+# `start` is 0-based
+
+test_that("can subset base vectors with compact seqs", {
+  start <- 1L
+  size <- 2L
+  increasing <- TRUE
+  expect_identical(vec_slice_seq(lgl(1, 0, 1), start, size, increasing), lgl(0, 1))
+  expect_identical(vec_slice_seq(int(1, 2, 3), start, size, increasing), int(2, 3))
+  expect_identical(vec_slice_seq(dbl(1, 2, 3), start, size, increasing), dbl(2, 3))
+  expect_identical(vec_slice_seq(cpl(1, 2, 3), start, size, increasing), cpl(2, 3))
+  expect_identical(vec_slice_seq(chr("1", "2", "3"), start, size, increasing), chr("2", "3"))
+  expect_identical(vec_slice_seq(bytes(1, 2, 3), start, size, increasing), bytes(2, 3))
+  expect_identical(vec_slice_seq(list(1, 2, 3), start, size, increasing), list(2, 3))
+})
+
+test_that("can subset base vectors with decreasing compact seqs", {
+  start <- 2L
+  size <- 2L
+  increasing <- FALSE
+  expect_identical(vec_slice_seq(lgl(1, 0, 1), start, size, increasing), lgl(1, 0))
+  expect_identical(vec_slice_seq(int(1, 2, 3), start, size, increasing), int(3, 2))
+  expect_identical(vec_slice_seq(dbl(1, 2, 3), start, size, increasing), dbl(3, 2))
+  expect_identical(vec_slice_seq(cpl(1, 2, 3), start, size, increasing), cpl(3, 2))
+  expect_identical(vec_slice_seq(chr("1", "2", "3"), start, size, increasing), chr("3", "2"))
+  expect_identical(vec_slice_seq(bytes(1, 2, 3), start, size, increasing), bytes(3, 2))
+  expect_identical(vec_slice_seq(list(1, 2, 3), start, size, increasing), list(3, 2))
+})
+
+test_that("can subset base vectors with size 0 compact seqs", {
+  start <- 1L
+  size <- 0L
+  increasing <- TRUE
+  expect_identical(vec_slice_seq(lgl(1, 0, 1), start, size, increasing), lgl())
+  expect_identical(vec_slice_seq(int(1, 2, 3), start, size, increasing), int())
+  expect_identical(vec_slice_seq(dbl(1, 2, 3), start, size, increasing), dbl())
+  expect_identical(vec_slice_seq(cpl(1, 2, 3), start, size, increasing), cpl())
+  expect_identical(vec_slice_seq(chr("1", "2", "3"), start, size, increasing), chr())
+  expect_identical(vec_slice_seq(bytes(1, 2, 3), start, size, increasing), bytes())
+  expect_identical(vec_slice_seq(list(1, 2, 3), start, size, increasing), list())
+})
+
+test_that("can subset shaped base vectors with compact seqs", {
+  start <- 1L
+  size <- 2L
+  increasing <- TRUE
+  mat <- as.matrix
+  expect_identical(vec_slice_seq(mat(lgl(1, 0, 1)), start, size, increasing), mat(lgl(0, 1)))
+  expect_identical(vec_slice_seq(mat(int(1, 2, 3)), start, size, increasing), mat(int(2, 3)))
+  expect_identical(vec_slice_seq(mat(dbl(1, 2, 3)), start, size, increasing), mat(dbl(2, 3)))
+  expect_identical(vec_slice_seq(mat(cpl(1, 2, 3)), start, size, increasing), mat(cpl(2, 3)))
+  expect_identical(vec_slice_seq(mat(chr("1", "2", "3")), start, size, increasing), mat(chr("2", "3")))
+  expect_identical(vec_slice_seq(mat(bytes(1, 2, 3)), start, size, increasing), mat(bytes(2, 3)))
+  expect_identical(vec_slice_seq(mat(list(1, 2, 3)), start, size, increasing), mat(list(2, 3)))
+})
+
+test_that("can subset shaped base vectors with decreasing compact seqs", {
+  start <- 2L
+  size <- 2L
+  increasing <- FALSE
+  mat <- as.matrix
+  expect_identical(vec_slice_seq(mat(lgl(1, 0, 1)), start, size, increasing), mat(lgl(1, 0)))
+  expect_identical(vec_slice_seq(mat(int(1, 2, 3)), start, size, increasing), mat(int(3, 2)))
+  expect_identical(vec_slice_seq(mat(dbl(1, 2, 3)), start, size, increasing), mat(dbl(3, 2)))
+  expect_identical(vec_slice_seq(mat(cpl(1, 2, 3)), start, size, increasing), mat(cpl(3, 2)))
+  expect_identical(vec_slice_seq(mat(chr("1", "2", "3")), start, size, increasing), mat(chr("3", "2")))
+  expect_identical(vec_slice_seq(mat(bytes(1, 2, 3)), start, size, increasing), mat(bytes(3, 2)))
+  expect_identical(vec_slice_seq(mat(list(1, 2, 3)), start, size, increasing), mat(list(3, 2)))
+})
+
+test_that("can subset shaped base vectors with size 0 compact seqs", {
+  start <- 1L
+  size <- 0L
+  increasing <- TRUE
+  mat <- as.matrix
+  expect_identical(vec_slice_seq(mat(lgl(1, 0, 1)), start, size, increasing), mat(lgl()))
+  expect_identical(vec_slice_seq(mat(int(1, 2, 3)), start, size, increasing), mat(int()))
+  expect_identical(vec_slice_seq(mat(dbl(1, 2, 3)), start, size, increasing), mat(dbl()))
+  expect_identical(vec_slice_seq(mat(cpl(1, 2, 3)), start, size, increasing), mat(cpl()))
+  expect_identical(vec_slice_seq(mat(chr("1", "2", "3")), start, size, increasing), mat(chr()))
+  expect_identical(vec_slice_seq(mat(bytes(1, 2, 3)), start, size, increasing), mat(bytes()))
+  expect_identical(vec_slice_seq(mat(list(1, 2, 3)), start, size, increasing), mat(list()))
+})
+
+test_that("can subset object of any dimensionality with compact seqs", {
+  x0 <- c(1, 1)
+  x1 <- ones(2)
+  x2 <- ones(2, 3)
+  x3 <- ones(2, 3, 4)
+  x4 <- ones(2, 3, 4, 5)
+
+  expect_equal(vec_slice_seq(x0, 0L, 1L), 1)
+  expect_identical(vec_slice_seq(x1, 0L, 1L), ones(1))
+  expect_identical(vec_slice_seq(x2, 0L, 1L), ones(1, 3))
+  expect_identical(vec_slice_seq(x3, 0L, 1L), ones(1, 3, 4))
+  expect_identical(vec_slice_seq(x4, 0L, 1L), ones(1, 3, 4, 5))
+})
+
+test_that("can subset data frames with compact seqs", {
+  df <- data_frame(x = 1:5, y = letters[1:5])
+  expect_equal(vec_slice_seq(df, 0L, 0L), vec_slice(df, integer()))
+  expect_equal(vec_slice_seq(df, 0L, 1L), vec_slice(df, 1L))
+  expect_equal(vec_slice_seq(df, 0L, 3L), vec_slice(df, 1:3))
+  expect_equal(vec_slice_seq(df, 2L, 3L, FALSE), vec_slice(df, 3:1))
+
+  df$df <- df
+  expect_equal(vec_slice_seq(df, 0L, 0L), vec_slice(df, integer()))
+  expect_equal(vec_slice_seq(df, 0L, 1L), vec_slice(df, 1L))
+  expect_equal(vec_slice_seq(df, 0L, 3L), vec_slice(df, 1:3))
+  expect_equal(vec_slice_seq(df, 2L, 3L, FALSE), vec_slice(df, 3:1))
+})
+
+test_that("can subset S3 objects using the fallback method with compact seqs", {
+  x <- factor(c("a", "b", "c", "d"))
+  expect_equal(vec_slice_seq(x, 0L, 0L), vec_slice(x, integer()))
+  expect_equal(vec_slice_seq(x, 0L, 1L), vec_slice(x, 1L))
+  expect_equal(vec_slice_seq(x, 2L, 2L), vec_slice(x, 3:4))
+  expect_equal(vec_slice_seq(x, 3L, 2L, FALSE), vec_slice(x, 4:3))
+})


### PR DESCRIPTION
Closes #490 
Closes #489 

This PR does two things:

- It teaches `vec_slice_impl()` how to work with `compact_seq()` objects
- It allows `compact_seq()`s to be negative by redefining a `compact_seq()` object in terms of a start location, a total size, and a step size (`+/-1`). Both `vec_slice_impl()` and `vec_assign_impl()` know how to deal with this.

We don't have a use case for this in vctrs, but I do have a potential use case for this in a C impl of `slide()` so I figured I would add it. 

I have exposed `vec_slice_seq()` to the R side for testing purposes.

Notes: 

- `compact_seq()`s are now _inclusive_ on both endpoints: `[from, to]` rather than the previous behavior of `[from, to)`. The original behavior was a bit hard to reason about with decreasing sequences, and kept you from being able to compute a decreasing sequence with only the 1st value, i.e. you would try `[0, 0)` but the size of the sequence would be computed as 0 and the sequence would be empty. Now it would be computed as `[0, 0]`, which is a sequence of 1 value at position 1.

- You can't have a seq with `NA` in it, so you'll see that `NA_VALUE` is not passed through in the macros.

- The use of `memcpy()` in `ASSIGN_COMPACT` was replaced with an assignment loop to be compatible with decreasing compact sequences. A few bench marks didn't show any loss in performance.

Using `compact_seq()`s in `vec_slice_impl()` can have some nice performance improvements:

``` r
library(nycflights13)
library(vctrs)

x <- flights

nrow(x)
#> [1] 336776

vec_slice_seq <- vctrs:::vec_slice_seq

bench::mark(
  vec_slice_seq(x, 0L, 99999L),
  vec_slice(x, 1:100000),
  x[1:100000,],
  iterations = 1000
)
#> # A tibble: 3 x 6
#>   expression                       min  median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                   <bch:t> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 vec_slice_seq(x, 0L, 99999L)  1.66ms  2.34ms      407.    11.8MB    116. 
#> 2 vec_slice(x, 1:1e+05)         1.93ms  2.64ms      372.    11.8MB    101. 
#> 3 x[1:1e+05, ]                  4.38ms  5.93ms      170.    11.9MB     47.0

year <- x$year

bench::mark(
  vec_slice_seq(year, 0L, 99999L),
  vec_slice(year, 1:100000),
  year[1:100000],
  iterations = 5000
)
#> # A tibble: 3 x 6
#>   expression                          min  median `itr/sec` mem_alloc
#>   <bch:expr>                      <bch:t> <bch:t>     <dbl> <bch:byt>
#> 1 vec_slice_seq(year, 0L, 99999L)  36.8µs  62.4µs    16129.     391KB
#> 2 vec_slice(year, 1:1e+05)        143.9µs 219.7µs     4418.     781KB
#> 3 year[1:1e+05]                   186.3µs 263.1µs     3908.     781KB
#> # … with 1 more variable: `gc/sec` <dbl>
```