### PR TITLE
Fix string comparison with non-utf8 encodings

### DIFF
--- a/R/hash.R
+++ b/R/hash.R
@@ -3,8 +3,8 @@
 # 32 bit hashes. Thus, the size of the raw vector of hashes is 4 times
 # the size of the input.
 
-vec_hash <- function(x, rowwise = TRUE) {
-  .Call(vctrs_hash, x, rowwise)
+vec_hash <- function(x) {
+  .Call(vctrs_hash, x)
 }
 
 obj_hash <- function(x) {

--- a/src/equal.c
+++ b/src/equal.c
@@ -139,7 +139,11 @@ static int cpl_equal_scalar(const Rcomplex* x, const Rcomplex* y, bool na_equal)
 }
 
 static int chr_equal_scalar_impl(const SEXP x, const SEXP y) {
-  return !strcmp(Rf_translateCharUTF8(x), Rf_translateCharUTF8(y));
+  if (Rf_getCharCE(x) == Rf_getCharCE(y)) {
+    return x == y;
+  } else {
+    return !strcmp(Rf_translateCharUTF8(x), Rf_translateCharUTF8(y));
+  }
 }
 
 static int chr_equal_scalar(const SEXP* x, const SEXP* y, bool na_equal) {

--- a/src/equal.c
+++ b/src/equal.c
@@ -137,14 +137,18 @@ static int cpl_equal_scalar(const Rcomplex* x, const Rcomplex* y, bool na_equal)
     return real_equal && imag_equal;
   }
 }
+
+static int chr_equal_scalar_impl(const SEXP x, const SEXP y) {
+  return !strcmp(Rf_translateCharUTF8(x), Rf_translateCharUTF8(y));
+}
+
 static int chr_equal_scalar(const SEXP* x, const SEXP* y, bool na_equal) {
   const SEXP xi = *x;
   const SEXP yj = *y;
   if (na_equal) {
-    // Ignoring encoding for now
-    return xi == yj;
+    return chr_equal_scalar_impl(xi, yj);
   } else {
-    return (xi == NA_STRING || yj == NA_STRING) ? NA_LOGICAL : xi == yj;
+    return (xi == NA_STRING || yj == NA_STRING) ? NA_LOGICAL : chr_equal_scalar_impl(xi, yj);
   }
 }
 

--- a/src/equal.c
+++ b/src/equal.c
@@ -138,12 +138,21 @@ static int cpl_equal_scalar(const Rcomplex* x, const Rcomplex* y, bool na_equal)
   }
 }
 
