### PR TITLE
Improve `vec_equal_na()` performance

### DIFF
--- a/src/equal.c
+++ b/src/equal.c
@@ -378,23 +378,23 @@ int equal_na(SEXP x, R_len_t i) {
   vctrs_stop_unsupported_type(vec_typeof(x), "equal_na()");
 }
 
-#define EQUAL_NA(CTYPE, CONST_DEREF, SCALAR_EQUAL_NA)   \
-do {                                                    \
-  const CTYPE* xp = CONST_DEREF(x);                     \
-                                                        \
-  for (R_len_t i = 0; i < n; ++i, ++xp) {               \
-    p[i] = SCALAR_EQUAL_NA(xp);                         \
-  }                                                     \
-}                                                       \
-while (0)
+#define EQUAL_NA(CTYPE, CONST_DEREF, SCALAR_EQUAL_NA)     \
+  do {                                                    \
+    const CTYPE* xp = CONST_DEREF(x);                     \
+                                                          \
+    for (R_len_t i = 0; i < n; ++i, ++xp) {               \
+      p[i] = SCALAR_EQUAL_NA(xp);                         \
+    }                                                     \
+  }                                                       \
+  while (0)
 
-#define EQUAL_NA_BARRIER(SCALAR_EQUAL_NA)               \
-do {                                                    \
-  for (R_len_t i = 0; i < n; ++i) {                     \
-    p[i] = SCALAR_EQUAL_NA(x, i);                       \
-  }                                                     \
-}                                                       \
-while (0)
+#define EQUAL_NA_BARRIER(SCALAR_EQUAL_NA)                 \
+  do {                                                    \
+    for (R_len_t i = 0; i < n; ++i) {                     \
+      p[i] = SCALAR_EQUAL_NA(x, i);                       \
+    }                                                     \
+  }                                                       \
+  while (0)
 
 // [[ register() ]]
 SEXP vctrs_equal_na(SEXP x) {

--- a/src/equal.c
+++ b/src/equal.c
@@ -358,8 +358,6 @@ static int df_equal_na_scalar(SEXP x, R_len_t i);
 
 // If `x` is a data frame, it must have been recursively proxied
 // beforehand so we can safely use `TYPEOF(x)`
-//
-// [[ include("vctrs.h") ]]
 int equal_na(SEXP x, R_len_t i) {
   switch (TYPEOF(x)) {
   case LGLSXP: return lgl_equal_na_scalar(LOGICAL(x) + i);

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -133,6 +133,12 @@ test_that("vectorised over rows of a data frame", {
   expect_equal(vec_equal_na(df), c(FALSE, FALSE, FALSE, TRUE))
 })
 
+test_that("works recursively with data frame columns", {
+  df <- data.frame(x = c(1, 1, NA, NA))
+  df$df <- data.frame(y = c(NA, 1, 1, NA), z = c(1, NA, 1, NA))
+  expect_equal(vec_equal_na(df), c(FALSE, FALSE, FALSE, TRUE))
+})
+
 test_that("NA propagate symmetrically (#204)", {
   exp <- c(NA, NA)
 


### PR DESCRIPTION
I noticed `vec_equal_na()` was slower than `is.na()`. Using the same trick as `vec_equal()`, I moved the comparison loop to be _after_ the check of the vector type. This means you don't have to repeatedly go through the `TYPEOF(x)` switch statement, and really helps performance. In some cases it is faster than `is.na()` now.

``` r
library(vctrs)

# BEFORE
# with a double vector
bench::press(
  times = c(100, 1000, 10000, 100000),
  {
    x <- rep(1, times)
    bench::mark(
      vec_equal_na(x), 
      is.na(x),
      iterations = 10000
    )
  }
)
#> # A tibble: 8 x 7
#>   expression       times      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <dbl> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(x)    100    944ns   1.31µs   659744.    4.29KB      0  
#> 2 is.na(x)           100    238ns    282ns  2052100.      448B      0  
#> 3 vec_equal_na(x)   1000   5.51µs   6.89µs   132015.    3.95KB      0  
#> 4 is.na(x)          1000   1.14µs   2.23µs   442869.    3.95KB     44.3
#> 5 vec_equal_na(x)  10000  49.88µs     61µs    16189.   39.11KB     11.3
#> 6 is.na(x)         10000   7.43µs  12.29µs    74900.   39.11KB     52.5
#> 7 vec_equal_na(x) 100000 480.11µs 530.68µs     1781.  390.67KB     13.1
#> 8 is.na(x)        100000  67.96µs 109.12µs     8703.  390.67KB     63.1

# AFTER
# with a double vector
bench::press(
  times = c(100, 1000, 10000, 100000),
  {
    x <- rep(1, times)
    bench::mark(
      vec_equal_na(x), 
      is.na(x),
      iterations = 10000
    )
  }
)
#> # A tibble: 8 x 7
#>   expression       times      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <dbl> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(x)    100    686ns    834ns   880071.    4.29KB      0  
#> 2 is.na(x)           100    264ns    306ns  1884447.      448B      0  
#> 3 vec_equal_na(x)   1000    1.2µs   2.71µs   336807.    3.95KB      0  
#> 4 is.na(x)          1000    1.2µs    1.7µs   488640.    3.95KB     48.9
#> 5 vec_equal_na(x)  10000   4.28µs  17.12µs    73791.   39.11KB     51.7
#> 6 is.na(x)         10000   8.04µs  11.47µs    79972.   39.11KB     56.0
#> 7 vec_equal_na(x) 100000  29.34µs  55.84µs    17188.  390.67KB    126. 
#> 8 is.na(x)        100000  66.74µs 108.78µs     8733.  390.67KB     63.3

```

```r
df <- data.frame(x = 1, y = "a", z = TRUE)
df <- vec_rbind(!!!rep_len(list(df), length.out = 10000))

# BEFORE
bench::mark(vec_equal_na(df), iterations = 10000)
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(df)    265µs    300µs     3187.    43.5KB     2.55

# AFTER
bench::mark(vec_equal_na(df), iterations = 10000)
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(df)   97.7µs    111µs     8752.    43.5KB     7.01
```