### PR TITLE
Add encoding support for `vec_match()` and `vec_in()`

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -229,7 +229,7 @@ SEXP vctrs_match(SEXP needles, SEXP haystack) {
   R_len_t n_haystack = vec_size(haystack);
   R_len_t n_needle = vec_size(needles);
 
-  SEXP translated = PROTECT_N(translate_common_encoding(needles, n_needle, haystack, n_haystack), &nprot);
+  SEXP translated = PROTECT_N(translate_encoding2(needles, n_needle, haystack, n_haystack), &nprot);
   needles = VECTOR_ELT(translated, 0);
   haystack = VECTOR_ELT(translated, 1);
 
@@ -282,7 +282,7 @@ SEXP vctrs_in(SEXP needles, SEXP haystack) {
   R_len_t n_haystack = vec_size(haystack);
   R_len_t n_needle = vec_size(needles);
 
-  SEXP translated = PROTECT_N(translate_common_encoding(needles, n_needle, haystack, n_haystack), &nprot);
+  SEXP translated = PROTECT_N(translate_encoding2(needles, n_needle, haystack, n_haystack), &nprot);
   needles = VECTOR_ELT(translated, 0);
   haystack = VECTOR_ELT(translated, 1);
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -226,12 +226,18 @@ SEXP vctrs_match(SEXP needles, SEXP haystack) {
   needles = PROTECT_N(vec_proxy_equal(needles), &nprot);
   haystack = PROTECT_N(vec_proxy_equal(haystack), &nprot);
 
+  R_len_t n_haystack = vec_size(haystack);
+  R_len_t n_needle = vec_size(needles);
+
+  SEXP translated = PROTECT_N(translate_common_encoding(needles, n_needle, haystack, n_haystack), &nprot);
+  needles = VECTOR_ELT(translated, 0);
+  haystack = VECTOR_ELT(translated, 1);
+
   dictionary d;
   dict_init(&d, haystack);
   PROTECT_DICT(&d, &nprot);
 
   // Load dictionary with haystack
-  R_len_t n_haystack = vec_size(haystack);
   for (int i = 0; i < n_haystack; ++i) {
     uint32_t hash = dict_hash_scalar(&d, i);
 
@@ -244,7 +250,6 @@ SEXP vctrs_match(SEXP needles, SEXP haystack) {
   dict_init_partial(&d_needles, needles);
 
   // Locate needles
-  R_len_t n_needle = vec_size(needles);
   SEXP out = PROTECT_N(Rf_allocVector(INTSXP, n_needle), &nprot);
   int* p_out = INTEGER(out);
 
@@ -274,12 +279,18 @@ SEXP vctrs_in(SEXP needles, SEXP haystack) {
   needles = PROTECT_N(vec_proxy_equal(needles), &nprot);
   haystack = PROTECT_N(vec_proxy_equal(haystack), &nprot);
 
+  R_len_t n_haystack = vec_size(haystack);
+  R_len_t n_needle = vec_size(needles);
+
+  SEXP translated = PROTECT_N(translate_common_encoding(needles, n_needle, haystack, n_haystack), &nprot);
+  needles = VECTOR_ELT(translated, 0);
+  haystack = VECTOR_ELT(translated, 1);
+
   dictionary d;
   dict_init(&d, haystack);
   PROTECT_DICT(&d, &nprot);
 
   // Load dictionary with haystack
-  R_len_t n_haystack = vec_size(haystack);
   for (int i = 0; i < n_haystack; ++i) {
     uint32_t hash = dict_hash_scalar(&d, i);
 
@@ -293,7 +304,6 @@ SEXP vctrs_in(SEXP needles, SEXP haystack) {
   PROTECT_DICT(&d_needles, &nprot);
 
   // Locate needles
-  R_len_t n_needle = vec_size(needles);
   SEXP out = PROTECT_N(Rf_allocVector(LGLSXP, n_needle), &nprot);
   int* p_out = LOGICAL(out);
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -229,7 +229,7 @@ SEXP vctrs_match(SEXP needles, SEXP haystack) {
   R_len_t n_haystack = vec_size(haystack);
   R_len_t n_needle = vec_size(needles);
 
-  SEXP translated = PROTECT_N(translate_encoding2(needles, n_needle, haystack, n_haystack), &nprot);
+  SEXP translated = PROTECT_N(obj_translate_encoding2(needles, n_needle, haystack, n_haystack), &nprot);
   needles = VECTOR_ELT(translated, 0);
   haystack = VECTOR_ELT(translated, 1);
 
@@ -282,7 +282,7 @@ SEXP vctrs_in(SEXP needles, SEXP haystack) {
   R_len_t n_haystack = vec_size(haystack);
   R_len_t n_needle = vec_size(needles);
 
-  SEXP translated = PROTECT_N(translate_encoding2(needles, n_needle, haystack, n_haystack), &nprot);
+  SEXP translated = PROTECT_N(obj_translate_encoding2(needles, n_needle, haystack, n_haystack), &nprot);
   needles = VECTOR_ELT(translated, 0);
   haystack = VECTOR_ELT(translated, 1);
 

--- a/src/equal.c
+++ b/src/equal.c
@@ -150,7 +150,7 @@ static int chr_equal_scalar_impl(const SEXP x, const SEXP y) {
     return 1;
   }
 
-  if (CHAR_ENC_TYPE(x) != CHAR_ENC_TYPE(y)) {
+  if (Rf_getCharCE(x) != Rf_getCharCE(y)) {
     const void *vmax = vmaxget();
     int out = !strcmp(Rf_translateCharUTF8(x), Rf_translateCharUTF8(y));
     vmaxset(vmax);

--- a/src/hash.c
+++ b/src/hash.c
@@ -184,7 +184,7 @@ static uint32_t dbl_hash(SEXP x) {
   HASH(double, REAL_RO, dbl_hash_scalar);
 }
 static uint32_t chr_hash(SEXP x) {
-  if (translation_required_chr(x, Rf_length(x))) {
+  if (chr_translation_required(x, Rf_length(x))) {
     HASH(SEXP, STRING_PTR_RO, chr_hash_scalar_translate);
   } else {
     HASH(SEXP, STRING_PTR_RO, chr_hash_scalar);
@@ -289,7 +289,7 @@ static void cpl_hash_fill(uint32_t* p, R_len_t size, SEXP x) {
   HASH_FILL(Rcomplex, COMPLEX_RO, cpl_hash_scalar);
 }
 static void chr_hash_fill(uint32_t* p, R_len_t size, SEXP x) {
-  if (translation_required_chr(x, size)) {
+  if (chr_translation_required(x, size)) {
     HASH_FILL(SEXP, STRING_PTR_RO, chr_hash_scalar_translate);
   } else {
     HASH_FILL(SEXP, STRING_PTR_RO, chr_hash_scalar);

--- a/src/hash.c
+++ b/src/hash.c
@@ -48,7 +48,7 @@ static uint32_t hash_char(SEXP x) {
 static uint32_t hash_char_translate(SEXP x) {
   const void *vmax = vmaxget();
 
-  const char* x_utf8 = CHAR_IS_UTF8(x) ? CHAR(x) : Rf_translateCharUTF8(x);
+  const char* x_utf8 = Rf_getCharCE(x) == CE_UTF8 ? CHAR(x) : Rf_translateCharUTF8(x);
 
   uint32_t hash = 0;
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -184,7 +184,7 @@ static uint32_t dbl_hash(SEXP x) {
   HASH(double, REAL_RO, dbl_hash_scalar);
 }
 static uint32_t chr_hash(SEXP x) {
-  if (chr_requires_translation(x, Rf_length(x))) {
+  if (translation_required_chr(x, Rf_length(x))) {
     HASH(SEXP, STRING_PTR_RO, chr_hash_scalar_translate);
   } else {
     HASH(SEXP, STRING_PTR_RO, chr_hash_scalar);
@@ -289,7 +289,7 @@ static void cpl_hash_fill(uint32_t* p, R_len_t size, SEXP x) {
   HASH_FILL(Rcomplex, COMPLEX_RO, cpl_hash_scalar);
 }
 static void chr_hash_fill(uint32_t* p, R_len_t size, SEXP x) {
-  if (chr_requires_translation(x, size)) {
+  if (translation_required_chr(x, size)) {
     HASH_FILL(SEXP, STRING_PTR_RO, chr_hash_scalar_translate);
   } else {
     HASH_FILL(SEXP, STRING_PTR_RO, chr_hash_scalar);

--- a/src/hash.c
+++ b/src/hash.c
@@ -60,26 +60,6 @@ static uint32_t hash_char_translate(SEXP x) {
   return hash;
 }
 
-// Determine if `x` must be translated to UTF-8
-// UTF-8 translation will be successful in these cases:
-// - (utf8 + latin1), (unknown + utf8), (unknown + latin1)
-// UTF-8 translation will fail purposefully in these cases:
-// - (bytes + utf8), (bytes + latin1), (bytes + unknown)
-// UTF-8 translation is not attempted in these cases:
-// - (utf8 + utf8), (latin1 + latin1), (unknown + unknown), (bytes + bytes)
-static bool chr_requires_translation(SEXP x, R_len_t size) {
-  const SEXP* xp = STRING_PTR_RO(x);
-  int reference_encoding = CHAR_ENC_TYPE(*xp);
-
-  for (R_len_t i = 0; i < size; ++i, ++xp) {
-    if (CHAR_ENC_TYPE(*xp) != reference_encoding) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 // Hashing scalars -----------------------------------------------------
 
 static uint32_t lgl_hash_scalar(const int* x);

--- a/src/translate.c
+++ b/src/translate.c
@@ -10,7 +10,7 @@
 // UTF-8 translation is not attempted in these cases:
 // - (utf8 + utf8), (latin1 + latin1), (unknown + unknown), (bytes + bytes)
 
-static bool translation_required_chr_impl(const SEXP* x, R_len_t size, cetype_t reference) {
+static bool chr_translation_required_impl(const SEXP* x, R_len_t size, cetype_t reference) {
   for (R_len_t i = 0; i < size; ++i, ++x) {
     if (Rf_getCharCE(*x) != reference) {
       return true;
@@ -21,7 +21,7 @@ static bool translation_required_chr_impl(const SEXP* x, R_len_t size, cetype_t 
 }
 
 // [[ include("vctrs.h") ]]
-bool translation_required_chr(SEXP x, R_len_t size) {
+bool chr_translation_required(SEXP x, R_len_t size) {
   if (size == 0) {
     return false;
   }
@@ -29,11 +29,11 @@ bool translation_required_chr(SEXP x, R_len_t size) {
   const SEXP* p_x = STRING_PTR_RO(x);
   cetype_t reference = Rf_getCharCE(*p_x);
 
-  return translation_required_chr_impl(p_x, size, reference);
+  return chr_translation_required_impl(p_x, size, reference);
 }
 
 // Check if `x` or `y` need to be translated to UTF-8, relative to each other
-static bool translation_required_chr2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+static bool chr_translation_required2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   const SEXP* p_x;
   const SEXP* p_y;
 
@@ -46,24 +46,24 @@ static bool translation_required_chr2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_
 
   if (x_empty) {
     p_y = STRING_PTR_RO(y);
-    return translation_required_chr_impl(p_y, y_size, Rf_getCharCE(*p_y));
+    return chr_translation_required_impl(p_y, y_size, Rf_getCharCE(*p_y));
   }
 
   if (y_empty) {
     p_x = STRING_PTR_RO(x);
-    return translation_required_chr_impl(p_x, x_size, Rf_getCharCE(*p_x));
+    return chr_translation_required_impl(p_x, x_size, Rf_getCharCE(*p_x));
   }
 
   p_x = STRING_PTR_RO(x);
   cetype_t reference = Rf_getCharCE(*p_x);
 
-  if (translation_required_chr_impl(p_x, x_size, reference)) {
+  if (chr_translation_required_impl(p_x, x_size, reference)) {
     return true;
   }
 
   p_y = STRING_PTR_RO(y);
 
-  if (translation_required_chr_impl(p_y, y_size, reference)) {
+  if (chr_translation_required_impl(p_y, y_size, reference)) {
     return true;
   }
 
@@ -76,20 +76,20 @@ static bool translation_required_chr2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_
 // elements of the list to UTF-8. This function is solely used by
 // `translate_encoding_list2()`.
 
-static bool any_known_encoding_chr(SEXP x, R_len_t size);
-static bool any_known_encoding_list(SEXP x, R_len_t size);
-static bool any_known_encoding_df(SEXP x, R_len_t size);
+static bool chr_any_known_encoding(SEXP x, R_len_t size);
+static bool list_any_known_encoding(SEXP x, R_len_t size);
+static bool df_any_known_encoding(SEXP x, R_len_t size);
 
-static bool any_known_encoding(SEXP x, R_len_t size) {
+static bool obj_any_known_encoding(SEXP x, R_len_t size) {
   switch (vec_proxy_typeof(x)) {
-  case vctrs_type_character: return any_known_encoding_chr(x, size);
-  case vctrs_type_list: return any_known_encoding_list(x, size);
-  case vctrs_type_dataframe: return any_known_encoding_df(x, size);
+  case vctrs_type_character: return chr_any_known_encoding(x, size);
+  case vctrs_type_list: return list_any_known_encoding(x, size);
+  case vctrs_type_dataframe: return df_any_known_encoding(x, size);
   default: return false;
   }
 }
 
-static bool any_known_encoding_chr(SEXP x, R_len_t size) {
+static bool chr_any_known_encoding(SEXP x, R_len_t size) {
   if (size == 0) {
     return false;
   }
@@ -105,13 +105,13 @@ static bool any_known_encoding_chr(SEXP x, R_len_t size) {
   return false;
 }
 
-static bool any_known_encoding_list(SEXP x, R_len_t size) {
+static bool list_any_known_encoding(SEXP x, R_len_t size) {
   SEXP elt;
 
   for (int i = 0; i < size; ++i) {
     elt = VECTOR_ELT(x, i);
 
-    if (any_known_encoding(elt, vec_size(elt))) {
+    if (obj_any_known_encoding(elt, vec_size(elt))) {
       return true;
     }
   }
@@ -119,11 +119,11 @@ static bool any_known_encoding_list(SEXP x, R_len_t size) {
   return false;
 }
 
-static bool any_known_encoding_df(SEXP x, R_len_t size) {
+static bool df_any_known_encoding(SEXP x, R_len_t size) {
   int n_col = Rf_length(x);
 
   for (int i = 0; i < n_col; ++i) {
-    if (any_known_encoding(VECTOR_ELT(x, i), size)) {
+    if (obj_any_known_encoding(VECTOR_ELT(x, i), size)) {
       return true;
     }
   }
@@ -135,20 +135,20 @@ static bool any_known_encoding_df(SEXP x, R_len_t size) {
 // Utilities required for translating the character vector elements of a list
 // to UTF-8. This function is solely used by `translate_encoding_list2()`.
 
-static SEXP translate_encoding_chr(SEXP x, R_len_t size);
-static SEXP translate_encoding_list(SEXP x, R_len_t size);
-static SEXP translate_encoding_df(SEXP x, R_len_t size);
+static SEXP chr_translate_encoding(SEXP x, R_len_t size);
+static SEXP list_translate_encoding(SEXP x, R_len_t size);
+static SEXP df_translate_encoding(SEXP x, R_len_t size);
 
-static SEXP translate_encoding(SEXP x, R_len_t size) {
+static SEXP obj_translate_encoding(SEXP x, R_len_t size) {
   switch (vec_proxy_typeof(x)) {
-  case vctrs_type_character: return translate_encoding_chr(x, size);
-  case vctrs_type_list: return translate_encoding_list(x, size);
-  case vctrs_type_dataframe: return translate_encoding_df(x, size);
+  case vctrs_type_character: return chr_translate_encoding(x, size);
+  case vctrs_type_list: return list_translate_encoding(x, size);
+  case vctrs_type_dataframe: return df_translate_encoding(x, size);
   default: return x;
   }
 }
 
-static SEXP translate_encoding_chr(SEXP x, R_len_t size) {
+static SEXP chr_translate_encoding(SEXP x, R_len_t size) {
   if (size == 0) {
     return x;
   }
@@ -177,20 +177,20 @@ static SEXP translate_encoding_chr(SEXP x, R_len_t size) {
   return out;
 }
 
-static SEXP translate_encoding_list(SEXP x, R_len_t size) {
+static SEXP list_translate_encoding(SEXP x, R_len_t size) {
   SEXP elt;
   x = PROTECT(r_maybe_duplicate(x));
 
   for (int i = 0; i < size; ++i) {
     elt = VECTOR_ELT(x, i);
-    SET_VECTOR_ELT(x, i, translate_encoding(elt, vec_size(elt)));
+    SET_VECTOR_ELT(x, i, obj_translate_encoding(elt, vec_size(elt)));
   }
 
   UNPROTECT(1);
   return x;
 }
 
-static SEXP translate_encoding_df(SEXP x, R_len_t size) {
+static SEXP df_translate_encoding(SEXP x, R_len_t size) {
   SEXP col;
   x = PROTECT(r_maybe_duplicate(x));
 
@@ -198,7 +198,7 @@ static SEXP translate_encoding_df(SEXP x, R_len_t size) {
 
   for (int i = 0; i < n_col; ++i) {
     col = VECTOR_ELT(x, i);
-    SET_VECTOR_ELT(x, i, translate_encoding(col, size));
+    SET_VECTOR_ELT(x, i, obj_translate_encoding(col, size));
   }
 
   UNPROTECT(1);
@@ -208,9 +208,9 @@ static SEXP translate_encoding_df(SEXP x, R_len_t size) {
 // -----------------------------------------------------------------------------
 
 static SEXP translate_none(SEXP x, SEXP y);
-static SEXP translate_encoding_chr2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
-static SEXP translate_encoding_list2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
-static SEXP translate_encoding_df2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+static SEXP chr_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+static SEXP list_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+static SEXP df_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
 
 // Notes:
 // - Assumes that `x` and `y` are the same type from calling `vec_cast()`.
@@ -218,11 +218,11 @@ static SEXP translate_encoding_df2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_siz
 // - Returns a list holding `x` and `y` translated to their common encoding.
 
 // [[ include("vctrs.h") ]]
-SEXP translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+SEXP obj_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   switch (vec_proxy_typeof(x)) {
-  case vctrs_type_character: return translate_encoding_chr2(x, x_size, y, y_size);
-  case vctrs_type_list: return translate_encoding_list2(x, x_size, y, y_size);
-  case vctrs_type_dataframe: return translate_encoding_df2(x, x_size, y, y_size);
+  case vctrs_type_character: return chr_translate_encoding2(x, x_size, y, y_size);
+  case vctrs_type_list: return list_translate_encoding2(x, x_size, y, y_size);
+  case vctrs_type_dataframe: return df_translate_encoding2(x, x_size, y, y_size);
   default: return translate_none(x, y);
   }
 }
@@ -237,12 +237,12 @@ static SEXP translate_none(SEXP x, SEXP y) {
   return out;
 }
 
-static SEXP translate_encoding_chr2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+static SEXP chr_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
 
-  if (translation_required_chr2(x, x_size, y, y_size)) {
-    SET_VECTOR_ELT(out, 0, translate_encoding_chr(x, x_size));
-    SET_VECTOR_ELT(out, 1, translate_encoding_chr(y, y_size));
+  if (chr_translation_required2(x, x_size, y, y_size)) {
+    SET_VECTOR_ELT(out, 0, chr_translate_encoding(x, x_size));
+    SET_VECTOR_ELT(out, 1, chr_translate_encoding(y, y_size));
   } else {
     SET_VECTOR_ELT(out, 0, x);
     SET_VECTOR_ELT(out, 1, y);
@@ -252,12 +252,12 @@ static SEXP translate_encoding_chr2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_si
   return out;
 }
 
-static SEXP translate_encoding_list2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+static SEXP list_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
 
-  if (any_known_encoding_list(x, x_size) || any_known_encoding_list(y, y_size)) {
-    SET_VECTOR_ELT(out, 0, translate_encoding_list(x, x_size));
-    SET_VECTOR_ELT(out, 1, translate_encoding_list(y, y_size));
+  if (list_any_known_encoding(x, x_size) || list_any_known_encoding(y, y_size)) {
+    SET_VECTOR_ELT(out, 0, list_translate_encoding(x, x_size));
+    SET_VECTOR_ELT(out, 1, list_translate_encoding(y, y_size));
   } else {
     SET_VECTOR_ELT(out, 0, x);
     SET_VECTOR_ELT(out, 1, y);
@@ -267,7 +267,7 @@ static SEXP translate_encoding_list2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_s
   return out;
 }
 
-static SEXP translate_encoding_df2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+static SEXP df_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   SEXP x_elt;
   SEXP y_elt;
   SEXP translated;
@@ -283,7 +283,7 @@ static SEXP translate_encoding_df2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_siz
     x_elt = VECTOR_ELT(x, i);
     y_elt = VECTOR_ELT(y, i);
 
-    translated = PROTECT(translate_encoding2(x_elt, x_size, y_elt, y_size));
+    translated = PROTECT(obj_translate_encoding2(x_elt, x_size, y_elt, y_size));
 
     SET_VECTOR_ELT(x, i, VECTOR_ELT(translated, 0));
     SET_VECTOR_ELT(y, i, VECTOR_ELT(translated, 1));

--- a/src/translate.c
+++ b/src/translate.c
@@ -10,7 +10,7 @@
 // UTF-8 translation is not attempted in these cases:
 // - (utf8 + utf8), (latin1 + latin1), (unknown + unknown), (bytes + bytes)
 
-static bool chr_requires_translation_impl(const SEXP* x, R_len_t size, int reference) {
+static bool translation_required_chr_impl(const SEXP* x, R_len_t size, int reference) {
   for (R_len_t i = 0; i < size; ++i, ++x) {
     if (CHAR_ENC_TYPE(*x) != reference) {
       return true;
@@ -21,25 +21,25 @@ static bool chr_requires_translation_impl(const SEXP* x, R_len_t size, int refer
 }
 
 // [[ include("vctrs.h") ]]
-bool chr_requires_translation(SEXP x, R_len_t size) {
+bool translation_required_chr(SEXP x, R_len_t size) {
   const SEXP* xp = STRING_PTR_RO(x);
   int reference = CHAR_ENC_TYPE(*xp);
 
-  return chr_requires_translation_impl(xp, size, reference);
+  return translation_required_chr_impl(xp, size, reference);
 }
 
 // Check if `x` or `y` need to be translated to UTF-8, relative to each other
-static bool chr_requires_translation2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+static bool translation_required_chr2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   const SEXP* p_x = STRING_PTR_RO(x);
   int reference = CHAR_ENC_TYPE(*p_x);
 
-  if (chr_requires_translation_impl(p_x, x_size, reference)) {
+  if (translation_required_chr_impl(p_x, x_size, reference)) {
     return true;
   }
 
   const SEXP* p_y = STRING_PTR_RO(y);
 
-  if (chr_requires_translation_impl(p_y, y_size, reference)) {
+  if (translation_required_chr_impl(p_y, y_size, reference)) {
     return true;
   }
 
@@ -107,20 +107,20 @@ static bool any_known_encoding_df(SEXP x, R_len_t size) {
 // Utilities required for translating the character vector elements of a list
 // to UTF-8. This function is required by `translate_common_encoding_list()`.
 
-static SEXP translate_utf8_chr(SEXP x, R_len_t size);
-static SEXP translate_utf8_list(SEXP x, R_len_t size);
-static SEXP translate_utf8_df(SEXP x, R_len_t size);
+static SEXP translate_encoding_chr(SEXP x, R_len_t size);
+static SEXP translate_encoding_list(SEXP x, R_len_t size);
+static SEXP translate_encoding_df(SEXP x, R_len_t size);
 
-static SEXP translate_utf8(SEXP x, R_len_t size) {
+static SEXP translate_encoding(SEXP x, R_len_t size) {
   switch (vec_typeof(x)) {
-  case vctrs_type_character: return translate_utf8_chr(x, size);
-  case vctrs_type_list: return translate_utf8_list(x, size);
-  case vctrs_type_dataframe: return translate_utf8_df(x, size);
+  case vctrs_type_character: return translate_encoding_chr(x, size);
+  case vctrs_type_list: return translate_encoding_list(x, size);
+  case vctrs_type_dataframe: return translate_encoding_df(x, size);
   default: return x;
   }
 }
 
-static SEXP translate_utf8_chr(SEXP x, R_len_t size) {
+static SEXP translate_encoding_chr(SEXP x, R_len_t size) {
   const SEXP* p_x = STRING_PTR_RO(x);
 
   SEXP out = PROTECT(Rf_allocVector(STRSXP, size));
@@ -145,20 +145,20 @@ static SEXP translate_utf8_chr(SEXP x, R_len_t size) {
   return out;
 }
 
-static SEXP translate_utf8_list(SEXP x, R_len_t size) {
+static SEXP translate_encoding_list(SEXP x, R_len_t size) {
   SEXP x_elt;
   x = PROTECT(r_maybe_duplicate(x));
 
   for (int i = 0; i < size; ++i) {
     x_elt = VECTOR_ELT(x, i);
-    SET_VECTOR_ELT(x, i, translate_utf8(x_elt, vec_size(x_elt)));
+    SET_VECTOR_ELT(x, i, translate_encoding(x_elt, vec_size(x_elt)));
   }
 
   UNPROTECT(1);
   return x;
 }
 
-static SEXP translate_utf8_df(SEXP x, R_len_t size) {
+static SEXP translate_encoding_df(SEXP x, R_len_t size) {
   SEXP x_col;
   x = PROTECT(r_maybe_duplicate(x));
 
@@ -166,7 +166,7 @@ static SEXP translate_utf8_df(SEXP x, R_len_t size) {
 
   for (int i = 0; i < n_col; ++i) {
     x_col = VECTOR_ELT(x, i);
-    SET_VECTOR_ELT(x, i, translate_utf8(x_col, size));
+    SET_VECTOR_ELT(x, i, translate_encoding(x_col, size));
   }
 
   UNPROTECT(1);
@@ -174,12 +174,11 @@ static SEXP translate_utf8_df(SEXP x, R_len_t size) {
 }
 
 // -----------------------------------------------------------------------------
-// translate_common_encoding()
 
 static SEXP translate_none(SEXP x, SEXP y);
-static SEXP translate_common_encoding_chr(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
-static SEXP translate_common_encoding_list(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
-static SEXP translate_common_encoding_df(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+static SEXP translate_encoding_chr2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+static SEXP translate_encoding_list2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+static SEXP translate_encoding_df2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
 
 // Notes:
 // - Assumes that `x` and `y` are the same type from calling `vec_cast()`.
@@ -187,11 +186,11 @@ static SEXP translate_common_encoding_df(SEXP x, R_len_t x_size, SEXP y, R_len_t
 // - Returns a list holding `x` and `y` translated to their common encoding.
 
 // [[ include("vctrs.h") ]]
-SEXP translate_common_encoding(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+SEXP translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   switch (vec_typeof(x)) {
-  case vctrs_type_character: return translate_common_encoding_chr(x, x_size, y, y_size);
-  case vctrs_type_list: return translate_common_encoding_list(x, x_size, y, y_size);
-  case vctrs_type_dataframe: return translate_common_encoding_df(x, x_size, y, y_size);
+  case vctrs_type_character: return translate_encoding_chr2(x, x_size, y, y_size);
+  case vctrs_type_list: return translate_encoding_list2(x, x_size, y, y_size);
+  case vctrs_type_dataframe: return translate_encoding_df2(x, x_size, y, y_size);
   default: return translate_none(x, y);
   }
 }
@@ -206,12 +205,12 @@ static SEXP translate_none(SEXP x, SEXP y) {
   return out;
 }
 
-static SEXP translate_common_encoding_chr(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+static SEXP translate_encoding_chr2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
 
-  if (chr_requires_translation2(x, x_size, y, y_size)) {
-    SET_VECTOR_ELT(out, 0, translate_utf8_chr(x, x_size));
-    SET_VECTOR_ELT(out, 1, translate_utf8_chr(y, y_size));
+  if (translation_required_chr2(x, x_size, y, y_size)) {
+    SET_VECTOR_ELT(out, 0, translate_encoding_chr(x, x_size));
+    SET_VECTOR_ELT(out, 1, translate_encoding_chr(y, y_size));
   } else {
     SET_VECTOR_ELT(out, 0, x);
     SET_VECTOR_ELT(out, 1, y);
@@ -221,12 +220,12 @@ static SEXP translate_common_encoding_chr(SEXP x, R_len_t x_size, SEXP y, R_len_
   return out;
 }
 
-static SEXP translate_common_encoding_list(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+static SEXP translate_encoding_list2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
 
   if (any_known_encoding(x, x_size) || any_known_encoding(y, y_size)) {
-    SET_VECTOR_ELT(out, 0, translate_utf8_list(x, x_size));
-    SET_VECTOR_ELT(out, 1, translate_utf8_list(y, y_size));
+    SET_VECTOR_ELT(out, 0, translate_encoding_list(x, x_size));
+    SET_VECTOR_ELT(out, 1, translate_encoding_list(y, y_size));
   } else {
     SET_VECTOR_ELT(out, 0, x);
     SET_VECTOR_ELT(out, 1, y);
@@ -236,7 +235,7 @@ static SEXP translate_common_encoding_list(SEXP x, R_len_t x_size, SEXP y, R_len
   return out;
 }
 
-static SEXP translate_common_encoding_df(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+static SEXP translate_encoding_df2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   SEXP x_i;
   SEXP y_i;
   SEXP translated;
@@ -252,7 +251,7 @@ static SEXP translate_common_encoding_df(SEXP x, R_len_t x_size, SEXP y, R_len_t
     x_i = VECTOR_ELT(x, i);
     y_i = VECTOR_ELT(y, i);
 
-    translated = PROTECT(translate_common_encoding(x_i, x_size, y_i, y_size));
+    translated = PROTECT(translate_encoding2(x_i, x_size, y_i, y_size));
 
     SET_VECTOR_ELT(x, i, VECTOR_ELT(translated, 0));
     SET_VECTOR_ELT(y, i, VECTOR_ELT(translated, 1));

--- a/src/translate.c
+++ b/src/translate.c
@@ -255,7 +255,7 @@ static SEXP translate_encoding_chr2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_si
 static SEXP translate_encoding_list2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
 
-  if (any_known_encoding(x, x_size) || any_known_encoding(y, y_size)) {
+  if (any_known_encoding_list(x, x_size) || any_known_encoding_list(y, y_size)) {
     SET_VECTOR_ELT(out, 0, translate_encoding_list(x, x_size));
     SET_VECTOR_ELT(out, 1, translate_encoding_list(y, y_size));
   } else {

--- a/src/translate.c
+++ b/src/translate.c
@@ -1,0 +1,268 @@
+#include "vctrs.h"
+#include "utils.h"
+
+// -----------------------------------------------------------------------------
+
+// UTF-8 translation will be successful in these cases:
+// - (utf8 + latin1), (unknown + utf8), (unknown + latin1)
+// UTF-8 translation will fail purposefully in these cases:
+// - (bytes + utf8), (bytes + latin1), (bytes + unknown)
+// UTF-8 translation is not attempted in these cases:
+// - (utf8 + utf8), (latin1 + latin1), (unknown + unknown), (bytes + bytes)
+
+static bool chr_requires_translation_impl(const SEXP* x, R_len_t size, int reference) {
+  for (R_len_t i = 0; i < size; ++i, ++x) {
+    if (CHAR_ENC_TYPE(*x) != reference) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// [[ include("vctrs.h") ]]
+bool chr_requires_translation(SEXP x, R_len_t size) {
+  const SEXP* xp = STRING_PTR_RO(x);
+  int reference = CHAR_ENC_TYPE(*xp);
+
+  return chr_requires_translation_impl(xp, size, reference);
+}
+
+// Check if `x` or `y` need to be translated to UTF-8, relative to each other
+static bool chr_requires_translation2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+  const SEXP* p_x = STRING_PTR_RO(x);
+  int reference = CHAR_ENC_TYPE(*p_x);
+
+  if (chr_requires_translation_impl(p_x, x_size, reference)) {
+    return true;
+  }
+
+  const SEXP* p_y = STRING_PTR_RO(y);
+
+  if (chr_requires_translation_impl(p_y, y_size, reference)) {
+    return true;
+  }
+
+  return false;
+}
+
+// -----------------------------------------------------------------------------
+// Utilities required for checking if any character elements of a list have a
+// "known" encoding. This implies that we have to convert all character
+// elements of the list to UTF-8. This function is required by
+// `translate_common_encoding_list()`.
+
+static bool any_known_encoding_chr(SEXP x, R_len_t size);
+static bool any_known_encoding_list(SEXP x, R_len_t size);
+static bool any_known_encoding_df(SEXP x, R_len_t size);
+
+static bool any_known_encoding(SEXP x, R_len_t size) {
+  switch (vec_typeof(x)) {
+  case vctrs_type_character: return any_known_encoding_chr(x, size);
+  case vctrs_type_list: return any_known_encoding_list(x, size);
+  case vctrs_type_dataframe: return any_known_encoding_df(x, size);
+  default: return true;
+  }
+}
+
+static bool any_known_encoding_chr(SEXP x, R_len_t size) {
+  const SEXP* p_x = STRING_PTR_RO(x);
+
+  for (int i = 0; i < size; ++i, ++p_x) {
+    if (CHAR_ENC_TYPE(*p_x) != 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static bool any_known_encoding_list(SEXP x, R_len_t size) {
+  SEXP elt;
+
+  for (int i = 0; i < size; ++i) {
+    elt = VECTOR_ELT(x, i);
+
+    if (any_known_encoding(elt, vec_size(elt))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static bool any_known_encoding_df(SEXP x, R_len_t size) {
+  int n_col = Rf_length(x);
+
+  for (int i = 0; i < n_col; ++i) {
+    if (any_known_encoding(VECTOR_ELT(x, i), size)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// -----------------------------------------------------------------------------
+// Utilities required for translating the character vector elements of a list
+// to UTF-8. This function is required by `translate_common_encoding_list()`.
+
+static SEXP translate_utf8_chr(SEXP x, R_len_t size);
+static SEXP translate_utf8_list(SEXP x, R_len_t size);
+static SEXP translate_utf8_df(SEXP x, R_len_t size);
+
+static SEXP translate_utf8(SEXP x, R_len_t size) {
+  switch (vec_typeof(x)) {
+  case vctrs_type_character: return translate_utf8_chr(x, size);
+  case vctrs_type_list: return translate_utf8_list(x, size);
+  case vctrs_type_dataframe: return translate_utf8_df(x, size);
+  default: return x;
+  }
+}
+
+static SEXP translate_utf8_chr(SEXP x, R_len_t size) {
+  const SEXP* p_x = STRING_PTR_RO(x);
+
+  SEXP out = PROTECT(Rf_allocVector(STRSXP, size));
+  SEXP* p_out = STRING_PTR(out);
+
+  SEXP chr;
+  const void *vmax = vmaxget();
+
+  for (int i = 0; i < size; ++i, ++p_x, ++p_out) {
+    chr = *p_x;
+
+    if (CHAR_IS_UTF8(chr)) {
+      *p_out = chr;
+      continue;
+    }
+
+    *p_out = Rf_mkCharCE(Rf_translateCharUTF8(chr), CE_UTF8);
+  }
+
+  vmaxset(vmax);
+  UNPROTECT(1);
+  return out;
+}
+
+static SEXP translate_utf8_list(SEXP x, R_len_t size) {
+  SEXP x_elt;
+  x = PROTECT(r_maybe_duplicate(x));
+
+  for (int i = 0; i < size; ++i) {
+    x_elt = VECTOR_ELT(x, i);
+    SET_VECTOR_ELT(x, i, translate_utf8(x_elt, vec_size(x_elt)));
+  }
+
+  UNPROTECT(1);
+  return x;
+}
+
+static SEXP translate_utf8_df(SEXP x, R_len_t size) {
+  SEXP x_col;
+  x = PROTECT(r_maybe_duplicate(x));
+
+  int n_col = Rf_length(x);
+
+  for (int i = 0; i < n_col; ++i) {
+    x_col = VECTOR_ELT(x, i);
+    SET_VECTOR_ELT(x, i, translate_utf8(x_col, size));
+  }
+
+  UNPROTECT(1);
+  return x;
+}
+
+// -----------------------------------------------------------------------------
+// translate_common_encoding()
+
+static SEXP translate_none(SEXP x, SEXP y);
+static SEXP translate_common_encoding_chr(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+static SEXP translate_common_encoding_list(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+static SEXP translate_common_encoding_df(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+
+// Notes:
+// - Assumes that `x` and `y` are the same type from calling `vec_cast()`.
+// - Does not assume that `x` and `y` are the same size.
+// - Returns a list holding `x` and `y` translated to their common encoding.
+
+// [[ include("vctrs.h") ]]
+SEXP translate_common_encoding(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+  switch (vec_typeof(x)) {
+  case vctrs_type_character: return translate_common_encoding_chr(x, x_size, y, y_size);
+  case vctrs_type_list: return translate_common_encoding_list(x, x_size, y, y_size);
+  case vctrs_type_dataframe: return translate_common_encoding_df(x, x_size, y, y_size);
+  default: return translate_none(x, y);
+  }
+}
+
+static SEXP translate_none(SEXP x, SEXP y) {
+  SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
+
+  SET_VECTOR_ELT(out, 0, x);
+  SET_VECTOR_ELT(out, 1, y);
+
+  UNPROTECT(1);
+  return out;
+}
+
+static SEXP translate_common_encoding_chr(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+  SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
+
+  if (chr_requires_translation2(x, x_size, y, y_size)) {
+    SET_VECTOR_ELT(out, 0, translate_utf8_chr(x, x_size));
+    SET_VECTOR_ELT(out, 1, translate_utf8_chr(y, y_size));
+  } else {
+    SET_VECTOR_ELT(out, 0, x);
+    SET_VECTOR_ELT(out, 1, y);
+  }
+
+  UNPROTECT(1);
+  return out;
+}
+
+static SEXP translate_common_encoding_list(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+  SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
+
+  if (any_known_encoding(x, x_size) || any_known_encoding(y, y_size)) {
+    SET_VECTOR_ELT(out, 0, translate_utf8_list(x, x_size));
+    SET_VECTOR_ELT(out, 1, translate_utf8_list(y, y_size));
+  } else {
+    SET_VECTOR_ELT(out, 0, x);
+    SET_VECTOR_ELT(out, 1, y);
+  }
+
+  UNPROTECT(1);
+  return out;
+}
+
+static SEXP translate_common_encoding_df(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
+  SEXP x_i;
+  SEXP y_i;
+  SEXP translated;
+
+  x = PROTECT(r_maybe_duplicate(x));
+  y = PROTECT(r_maybe_duplicate(y));
+
+  SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
+
+  int n_col = Rf_length(x);
+
+  for (int i = 0; i < n_col; ++i) {
+    x_i = VECTOR_ELT(x, i);
+    y_i = VECTOR_ELT(y, i);
+
+    translated = PROTECT(translate_common_encoding(x_i, x_size, y_i, y_size));
+
+    SET_VECTOR_ELT(x, i, VECTOR_ELT(translated, 0));
+    SET_VECTOR_ELT(y, i, VECTOR_ELT(translated, 1));
+
+    UNPROTECT(1);
+  }
+
+  SET_VECTOR_ELT(out, 0, x);
+  SET_VECTOR_ELT(out, 1, y);
+
+  UNPROTECT(3);
+  return out;
+}

--- a/src/translate.c
+++ b/src/translate.c
@@ -26,10 +26,10 @@ bool translation_required_chr(SEXP x, R_len_t size) {
     return false;
   }
 
-  const SEXP* xp = STRING_PTR_RO(x);
-  int reference = CHAR_ENC_TYPE(*xp);
+  const SEXP* p_x = STRING_PTR_RO(x);
+  int reference = CHAR_ENC_TYPE(*p_x);
 
-  return translation_required_chr_impl(xp, size, reference);
+  return translation_required_chr_impl(p_x, size, reference);
 }
 
 // Check if `x` or `y` need to be translated to UTF-8, relative to each other
@@ -178,12 +178,12 @@ static SEXP translate_encoding_chr(SEXP x, R_len_t size) {
 }
 
 static SEXP translate_encoding_list(SEXP x, R_len_t size) {
-  SEXP x_elt;
+  SEXP elt;
   x = PROTECT(r_maybe_duplicate(x));
 
   for (int i = 0; i < size; ++i) {
-    x_elt = VECTOR_ELT(x, i);
-    SET_VECTOR_ELT(x, i, translate_encoding(x_elt, vec_size(x_elt)));
+    elt = VECTOR_ELT(x, i);
+    SET_VECTOR_ELT(x, i, translate_encoding(elt, vec_size(elt)));
   }
 
   UNPROTECT(1);
@@ -191,14 +191,14 @@ static SEXP translate_encoding_list(SEXP x, R_len_t size) {
 }
 
 static SEXP translate_encoding_df(SEXP x, R_len_t size) {
-  SEXP x_col;
+  SEXP col;
   x = PROTECT(r_maybe_duplicate(x));
 
   int n_col = Rf_length(x);
 
   for (int i = 0; i < n_col; ++i) {
-    x_col = VECTOR_ELT(x, i);
-    SET_VECTOR_ELT(x, i, translate_encoding(x_col, size));
+    col = VECTOR_ELT(x, i);
+    SET_VECTOR_ELT(x, i, translate_encoding(col, size));
   }
 
   UNPROTECT(1);
@@ -268,8 +268,8 @@ static SEXP translate_encoding_list2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_s
 }
 
 static SEXP translate_encoding_df2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
-  SEXP x_i;
-  SEXP y_i;
+  SEXP x_elt;
+  SEXP y_elt;
   SEXP translated;
 
   x = PROTECT(r_maybe_duplicate(x));
@@ -280,10 +280,10 @@ static SEXP translate_encoding_df2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_siz
   int n_col = Rf_length(x);
 
   for (int i = 0; i < n_col; ++i) {
-    x_i = VECTOR_ELT(x, i);
-    y_i = VECTOR_ELT(y, i);
+    x_elt = VECTOR_ELT(x, i);
+    y_elt = VECTOR_ELT(y, i);
 
-    translated = PROTECT(translate_encoding2(x_i, x_size, y_i, y_size));
+    translated = PROTECT(translate_encoding2(x_elt, x_size, y_elt, y_size));
 
     SET_VECTOR_ELT(x, i, VECTOR_ELT(translated, 0));
     SET_VECTOR_ELT(y, i, VECTOR_ELT(translated, 1));

--- a/src/translate.c
+++ b/src/translate.c
@@ -61,7 +61,7 @@ static bool any_known_encoding(SEXP x, R_len_t size) {
   case vctrs_type_character: return any_known_encoding_chr(x, size);
   case vctrs_type_list: return any_known_encoding_list(x, size);
   case vctrs_type_dataframe: return any_known_encoding_df(x, size);
-  default: return true;
+  default: return false;
   }
 }
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -10,9 +10,9 @@
 // UTF-8 translation is not attempted in these cases:
 // - (utf8 + utf8), (latin1 + latin1), (unknown + unknown), (bytes + bytes)
 
-static bool translation_required_chr_impl(const SEXP* x, R_len_t size, int reference) {
+static bool translation_required_chr_impl(const SEXP* x, R_len_t size, cetype_t reference) {
   for (R_len_t i = 0; i < size; ++i, ++x) {
-    if (CHAR_ENC_TYPE(*x) != reference) {
+    if (Rf_getCharCE(*x) != reference) {
       return true;
     }
   }
@@ -27,7 +27,7 @@ bool translation_required_chr(SEXP x, R_len_t size) {
   }
 
   const SEXP* p_x = STRING_PTR_RO(x);
-  int reference = CHAR_ENC_TYPE(*p_x);
+  cetype_t reference = Rf_getCharCE(*p_x);
 
   return translation_required_chr_impl(p_x, size, reference);
 }
@@ -46,16 +46,16 @@ static bool translation_required_chr2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_
 
   if (x_empty) {
     p_y = STRING_PTR_RO(y);
-    return translation_required_chr_impl(p_y, y_size, CHAR_ENC_TYPE(*p_y));
+    return translation_required_chr_impl(p_y, y_size, Rf_getCharCE(*p_y));
   }
 
   if (y_empty) {
     p_x = STRING_PTR_RO(x);
-    return translation_required_chr_impl(p_x, x_size, CHAR_ENC_TYPE(*p_x));
+    return translation_required_chr_impl(p_x, x_size, Rf_getCharCE(*p_x));
   }
 
   p_x = STRING_PTR_RO(x);
-  int reference = CHAR_ENC_TYPE(*p_x);
+  cetype_t reference = Rf_getCharCE(*p_x);
 
   if (translation_required_chr_impl(p_x, x_size, reference)) {
     return true;
@@ -97,7 +97,7 @@ static bool any_known_encoding_chr(SEXP x, R_len_t size) {
   const SEXP* p_x = STRING_PTR_RO(x);
 
   for (int i = 0; i < size; ++i, ++p_x) {
-    if (CHAR_ENC_TYPE(*p_x) != 0) {
+    if (Rf_getCharCE(*p_x) != CE_NATIVE) {
       return true;
     }
   }
@@ -164,7 +164,7 @@ static SEXP translate_encoding_chr(SEXP x, R_len_t size) {
   for (int i = 0; i < size; ++i, ++p_x, ++p_out) {
     chr = *p_x;
 
-    if (CHAR_IS_UTF8(chr)) {
+    if (Rf_getCharCE(chr) == CE_UTF8) {
       *p_out = chr;
       continue;
     }

--- a/src/translate.c
+++ b/src/translate.c
@@ -57,7 +57,7 @@ static bool any_known_encoding_list(SEXP x, R_len_t size);
 static bool any_known_encoding_df(SEXP x, R_len_t size);
 
 static bool any_known_encoding(SEXP x, R_len_t size) {
-  switch (vec_typeof(x)) {
+  switch (vec_proxy_typeof(x)) {
   case vctrs_type_character: return any_known_encoding_chr(x, size);
   case vctrs_type_list: return any_known_encoding_list(x, size);
   case vctrs_type_dataframe: return any_known_encoding_df(x, size);
@@ -112,7 +112,7 @@ static SEXP translate_encoding_list(SEXP x, R_len_t size);
 static SEXP translate_encoding_df(SEXP x, R_len_t size);
 
 static SEXP translate_encoding(SEXP x, R_len_t size) {
-  switch (vec_typeof(x)) {
+  switch (vec_proxy_typeof(x)) {
   case vctrs_type_character: return translate_encoding_chr(x, size);
   case vctrs_type_list: return translate_encoding_list(x, size);
   case vctrs_type_dataframe: return translate_encoding_df(x, size);
@@ -187,7 +187,7 @@ static SEXP translate_encoding_df2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_siz
 
 // [[ include("vctrs.h") ]]
 SEXP translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
-  switch (vec_typeof(x)) {
+  switch (vec_proxy_typeof(x)) {
   case vctrs_type_character: return translate_encoding_chr2(x, x_size, y, y_size);
   case vctrs_type_list: return translate_encoding_list2(x, x_size, y, y_size);
   case vctrs_type_dataframe: return translate_encoding_df2(x, x_size, y, y_size);

--- a/src/translate.c
+++ b/src/translate.c
@@ -49,8 +49,8 @@ static bool translation_required_chr2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_
 // -----------------------------------------------------------------------------
 // Utilities required for checking if any character elements of a list have a
 // "known" encoding. This implies that we have to convert all character
-// elements of the list to UTF-8. This function is required by
-// `translate_common_encoding_list()`.
+// elements of the list to UTF-8. This function is solely used by
+// `translate_encoding_list2()`.
 
 static bool any_known_encoding_chr(SEXP x, R_len_t size);
 static bool any_known_encoding_list(SEXP x, R_len_t size);
@@ -105,7 +105,7 @@ static bool any_known_encoding_df(SEXP x, R_len_t size) {
 
 // -----------------------------------------------------------------------------
 // Utilities required for translating the character vector elements of a list
-// to UTF-8. This function is required by `translate_common_encoding_list()`.
+// to UTF-8. This function is solely used by `translate_encoding_list2()`.
 
 static SEXP translate_encoding_chr(SEXP x, R_len_t size);
 static SEXP translate_encoding_list(SEXP x, R_len_t size);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -282,16 +282,6 @@ SEXP vec_as_unique_names(SEXP names, bool quiet);
 
 // Character translation ----------------------------------------
 
-// `sxpinfo.gp` is exposed through `LEVELS()`, and CHARSXP info is
-// extractable through a bitwise and. This copies the unexposed
-// interface in Defn.h
-#define BYTES_MASK 2
-#define LATIN1_MASK 4
-#define UTF8_MASK 8
-
-#define CHAR_IS_UTF8(x) (LEVELS(x) & UTF8_MASK)
-#define CHAR_ENC_TYPE(x) (LEVELS(x) & (BYTES_MASK | UTF8_MASK | LATIN1_MASK))
-
 bool translation_required_chr(SEXP x, R_len_t size);
 SEXP translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -282,8 +282,8 @@ SEXP vec_as_unique_names(SEXP names, bool quiet);
 
 // Character translation ----------------------------------------
 
-bool translation_required_chr(SEXP x, R_len_t size);
-SEXP translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+bool chr_translation_required(SEXP x, R_len_t size);
+SEXP obj_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
 
 // Growable vector ----------------------------------------------
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -6,16 +6,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-// `sxpinfo.gp` is exposed through `LEVELS()`, and CHARSXP info is
-// extractable through a bitwise and. This copies the unexposed
-// interface in Defn.h
-#define BYTES_MASK 2
-#define LATIN1_MASK 4
-#define UTF8_MASK 8
-
-#define CHAR_IS_UTF8(x) (LEVELS(x) & UTF8_MASK)
-#define CHAR_ENC_TYPE(x) (LEVELS(x) & (BYTES_MASK | UTF8_MASK | LATIN1_MASK))
-
 typedef R_xlen_t r_ssize_t;
 
 
@@ -290,6 +280,20 @@ SEXP vec_as_names(SEXP names, enum name_repair_arg type, bool quiet);
 bool is_unique_names(SEXP names);
 SEXP vec_as_unique_names(SEXP names, bool quiet);
 
+// Character translation ----------------------------------------
+
+// `sxpinfo.gp` is exposed through `LEVELS()`, and CHARSXP info is
+// extractable through a bitwise and. This copies the unexposed
+// interface in Defn.h
+#define BYTES_MASK 2
+#define LATIN1_MASK 4
+#define UTF8_MASK 8
+
+#define CHAR_IS_UTF8(x) (LEVELS(x) & UTF8_MASK)
+#define CHAR_ENC_TYPE(x) (LEVELS(x) & (BYTES_MASK | UTF8_MASK | LATIN1_MASK))
+
+bool chr_requires_translation(SEXP x, R_len_t size);
+SEXP translate_common_encoding(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
 
 // Growable vector ----------------------------------------------
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -292,8 +292,8 @@ SEXP vec_as_unique_names(SEXP names, bool quiet);
 #define CHAR_IS_UTF8(x) (LEVELS(x) & UTF8_MASK)
 #define CHAR_ENC_TYPE(x) (LEVELS(x) & (BYTES_MASK | UTF8_MASK | LATIN1_MASK))
 
-bool chr_requires_translation(SEXP x, R_len_t size);
-SEXP translate_common_encoding(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+bool translation_required_chr(SEXP x, R_len_t size);
+SEXP translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
 
 // Growable vector ----------------------------------------------
 

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -253,6 +253,20 @@ test_that("can use matching functions with strings with different encodings", {
   expect_equal(vec_in(utf8, latin1), utf8 %in% latin1)
 })
 
+test_that("can use matching functions when one string has multiple encodings", {
+  utf8 <- "\u00B0C"
+
+  unknown <- utf8
+  Encoding(unknown) <- "unknown"
+
+  latin1 <- iconv(utf8, "UTF-8", "latin1")
+
+  x <- c(utf8, unknown)
+
+  expect_equal(vec_match(x, latin1), c(1L, 1L))
+  expect_equal(vec_match(x, latin1), match(x, latin1))
+})
+
 test_that("can use matching functions within the same encoding", {
   unknown <- "fa\xE7ile"
 
@@ -295,11 +309,64 @@ test_that("can use matching functions with lists of characters with different en
 
   utf8 <- enc2utf8(latin1)
 
-  lst_latin1 <- list("ascii", latin1)
+  lst_ascii <- list("ascii")
+  lst_latin1 <- list(latin1)
+  lst_ascii_latin1 <- c(lst_ascii, lst_latin1)
   lst_utf8 <- list(utf8)
 
-  expect_equal(vec_match(lst_utf8, lst_latin1), 2L)
-  expect_equal(vec_match(lst_utf8, lst_latin1), match(lst_utf8, lst_latin1))
+  lst_of_lst_utf8 <- list(lst_utf8)
+  lst_of_lst_ascii_latin1 <- list(lst_ascii, lst_latin1)
+
+  expect_equal(vec_match(lst_ascii, lst_ascii), 1L)
+  expect_equal(vec_in(lst_ascii, lst_ascii), TRUE)
+
+  expect_equal(vec_match(lst_utf8, lst_ascii_latin1), 2L)
+  expect_equal(vec_in(lst_utf8, lst_ascii_latin1), TRUE)
+
+  expect_equal(vec_match(lst_utf8, lst_ascii_latin1), match(lst_utf8, lst_ascii_latin1))
+  expect_equal(vec_in(lst_utf8, lst_ascii_latin1), lst_utf8 %in% lst_ascii_latin1)
+
+  expect_equal(vec_match(lst_of_lst_utf8, lst_of_lst_ascii_latin1), 2L)
+  expect_equal(vec_in(lst_of_lst_utf8, lst_of_lst_ascii_latin1), TRUE)
+
+  expect_equal(vec_match(lst_of_lst_utf8, lst_of_lst_ascii_latin1), match(lst_of_lst_utf8, lst_of_lst_ascii_latin1))
+  expect_equal(vec_in(lst_of_lst_utf8, lst_of_lst_ascii_latin1), lst_of_lst_utf8 %in% lst_of_lst_ascii_latin1)
+})
+
+test_that("can use matching functions with data frames with string columns", {
+  utf8 <- "\u00B0C"
+
+  unknown <- utf8
+  Encoding(unknown) <- "unknown"
+
+  df_utf8 <- data_frame(x = utf8, y = 2)
+  df_unknown <- data_frame(x = c(unknown, unknown), y = c(1, 2))
+
+  expect_equal(vec_match(df_unknown, df_unknown), 1:2)
+  expect_equal(vec_in(df_unknown, df_unknown), c(TRUE, TRUE))
+
+  expect_equal(vec_match(df_utf8, df_unknown), 2L)
+  expect_equal(vec_in(df_utf8, df_unknown), TRUE)
+})
+
+test_that("can use matching functions with lists of data frames with string columns", {
+  utf8 <- "\u00B0C"
+
+  unknown <- utf8
+  Encoding(unknown) <- "unknown"
+
+  df_utf8 <- data_frame(x = utf8, y = 2)
+  df_unknown_1 <- data_frame(x = unknown, y = 1)
+  df_unknown_2 <- data_frame(x = unknown, y = 2)
+
+  lst_of_df_utf8 <- list(df_utf8)
+  lst_of_df_unknown <- list(df_unknown_1, df_unknown_2)
+
+  expect_equal(vec_match(lst_of_df_unknown, lst_of_df_unknown), 1:2)
+  expect_equal(vec_in(lst_of_df_unknown, lst_of_df_unknown), c(TRUE, TRUE))
+
+  expect_equal(vec_match(lst_of_df_utf8, lst_of_df_unknown), 2L)
+  expect_equal(vec_in(lst_of_df_utf8, lst_of_df_unknown), TRUE)
 })
 
 # splits ------------------------------------------------------------------

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -232,6 +232,75 @@ test_that("can take the unique loc of 1d arrays (#461)", {
   expect_silent(expect_identical(vctrs::vec_unique_loc(y), int(1, 3, 5)))
 })
 
+test_that("can use matching functions with strings with different encodings", {
+  utf8 <- "\u00B0C"
+
+  unknown <- utf8
+  Encoding(unknown) <- "unknown"
+
+  latin1 <- iconv(utf8, "UTF-8", "latin1")
+
+  expect_equal(vec_match(utf8, unknown), 1L)
+  expect_equal(vec_match(utf8, unknown), match(utf8, unknown))
+
+  expect_equal(vec_match(utf8, latin1), 1L)
+  expect_equal(vec_match(utf8, latin1), match(utf8, latin1))
+
+  expect_equal(vec_in(utf8, unknown), TRUE)
+  expect_equal(vec_in(utf8, unknown), utf8 %in% unknown)
+
+  expect_equal(vec_in(utf8, latin1), TRUE)
+  expect_equal(vec_in(utf8, latin1), utf8 %in% latin1)
+})
+
+test_that("can use matching functions within the same encoding", {
+  unknown <- "fa\xE7ile"
+
+  latin1 <- unknown
+  Encoding(latin1) <- "latin1"
+
+  utf8 <- enc2utf8(latin1)
+
+  bytes <- unknown
+  Encoding(bytes) <- "bytes"
+
+  expect_equal(vec_match(unknown, unknown), 1L)
+  expect_equal(vec_match(unknown, unknown), match(unknown, unknown))
+
+  expect_equal(vec_match(latin1, latin1), 1L)
+  expect_equal(vec_match(latin1, latin1), match(latin1, latin1))
+
+  expect_equal(vec_match(utf8, utf8), 1L)
+  expect_equal(vec_match(utf8, utf8), match(utf8, utf8))
+
+  expect_equal(vec_match(bytes, bytes), 1L)
+  expect_equal(vec_match(bytes, bytes), match(bytes, bytes))
+
+  expect_equal(vec_in(unknown, unknown), TRUE)
+  expect_equal(vec_in(unknown, unknown), unknown %in% unknown)
+
+  expect_equal(vec_in(latin1, latin1), TRUE)
+  expect_equal(vec_in(latin1, latin1), latin1 %in% latin1)
+
+  expect_equal(vec_in(utf8, utf8), TRUE)
+  expect_equal(vec_in(utf8, utf8), utf8 %in% utf8)
+
+  expect_equal(vec_in(bytes, bytes), TRUE)
+  expect_equal(vec_in(bytes, bytes), bytes %in% bytes)
+})
+
+test_that("can use matching functions with lists of characters with different encodings", {
+  latin1 <- "fa\xE7ile"
+  Encoding(latin1) <- "latin1"
+
+  utf8 <- enc2utf8(latin1)
+
+  lst_latin1 <- list("ascii", latin1)
+  lst_utf8 <- list(utf8)
+
+  expect_equal(vec_match(lst_utf8, lst_latin1), 2L)
+  expect_equal(vec_match(lst_utf8, lst_latin1), match(lst_utf8, lst_latin1))
+})
 
 # splits ------------------------------------------------------------------
 

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -349,6 +349,22 @@ test_that("can use matching functions with data frames with string columns", {
   expect_equal(vec_in(df_utf8, df_unknown), TRUE)
 })
 
+test_that("can use matching functions with data frame subclasses with string columns", {
+  utf8 <- "\u00B0C"
+
+  unknown <- utf8
+  Encoding(unknown) <- "unknown"
+
+  df_utf8 <- new_data_frame(list(x = utf8, y = 2), class = "subclass")
+  df_unknown <- new_data_frame(list(x = c(unknown, unknown), y = c(1, 2)), class = "subclass")
+
+  expect_equal(vec_match(df_unknown, df_unknown), 1:2)
+  expect_equal(vec_in(df_unknown, df_unknown), c(TRUE, TRUE))
+
+  expect_equal(vec_match(df_utf8, df_unknown), 2L)
+  expect_equal(vec_in(df_utf8, df_unknown), TRUE)
+})
+
 test_that("can use matching functions with lists of data frames with string columns", {
   utf8 <- "\u00B0C"
 

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -130,3 +130,16 @@ test_that("Subclasses of `tbl_df` have `tbl_df` common type (#481)", {
   expect_identical(vec_ptype2(quux, tibble()), tibble())
   expect_identical(vec_ptype2(tibble(), quux), tibble())
 })
+
+test_that("Column name encodings are handled correctly in the common type (#553)", {
+  name_utf8 <- "\u00B0C"
+  name_unknown <- name_utf8
+  Encoding(name_unknown) <- "unknown"
+
+  data <- list(chr())
+
+  df_utf8 <- tibble::as_tibble(set_names(data, name_utf8))
+  df_unknown <- tibble::as_tibble(set_names(data, name_unknown))
+
+  expect_identical(vec_ptype2(df_utf8, df_unknown), df_utf8)
+})


### PR DESCRIPTION
Closes #553 

Big picture ideas, I'll add some benchmarks in a bit:

- New `translate.c` file holds a number of translation utility functions.

- `vec_match()` and `vec_in()` are a bit tough to handle because they create 2 hashed dictionaries (one for `needles` and one for `haystack`) separate of each other. This is a problem if we have `vec_match(needles = <utf8>, haystack = <unknown>)` since `haystack` won't be translated to utf8. My solution is to have a `translate_encoding2()` that is run before the dictionary hashing, which translates both inputs to UTF8 if either requires it.

- `translate_encoding2()` is simple when the inputs are character vectors. It uses `translation_required_chr2()` to determine if either input needs translation, and if either does it translates them.

But we obviously want to be more general, since `vec_match()` should work with data frames / lists too. That's where the rest of the code comes in.

- In the case of data frame inputs, `translate_encoding2()` takes advantage of the fact that we ran `vec_cast()` to get `needles` and `haystack` to a common type beforehand. It loops over the columns (which are guaranteed to be in the same order and have the same type) and calls `translate_encoding2()` recursively.

- The case of having list inputs is the toughest. `vec_cast()` guarantees that `needles` and `haystack` are both lists, but there is no guarantee that if the first element of `needles` is a character vector, then the first element of `haystack` is too. I think the best solution is to perform an initial loop through `needles` and `haystack`, determine if any element of either is a character vector with a "known" encoding (utf8, latin1, bytes), and if that is true then we translate _every_ character vector in both lists to UTF-8. 

While this case with lists sounds expensive, I think this is better than the base R strategy. When you give `match()` lists or data frames, [it literally just runs `as.character()` on the inputs](https://github.com/wch/r-source/blob/2480f4d76dbdce30db615ee8c2cd43d655cb1241/src/main/unique.c#L906), which has some really odd looking intermediate results and can be pretty expensive. It seems to work for them though. There is even a note in `?match` of "Matching for lists is potentially very slow and best avoided except in simple cases."