+// TODO - doesn't work when comparing a string with "bytes" encoding
+// to another string with a different encoding. `Rf_translateCharUTF8()`
+// fails to convert with a nice error.
 static int chr_equal_scalar_impl(const SEXP x, const SEXP y) {
-  if (Rf_getCharCE(x) == Rf_getCharCE(y)) {
-    return x == y;
-  } else {
-    return !strcmp(Rf_translateCharUTF8(x), Rf_translateCharUTF8(y));
+  // String pointers are the same. Always means equivalent.
+  if (x == y) {
+    return 1;
   }
+
+  // String pointers were different, but encoding is the same
+  if (Rf_getCharCE(x) == Rf_getCharCE(y)) {
+    return 0;
+  }
+
+  return !strcmp(Rf_translateCharUTF8(x), Rf_translateCharUTF8(y));
 }
 
 static int chr_equal_scalar(const SEXP* x, const SEXP* y, bool na_equal) {

--- a/src/equal.c
+++ b/src/equal.c
@@ -148,7 +148,6 @@ static int cpl_equal_scalar(const Rcomplex* x, const Rcomplex* y, bool na_equal)
 //   - bytes / utf8 (error, can't translate bytes)
 //   - bytes / latin1 (error, can't translate bytes)
 static int chr_equal_scalar_impl(const SEXP x, const SEXP y) {
-  // String pointers are the same. Always equivalent.
   if (x == y) {
     return 1;
   }

--- a/src/hash.c
+++ b/src/hash.c
@@ -153,8 +153,8 @@ static uint32_t sexp_hash(SEXP x);
 uint32_t hash_object(SEXP x) {
   uint32_t hash = sexp_hash(x);
 
-  // CHARSXP object have attributes that are purely related to the cache
-  // https://github.com/wch/r-source/blob/5a156a0865362bb8381dcd69ac335f5174a4f60c/src/main/identical.c#L99
+  // Skip attribute check on CHARSXP, which might have attribute related
+  // to the global string pool (#555)
   if (TYPEOF(x) == CHARSXP) {
     return hash;
   }

--- a/src/hash.c
+++ b/src/hash.c
@@ -153,7 +153,7 @@ static uint32_t sexp_hash(SEXP x);
 uint32_t hash_object(SEXP x) {
   uint32_t hash = sexp_hash(x);
 
-  // Skip attribute check on CHARSXP, which might have attribute related
+  // Skip attribute check on CHARSXP, which might have an attribute related
   // to the global string pool (#555)
   if (TYPEOF(x) == CHARSXP) {
     return hash;

--- a/src/init.c
+++ b/src/init.c
@@ -14,7 +14,7 @@ extern SEXP vctrs_field_get(SEXP, SEXP);
 extern SEXP vctrs_field_set(SEXP, SEXP, SEXP);
 extern SEXP vctrs_fields(SEXP);
 extern SEXP vctrs_n_fields(SEXP);
-extern SEXP vctrs_hash(SEXP, SEXP );
+extern SEXP vctrs_hash(SEXP);
 extern SEXP vctrs_hash_object(SEXP);
 extern SEXP vctrs_equal_object(SEXP, SEXP, SEXP);
 extern SEXP vctrs_in(SEXP, SEXP);
@@ -83,7 +83,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_field_set",                  (DL_FUNC) &vctrs_field_set, 3},
   {"vctrs_fields",                     (DL_FUNC) &vctrs_fields, 1},
   {"vctrs_n_fields",                   (DL_FUNC) &vctrs_n_fields, 1},
-  {"vctrs_hash",                       (DL_FUNC) &vctrs_hash, 2},
+  {"vctrs_hash",                       (DL_FUNC) &vctrs_hash, 1},
   {"vctrs_hash_object",                (DL_FUNC) &vctrs_hash_object, 1},
   {"vctrs_equal_object",               (DL_FUNC) &vctrs_equal_object, 3},
   {"vctrs_in",                         (DL_FUNC) &vctrs_in, 2},

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -6,6 +6,16 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+// `sxpinfo.gp` is exposed through `LEVELS()`, and CHARSXP info is
+// extractable through a bitwise and. This copies the unexposed
+// interface in Defn.h
+#define BYTES_MASK 2
+#define LATIN1_MASK 4
+#define UTF8_MASK 8
+
+#define CHAR_IS_BYTES(x) (LEVELS(x) & BYTES_MASK)
+#define CHAR_IS_UTF8(x) (LEVELS(x) & UTF8_MASK)
+#define CHAR_ENC_TYPE(x) (LEVELS(x) & (UTF8_MASK | LATIN1_MASK))
 
 typedef R_xlen_t r_ssize_t;
 
@@ -260,7 +270,6 @@ int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal);
 int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal);
 
 uint32_t hash_object(SEXP x);
-uint32_t hash_scalar(SEXP x, R_len_t i);
 void hash_fill(uint32_t* p, R_len_t n, SEXP x);
 
 bool duplicated_any(SEXP names);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -13,7 +13,6 @@
 #define LATIN1_MASK 4
 #define UTF8_MASK 8
 
-#define CHAR_IS_BYTES(x) (LEVELS(x) & BYTES_MASK)
 #define CHAR_IS_UTF8(x) (LEVELS(x) & UTF8_MASK)
 #define CHAR_ENC_TYPE(x) (LEVELS(x) & (BYTES_MASK | UTF8_MASK | LATIN1_MASK))
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -15,7 +15,7 @@
 
 #define CHAR_IS_BYTES(x) (LEVELS(x) & BYTES_MASK)
 #define CHAR_IS_UTF8(x) (LEVELS(x) & UTF8_MASK)
-#define CHAR_ENC_TYPE(x) (LEVELS(x) & (UTF8_MASK | LATIN1_MASK))
+#define CHAR_ENC_TYPE(x) (LEVELS(x) & (BYTES_MASK | UTF8_MASK | LATIN1_MASK))
 
 typedef R_xlen_t r_ssize_t;
 

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -108,32 +108,22 @@ test_that("unique functions take the equality proxy (#375)", {
   expect_identical(vec_match(tuple(2, 100), x), 2L)
 })
 
-test_that("vec_unique() can detect uniqueness with UTF-8 VS unknown encodings (#553)", {
-  utf8 <- "temp (\u00B0C)"
+test_that("vec_unique() can detect uniqueness with the same string in various encodings (#553)", {
+  utf8 <- "\u00B0C"
 
   unknown <- utf8
   Encoding(unknown) <- "unknown"
 
-  x <- c(unknown, utf8)
+  latin1 <- iconv(utf8, "UTF-8", "latin1")
+
+  x <- c(unknown, utf8, latin1)
 
   expect_equal(vec_unique(x), x[1])
   expect_equal(vec_unique(x), unique(x))
 })
 
-test_that("vec_unique() treats Latin1 vs unknown encoded strings as not equal", {
-  unknown <- "fa\xE7ile"
-
-  latin1 <- unknown
-  Encoding(latin1) <- "latin1"
-
-  x <- c(unknown, latin1)
-
-  expect_equal(vec_unique(x), x)
-  expect_equal(vec_unique(x), unique(x))
-})
-
 test_that("vec_unique() returns differently encoded strings in the order they appear", {
-  utf8 <- "temp (\u00B0C)"
+  utf8 <- "\u00B0C"
 
   unknown <- utf8
   Encoding(unknown) <- "unknown"
@@ -151,8 +141,7 @@ test_that("vec_unique() can determine uniqueness when the encoding is the same",
   latin1 <- unknown
   Encoding(latin1) <- "latin1"
 
-  utf8 <- unknown
-  Encoding(utf8) <- "UTF-8"
+  utf8 <- enc2utf8(latin1)
 
   x <- c(unknown, unknown)
   y <- c(latin1, latin1)
@@ -166,6 +155,25 @@ test_that("vec_unique() can determine uniqueness when the encoding is the same",
 
   expect_equal(vec_unique(z), z[1])
   expect_equal(vec_unique(z), unique(z))
+})
+
+test_that("vec_unique() works with bytes strings", {
+  utf8 <- "\u00B0C"
+
+  bytes <- utf8
+  Encoding(bytes) <- "bytes"
+
+  x <- c(bytes, bytes)
+
+  expect_equal(vec_unique(x), x[1])
+  expect_equal(vec_unique(x), unique(x))
+
+  y <- c(bytes, utf8)
+
+  # Error with base R
+  # unique(y)
+
+  expect_equal(vec_unique(y), y)
 })
 
 # matching ----------------------------------------------------------------

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -108,6 +108,65 @@ test_that("unique functions take the equality proxy (#375)", {
   expect_identical(vec_match(tuple(2, 100), x), 2L)
 })
 
+test_that("vec_unique() can detect uniqueness with UTF-8 VS unknown encodings (#553)", {
+  utf8 <- "temp (\u00B0C)"
+
+  unknown <- utf8
+  Encoding(unknown) <- "unknown"
+
+  x <- c(unknown, utf8)
+
+  expect_equal(vec_unique(x), x[1])
+  expect_equal(vec_unique(x), unique(x))
+})
+
+test_that("vec_unique() treats Latin1 vs unknown encoded strings as not equal", {
+  unknown <- "fa\xE7ile"
+
+  latin1 <- unknown
+  Encoding(latin1) <- "latin1"
+
+  x <- c(unknown, latin1)
+
+  expect_equal(vec_unique(x), x)
+  expect_equal(vec_unique(x), unique(x))
+})
+
+test_that("vec_unique() returns differently encoded strings in the order they appear", {
+  utf8 <- "temp (\u00B0C)"
+
+  unknown <- utf8
+  Encoding(unknown) <- "unknown"
+
+  x <- c(unknown, utf8)
+  y <- c(utf8, unknown)
+
+  expect_equal(Encoding(vec_unique(x)), "unknown")
+  expect_equal(Encoding(vec_unique(y)), "UTF-8")
+})
+
+test_that("vec_unique() can determine uniqueness when the encoding is the same", {
+  unknown <- "fa\xE7ile"
+
+  latin1 <- unknown
+  Encoding(latin1) <- "latin1"
+
+  utf8 <- unknown
+  Encoding(utf8) <- "UTF-8"
+
+  x <- c(unknown, unknown)
+  y <- c(latin1, latin1)
+  z <- c(utf8, utf8)
+
+  expect_equal(vec_unique(x), x[1])
+  expect_equal(vec_unique(x), unique(x))
+
+  expect_equal(vec_unique(y), y[1])
+  expect_equal(vec_unique(y), unique(y))
+
+  expect_equal(vec_unique(z), z[1])
+  expect_equal(vec_unique(z), unique(z))
+})
 
 # matching ----------------------------------------------------------------
 

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -143,9 +143,13 @@ test_that("vec_unique() can determine uniqueness when the encoding is the same",
 
   utf8 <- enc2utf8(latin1)
 
+  bytes <- unknown
+  Encoding(bytes) <- "bytes"
+
   x <- c(unknown, unknown)
   y <- c(latin1, latin1)
   z <- c(utf8, utf8)
+  w <- c(bytes, bytes)
 
   expect_equal(vec_unique(x), x[1])
   expect_equal(vec_unique(x), unique(x))
@@ -155,25 +159,29 @@ test_that("vec_unique() can determine uniqueness when the encoding is the same",
 
   expect_equal(vec_unique(z), z[1])
   expect_equal(vec_unique(z), unique(z))
+
+  expect_equal(vec_unique(w), w[1])
+  expect_equal(vec_unique(w), unique(w))
 })
 
-test_that("vec_unique() works with bytes strings", {
+test_that("vec_unique() fails purposefully with bytes strings and other encodings", {
   utf8 <- "\u00B0C"
 
   bytes <- utf8
   Encoding(bytes) <- "bytes"
 
-  x <- c(bytes, bytes)
+  unknown <- utf8
+  Encoding(unknown) <- "unknown"
 
-  expect_equal(vec_unique(x), x[1])
-  expect_equal(vec_unique(x), unique(x))
+  latin1 <- iconv(utf8, "UTF-8", "latin1")
 
-  y <- c(bytes, utf8)
+  bytes_utf8 <- c(bytes, utf8)
+  bytes_unknown <- c(bytes, unknown)
+  bytes_latin1 <- c(bytes, latin1)
 
-  # Error with base R
-  # unique(y)
-
-  expect_equal(vec_unique(y), y)
+  expect_error(vec_unique(bytes_utf8), '"bytes" encoding is not allowed')
+  expect_error(vec_unique(bytes_unknown), '"bytes" encoding is not allowed')
+  expect_error(vec_unique(bytes_latin1), '"bytes" encoding is not allowed')
 })
 
 # matching ----------------------------------------------------------------

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -104,19 +104,20 @@ test_that("equality can be determined when strings have identical encodings", {
   expect_equal(vec_equal(x, x), x == x)
 })
 
-test_that("equality can be determined with bytes strings", {
+test_that("equality is known to fail when comparing bytes to other encodings", {
   utf8 <- "\u00B0C"
 
   bytes <- utf8
   Encoding(bytes) <- "bytes"
 
-  expect_true(vec_equal(bytes, bytes))
-  expect_equal(vec_equal(bytes, bytes), bytes == bytes)
+  unknown <- utf8
+  Encoding(unknown) <- "unknown"
 
-  # Error with base R, but they aren't equal
-  # utf8 == bytes
+  latin1 <- iconv(utf8, "UTF-8", "latin1")
 
-  expect_false(vec_equal(utf8, bytes))
+  expect_error(vec_equal(bytes, utf8), '"bytes" encoding is not allowed')
+  expect_error(vec_equal(bytes, unknown), '"bytes" encoding is not allowed')
+  expect_error(vec_equal(bytes, latin1), '"bytes" encoding is not allowed')
 })
 
 # object ------------------------------------------------------------------

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -274,6 +274,7 @@ test_that("NA do not propagate from function bodies or formals", {
   expect_false(vec_equal(list(fn), list(other)))
 })
 
+
 # proxy -------------------------------------------------------------------
 
 test_that("vec_equal() takes vec_proxy() by default", {

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -70,43 +70,55 @@ test_that("data frames must have same size and columns", {
 })
 
 test_that("UTF-8 strings with UTF-8 VS unknown encodings are equal (#553)", {
-  x <- "temp (\u00B0C)"
+  utf8 <- "temp (\u00B0C)"
 
-  y <- x
-  Encoding(y) <- "unknown"
+  unknown <- utf8
+  Encoding(unknown) <- "unknown"
 
-  expect_equal(vec_equal(x, y), x == y)
+  expect_true(vec_equal(utf8, unknown))
+  expect_equal(vec_equal(utf8, unknown), utf8 == unknown)
 })
 
-test_that("Latin1 strings with Latin1 VS unknown encodings are not equal", {
-  x <- "fa\xE7ile"
-  y <- x
-  Encoding(y) <- "latin1"
+test_that("Latin1 characters with Latin1 VS unknown encodings are not equal", {
+  unknown <- "fa\xE7ile"
+  latin1 <- unknown
+  Encoding(latin1) <- "latin1"
 
-  expect_equal(vec_equal(x, y), x == y)
+  expect_false(vec_equal(unknown, latin1))
+  expect_equal(vec_equal(unknown, latin1), unknown == latin1)
 
   # Still not equal
-  Encoding(y) <- "UTF-8"
-  expect_equal(vec_equal(x, y), x == y)
+  latin1_as_utf8 <- latin1
+  Encoding(latin1_as_utf8) <- "UTF-8"
+
+  expect_false(vec_equal(unknown, latin1_as_utf8))
+  expect_equal(vec_equal(unknown, latin1_as_utf8), unknown == latin1_as_utf8)
 
   # Both must be UTF-8 in this case
-  Encoding(x) <- "UTF-8"
-  expect_equal(vec_equal(x, y), x == y)
+  unknown_as_utf8 <- unknown
+  Encoding(unknown_as_utf8) <- "UTF-8"
+
+  expect_true(vec_equal(unknown_as_utf8, latin1_as_utf8))
+  expect_equal(vec_equal(unknown_as_utf8, latin1_as_utf8), unknown_as_utf8 == latin1_as_utf8)
 })
 
 test_that("equality can be determined when strings have identical encodings", {
   x <- "fa\xE7ile"
 
-  Encoding(x) <- "unknown"
+  # unknown
+  expect_true(vec_equal(x, x))
   expect_equal(vec_equal(x, x), x == x)
 
   Encoding(x) <- "latin1"
+  expect_true(vec_equal(x, x))
   expect_equal(vec_equal(x, x), x == x)
 
   Encoding(x) <- "UTF-8"
+  expect_true(vec_equal(x, x))
   expect_equal(vec_equal(x, x), x == x)
 
   Encoding(x) <- "bytes"
+  expect_true(vec_equal(x, x))
   expect_equal(vec_equal(x, x), x == x)
 })
 

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -69,6 +69,47 @@ test_that("data frames must have same size and columns", {
 
 })
 
+test_that("UTF-8 strings with UTF-8 VS unknown encodings are equal (#553)", {
+  x <- "temp (\u00B0C)"
+
+  y <- x
+  Encoding(y) <- "unknown"
+
+  expect_equal(vec_equal(x, y), x == y)
+})
+
+test_that("Latin1 strings with Latin1 VS unknown encodings are not equal", {
+  x <- "fa\xE7ile"
+  y <- x
+  Encoding(y) <- "latin1"
+
+  expect_equal(vec_equal(x, y), x == y)
+
+  # Still not equal
+  Encoding(y) <- "UTF-8"
+  expect_equal(vec_equal(x, y), x == y)
+
+  # Both must be UTF-8 in this case
+  Encoding(x) <- "UTF-8"
+  expect_equal(vec_equal(x, y), x == y)
+})
+
+test_that("equality can be determined when strings have identical encodings", {
+  x <- "fa\xE7ile"
+
+  Encoding(x) <- "unknown"
+  expect_equal(vec_equal(x, x), x == x)
+
+  Encoding(x) <- "latin1"
+  expect_equal(vec_equal(x, x), x == x)
+
+  Encoding(x) <- "UTF-8"
+  expect_equal(vec_equal(x, x), x == x)
+
+  Encoding(x) <- "bytes"
+  expect_equal(vec_equal(x, x), x == x)
+})
+
 # object ------------------------------------------------------------------
 
 test_that("can compare NULL",{
@@ -220,7 +261,6 @@ test_that("NA do not propagate from function bodies or formals", {
   expect_true(vec_equal(list(fn), list(fn)))
   expect_false(vec_equal(list(fn), list(other)))
 })
-
 
 # proxy -------------------------------------------------------------------
 

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -69,37 +69,19 @@ test_that("data frames must have same size and columns", {
 
 })
 
-test_that("UTF-8 strings with UTF-8 VS unknown encodings are equal (#553)", {
-  utf8 <- "temp (\u00B0C)"
+test_that("can determine equality of strings with different encodings (#553)", {
+  utf8 <- "\u00B0C"
 
   unknown <- utf8
   Encoding(unknown) <- "unknown"
 
+  latin1 <- iconv(utf8, "UTF-8", "latin1")
+
   expect_true(vec_equal(utf8, unknown))
   expect_equal(vec_equal(utf8, unknown), utf8 == unknown)
-})
 
-test_that("Latin1 characters with Latin1 VS unknown encodings are not equal", {
-  unknown <- "fa\xE7ile"
-  latin1 <- unknown
-  Encoding(latin1) <- "latin1"
-
-  expect_false(vec_equal(unknown, latin1))
-  expect_equal(vec_equal(unknown, latin1), unknown == latin1)
-
-  # Still not equal
-  latin1_as_utf8 <- latin1
-  Encoding(latin1_as_utf8) <- "UTF-8"
-
-  expect_false(vec_equal(unknown, latin1_as_utf8))
-  expect_equal(vec_equal(unknown, latin1_as_utf8), unknown == latin1_as_utf8)
-
-  # Both must be UTF-8 in this case
-  unknown_as_utf8 <- unknown
-  Encoding(unknown_as_utf8) <- "UTF-8"
-
-  expect_true(vec_equal(unknown_as_utf8, latin1_as_utf8))
-  expect_equal(vec_equal(unknown_as_utf8, latin1_as_utf8), unknown_as_utf8 == latin1_as_utf8)
+  expect_true(vec_equal(utf8, latin1))
+  expect_equal(vec_equal(utf8, latin1), utf8 == latin1)
 })
 
 test_that("equality can be determined when strings have identical encodings", {
@@ -113,13 +95,28 @@ test_that("equality can be determined when strings have identical encodings", {
   expect_true(vec_equal(x, x))
   expect_equal(vec_equal(x, x), x == x)
 
-  Encoding(x) <- "UTF-8"
+  x <- iconv(x, "latin1", "UTF-8")
   expect_true(vec_equal(x, x))
   expect_equal(vec_equal(x, x), x == x)
 
   Encoding(x) <- "bytes"
   expect_true(vec_equal(x, x))
   expect_equal(vec_equal(x, x), x == x)
+})
+
+test_that("equality can be determined with bytes strings", {
+  utf8 <- "\u00B0C"
+
+  bytes <- utf8
+  Encoding(bytes) <- "bytes"
+
+  expect_true(vec_equal(bytes, bytes))
+  expect_equal(vec_equal(bytes, bytes), bytes == bytes)
+
+  # Error with base R, but they aren't equal
+  # utf8 == bytes
+
+  expect_false(vec_equal(utf8, bytes))
 })
 
 # object ------------------------------------------------------------------

--- a/tests/testthat/test-hash-hash.txt
+++ b/tests/testthat/test-hash-hash.txt
@@ -1,57 +1,57 @@
 $lgl
- [1] b7 28 4e 51 00 00 00 00 a0 65 3c 6d
+ [1] 70 a2 85 ef b9 79 37 9e 59 df 73 0b
 
 $int
-  [1] b7 28 4e 51 06 c3 f4 30 27 b4 f0 85 85 b2 9c 24 cd 53 0d cc 08 4d eb 5c c4
- [26] ae c9 18 0b 65 39 49 13 29 7c c2 90 04 25 e9 04 fe a0 93 73 ad 88 7c 92 7d
- [51] bb 95 f1 d3 eb bf 45 d8 1a cc bc 53 25 55 e8 9e d0 d8 17 53 04 d6 14 55 f1
- [76] e1 21 09 4b d2 65 61 12 ea 36 f1 4b 78 8c 3c b8 d1 ef e9 c4 bb 3a d7 73 7f
-[101] 9d 69 cf b9 a8 96 1f 45 e0 c4 89 42 9a fd ea 2e cd 3f 3e e9 5b b9 f6 4a 78
-[126] a7 4a aa 12 0e ed fa 0e 38 ab 02 2a b1 3e ee e0 d6 bb 6e 4f 07 56 98 f1 3b
-[151] 3b 52 88 fe 67 7c 43 02 4a 67 98 13 00 6f 5c cd 7f 08 c2 49 44 dd 15 6c ef
-[176] 7e 8a e6 5d f9 19 79 71 a3 6a c2 ee e3 18 9a 93 c8 88 6b e6 ec 75 ae e7 fe
-[201] 38 f6 2f 10 53 a1 f7 01 81 cb a1 74 51 19 f2 4c 94 2a c2 3a b9 1f 6b 13 75
-[226] 94 da 82 35 fb d5 5d 56 79 72 21 93 7f 88 23 35 38 0b 97 b7 72 ed 95 88 45
-[251] f7 73 88 f8 ec e2 af 09 17 72 bd 20 8e b8 18 a4 1e f7 e4 e6 ae 93 a6 58 11
-[276] ca 54 62 7c dc 81 37 d5 e4 69 30 82 2e 82 f8 9c ce 9f 0e ad 30 b4 c5 43 5b
-[301] 5a e1 ce 32 fc 57 cc af 92 0f 81 bb 45 51 73 f6 2e 8a 3c 40 45 5b da 76 30
-[326] 27 00 de 27 e8 53 9e 21 7d 5a 45 84 db ca e0 7a aa 3b 7d 02 98 2d b2 2a d8
-[351] de fd e9 62 64 db 27 ae c4 43 45 4b 23 e0 93 6a 96 09 8a 7f 9d e4 3c 15 34
-[376] 56 61 2b 18 a3 92 00 d9 53 19 1f 37 e0 c6 97 d7 2a da 71 4d 9c ea 5c ce fd
+  [1] 70 a2 85 ef bf 3c 2c cf e0 2d 28 24 3e 2c d4 c2 86 cd 44 6a c1 c6 22 fb 7d
+ [26] 28 01 b7 c4 de 70 e7 cc a2 b3 60 49 7e 5c 87 bd 77 d8 31 2c 27 c0 1a 4b f7
+ [51] f2 33 aa 4d 23 5e fe 51 52 6a 75 cd 5c f3 a1 18 08 77 d0 cc 3b 74 cd ce 28
+ [76] 80 da 82 82 70 1e db 49 88 ef 6a 83 16 45 b6 ef 6f a8 63 fc 59 f3 50 ab 1d
+[101] 56 e3 06 58 61 10 57 e3 99 3e c1 e0 53 77 22 cd 86 b9 75 87 14 33 2e e9 31
+[126] 21 82 48 cb 87 24 99 c7 b1 e2 a0 e3 2a 76 8c 99 50 f3 0c 08 81 8d 36 aa b5
+[151] 72 f0 41 78 9f 1a fc 7b 81 05 51 8d 37 0d 15 47 b7 a6 7b c3 7b 7b ce e5 26
+[176] 1d 43 60 95 97 d2 f2 a8 41 23 3c 26 82 d1 13 cb 66 41 e5 1d 8b 2e 28 1f 9d
+[201] f1 6f 67 ae 0c 1b 2f a0 3a 45 d9 12 0a 93 29 eb 4d a4 f9 d8 72 99 a2 b1 2e
+[226] 0e 12 21 ee 74 0d fc 0f f3 a9 bf 4c f9 bf c1 ee b1 42 35 70 ec 24 34 41 bf
+[251] 2e 12 41 72 24 81 68 83 4e 10 76 9a c5 56 d1 1d 56 95 9d 60 e6 31 5f d2 48
+[276] 68 0d dc b3 7a 3a b1 0c 83 22 aa b9 cc 3b 72 d4 6c 58 88 e4 ce 6d 3f 7b f9
+[301] 13 5b 06 d1 b5 d1 03 4e 4b 89 b8 59 fe ca aa 94 e7 03 74 de fe d4 11 15 e9
+[326] a0 37 7c e0 61 8b 3c da f6 91 e3 3d 55 02 7f 33 24 73 1b bb 11 65 50 e3 51
+[351] 16 9c a2 dc 9b 79 e0 27 fc e1 fe c4 5a 7e 4c e4 cd a7 43 f9 d4 82 f5 8e 6b
+[376] f4 1a a5 4f 41 4b 7a 10 f2 d2 98 6e 7e 7f 11 0f c9 93 eb 84 3a a3 d6 05 9c
 
 $dbl1
-  [1] 47 47 cd 8a a0 89 a9 55 b1 ac 59 80 ee 90 5c e3 17 49 21 51 b1 36 f8 ba 09
- [26] 7e c7 c5 0a 55 53 f2 64 a3 96 76 4c 4e 9d 4a 76 55 61 a8 29 20 78 45 00 56
- [51] e4 ac 80 11 10 55 2a d0 2b 33 51 35 0b ff 8f 84 90 dd f2 3a 74 bd ef 5d 5d
- [76] d0 53 08 ed 69 43 a7 a0 2d c1 41 90 1c e5 c1 d5 36 1d 13 67 8d 8f 1d 67 2a
-[101] 37 50 14 0f 21 f2 66 a3 d2 08 b1 e4 01 f1 ba fb e8 07 4b 37 07 51 06 5d 15
-[126] db 28 70 c4 19 86 94 d5 88 a0 3d 27 52 c2 49 3c 35 aa 1b ba 9d 25 4f 46 2e
-[151] 0c ca 6a 74 f6 c4 ba 5f 69 a5 3d f9 f5 c9 60 85 c5 a8 52 cf 31 a0 66 42 cc
-[176] 7e 61 31 a7 2b f7 d0 b5 e7 f6 b5 ab 5e c7 1f 80 26 c6 eb 74 23 dd 9d 23 e8
-[201] bf b4 90 c9 ac cb 25 f7 be c3 02 fd 1f 4e ca 5e 2e a4 23 8f 3d a0 43 7a 67
-[226] ed 44 11 8a 87 1c 18 73 1f d9 e6 6f 4a 31 43 e0 ed a1 10 3b e1 aa 66 ce 9a
-[251] 2b ec d0 1c 27 58 43 23 6c cc 38 aa f1 6a c9 4f f3 2d 98 3d 58 89 9a cd 68
-[276] 08 41 fa f5 68 cd 7b 95 69 df a0 ba ce 1b 67 bb a5 78 16 61 8e db ae ed a1
-[301] 6a a5 f7 90 88 d6 8b 34 ac f5 c9 93 e8 05 43 a2 ef e2 d9 3c cf 03 47 06 64
-[326] 03 0c 25 5e 53 f7 2b 23 dd 72 25 bb 13 00 7c 5d 8d 9c 27 51 7f cc f0 ee f3
-[351] eb 26 ff 8b 75 de 28 ba 99 70 55 12 e2 d3 54 06 07 29 c7 e2 3f ba f8 75 52
-[376] 9b ec 28 3b 6c 0b 4b 8e 78 8e 16 a3 a9 90 27 7a e3 b7 54 98 31 fa e2 92 9c
+  [1] 00 c1 04 29 59 03 e1 f3 6a 26 91 1e a7 0a 94 81 d0 c2 58 ef 6a b0 2f 59 c2
+ [26] f7 fe 63 c3 ce 8a 90 1d 1d ce 14 05 c8 d4 e8 2f cf 98 46 e2 99 af e3 b9 cf
+ [51] 1b 4b 39 8b 47 f3 e3 49 63 d1 0a af 42 9d 48 fe c7 7b ab b4 ab 5b a8 d7 94
+ [76] 6e 0c 82 24 08 fc 20 d8 cb 7a bb c7 ba 9e 3b 0d d5 d6 8c 9e 2b 48 97 9e c8
+[101] f0 c9 4b ad da 6b 9e 41 8b 82 e8 82 ba 6a f2 99 a1 81 82 d5 c0 ca 3d fb ce
+[126] 54 60 0e 7d 93 bd 32 8e 02 d8 db e0 cb f9 e7 f5 ae e1 b9 73 17 5d ed ff a7
+[151] 43 68 23 ee 2d 63 73 d9 a0 43 f6 72 2d 68 19 ff fc 46 0b 49 69 3e 1f bc 03
+[176] 1d 1a ab de c9 b0 4a ed 85 af 2f e3 fc 80 99 b7 c4 7f 65 ac c1 96 17 5b 86
+[201] 78 2e c8 67 65 45 5d 95 77 3d 3a 9b d8 c7 01 fd e7 1d 5b 2d f6 19 7b 18 20
+[226] 67 7c af 43 01 54 b6 2c 99 10 85 28 c4 68 e1 99 67 d9 ae f4 5a e2 04 87 14
+[251] 63 8a 89 96 5e f6 fc 9c a3 6a f1 23 29 09 82 c9 2a cc 51 b7 8f 27 53 47 a0
+[276] a6 fa 73 2d 07 86 f5 cc 07 98 1a f2 6c d4 e0 f2 43 31 90 98 2c 94 28 25 40
+[301] 23 1f 2f 2f 41 50 c3 d2 65 6f 01 32 a1 7f 7a 40 a8 5c 11 db 88 7d 7e a4 1d
+[326] 7d 43 c3 17 cd 2e ca dc 56 aa c3 74 8d 37 1a 16 07 d4 c5 0a f9 03 8f a7 6d
+[351] 23 c5 b8 05 ad 7c e1 33 d1 0e 0e 8c 19 72 0d 80 3e c7 80 5c 77 58 b1 ef 89
+[376] 39 a5 a2 72 0a c4 c4 c5 16 47 90 da 47 49 a1 b1 81 70 ce cf cf b3 5c ca 3a
 
 $dbl2
-  [1] 00 00 00 00 ce 6c 99 66 46 de fc a8 30 61 a4 6a 7c 9e 0e 86 7d 01 11 55 bc
- [26] fe a3 8f b3 fd 3e 27 ae 90 13 1b ab dd e1 19 3b f0 9d bf 09 8b 57 f3 9c f0
- [51] 9d 91 7a b3 3e 4b e4 7c c1 c0 16 4d cf be b1 f9 5e 28 68 6b 93 0f 86 5c 15
- [76] 7f 83 f8 63 15 81 ec 42 46 d8 93 5e e4 aa a8 18 74 9d f1 e2 e0 56 c4 23 4a
-[101] 03 af 1d fe d7 a8 64 59 e1 7f 29 c1 ab 12 99 2a 0b 54 c3 8f 67 a0 a3 c7 07
-[126] 05 39 c1 74 df 1f d1 13 d9 17 d7 ce 7f 33 dc 2f a5 f4 bd 2e a2 3a 4c b0 10
-[151] 34 5d ec 03 0a 67 61 69 b6 48 31 d7 f3 67 86 bf b0 03 27 f0 f1 b7 a5 94 3a
-[176] 8b f9 d2 2d 10 bd 58 96 7a b3 fa 05 56 a9 a5 2f b3 7e 6a e8 4c 9b 95 c8 d2
-[201] a2 60 fb 98 1c 83 66 55 0a 95 6e e3 50 9f ed 7f 4d e7 f7 8d a9 00 fc 5d 88
-[226] 99 c4 5b 8b db 1f ff 1d d2 6f 1c ce 84 e7 61 1e a3 d4 95 01 ac 96 83 c6 1d
-[251] 9e 73 3c 56 f8 05 7b b5 28 09 f9 2b f5 f0 d7 af 8d b7 4d 4c 33 7b 2b 43 0f
-[276] 86 07 ca 54 21 f3 5f a4 a5 31 b6 f1 3b 8f ea c2 b3 9c 0b 4a a2 14 33 85 d0
-[301] e2 58 d0 43 db 65 f3 de 09 44 2c e9 a5 e4 0f ef 74 a7 74 f4 51 3e 1b 46 2c
-[326] 82 b5 38 a2 9d fc 62 49 a7 40 14 ca ae c1 52 3c 35 59 89 77 30 14 be b1 58
-[351] a3 d3 75 c2 8e ca ee 25 72 98 5d 07 94 2d 1f f4 cf f7 b5 7a c2 8b d4 e7 bf
-[376] e8 98 35 bb e0 13 c4 17 86 d5 66 68 d2 05 38 78 2b ba 78 14 2b 47 47 cd 8a
+  [1] b9 79 37 9e 87 e6 d0 04 ff 57 34 47 e9 da db 08 35 18 46 24 36 7b 48 f3 75
+ [26] 78 db 2d 6c 77 76 c5 67 0a 4b b9 64 57 19 b8 f4 69 d5 5d c2 04 8f 91 55 6a
+ [51] d5 2f 33 2d 76 e9 9d f6 f8 5e cf c6 06 5d 6a 73 96 c6 21 e5 ca ad 3f d6 4c
+ [76] 1d 3c 72 9b b3 3a 66 7a e4 91 0d 96 82 63 22 50 12 56 6b 1a 7f 0f 3e 5b e8
+[101] bc 28 55 9c 90 22 9c f7 9a f9 60 5f 64 8c d0 c8 c4 cd fa 2d 20 1a db 65 c0
+[126] 7e 70 5f 2d 59 57 6f cc 52 4f 75 87 f9 6a 7a e8 1e 2c 5c e7 1b 72 ea 69 8a
+[151] 6b fb a5 7d 41 05 1a e3 ed e6 ea 50 2b 06 3f 39 e8 a1 e0 69 29 56 5e 0e 72
+[176] 29 b2 4c 65 ae 76 d2 cd 18 6c 74 3d f4 62 1f 67 51 37 e4 1f eb 54 0f 00 71
+[201] 5b da 32 37 d5 fc 9d f3 c3 0e a6 81 09 19 25 1e 06 61 2f 2c 62 7a 33 fc 41
+[226] 13 fc f9 44 55 57 9d d6 4b a7 ba 87 fe 1e 00 d7 1c 0c 34 ba 25 ce 21 7f 97
+[251] d5 11 f5 cf 2f a4 34 2f 60 a7 b2 a5 2c 8f 90 29 c5 55 06 c6 6a 19 e4 bc 46
+[276] 24 c0 43 8c bf ac d9 db 43 ea 2f 29 da 48 64 fa 51 55 85 81 40 cd ac bc 6e
+[301] 9b d2 07 e2 94 df 2a 7d c2 bd 63 87 5e 5e 47 8d 2d 21 ac 92 0a b8 52 e4 e5
+[326] fb ec d6 5b 17 34 01 02 21 78 b2 83 28 f9 f0 f5 ae 90 27 30 aa 4b 5c 6a d2
+[351] da 71 2e 3c c6 68 a7 9f a9 36 16 81 cb cb d8 6d 07 96 6e f4 f9 29 8d 61 f7
+[376] 86 51 af f2 7e cc 3d 4f 24 8e e0 9f 70 be b1 af c9 73 f2 4b c9 00 c1 04 29
 

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -81,52 +81,38 @@ test_that("can hash list of non-vectors", {
   )
 })
 
-test_that("can hash matrices rowwise", {
-  x <- matrix(c(1, 2, 3, 4), c(2, 2))
-  expect_identical(
-    vec_hash(x, rowwise = TRUE),
-    vec_hash(x, rowwise = TRUE)
-  )
-
-  y <- matrix(c(1, 2, 3, 5), c(2, 2))
-  expect_false(identical(
-    vec_hash(x, rowwise = TRUE),
-    vec_hash(y, rowwise = TRUE)
-  ))
-})
-
-test_that("can hash matrices non-rowwise", {
+test_that("can hash matrices", {
   x <- matrix(c(1, 1, 1, 2, 2, 1), c(3, 2))
 
   expect_identical(
-    vec_hash(x, rowwise = FALSE),
-    vec_hash(x, rowwise = FALSE)
+    vec_hash(x),
+    vec_hash(x)
   )
 
   x <- matrix(c(1, 2, 3, 4), c(2, 2))
 
   expect_identical(
-    vec_hash(x, rowwise = FALSE),
-    vec_hash(x, rowwise = FALSE)
+    vec_hash(x),
+    vec_hash(x)
   )
 
   expect_false(identical(
-    vec_hash(x, rowwise = FALSE),
-    vec_hash(c(1, 2), rowwise = FALSE)
+    vec_hash(x),
+    vec_hash(c(1, 2))
   ))
 
   y <- matrix(c(1, 2, 3, 5), c(2, 2))
 
   expect_false(identical(
-    vec_hash(x, rowwise = FALSE),
-    vec_hash(y, rowwise = FALSE)
+    vec_hash(x),
+    vec_hash(y)
   ))
 })
 
-test_that("can hash with non-rowwise method", {
+test_that("can hash NA", {
   expect_identical(
-    vec_hash(NA, rowwise = FALSE),
-    vec_hash(NA, rowwise = FALSE),
+    vec_hash(NA),
+    vec_hash(NA),
   )
 })
 
@@ -134,8 +120,8 @@ test_that("can hash 1D arrays", {
   # 1D arrays are dispatched to `as.data.frame.vector()` which
   # currently does not strip dimensions. This caused an infinite
   # recursion.
-  expect_length(vec_hash(array(1:2), TRUE), 8)
-  expect_identical(vec_hash(array(1:2), FALSE), vec_hash(1:2, FALSE))
+  expect_length(vec_hash(array(1:2)), 8)
+  expect_identical(vec_hash(array(1:2)), vec_hash(1:2))
 })
 
 test_that("can hash raw vectors", {
@@ -145,7 +131,7 @@ test_that("can hash raw vectors", {
 test_that("can hash complex vectors", {
   expect_identical(
     vec_hash(c(1, 2) + 0i),
-    vec_hash(matrix(c(1, 2, 0, 0), ncol = 2))
+    c(obj_hash(c(1, 0)), obj_hash(c(2, 0)))
   )
 })
 


### PR DESCRIPTION
Related to #553 

CC @jennybc @paleolimbot

I did some investigation into this, and have a solution, but would really love another pair of eyes on this.

3 things:

- `chr_equal_scalar()` now supports comparing strings with different encodings. This is a part of the dictionary hashing, and also fixes these problems with `vec_equal()`.
- For the hashing, I added `hash_char()` to translate to UTF-8 before hashing a `CHARSXP`.
- Apparently, `CHARSXP` objects have attributes related to the global string pool. This caused me quite the headache, as I was unaware. I special cased them in `hash_object()`, so we don't check their attributes. I can't think of a better solution.

Base R skipping over `CHARSXP` attributes:
https://github.com/wch/r-source/blob/5a156a0865362bb8381dcd69ac335f5174a4f60c/src/main/identical.c#L99

Rationale for the `!strcmp(x,y)` approach used in `chr_equal_scalar_impl()`
https://stackoverflow.com/questions/37712672/and-in-differ-based-on-character-encoding

Feel free to modify/reject/redo this PR. Just wanted to get my thoughts down after investigating.

``` r
library(purrr)
library(vctrs)

bad_df_file <- tempfile(fileext = ".rds")
curl::curl_download(
  "https://gist.github.com/paleolimbot/ec9b62b758ae57a5b4669fa771fc40a0/raw/e96b55f54d68b1cb3877bb358b28b99dc8836ceb/bad_df.rds",
  bad_df_file
)
result_bad <- readRDS(bad_df_file)[["result"]]

names <- result_bad %>% 
  map(names) %>% 
  unlist()

# before
vec_unique(names)
#> [1] "Max Temp Flag"  "Min Temp (°C)"  "Min Temp Flag"  "Mean Temp (°C)"
#> [5] "Min Temp (°C)"  "Mean Temp (°C)"

# after
vec_unique(names)
#> [1] "Max Temp Flag"  "Min Temp (°C)"  "Min Temp Flag"  "Mean Temp (°C)"
```

```r
names[c(2, 6)]
#> [1] "Min Temp (°C)" "Min Temp (°C)"

# before
vec_equal(names[2], names[6])
#> [1] FALSE

# after
vec_equal(names[2], names[6])
#> [1] TRUE
```