### PR TITLE
Stricter checking of index for vec_as_index()

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -238,7 +238,7 @@ vec_coerce_index <- function(i,
                              allow_types = c("indicator", "position", "name"),
                              arg = "i") {
   if (!missing(...)) ellipsis::check_dots_empty()
- maybe_get(vec_maybe_coerce_index(
+  maybe_get(vec_maybe_coerce_index(
     i,
     arg = arg,
     allow_types = allow_types

--- a/src/slice.c
+++ b/src/slice.c
@@ -602,6 +602,11 @@ SEXP vec_as_index(SEXP i, R_len_t n, SEXP names) {
 
 SEXP vec_as_index_opts(SEXP i, R_len_t n, SEXP names,
                        struct vec_as_index_options* opts) {
+
+  if (vec_dim_n(i) != 1) {
+    Rf_errorcall(R_NilValue, "`i` must have one dimension, not %d.", vec_dim_n(i));
+  }
+
   switch (TYPEOF(i)) {
   case NILSXP: return vctrs_shared_empty_int;
   case INTSXP: return int_as_index(i, n, opts);

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -1,7 +1,10 @@
-context("test-slice")
-
 test_that("vec_slice throws error with non-vector inputs", {
   expect_error(vec_slice(environment(), 1L), class = "vctrs_error_scalar_type")
+})
+
+test_that("vec_slice throws error with non-vector indexes", {
+  expect_error(vec_slice(1:3, Sys.Date()), class = "vctrs_error_incompatible_cast")
+  expect_error(vec_slice(1:3, matrix(TRUE, nrow = 1)), "must have one dimension")
 })
 
 test_that("can subset base vectors", {
@@ -199,6 +202,8 @@ test_that("vec_as_index() checks type", {
   expect_error(vec_as_index(quote(foo), 1L), class = "vctrs_error_index_bad_type")
   expect_error(vec_as_index("foo", "bar"), class = "vctrs_error_assert_ptype")
   expect_error(vec_as_index("foo", 1L, names = 1L), "must be a character vector")
+  expect_error(vec_as_index(Sys.Date(), 3L), class = "vctrs_error_index_bad_type")
+  expect_error(vec_as_index(matrix(TRUE, nrow = 1), 3L), "must have one dimension")
 })
 
 test_that("can `vec_slice()` S3 objects without dispatch infloop", {


### PR DESCRIPTION
For tibble.

Closes https://github.com/tidyverse/tibble/issues/649.