### PR TITLE
Register C callables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vctrs
 Title: Vector Helpers
-Version: 0.2.0.9001
+Version: 0.2.0.9002
 Authors@R: 
     c(person(given = "Hadley",
              family = "Wickham",

--- a/inst/include/vctrs.c
+++ b/inst/include/vctrs.c
@@ -1,6 +1,5 @@
 #include "vctrs.h"
 
-R_len_t (*vec_size)(SEXP) = NULL;
 SEXP (*vec_proxy)(SEXP) = NULL;
 SEXP (*vec_restore)(SEXP, SEXP, SEXP) = NULL;
 SEXP (*vec_init)(SEXP, R_len_t) = NULL;
@@ -10,7 +9,6 @@ SEXP (*vec_names)(SEXP) = NULL;
 SEXP (*vec_set_names)(SEXP, SEXP) = NULL;
 
 void vctrs_init_api() {
-  vec_size = (R_len_t (*)(SEXP)) R_GetCCallable("vctrs", "vec_size");
   vec_proxy = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_proxy");
   vec_restore = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vec_restore");
   vec_init = (SEXP (*)(SEXP, R_len_t)) R_GetCCallable("vctrs", "vec_init");

--- a/inst/include/vctrs.c
+++ b/inst/include/vctrs.c
@@ -9,10 +9,6 @@ SEXP (*vec_slice_impl)(SEXP, SEXP) = NULL;
 SEXP (*vec_names)(SEXP) = NULL;
 SEXP (*vec_set_names)(SEXP, SEXP) = NULL;
 
-SEXP (*vctrs_cast)(SEXP, SEXP, SEXP, SEXP) = NULL;
-SEXP (*compact_seq)(R_len_t, R_len_t, bool) = NULL;
-SEXP (*init_compact_seq)(int*, R_len_t, R_len_t, bool) = NULL;
-
 void vctrs_init_api() {
   vec_size = (R_len_t (*)(SEXP)) R_GetCCallable("vctrs", "vec_size");
   vec_proxy = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_proxy");
@@ -22,8 +18,4 @@ void vctrs_init_api() {
   vec_slice_impl = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_slice_impl");
   vec_names = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_names");
   vec_set_names = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_set_names");
-
-  vctrs_cast = (SEXP (*)(SEXP, SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vctrs_cast");
-  compact_seq = (SEXP (*)(R_len_t, R_len_t, bool)) R_GetCCallable("vctrs", "compact_seq");
-  init_compact_seq = (SEXP (*)(int*, R_len_t, R_len_t, bool)) R_GetCCallable("vctrs", "init_compact_seq");
 }

--- a/inst/include/vctrs.c
+++ b/inst/include/vctrs.c
@@ -1,0 +1,29 @@
+#include "vctrs.h"
+
+R_len_t (*vec_size)(SEXP) = NULL;
+SEXP (*vec_proxy)(SEXP) = NULL;
+SEXP (*vec_restore)(SEXP, SEXP, SEXP) = NULL;
+SEXP (*vec_init)(SEXP, R_len_t) = NULL;
+SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool) = NULL;
+SEXP (*vec_slice_impl)(SEXP, SEXP) = NULL;
+SEXP (*vec_names)(SEXP) = NULL;
+SEXP (*vec_set_names)(SEXP, SEXP) = NULL;
+
+SEXP (*vctrs_cast)(SEXP, SEXP, SEXP, SEXP) = NULL;
+SEXP (*compact_seq)(R_len_t, R_len_t, bool) = NULL;
+SEXP (*init_compact_seq)(int*, R_len_t, R_len_t, bool) = NULL;
+
+void vctrs_init_api() {
+  vec_size = (R_len_t (*)(SEXP)) R_GetCCallable("vctrs", "vec_size");
+  vec_proxy = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_proxy");
+  vec_restore = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vec_restore");
+  vec_init = (SEXP (*)(SEXP, R_len_t)) R_GetCCallable("vctrs", "vec_init");
+  vec_assign_impl = (SEXP (*)(SEXP, SEXP, SEXP, bool)) R_GetCCallable("vctrs", "vec_assign_impl");
+  vec_slice_impl = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_slice_impl");
+  vec_names = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_names");
+  vec_set_names = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_set_names");
+
+  vctrs_cast = (SEXP (*)(SEXP, SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vctrs_cast");
+  compact_seq = (SEXP (*)(R_len_t, R_len_t, bool)) R_GetCCallable("vctrs", "compact_seq");
+  init_compact_seq = (SEXP (*)(int*, R_len_t, R_len_t, bool)) R_GetCCallable("vctrs", "init_compact_seq");
+}

--- a/inst/include/vctrs.h
+++ b/inst/include/vctrs.h
@@ -5,115 +5,19 @@
 #include <R_ext/Rdynload.h>
 #include <stdbool.h>
 
-static R_INLINE R_len_t vec_size(SEXP x) {
-  static R_len_t (*fn)(SEXP) = NULL;
+R_len_t (*vec_size)(SEXP);
+SEXP (*vec_proxy)(SEXP);
+SEXP (*vec_restore)(SEXP, SEXP, SEXP);
+SEXP (*vec_init)(SEXP, R_len_t);
+SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool);
+SEXP (*vec_slice_impl)(SEXP, SEXP);
+SEXP (*vec_names)(SEXP);
+SEXP (*vec_set_names)(SEXP, SEXP);
 
-  if (fn == NULL) {
-    fn = (R_len_t (*)(SEXP)) R_GetCCallable("vctrs", "vec_size");
-  }
+SEXP (*vctrs_cast)(SEXP, SEXP, SEXP, SEXP);
+SEXP (*compact_seq)(R_len_t, R_len_t, bool);
+SEXP (*init_compact_seq)(int*, R_len_t, R_len_t, bool);
 
-  return fn(x);
-}
-
-static R_INLINE SEXP vec_proxy(SEXP x) {
-  static SEXP (*fn)(SEXP) = NULL;
-
-  if (fn == NULL) {
-    fn = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_proxy");
-  }
-
-  return fn(x);
-}
-
-static R_INLINE SEXP vec_restore(SEXP x, SEXP to, SEXP n) {
-  static SEXP (*fn)(SEXP, SEXP, SEXP) = NULL;
-
-  if (fn == NULL) {
-    fn = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vec_restore");
-  }
-
-  return fn(x, to, n);
-}
-
-static R_INLINE SEXP vctrs_cast(SEXP x, SEXP to, SEXP x_arg_, SEXP to_arg_) {
-  static SEXP (*fn)(SEXP, SEXP, SEXP, SEXP) = NULL;
-
-  if (fn == NULL) {
-    fn = (SEXP (*)(SEXP, SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vctrs_cast");
-  }
-
-  return fn(x, to, x_arg_, to_arg_);
-}
-
-static R_INLINE SEXP vec_init(SEXP x, R_len_t n) {
-  static SEXP (*fn)(SEXP, R_len_t) = NULL;
-
-  if (fn == NULL) {
-    fn = (SEXP (*)(SEXP, R_len_t)) R_GetCCallable("vctrs", "vec_init");
-  }
-
-  return fn(x, n);
-}
-
-static R_INLINE SEXP vec_assign_impl(SEXP x, SEXP i, SEXP value, bool clone) {
-  static SEXP (*fn)(SEXP, SEXP, SEXP, bool) = NULL;
-
-  if (fn == NULL) {
-    fn = (SEXP (*)(SEXP, SEXP, SEXP, bool)) R_GetCCallable("vctrs", "vec_assign_impl");
-  }
-
-  return fn(x, i, value, clone);
-}
-
-static R_INLINE SEXP vec_slice_impl(SEXP x, SEXP index) {
-  static SEXP (*fn)(SEXP, SEXP) = NULL;
-
-  if (fn == NULL) {
-    fn = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_slice_impl");
-  }
-
-  return fn(x, index);
-}
-
-static R_INLINE SEXP vec_names(SEXP x) {
-  static SEXP (*fn)(SEXP) = NULL;
-
-  if (fn == NULL) {
-    fn = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_names");
-  }
-
-  return fn(x);
-}
-
-static R_INLINE SEXP vec_set_names(SEXP x, SEXP names) {
-  static SEXP (*fn)(SEXP, SEXP) = NULL;
-
-  if (fn == NULL) {
-    fn = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_set_names");
-  }
-
-  return fn(x, names);
-}
-
-
-static R_INLINE SEXP compact_seq(R_len_t start, R_len_t size, bool increasing) {
-  static SEXP (*fn)(R_len_t, R_len_t, bool) = NULL;
-
-  if (fn == NULL) {
-    fn = (SEXP (*)(R_len_t, R_len_t, bool)) R_GetCCallable("vctrs", "compact_seq");
-  }
-
-  return fn(start, size, increasing);
-}
-
-static R_INLINE SEXP init_compact_seq(int* p, R_len_t start, R_len_t size, bool increasing) {
-  static SEXP (*fn)(int*, R_len_t, R_len_t, bool) = NULL;
-
-  if (fn == NULL) {
-    fn = (SEXP (*)(int*, R_len_t, R_len_t, bool)) R_GetCCallable("vctrs", "init_compact_seq");
-  }
-
-  return fn(p, start, size, increasing);
-}
+void vctrs_init_api();
 
 #endif

--- a/inst/include/vctrs.h
+++ b/inst/include/vctrs.h
@@ -14,10 +14,6 @@ SEXP (*vec_slice_impl)(SEXP, SEXP);
 SEXP (*vec_names)(SEXP);
 SEXP (*vec_set_names)(SEXP, SEXP);
 
-SEXP (*vctrs_cast)(SEXP, SEXP, SEXP, SEXP);
-SEXP (*compact_seq)(R_len_t, R_len_t, bool);
-SEXP (*init_compact_seq)(int*, R_len_t, R_len_t, bool);
-
 void vctrs_init_api();
 
 #endif

--- a/inst/include/vctrs.h
+++ b/inst/include/vctrs.h
@@ -5,7 +5,6 @@
 #include <R_ext/Rdynload.h>
 #include <stdbool.h>
 
-R_len_t (*vec_size)(SEXP);
 SEXP (*vec_proxy)(SEXP);
 SEXP (*vec_restore)(SEXP, SEXP, SEXP);
 SEXP (*vec_init)(SEXP, R_len_t);

--- a/inst/include/vctrs.h
+++ b/inst/include/vctrs.h
@@ -95,4 +95,25 @@ static R_INLINE SEXP vec_set_names(SEXP x, SEXP names) {
   return fn(x, names);
 }
 
+
+static R_INLINE SEXP compact_seq(R_len_t start, R_len_t size, bool increasing) {
+  static SEXP (*fn)(R_len_t, R_len_t, bool) = NULL;
+
+  if (fn == NULL) {
+    fn = (SEXP (*)(R_len_t, R_len_t, bool)) R_GetCCallable("vctrs", "compact_seq");
+  }
+
+  return fn(start, size, increasing);
+}
+
+static R_INLINE SEXP init_compact_seq(int* p, R_len_t start, R_len_t size, bool increasing) {
+  static SEXP (*fn)(int*, R_len_t, R_len_t, bool) = NULL;
+
+  if (fn == NULL) {
+    fn = (SEXP (*)(int*, R_len_t, R_len_t, bool)) R_GetCCallable("vctrs", "init_compact_seq");
+  }
+
+  return fn(p, start, size, increasing);
+}
+
 #endif

--- a/inst/include/vctrs.h
+++ b/inst/include/vctrs.h
@@ -1,0 +1,98 @@
+#ifndef VCTRS_H
+#define VCTRS_H
+
+#include <Rinternals.h>
+#include <R_ext/Rdynload.h>
+#include <stdbool.h>
+
+static R_INLINE R_len_t vec_size(SEXP x) {
+  static R_len_t (*fn)(SEXP) = NULL;
+
+  if (fn == NULL) {
+    fn = (R_len_t (*)(SEXP)) R_GetCCallable("vctrs", "vec_size");
+  }
+
+  return fn(x);
+}
+
+static R_INLINE SEXP vec_proxy(SEXP x) {
+  static SEXP (*fn)(SEXP) = NULL;
+
+  if (fn == NULL) {
+    fn = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_proxy");
+  }
+
+  return fn(x);
+}
+
+static R_INLINE SEXP vec_restore(SEXP x, SEXP to, SEXP n) {
+  static SEXP (*fn)(SEXP, SEXP, SEXP) = NULL;
+
+  if (fn == NULL) {
+    fn = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vec_restore");
+  }
+
+  return fn(x, to, n);
+}
+
+static R_INLINE SEXP vctrs_cast(SEXP x, SEXP to, SEXP x_arg_, SEXP to_arg_) {
+  static SEXP (*fn)(SEXP, SEXP, SEXP, SEXP) = NULL;
+
+  if (fn == NULL) {
+    fn = (SEXP (*)(SEXP, SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vctrs_cast");
+  }
+
+  return fn(x, to, x_arg_, to_arg_);
+}
+
+static R_INLINE SEXP vec_init(SEXP x, R_len_t n) {
+  static SEXP (*fn)(SEXP, R_len_t) = NULL;
+
+  if (fn == NULL) {
+    fn = (SEXP (*)(SEXP, R_len_t)) R_GetCCallable("vctrs", "vec_init");
+  }
+
+  return fn(x, n);
+}
+
+static R_INLINE SEXP vec_assign_impl(SEXP x, SEXP i, SEXP value, bool clone) {
+  static SEXP (*fn)(SEXP, SEXP, SEXP, bool) = NULL;
+
+  if (fn == NULL) {
+    fn = (SEXP (*)(SEXP, SEXP, SEXP, bool)) R_GetCCallable("vctrs", "vec_assign_impl");
+  }
+
+  return fn(x, i, value, clone);
+}
+
+static R_INLINE SEXP vec_slice_impl(SEXP x, SEXP index) {
+  static SEXP (*fn)(SEXP, SEXP) = NULL;
+
+  if (fn == NULL) {
+    fn = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_slice_impl");
+  }
+
+  return fn(x, index);
+}
+
+static R_INLINE SEXP vec_names(SEXP x) {
+  static SEXP (*fn)(SEXP) = NULL;
+
+  if (fn == NULL) {
+    fn = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_names");
+  }
+
+  return fn(x);
+}
+
+static R_INLINE SEXP vec_set_names(SEXP x, SEXP names) {
+  static SEXP (*fn)(SEXP, SEXP) = NULL;
+
+  if (fn == NULL) {
+    fn = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_set_names");
+  }
+
+  return fn(x, names);
+}
+
+#endif

--- a/src/init.c
+++ b/src/init.c
@@ -1,6 +1,7 @@
 #include <R.h>
 #include <Rinternals.h>
 #include <stdlib.h> // for NULL
+#include <stdbool.h> // for bool
 #include <R_ext/Rdynload.h>
 
 /* FIXME:
@@ -72,6 +73,12 @@ extern SEXP vctrs_as_df_col(SEXP, SEXP);
 extern SEXP vctrs_apply_name_spec(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_proxy_recursive(SEXP, SEXP);
 
+// C callables only
+extern R_len_t vec_size(SEXP);
+extern SEXP vec_init(SEXP, R_len_t);
+extern SEXP vec_assign_impl(SEXP, SEXP, SEXP, bool);
+extern SEXP vec_slice_impl(SEXP, SEXP);
+extern SEXP vec_names(SEXP);
 
 // Defined below
 SEXP vctrs_init(SEXP);
@@ -165,6 +172,16 @@ void R_init_vctrs(DllInfo *dll)
 {
     R_registerRoutines(dll, NULL, CallEntries, NULL, ExtEntries);
     R_useDynamicSymbols(dll, FALSE);
+
+    R_RegisterCCallable("vctrs", "vec_size", (DL_FUNC) &vec_size);
+    R_RegisterCCallable("vctrs", "vec_proxy", (DL_FUNC) &vec_proxy);
+    R_RegisterCCallable("vctrs", "vec_restore", (DL_FUNC) &vec_restore);
+    R_RegisterCCallable("vctrs", "vctrs_cast", (DL_FUNC) &vctrs_cast);
+    R_RegisterCCallable("vctrs", "vec_init", (DL_FUNC) &vec_init);
+    R_RegisterCCallable("vctrs", "vec_assign_impl", (DL_FUNC) &vec_assign_impl);
+    R_RegisterCCallable("vctrs", "vec_slice_impl", (DL_FUNC) &vec_slice_impl);
+    R_RegisterCCallable("vctrs", "vec_names", (DL_FUNC) &vec_names);
+    R_RegisterCCallable("vctrs", "vec_set_names", (DL_FUNC) &vec_set_names);
 }
 
 

--- a/src/init.c
+++ b/src/init.c
@@ -180,7 +180,6 @@ void R_init_vctrs(DllInfo *dll)
     R_useDynamicSymbols(dll, FALSE);
 
     // Very experimental
-    R_RegisterCCallable("vctrs", "vec_size", (DL_FUNC) &vec_size);
     R_RegisterCCallable("vctrs", "vec_proxy", (DL_FUNC) &vec_proxy);
     R_RegisterCCallable("vctrs", "vec_restore", (DL_FUNC) &vec_restore);
     R_RegisterCCallable("vctrs", "vec_init", (DL_FUNC) &vec_init);
@@ -194,6 +193,9 @@ void R_init_vctrs(DllInfo *dll)
     R_RegisterCCallable("vctrs", "vctrs_cast", (DL_FUNC) &vctrs_cast);
     R_RegisterCCallable("vctrs", "compact_seq", (DL_FUNC) &compact_seq);
     R_RegisterCCallable("vctrs", "init_compact_seq", (DL_FUNC) &init_compact_seq);
+
+    // Extremely experimental as eventually this might support R_xlen_t
+    R_RegisterCCallable("vctrs", "vec_size", (DL_FUNC) &vec_size);
 }
 
 

--- a/src/init.c
+++ b/src/init.c
@@ -73,15 +73,16 @@ extern SEXP vctrs_as_df_col(SEXP, SEXP);
 extern SEXP vctrs_apply_name_spec(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_proxy_recursive(SEXP, SEXP);
 
-// Very experimental - C callables only
+// Very experimental
+// Available in the API header
 extern R_len_t vec_size(SEXP);
 extern SEXP vec_init(SEXP, R_len_t);
 extern SEXP vec_assign_impl(SEXP, SEXP, SEXP, bool);
 extern SEXP vec_slice_impl(SEXP, SEXP);
 extern SEXP vec_names(SEXP);
 
-// Extremely experimental - C callables required for
-// efficient use of `vec_slice_impl()`
+// Extremely experimental
+// Exported but not directly available in the API header
 extern SEXP compact_seq(R_len_t, R_len_t, bool);
 extern SEXP init_compact_seq(int*, R_len_t, R_len_t, bool);
 
@@ -182,7 +183,6 @@ void R_init_vctrs(DllInfo *dll)
     R_RegisterCCallable("vctrs", "vec_size", (DL_FUNC) &vec_size);
     R_RegisterCCallable("vctrs", "vec_proxy", (DL_FUNC) &vec_proxy);
     R_RegisterCCallable("vctrs", "vec_restore", (DL_FUNC) &vec_restore);
-    R_RegisterCCallable("vctrs", "vctrs_cast", (DL_FUNC) &vctrs_cast);
     R_RegisterCCallable("vctrs", "vec_init", (DL_FUNC) &vec_init);
     R_RegisterCCallable("vctrs", "vec_assign_impl", (DL_FUNC) &vec_assign_impl);
     R_RegisterCCallable("vctrs", "vec_slice_impl", (DL_FUNC) &vec_slice_impl);
@@ -190,6 +190,8 @@ void R_init_vctrs(DllInfo *dll)
     R_RegisterCCallable("vctrs", "vec_set_names", (DL_FUNC) &vec_set_names);
 
     // Extremely experimental
+    // Exported but not directly available in the API header
+    R_RegisterCCallable("vctrs", "vctrs_cast", (DL_FUNC) &vctrs_cast);
     R_RegisterCCallable("vctrs", "compact_seq", (DL_FUNC) &compact_seq);
     R_RegisterCCallable("vctrs", "init_compact_seq", (DL_FUNC) &init_compact_seq);
 }

--- a/src/init.c
+++ b/src/init.c
@@ -195,7 +195,7 @@ void R_init_vctrs(DllInfo *dll)
     R_RegisterCCallable("vctrs", "init_compact_seq", (DL_FUNC) &init_compact_seq);
 
     // Extremely experimental as eventually this might support R_xlen_t
-    R_RegisterCCallable("vctrs", "vec_size", (DL_FUNC) &vec_size);
+    R_RegisterCCallable("vctrs", "vec_short_size", (DL_FUNC) &vec_size);
 }
 
 

--- a/src/init.c
+++ b/src/init.c
@@ -73,12 +73,17 @@ extern SEXP vctrs_as_df_col(SEXP, SEXP);
 extern SEXP vctrs_apply_name_spec(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_proxy_recursive(SEXP, SEXP);
 
-// C callables only
+// Very experimental - C callables only
 extern R_len_t vec_size(SEXP);
 extern SEXP vec_init(SEXP, R_len_t);
 extern SEXP vec_assign_impl(SEXP, SEXP, SEXP, bool);
 extern SEXP vec_slice_impl(SEXP, SEXP);
 extern SEXP vec_names(SEXP);
+
+// Extremely experimental - C callables required for
+// efficient use of `vec_slice_impl()`
+extern SEXP compact_seq(R_len_t, R_len_t, bool);
+extern SEXP init_compact_seq(int*, R_len_t, R_len_t, bool);
 
 // Defined below
 SEXP vctrs_init(SEXP);
@@ -173,6 +178,7 @@ void R_init_vctrs(DllInfo *dll)
     R_registerRoutines(dll, NULL, CallEntries, NULL, ExtEntries);
     R_useDynamicSymbols(dll, FALSE);
 
+    // Very experimental
     R_RegisterCCallable("vctrs", "vec_size", (DL_FUNC) &vec_size);
     R_RegisterCCallable("vctrs", "vec_proxy", (DL_FUNC) &vec_proxy);
     R_RegisterCCallable("vctrs", "vec_restore", (DL_FUNC) &vec_restore);
@@ -182,6 +188,10 @@ void R_init_vctrs(DllInfo *dll)
     R_RegisterCCallable("vctrs", "vec_slice_impl", (DL_FUNC) &vec_slice_impl);
     R_RegisterCCallable("vctrs", "vec_names", (DL_FUNC) &vec_names);
     R_RegisterCCallable("vctrs", "vec_set_names", (DL_FUNC) &vec_set_names);
+
+    // Extremely experimental
+    R_RegisterCCallable("vctrs", "compact_seq", (DL_FUNC) &compact_seq);
+    R_RegisterCCallable("vctrs", "init_compact_seq", (DL_FUNC) &init_compact_seq);
 }
 
 


### PR DESCRIPTION
This PR registers a handful of C callables that are used by slurrr. It also creates a `inst/include/vctrs.h` API file so I just have to do `<vctrs.h>` in slurrr.

- `vctrs_cast()` is exported rather than `vec_cast()` because the last two arguments of `vec_cast()` are `struct vctrs_arg` types, but are `SEXP`s for `vctrs_cast()`. I have been told this might be changed in the next release anyways, so I'm not too worried about it for now.

- `compact_seq()` and `init_compact_seq()` are incredibly useful for efficient slicing with `vec_slice_impl()`, but aren't really part of the rest of the API. I've separated them a bit and marked them as "extremely" experimental.