### PR TITLE
Implement `new_list_of()` and `init_list_of()` in C

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -432,10 +432,8 @@ SEXP vctrs_split_id(SEXP x) {
   SEXP key_id = PROTECT_N(Rf_allocVector(INTSXP, d.used), &nprot);
   int* p_key_id = INTEGER(key_id);
 
-  // TODO - Replace ad hoc construction of `list_of<int>` with constructor
   SEXP out_id = PROTECT_N(Rf_allocVector(VECSXP, d.used), &nprot);
-  Rf_setAttrib(out_id, R_ClassSymbol, classes_list_of);
-  Rf_setAttrib(out_id, syms_ptype, vctrs_shared_empty_int);
+  init_list_of(out_id, vctrs_shared_empty_int);
 
   SEXP counters = PROTECT_N(Rf_allocVector(INTSXP, d.used), &nprot);
   int* p_counters = INTEGER(counters);

--- a/src/type-list-of.c
+++ b/src/type-list-of.c
@@ -1,0 +1,26 @@
+#include "vctrs.h"
+#include "utils.h"
+
+// [[ include("utils.h") ]]
+SEXP new_list_of(SEXP x, SEXP ptype) {
+  if (TYPEOF(x) != VECSXP) {
+    Rf_errorcall(R_NilValue, "Internal error: `x` must be a list.");
+  }
+
+  if (vec_size(ptype) != 0) {
+    Rf_errorcall(R_NilValue, "Internal error: `ptype` must be a prototype with size 0.");
+  }
+
+  x = PROTECT(r_maybe_duplicate(x));
+
+  init_list_of(x, ptype);
+
+  UNPROTECT(1);
+  return x;
+}
+
+// [[ include("utils.h") ]]
+void init_list_of(SEXP x, SEXP ptype) {
+  Rf_setAttrib(x, R_ClassSymbol, classes_list_of);
+  Rf_setAttrib(x, syms_ptype, ptype);
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -161,6 +161,28 @@ SEXP vctrs_set_attributes(SEXP x, SEXP attrib) {
   return x;
 }
 
+SEXP new_list_of(SEXP x, SEXP ptype) {
+  if (TYPEOF(x) != VECSXP) {
+    Rf_errorcall(R_NilValue, "Internal error: `x` must be a list.");
+  }
+
+  if (vec_size(ptype) != 0) {
+    Rf_errorcall(R_NilValue, "Internal error: `ptype` must be a prototype with size 0.");
+  }
+
+  x = PROTECT(r_maybe_duplicate(x));
+
+  init_list_of(x, ptype);
+
+  UNPROTECT(1);
+  return x;
+}
+
+void init_list_of(SEXP x, SEXP ptype) {
+  Rf_setAttrib(x, R_ClassSymbol, classes_list_of);
+  Rf_setAttrib(x, syms_ptype, ptype);
+}
+
 SEXP map(SEXP x, SEXP (*fn)(SEXP)) {
   R_len_t n = Rf_length(x);
   SEXP out = PROTECT(Rf_allocVector(VECSXP, n));

--- a/src/utils.c
+++ b/src/utils.c
@@ -161,28 +161,6 @@ SEXP vctrs_set_attributes(SEXP x, SEXP attrib) {
   return x;
 }
 
-SEXP new_list_of(SEXP x, SEXP ptype) {
-  if (TYPEOF(x) != VECSXP) {
-    Rf_errorcall(R_NilValue, "Internal error: `x` must be a list.");
-  }
-
-  if (vec_size(ptype) != 0) {
-    Rf_errorcall(R_NilValue, "Internal error: `ptype` must be a prototype with size 0.");
-  }
-
-  x = PROTECT(r_maybe_duplicate(x));
-
-  init_list_of(x, ptype);
-
-  UNPROTECT(1);
-  return x;
-}
-
-void init_list_of(SEXP x, SEXP ptype) {
-  Rf_setAttrib(x, R_ClassSymbol, classes_list_of);
-  Rf_setAttrib(x, syms_ptype, ptype);
-}
-
 SEXP map(SEXP x, SEXP (*fn)(SEXP)) {
   R_len_t n = Rf_length(x);
   SEXP out = PROTECT(Rf_allocVector(VECSXP, n));

--- a/src/utils.h
+++ b/src/utils.h
@@ -64,6 +64,9 @@ void never_reached(const char* fn) __attribute__((noreturn));
 
 enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x, enum vctrs_type type_y, int* left);
 
+SEXP new_list_of(SEXP x, SEXP ptype);
+void init_list_of(SEXP x, SEXP ptype);
+
 SEXP new_data_frame(SEXP x, R_len_t n);
 void init_data_frame(SEXP x, R_len_t n);
 void init_tibble(SEXP x, R_len_t n);


### PR DESCRIPTION
Closes #517 

I tried following the `new_data_frame()` + `init_data_frame()` model. This is nice because we can do the bare minimum in `vctrs_split_id()` by using `init_list_of()` where we _know_ the input is correct. That will be tested by `vec_split_id()` tests which compare against objects created with the R level `list_of()`.

Questions:

`new_list_of()` currently has no use, but I feel like it will be used eventually. So there are no tests for it. I'm not sure what to do here.

Should I put these in a new `type-list-of.c` file? Or keep them in `utils.c`?