### PR TITLE
Keep automatic row names in vec_restore()

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -421,6 +421,7 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
     while (node != R_NilValue) {
       SEXP tag = TAG(node);
 
+      // Skip special attributes
       if (tag == R_NamesSymbol || tag == R_DimSymbol ||
           tag == R_DimNamesSymbol || tag == R_ClassSymbol ||
           tag == R_RowNamesSymbol) {
@@ -448,7 +449,7 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
 
   if (dim == R_NilValue) {
     SEXP nms = PROTECT(Rf_getAttrib(x, R_NamesSymbol));
-    SEXP rownms = PROTECT(Rf_getAttrib(x, R_RowNamesSymbol));
+    SEXP rownms = PROTECT(get_rownames(x));
 
     SET_ATTRIB(x, attrib);
 
@@ -491,7 +492,7 @@ SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size) {
     Rf_setAttrib(x, R_NamesSymbol, vctrs_shared_empty_chr);
   }
 
-  SEXP rownames = PROTECT(Rf_getAttrib(x, R_RowNamesSymbol));
+  SEXP rownames = PROTECT(get_rownames(x));
   if (rownames == R_NilValue) {
     rownames = PROTECT(Rf_allocVector(INTSXP, 2));
 

--- a/src/cast.c
+++ b/src/cast.c
@@ -494,13 +494,7 @@ SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size) {
 
   SEXP rownames = PROTECT(get_rownames(x));
   if (rownames == R_NilValue) {
-    rownames = PROTECT(Rf_allocVector(INTSXP, 2));
-
-    INTEGER(rownames)[0] = NA_INTEGER;
-    INTEGER(rownames)[1] = -size;
-
-    Rf_setAttrib(x, R_RowNamesSymbol, rownames);
-    UNPROTECT(1);
+    init_compact_rownames(x, size);
   }
 
   UNPROTECT(3);

--- a/src/slice.c
+++ b/src/slice.c
@@ -193,7 +193,7 @@ static SEXP df_slice(SEXP x, SEXP index) {
     SET_VECTOR_ELT(out, i, sliced);
   }
 
-  SEXP row_nms = PROTECT(Rf_getAttrib(x, R_RowNamesSymbol));
+  SEXP row_nms = PROTECT(get_rownames(x));
   if (TYPEOF(row_nms) == STRSXP) {
     row_nms = PROTECT(slice_rownames(row_nms, index));
     Rf_setAttrib(out, R_RowNamesSymbol, row_nms);

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -60,6 +60,25 @@ static SEXP new_compact_rownames(R_len_t n) {
   return out;
 }
 
+// [[ include("utils.h") ]]
+SEXP get_rownames(SEXP x) {
+  // Required, because getAttrib() already does the transformation to a vector,
+  // and getAttrib0() is hidden
+  SEXP node = ATTRIB(x);
+
+  while (node != R_NilValue) {
+    SEXP tag = TAG(node);
+
+    if (tag == R_RowNamesSymbol) {
+      return CAR(node);
+    }
+
+    node = CDR(node);
+  }
+
+  return R_NilValue;
+}
+
 SEXP df_container_type(SEXP x) {
   SEXP type = PROTECT(Rf_allocVector(VECSXP, 0));
 

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -21,7 +21,6 @@ R_len_t compact_rownames_length(SEXP x) {
 }
 
 static void init_bare_data_frame(SEXP x, R_len_t n);
-static void init_compact_rownames(SEXP x, R_len_t n);
 static SEXP new_compact_rownames(R_len_t n);
 
 // [[ include("utils.h") ]]
@@ -43,11 +42,13 @@ static void init_bare_data_frame(SEXP x, R_len_t n) {
   init_compact_rownames(x, n);
 }
 
-static void init_compact_rownames(SEXP x, R_len_t n) {
+// [[ include("utils.h") ]]
+void init_compact_rownames(SEXP x, R_len_t n) {
   SEXP rn = PROTECT(new_compact_rownames(n));
   Rf_setAttrib(x, R_RowNamesSymbol, rn);
   UNPROTECT(1);
 }
+
 static SEXP new_compact_rownames(R_len_t n) {
   if (n <= 0) {
     return vctrs_shared_empty_int;

--- a/src/utils.h
+++ b/src/utils.h
@@ -70,6 +70,7 @@ void init_list_of(SEXP x, SEXP ptype);
 SEXP new_data_frame(SEXP x, R_len_t n);
 void init_data_frame(SEXP x, R_len_t n);
 void init_tibble(SEXP x, R_len_t n);
+void init_compact_rownames(SEXP x, R_len_t n);
 SEXP get_rownames(SEXP x);
 
 bool is_native_df(SEXP x);

--- a/src/utils.h
+++ b/src/utils.h
@@ -70,6 +70,8 @@ void init_list_of(SEXP x, SEXP ptype);
 SEXP new_data_frame(SEXP x, R_len_t n);
 void init_data_frame(SEXP x, R_len_t n);
 void init_tibble(SEXP x, R_len_t n);
+SEXP get_rownames(SEXP x);
+
 bool is_native_df(SEXP x);
 bool is_compact_rownames(SEXP x);
 R_len_t compact_rownames_length(SEXP x);

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -124,6 +124,16 @@ test_that("restore generates correct row/col names", {
   expect_equal(.row_names_info(df2), -2)
 })
 
+test_that("restore keeps automatic row/col names", {
+  df1 <- data.frame(x = NA, y = 1:4, z = 1:4)
+  df1$x <- data.frame(a = 1:4, b = 1:4)
+
+  df2 <- vec_restore(df1, df1)
+
+  expect_named(df2, c("x", "y", "z"))
+  expect_equal(.row_names_info(df2), -4)
+})
+
 test_that("cast to empty data frame preserves number of rows", {
   out <- vec_cast(new_data_frame(n = 10L), new_data_frame())
   expect_equal(nrow(out), 10L)


### PR DESCRIPTION
Otherwise:

``` r
library(vctrs)

df <- data.frame(a = 1:3)
.row_names_info(df)
 #> [1] -3

df2 <- vec_restore(df, df)
.row_names_info(df2)
 #> [1] 3
```

<sup>Created on 2019-08-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Closes #503.