### PR TITLE
Don't overwrite `locations` in `stop_lossy_cast()`

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -256,8 +256,9 @@ stop_lossy_cast <- function(x, to, result,
                             to_arg = "",
                             message = NULL,
                             .subclass = NULL) {
+  locations_message <- locations
   if (length(locations)) {
-    locations <- inline_list("Locations: ", locations)
+    locations_message <- inline_list("Locations: ", locations_message)
   }
 
   if (is_null(message)) {
@@ -266,7 +267,7 @@ stop_lossy_cast <- function(x, to, result,
 
     message <- glue_lines(
       "Lossy cast from {x_label} to {to_label}.",
-      locations,
+      locations_message,
       details
     )
   }


### PR DESCRIPTION
Closes #483 

In #483 I suggested that `lossy` should be passed through so it can be used when rethrowing the error. Actually we just need `locations` to not be overwritten when creating the message. 

I'm guessing this was the intention to begin with. The `locations` object that gets embedded in the condition should be the integer locations, not a character string that get's printed out.