### PR TITLE
Generalize `vec_split_along()` to implement `vec_split()` in C

### DIFF
--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -269,6 +269,10 @@ vec_split <- function(x, by) {
   out
 }
 
+vec_split2 <- function(x, by) {
+  .Call(vctrs_split, x, by)
+}
+
 #' Locate unique groups in a vector
 #'
 #' This locates unique groups in `x` and returns both the unique values and

--- a/R/slice.R
+++ b/R/slice.R
@@ -194,8 +194,8 @@ vec_init <- function(x, n = 1L) {
 }
 
 # Used internally by `vec_rbind()`, but exported for testing
-vec_split_along <- function(x) {
-  .Call(vctrs_split_along, x)
+vec_split_along <- function(x, indices = NULL) {
+  .Call(vctrs_split_along, x, indices)
 }
 
 # Exposed for testing (`start` is 0-based)

--- a/src/bind.c
+++ b/src/bind.c
@@ -169,7 +169,7 @@ static SEXP as_df_row_impl(SEXP x, enum name_repair_arg name_repair, bool quiet)
     nms = PROTECT_N(vec_as_names(nms, name_repair, quiet), &nprot);
   }
 
-  x = vec_split_along(x);
+  x = vec_split_along(x, R_NilValue, false);
 
   r_poke_names(x, nms);
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -489,11 +489,10 @@ SEXP vec_split(SEXP x, SEXP by) {
 
   SEXP indices = VECTOR_ELT(out, 1);
 
-  SEXP val = PROTECT(vec_split_along(x, indices, false));
+  SEXP ptype = PROTECT(vec_type(x));
 
-  // init_list_of()
-  Rf_setAttrib(val, R_ClassSymbol, classes_list_of);
-  Rf_setAttrib(val, syms_ptype, vec_type(x));
+  SEXP val = PROTECT(vec_split_along(x, indices, false));
+  init_list_of(val, ptype);
 
   SET_VECTOR_ELT(out, 1, val);
 
@@ -501,7 +500,7 @@ SEXP vec_split(SEXP x, SEXP by) {
   SET_STRING_ELT(names, 1, Rf_mkChar("val"));
   Rf_setAttrib(out, R_NamesSymbol, names);
 
-  UNPROTECT(3);
+  UNPROTECT(4);
   return out;
 }
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -497,7 +497,7 @@ SEXP vec_split(SEXP x, SEXP by) {
   SET_VECTOR_ELT(out, 1, val);
 
   SEXP names = PROTECT(Rf_getAttrib(out, R_NamesSymbol));
-  SET_STRING_ELT(names, 1, Rf_mkChar("val"));
+  SET_STRING_ELT(names, 1, strings_val);
   Rf_setAttrib(out, R_NamesSymbol, names);
 
   UNPROTECT(4);

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -391,7 +391,7 @@ SEXP vctrs_duplicated(SEXP x) {
   return out;
 }
 
-SEXP vctrs_split_id(SEXP x) {
+SEXP vec_split_id(SEXP x) {
   int nprot = 0;
 
   SEXP proxy = PROTECT_N(vec_proxy_equal(x), &nprot);
@@ -477,6 +477,31 @@ SEXP vctrs_split_id(SEXP x) {
   out = new_data_frame(out, d.used);
 
   UNPROTECT(nprot);
+  return out;
+}
+
+SEXP vec_split(SEXP x, SEXP by) {
+  if (vec_size(x) != vec_size(by)) {
+    Rf_errorcall(R_NilValue, "`x` and `by` must have the same size.");
+  }
+
+  SEXP out = PROTECT(vec_split_id(by));
+
+  SEXP indices = VECTOR_ELT(out, 1);
+
+  SEXP val = PROTECT(vec_split_along(x, indices, false));
+
+  // init_list_of()
+  Rf_setAttrib(val, R_ClassSymbol, classes_list_of);
+  Rf_setAttrib(val, syms_ptype, vec_type(x));
+
+  SET_VECTOR_ELT(out, 1, val);
+
+  SEXP names = PROTECT(Rf_getAttrib(out, R_NamesSymbol));
+  SET_STRING_ELT(names, 1, Rf_mkChar("val"));
+  Rf_setAttrib(out, R_NamesSymbol, names);
+
+  UNPROTECT(3);
   return out;
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -19,7 +19,8 @@ extern SEXP vctrs_hash_object(SEXP);
 extern SEXP vctrs_equal_object(SEXP, SEXP, SEXP);
 extern SEXP vctrs_in(SEXP, SEXP);
 extern SEXP vctrs_duplicated(SEXP);
-extern SEXP vctrs_split_id(SEXP);
+extern SEXP vec_split_id(SEXP);
+extern SEXP vec_split(SEXP, SEXP);
 extern SEXP vctrs_unique_loc(SEXP);
 extern SEXP vctrs_count(SEXP);
 extern SEXP vctrs_id(SEXP);
@@ -40,7 +41,7 @@ extern SEXP vctrs_typeof2(SEXP, SEXP);
 extern SEXP vctrs_cast(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_as_index(SEXP, SEXP, SEXP);
 extern SEXP vctrs_slice(SEXP, SEXP);
-extern SEXP vec_split_along(SEXP);
+extern SEXP vctrs_split_along(SEXP, SEXP);
 extern SEXP vec_slice_seq(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_restore(SEXP, SEXP, SEXP);
 extern SEXP vec_restore_default(SEXP, SEXP);
@@ -89,7 +90,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_in",                         (DL_FUNC) &vctrs_in, 2},
   {"vctrs_unique_loc",                 (DL_FUNC) &vctrs_unique_loc, 1},
   {"vctrs_duplicated",                 (DL_FUNC) &vctrs_duplicated, 1},
-  {"vctrs_split_id",                   (DL_FUNC) &vctrs_split_id, 1},
+  {"vctrs_split_id",                   (DL_FUNC) &vec_split_id, 1},
+  {"vctrs_split",                      (DL_FUNC) &vec_split, 2},
   {"vctrs_duplicated_any",             (DL_FUNC) &vctrs_duplicated_any, 1},
   {"vctrs_count",                      (DL_FUNC) &vctrs_count, 1},
   {"vctrs_id",                         (DL_FUNC) &vctrs_id, 1},
@@ -110,7 +112,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_cast",                       (DL_FUNC) &vctrs_cast, 4},
   {"vctrs_as_index",                   (DL_FUNC) &vctrs_as_index, 3},
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 2},
-  {"vctrs_split_along",                (DL_FUNC) &vec_split_along, 1},
+  {"vctrs_split_along",                (DL_FUNC) &vctrs_split_along, 2},
   {"vctrs_slice_seq",                  (DL_FUNC) &vec_slice_seq, 4},
   {"vctrs_restore",                    (DL_FUNC) &vec_restore, 3},
   {"vctrs_restore_default",            (DL_FUNC) &vec_restore_default, 2},

--- a/src/slice.c
+++ b/src/slice.c
@@ -839,6 +839,8 @@ SEXP split_along_df(SEXP x, SEXP indices, bool check_index, struct vctrs_proxy_i
   R_len_t x_size = vec_size(x);
   R_len_t out_size = has_indices ? vec_size(indices) : x_size;
 
+  int restore_sizes[out_size];
+
   PROTECT_INDEX index_prot_idx;
   SEXP index = r_int(0);
   PROTECT_WITH_INDEX(index, &index_prot_idx);
@@ -864,6 +866,7 @@ SEXP split_along_df(SEXP x, SEXP indices, bool check_index, struct vctrs_proxy_i
   for (int i = 0; i < out_size; ++i) {
     if (has_indices) {
       index = VECTOR_ELT(indices, i);
+      restore_sizes[i] = vec_size(index);
 
       // If we have to check the index, we also update it
       if (check_index) {
@@ -873,6 +876,7 @@ SEXP split_along_df(SEXP x, SEXP indices, bool check_index, struct vctrs_proxy_i
       }
     } else {
       ++(*p_index);
+      restore_sizes[i] = 1;
     }
 
     if (has_row_names) {
@@ -901,7 +905,7 @@ SEXP split_along_df(SEXP x, SEXP indices, bool check_index, struct vctrs_proxy_i
   // Restore each data frame
   for (int i = 0; i < out_size; ++i) {
     SEXP elt = VECTOR_ELT(out, i);
-    elt = vec_restore(elt, x, R_NilValue);
+    elt = vec_restore(elt, x, Rf_ScalarInteger(restore_sizes[i]));
     SET_VECTOR_ELT(out, i, elt);
   }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -928,6 +928,7 @@ SEXP strings_universal = NULL;
 SEXP strings_check_unique = NULL;
 SEXP strings_key = NULL;
 SEXP strings_id = NULL;
+SEXP strings_val = NULL;
 
 SEXP syms_i = NULL;
 SEXP syms_n = NULL;
@@ -967,7 +968,7 @@ void vctrs_init_utils(SEXP ns) {
 
   // Holds the CHARSXP objects because unlike symbols they can be
   // garbage collected
-  strings = Rf_allocVector(STRSXP, 13);
+  strings = Rf_allocVector(STRSXP, 14);
   R_PreserveObject(strings);
 
   strings_dots = Rf_mkChar("...");
@@ -1008,6 +1009,9 @@ void vctrs_init_utils(SEXP ns) {
 
   strings_id = Rf_mkChar("id");
   SET_STRING_ELT(strings, 12, strings_id);
+
+  strings_val = Rf_mkChar("val");
+  SET_STRING_ELT(strings, 13, strings_val);
 
 
   classes_data_frame = Rf_allocVector(STRSXP, 1);

--- a/src/utils.h
+++ b/src/utils.h
@@ -216,6 +216,7 @@ extern SEXP strings_universal;
 extern SEXP strings_check_unique;
 extern SEXP strings_key;
 extern SEXP strings_id;
+extern SEXP strings_val;
 
 extern SEXP syms_i;
 extern SEXP syms_n;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -213,7 +213,7 @@ SEXP vec_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg
 SEXP vec_cast_common(SEXP xs, SEXP to);
 SEXP vec_coercible_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_slice(SEXP x, SEXP index);
-SEXP vec_split_along(SEXP x);
+SEXP vec_split_along(SEXP x, SEXP indices, bool check_index);
 SEXP vec_slice_shaped(enum vctrs_type type, SEXP x, SEXP index);
 SEXP vec_assign(SEXP x, SEXP index, SEXP value);
 SEXP vec_init(SEXP x, R_len_t n);


### PR DESCRIPTION
I've generalized `vec_split_along()` to be more useful. Rather than just mimicking a faster version of:

```
indices <- as.list(vec_seq_along(x))
map(indices, vec_slice, x = x)
```

It can now take an arbitrary list of integer `indices`. The signature is now `vec_split_along(x, indices = NULL)` with `NULL` defaulting to the original behavior. 

The reason this is useful is for using it in `vec_split()`. Currently there is a call to:

```
x_split <- map(out$id, vec_slice, x = x)
```

This can be completely replaced with the new version of `vec_split_along()`, and then a C version of `vec_split()` can be written.

Below are a large number of benchmarks. The tl;dr is that the new versions of `vec_split_along()` and `vec_split()` perform much better than their older alternatives in most cases, and never perform worse. Vectors have a much more dramatic performance boost than data frames. Generally, the more unique values you have to split by, the bigger the performance gap.

`vec_split_along()` benchmarks:

<details>

``` r
library(nycflights13)
library(purrr)
library(vctrs)

vec_split_along <- vctrs:::vec_split_along

x <- flights[1:3]

# `vec_split_along()` generally outperforms repeated `vec_slice()`ing
idx <- rep_len(list(1:50), 10000)
bench::mark(
  vec_split_along(x, idx),
  map(idx, vec_slice, x = x),
  iterations = 100
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split_along(x, idx)      12.4ms   23.5ms     35.7     7.17MB     14.3
#> 2 map(idx, vec_slice, x = x)   66.2ms  104.6ms      9.20    7.22MB     24.1

# take a long factor and repeatedly subset the first 1000 values
z <- factor(rep(letters, times = 1000))
z_idx <- rep_len(list(1:1000), 1000)

bench::mark(
  vec_split_along(z, z_idx),
  map(z_idx, vec_slice, x = z)
)
#> # A tibble: 2 x 6
#>   expression                        min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                   <bch:tm> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split_along(z, z_idx)      9.13ms 10.7ms      93.0    3.88MB     22.6
#> 2 map(z_idx, vec_slice, x = z)  13.85ms   15ms      62.3    3.87MB     19.8

# take a long integer and repeatedly subset the first 1000 values
w <- 1:100000 + 0L
w_idx <- rep_len(list(1:1000), 1000)

bench::mark(
  vec_split_along(w, w_idx),
  map(w_idx, vec_slice, x = w),
  iterations = 1000
)
#> # A tibble: 2 x 6
#>   expression                       min  median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                   <bch:t> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split_along(w, w_idx)     1.32ms  1.74ms      544.    3.87MB     32.9
#> 2 map(w_idx, vec_slice, x = w)  1.95ms  2.37ms      409.    3.87MB     22.9

# mimic the defaults of `vec_split_along()`, i.e. split `a` along its size
# (as expected, the default method is slightly faster than supplying the index)
# (but both are much faster than repeated slicing)
a <- 1:100000 + 0L
a_idx <- as.list(vec_seq_along(a))

bench::mark(
  vec_split_along(a),
  vec_split_along(a, a_idx),
  map(a_idx, vec_slice, x = a),
  iterations = 100
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 3 x 6
#>   expression                       min   median `itr/sec` mem_alloc
#>   <bch:expr>                   <bch:t> <bch:tm>     <dbl> <bch:byt>
#> 1 vec_split_along(a)            3.79ms   4.49ms    172.       781KB
#> 2 vec_split_along(a, a_idx)     6.59ms   8.51ms    110.       781KB
#> 3 map(a_idx, vec_slice, x = a) 82.01ms 130.72ms      7.38     781KB
#> # … with 1 more variable: `gc/sec` <dbl>
```

<sup>Created on 2019-07-31 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

</details>

`vec_split()` benchmarks:

<details>

``` r

library(nycflights13)
library(purrr)
library(vctrs)

# A pure C version of vec_split() using the new vec_split_along()
vec_split2 <- vctrs:::vec_split2

# all unique
int <- 1:5000
bench::mark(
  vec_split(int, int),
  vec_split2(int, int)
)
#> # A tibble: 2 x 6
#>   expression                min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>           <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split(int, int)    3.81ms    4.6ms      217.     512KB     26.0
#> 2 vec_split2(int, int) 535.31µs  674.7µs     1447.     315KB     21.7

# all same
same_idx <- rep(1L, 5000)
bench::mark(
  vec_split(int, same_idx),
  vec_split2(int, same_idx)
)
#> # A tibble: 2 x 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split(int, same_idx)     103µs  136.2µs     6916.     174KB     20.6
#> 2 vec_split2(int, same_idx)     79µs   94.9µs    10127.     174KB     33.8

# large all unique
bench::mark(
  vec_split(1:50000, 1:50000),
  vec_split2(1:50000, 1:50000),
  iterations = 50
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 x 6
#>   expression                        min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                   <bch:tm> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split(1:50000, 1:50000)   57.92ms   85ms      10.6    3.99MB     22.7
#> 2 vec_split2(1:50000, 1:50000)   8.63ms 14.5ms      55.4    3.23MB     17.7

# two groups
idx <- c(rep(1, 2500), rep(2, 2500))
bench::mark(
  vec_split(1:5000, idx),
  vec_split2(1:5000, idx)
)
#> # A tibble: 2 x 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split(1:5000, idx)     154µs    192µs     5222.     194KB     18.4
#> 2 vec_split2(1:5000, idx)    123µs    153µs     6594.     194KB     25.0


fctr <- factor(rep(letters, 20000))
length(fctr)
#> [1] 520000

# factor - 2 groups
fctr_idx <- sample.int(2, size = length(fctr), replace = TRUE)
bench::mark(
  vec_split(fctr, fctr_idx),
  vec_split2(fctr, fctr_idx),
  iterations = 100
)
#> # A tibble: 2 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split(fctr, fctr_idx)    11.2ms   12.5ms      80.6    19.9MB     157.
#> 2 vec_split2(fctr, fctr_idx)   10.6ms   11.3ms      87.0    19.9MB     120.

# factor - 1000 unique groups
fctr_idx <- sample.int(1000, size = length(fctr), replace = TRUE)
bench::mark(
  vec_split(fctr, fctr_idx),
  vec_split2(fctr, fctr_idx),
  iterations = 100
)
#> # A tibble: 2 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split(fctr, fctr_idx)    21.6ms   25.1ms      39.6    20.1MB     80.2
#> 2 vec_split2(fctr, fctr_idx)   17.1ms   19.6ms      51.0    20.1MB     65.7


# lists - all unique
lst <- rep_len(list(1), 10000)
lst_idx <- vec_seq_along(lst)
bench::mark(
  vec_split(lst, lst_idx),
  vec_split2(lst, lst_idx)
)
#> # A tibble: 2 x 6
#>   expression                    min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>               <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split(lst, lst_idx)    8.65ms   9.16ms      108.     818KB     38.9
#> 2 vec_split2(lst, lst_idx)   1.12ms   1.37ms      709.     622KB     30.7

# small data frame
bench::mark(
  vec_split(mtcars, mtcars["cyl"]),
  vec_split2(mtcars, mtcars["cyl"])
)
#> # A tibble: 2 x 6
#>   expression                           min median `itr/sec` mem_alloc
#>   <bch:expr>                        <bch:> <bch:>     <dbl> <bch:byt>
#> 1 vec_split(mtcars, mtcars["cyl"])  73.2µs 89.6µs    11172.   18.07KB
#> 2 vec_split2(mtcars, mtcars["cyl"]) 37.7µs 47.8µs    20963.    1.26KB
#> # … with 1 more variable: `gc/sec` <dbl>

# large data frame - split by data frame with few unique values
# (not much performance boost)
bench::mark(
  vec_split(flights, flights["month"]),
  vec_split2(flights, flights["month"]),
  iterations = 100
)
#> # A tibble: 2 x 6
#>   expression                               min median `itr/sec` mem_alloc
#>   <bch:expr>                            <bch:> <bch:>     <dbl> <bch:byt>
#> 1 vec_split(flights, flights["month"])  39.9ms 47.3ms      21.0   179.5MB
#> 2 vec_split2(flights, flights["month"]) 40.6ms 43.9ms      22.3    48.4MB
#> # … with 1 more variable: `gc/sec` <dbl>

# large data frame - split by vector with few unique values
# (not much performance boost)
bench::mark(
  vec_split(flights, flights$month),
  vec_split2(flights, flights$month),
  iterations = 100
)
#> # A tibble: 2 x 6
#>   expression                            min median `itr/sec` mem_alloc
#>   <bch:expr>                         <bch:> <bch:>     <dbl> <bch:byt>
#> 1 vec_split(flights, flights$month)  11.7ms 14.1ms      68.7    48.4MB
#> 2 vec_split2(flights, flights$month) 10.9ms 13.6ms      72.4    48.4MB
#> # … with 1 more variable: `gc/sec` <dbl>

# large data frame - split by data frame with many unique values
# (more performance boost here)
vec_unique_count(flights["tailnum"])
#> [1] 4044

bench::mark(
  vec_split(flights, flights["tailnum"]),
  vec_split2(flights, flights["tailnum"]),
  iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 x 6
#>   expression                                min median `itr/sec` mem_alloc
#>   <bch:expr>                              <bch> <bch:>     <dbl> <bch:byt>
#> 1 vec_split(flights, flights["tailnum"])  215ms  239ms      3.86    51.5MB
#> 2 vec_split2(flights, flights["tailnum"]) 195ms  218ms      4.36    51.4MB
#> # … with 1 more variable: `gc/sec` <dbl>

# large data frame - split by vector with many unique values
# (more performance boost here)
bench::mark(
  vec_split(flights, flights$tailnum),
  vec_split2(flights, flights$tailnum),
  iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 x 6
#>   expression                             min median `itr/sec` mem_alloc
#>   <bch:expr>                           <bch> <bch:>     <dbl> <bch:byt>
#> 1 vec_split(flights, flights$tailnum)  172ms  199ms      4.78    51.5MB
#> 2 vec_split2(flights, flights$tailnum) 137ms  165ms      5.34    51.4MB
#> # … with 1 more variable: `gc/sec` <dbl>

# medium sized data frame
# has dbl/int/chr cols
mini_flights <- flights[1:1000, 6:10]

# split by a vector that only has 14 groups
bench::mark(
  vec_split(mini_flights, mini_flights$carrier),
  vec_split2(mini_flights, mini_flights$carrier)
)
#> # A tibble: 2 x 6
#>   expression                                         min  median `itr/sec`
#>   <bch:expr>                                     <bch:t> <bch:t>     <dbl>
#> 1 vec_split(mini_flights, mini_flights$carrier)  165.8µs 194.1µs     4865.
#> 2 vec_split2(mini_flights, mini_flights$carrier)  60.2µs  78.8µs    12054.
#> # … with 2 more variables: mem_alloc <bch:byt>, `gc/sec` <dbl>

# ~2/3 unique
vec_unique_count(mini_flights$arr_time)
#> [1] 640

bench::mark(
  vec_split(mini_flights, mini_flights$arr_time),
  vec_split2(mini_flights, mini_flights$arr_time)
)
#> # A tibble: 2 x 6
#>   expression                                           min median `itr/sec`
#>   <bch:expr>                                      <bch:tm> <bch:>     <dbl>
#> 1 vec_split(mini_flights, mini_flights$arr_time)    4.33ms 4.92ms      188.
#> 2 vec_split2(mini_flights, mini_flights$arr_time)  868.2µs 1.03ms      894.
#> # … with 2 more variables: mem_alloc <bch:byt>, `gc/sec` <dbl>

# arrays - all unique
arr <- array(1:20000, c(2000, 10))
arr_idx <- vec_seq_along(arr)
bench::mark(
  vec_split(arr, arr_idx),
  vec_split2(arr, arr_idx)
)
#> # A tibble: 2 x 6
#>   expression                    min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>               <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split(arr, arr_idx)    2.75ms   3.12ms      299.     174KB     13.0
#> 2 vec_split2(arr, arr_idx)   1.04ms   1.25ms      738.     134KB     13.2

# arrays - 3 groups
arr2 <- array(1:20000, c(2000, 10))
arr2_idx <- rep(1:3, length.out = nrow(arr2))
bench::mark(
  vec_split(arr2, arr2_idx),
  vec_split2(arr2, arr2_idx)
)
#> # A tibble: 2 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split(arr2, arr2_idx)    91.8µs  129.7µs     7766.     150KB     6.66
#> 2 vec_split2(arr2, arr2_idx)   58.8µs   82.3µs    11246.     150KB     9.37

# arrays - 3 groups - many columns
arr3 <- array(1:20000, c(10, 2000))
arr3_idx <- rep(1:3, length.out = nrow(arr3))
bench::mark(
  vec_split(arr3, arr3_idx),
  vec_split2(arr3, arr3_idx)
)
#> # A tibble: 2 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split(arr3, arr3_idx)      67µs   90.9µs    10606.    78.3KB     4.22
#> 2 vec_split2(arr3, arr3_idx)   44.4µs   58.2µs    16261.    78.3KB     9.10
```

<sup>Created on 2019-07-31 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

</details>