### PR TITLE
Fix data frame & proxied object name handling in `vec_c()`

### DIFF
--- a/R/names.R
+++ b/R/names.R
@@ -463,8 +463,14 @@ tick_if_needed <- function(x) {
 }
 
 # Used in names.c
-set_rownames <- function(x, names) {
+set_rownames_fallback <- function(x, names) {
   rownames(x) <- names
+  x
+}
+
+# Used in names.c
+set_names_fallback <- function(x, names) {
+  names(x) <- names
   x
 }
 

--- a/R/names.R
+++ b/R/names.R
@@ -474,6 +474,10 @@ set_names_fallback <- function(x, names) {
   x
 }
 
+vec_set_names <- function(x, names) {
+  .Call(vctrs_set_names, x, names)
+}
+
 #' Repair names with legacy method
 #'
 #' This standardises names with the legacy approach that was used in

--- a/src/c.c
+++ b/src/c.c
@@ -64,6 +64,7 @@ static SEXP vec_c(SEXP xs,
 
   SEXP xs_names = PROTECT(r_names(xs));
   bool has_names = xs_names != R_NilValue || list_has_inner_names(xs);
+  has_names = has_names && !is_data_frame(ptype);
   SEXP out_names = has_names ? Rf_allocVector(STRSXP, out_size) : R_NilValue;
   PROTECT(out_names);
 

--- a/src/c.c
+++ b/src/c.c
@@ -112,8 +112,9 @@ static SEXP vec_c(SEXP xs,
 
   if (has_names) {
     out_names = PROTECT(vec_as_names(out_names, name_repair, false));
-    out = PROTECT(vec_set_names(out, out_names));
-    UNPROTECT(2);
+    out = vec_set_names(out, out_names);
+    REPROTECT(out, out_pi);
+    UNPROTECT(1);
   }
 
   UNPROTECT(6);

--- a/src/c.c
+++ b/src/c.c
@@ -109,15 +109,8 @@ static SEXP vec_c(SEXP xs,
 
   if (has_names) {
     out_names = PROTECT(vec_as_names(out_names, name_repair, false));
-
-    if (is_shaped) {
-      out = set_rownames(out, out_names);
-      REPROTECT(out, out_pi);
-    } else {
-      Rf_setAttrib(out, R_NamesSymbol, out_names);
-    }
-
-    UNPROTECT(1);
+    out = PROTECT(vec_set_names(out, out_names));
+    UNPROTECT(2);
   }
 
   out = vec_restore(out, ptype, R_NilValue);

--- a/src/c.c
+++ b/src/c.c
@@ -107,13 +107,13 @@ static SEXP vec_c(SEXP xs,
     UNPROTECT(1);
   }
 
+  out = vec_restore(out, ptype, R_NilValue);
+
   if (has_names) {
     out_names = PROTECT(vec_as_names(out_names, name_repair, false));
     out = PROTECT(vec_set_names(out, out_names));
     UNPROTECT(2);
   }
-
-  out = vec_restore(out, ptype, R_NilValue);
 
   UNPROTECT(6);
   return out;

--- a/src/init.c
+++ b/src/init.c
@@ -54,6 +54,7 @@ extern SEXP vctrs_as_minimal_names(SEXP);
 extern SEXP vec_names(SEXP);
 extern SEXP vctrs_is_unique_names(SEXP);
 extern SEXP vctrs_as_unique_names(SEXP, SEXP);
+extern SEXP vec_set_names(SEXP, SEXP);
 extern SEXP vctrs_df_as_dataframe(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_type2_df_df(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_type_info(SEXP);
@@ -123,6 +124,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_names",                      (DL_FUNC) &vec_names, 1},
   {"vctrs_is_unique_names",            (DL_FUNC) &vctrs_is_unique_names, 1},
   {"vctrs_as_unique_names",            (DL_FUNC) &vctrs_as_unique_names, 2},
+  {"vctrs_set_names",                  (DL_FUNC) &vec_set_names, 2},
   {"vctrs_df_as_dataframe",            (DL_FUNC) &vctrs_df_as_dataframe, 4},
   {"vctrs_type2_df_df",                (DL_FUNC) &vctrs_type2_df_df, 4},
   {"vctrs_type_info",                  (DL_FUNC) &vctrs_type_info, 1},

--- a/src/names.c
+++ b/src/names.c
@@ -659,6 +659,8 @@ SEXP vec_set_rownames(SEXP x, SEXP names) {
   return x;
 }
 
+// FIXME: Do we need to get the vec_proxy() and only fall back if it doesn't
+// exist? See #526 and #531 for discussion and the related issue.
 // [[ include("utils.h"); register() ]]
 SEXP vec_set_names(SEXP x, SEXP names) {
   // Never on a data frame

--- a/src/names.c
+++ b/src/names.c
@@ -603,7 +603,6 @@ static SEXP set_names_fallback(SEXP x, SEXP names) {
                          syms_names, names);
 }
 
-// [[ include("utils.h") ]]
 SEXP vec_set_rownames(SEXP x, SEXP names) {
   if (!has_dim(x)) {
     Rf_errorcall(

--- a/src/names.c
+++ b/src/names.c
@@ -603,6 +603,32 @@ static SEXP set_names_fallback(SEXP x, SEXP names) {
                          syms_names, names);
 }
 
+static void check_names(SEXP x, SEXP names) {
+  if (names == R_NilValue) {
+    return;
+  }
+
+  if (TYPEOF(names) != STRSXP) {
+    Rf_errorcall(
+      R_NilValue,
+      "`names` must be a character vector, not a %s.",
+      Rf_type2char(TYPEOF(names))
+    );
+  }
+
+  R_len_t x_size = vec_size(x);
+  R_len_t names_size = vec_size(names);
+
+  if (x_size != names_size) {
+    Rf_errorcall(
+      R_NilValue,
+      "The size of `names`, %i, must be the same as the size of `x`, %i.",
+      names_size,
+      x_size
+    );
+  }
+}
+
 SEXP vec_set_rownames(SEXP x, SEXP names) {
   if (OBJECT(x)) {
     return set_rownames_fallback(x, names);
@@ -639,6 +665,8 @@ SEXP vec_set_names(SEXP x, SEXP names) {
   if (is_data_frame(x)) {
     return x;
   }
+
+  check_names(x, names);
 
   if (has_dim(x)) {
     return vec_set_rownames(x, names);

--- a/src/names.c
+++ b/src/names.c
@@ -641,7 +641,7 @@ SEXP vec_set_rownames(SEXP x, SEXP names) {
   return x;
 }
 
-// [[ include("utils.h") ]]
+// [[ include("utils.h"); register() ]]
 SEXP vec_set_names(SEXP x, SEXP names) {
   // Never on a data frame
   if (is_data_frame(x)) {

--- a/src/names.c
+++ b/src/names.c
@@ -587,7 +587,7 @@ static SEXP outer_names_seq(const char* outer, R_len_t n) {
 SEXP syms_set_rownames_fallback = NULL;
 SEXP fns_set_rownames_fallback = NULL;
 
-static SEXP set_rownames(SEXP x, SEXP names) {
+static SEXP set_rownames_fallback(SEXP x, SEXP names) {
   return vctrs_dispatch2(syms_set_rownames_fallback, fns_set_rownames_fallback,
                          syms_x, x,
                          syms_names, names);
@@ -597,7 +597,7 @@ static SEXP set_rownames(SEXP x, SEXP names) {
 SEXP syms_set_names_fallback = NULL;
 SEXP fns_set_names_fallback = NULL;
 
-static SEXP set_names(SEXP x, SEXP names) {
+static SEXP set_names_fallback(SEXP x, SEXP names) {
   return vctrs_dispatch2(syms_set_names_fallback, fns_set_names_fallback,
                          syms_x, x,
                          syms_names, names);
@@ -613,7 +613,7 @@ SEXP vec_set_rownames(SEXP x, SEXP names) {
   }
 
   if (OBJECT(x)) {
-    return set_rownames(x, names);
+    return set_rownames_fallback(x, names);
   }
 
   int nprot = 0;
@@ -653,7 +653,7 @@ SEXP vec_set_names(SEXP x, SEXP names) {
   }
 
   if (OBJECT(x)) {
-    return set_names(x, names);
+    return set_names_fallback(x, names);
   }
 
   // Early exit if no new names, and no existing names

--- a/src/names.c
+++ b/src/names.c
@@ -620,7 +620,7 @@ SEXP vec_set_rownames(SEXP x, SEXP names) {
 
   SEXP dim_names = Rf_getAttrib(x, R_DimNamesSymbol);
 
-  // Early exit when no new row names, and no existing row names
+  // Early exit when no new row names and no existing row names
   if (names == R_NilValue) {
     if (dim_names == R_NilValue || VECTOR_ELT(dim_names, 0) == R_NilValue) {
       return x;
@@ -656,7 +656,7 @@ SEXP vec_set_names(SEXP x, SEXP names) {
     return set_names_fallback(x, names);
   }
 
-  // Early exit if no new names, and no existing names
+  // Early exit if no new names and no existing names
   if (names == R_NilValue && Rf_getAttrib(x, R_NamesSymbol) == R_NilValue) {
     return x;
   }

--- a/src/names.c
+++ b/src/names.c
@@ -604,13 +604,6 @@ static SEXP set_names_fallback(SEXP x, SEXP names) {
 }
 
 SEXP vec_set_rownames(SEXP x, SEXP names) {
-  if (!has_dim(x)) {
-    Rf_errorcall(
-      R_NilValue,
-      "Internal error: Cannot set row names on a non-shaped object."
-    );
-  }
-
   if (OBJECT(x)) {
     return set_rownames_fallback(x, names);
   }

--- a/src/utils.h
+++ b/src/utils.h
@@ -91,7 +91,8 @@ R_len_t vec_index_size(SEXP x);
 
 SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n);
 SEXP outer_names(SEXP names, SEXP outer, R_len_t n);
-SEXP set_rownames(SEXP x, SEXP names);
+SEXP vec_set_rownames(SEXP x, SEXP names);
+SEXP vec_set_names(SEXP x, SEXP names);
 SEXP colnames(SEXP x);
 
 R_len_t size_validate(SEXP size, const char* arg);

--- a/src/utils.h
+++ b/src/utils.h
@@ -91,7 +91,6 @@ R_len_t vec_index_size(SEXP x);
 
 SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n);
 SEXP outer_names(SEXP names, SEXP outer, R_len_t n);
-SEXP vec_set_rownames(SEXP x, SEXP names);
 SEXP vec_set_names(SEXP x, SEXP names);
 SEXP colnames(SEXP x);
 

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -224,6 +224,11 @@ test_that("vec_set_names() can set NULL names", {
   expect_equal(vec_set_names(x_mat_named, NULL), exp)
 })
 
+test_that("vec_set_names() errors with bad `names`", {
+  expect_error(vec_set_names(1, 1), "character vector, not a double")
+  expect_error(vec_set_names(1, c("x", "y")), "The size of `names`, 2")
+})
+
 # minimal names -------------------------------------------------------------
 
 test_that("minimal names are made from `n` when `name = NULL`", {


### PR DESCRIPTION
Closes #524 
Closes #520 

This PR:

- Implements `vec_set_names()`. It has the following semantics:
   - Never sets row names on data frames
   - Sets names on unclassed vectors
   - Sets row names on unclassed matrices/arrays
   - Falls back to `names<-` on classed vectors
   - Falls back to `rownames<-` on classed matrices/arrays
- Uses `vec_set_names()` in `vec_c()` for better name handling with proxied objects
- Tweaks `has_names` in `vec_c()` to completely avoid outer name handling when the `ptype` is a data frame. Outer names are completely ignored here.

Here are a few examples of what this fixes:

``` r
library(vctrs)
library(rlang)
```

```r
# before
vec_c(x = data.frame(xx = 1), y = data.frame(yy = 2))
#>    x  y
#> 1  1 NA
#> 2 NA  2

# after
vec_c(x = data.frame(xx = 1), y = data.frame(yy = 2))
#>   xx yy
#> 1  1 NA
#> 2 NA  2
```

```r
# before
vec_c(x = data.frame(xx = 1), y = data.frame(xx = 2))
#> Error in vec_c(x = data.frame(xx = 1), y = data.frame(xx = 2)): 'names' attribute [2] must be the same length as the vector [1]

# after
vec_c(x = data.frame(xx = 1), y = data.frame(xx = 2))
#>   xx
#> 1  1
#> 2  2
```

```r
datetime_lt <- as.POSIXlt(new_datetime(0))
datetimes_lt <- as.POSIXlt(new_datetime(c(0, 1)))
named_datetime_lt <- set_names(datetime_lt, "dt_name")
```

```r
# before
vec_c(x = datetime_lt)
#> [1] "1969-12-31 19:00:00 EST"

# after
vec_c(x = datetime_lt)
#>                         x 
#> "1969-12-31 19:00:00 EST"
```

```r
# before
vec_c(x = datetimes_lt, .name_spec = "{outer}_{inner}")
#> [1] "1969-12-31 19:00:00 EST" "1969-12-31 19:00:01 EST"

# after
vec_c(x = datetimes_lt, .name_spec = "{outer}_{inner}")
#>                       x_1                       x_2 
#> "1969-12-31 19:00:00 EST" "1969-12-31 19:00:01 EST"
```

```r
# before
vec_c(x = named_datetime_lt, .name_spec = "{outer}_{inner}")
#> [1] "1969-12-31 19:00:00 EST"

# after
vec_c(x = named_datetime_lt, .name_spec = "{outer}_{inner}")
#>                 x_dt_name 
#> "1969-12-31 19:00:00 EST"
```

