### PR TITLE
Export `vec_recycle()` as callable from C

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vctrs
 Title: Vector Helpers
-Version: 0.2.0.9002
+Version: 0.2.0.9003
 Authors@R: 
     c(person(given = "Hadley",
              family = "Wickham",

--- a/inst/include/vctrs.c
+++ b/inst/include/vctrs.c
@@ -7,7 +7,6 @@ SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool) = NULL;
 SEXP (*vec_slice_impl)(SEXP, SEXP) = NULL;
 SEXP (*vec_names)(SEXP) = NULL;
 SEXP (*vec_set_names)(SEXP, SEXP) = NULL;
-SEXP (*vec_recycle)(SEXP, R_len_t) = NULL;
 
 void vctrs_init_api() {
   vec_proxy = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_proxy");
@@ -17,5 +16,4 @@ void vctrs_init_api() {
   vec_slice_impl = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_slice_impl");
   vec_names = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_names");
   vec_set_names = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_set_names");
-  vec_recycle = (SEXP (*)(SEXP, R_len_t)) R_GetCCallable("vctrs", "vec_recycle");
 }

--- a/inst/include/vctrs.c
+++ b/inst/include/vctrs.c
@@ -7,6 +7,7 @@ SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool) = NULL;
 SEXP (*vec_slice_impl)(SEXP, SEXP) = NULL;
 SEXP (*vec_names)(SEXP) = NULL;
 SEXP (*vec_set_names)(SEXP, SEXP) = NULL;
+SEXP (*vec_recycle)(SEXP, R_len_t) = NULL;
 
 void vctrs_init_api() {
   vec_proxy = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_proxy");
@@ -16,4 +17,5 @@ void vctrs_init_api() {
   vec_slice_impl = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_slice_impl");
   vec_names = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_names");
   vec_set_names = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_set_names");
+  vec_recycle = (SEXP (*)(SEXP, R_len_t)) R_GetCCallable("vctrs", "vec_recycle");
 }

--- a/inst/include/vctrs.c
+++ b/inst/include/vctrs.c
@@ -2,7 +2,6 @@
 
 SEXP (*vec_proxy)(SEXP) = NULL;
 SEXP (*vec_restore)(SEXP, SEXP, SEXP) = NULL;
-SEXP (*vec_init)(SEXP, R_len_t) = NULL;
 SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool) = NULL;
 SEXP (*vec_slice_impl)(SEXP, SEXP) = NULL;
 SEXP (*vec_names)(SEXP) = NULL;
@@ -11,7 +10,6 @@ SEXP (*vec_set_names)(SEXP, SEXP) = NULL;
 void vctrs_init_api() {
   vec_proxy = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_proxy");
   vec_restore = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vec_restore");
-  vec_init = (SEXP (*)(SEXP, R_len_t)) R_GetCCallable("vctrs", "vec_init");
   vec_assign_impl = (SEXP (*)(SEXP, SEXP, SEXP, bool)) R_GetCCallable("vctrs", "vec_assign_impl");
   vec_slice_impl = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_slice_impl");
   vec_names = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_names");

--- a/inst/include/vctrs.h
+++ b/inst/include/vctrs.h
@@ -12,6 +12,7 @@ SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool);
 SEXP (*vec_slice_impl)(SEXP, SEXP);
 SEXP (*vec_names)(SEXP);
 SEXP (*vec_set_names)(SEXP, SEXP);
+SEXP (*vec_recycle)(SEXP, R_len_t);
 
 void vctrs_init_api();
 

--- a/inst/include/vctrs.h
+++ b/inst/include/vctrs.h
@@ -7,7 +7,6 @@
 
 SEXP (*vec_proxy)(SEXP);
 SEXP (*vec_restore)(SEXP, SEXP, SEXP);
-SEXP (*vec_init)(SEXP, R_len_t);
 SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool);
 SEXP (*vec_slice_impl)(SEXP, SEXP);
 SEXP (*vec_names)(SEXP);

--- a/inst/include/vctrs.h
+++ b/inst/include/vctrs.h
@@ -12,7 +12,6 @@ SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool);
 SEXP (*vec_slice_impl)(SEXP, SEXP);
 SEXP (*vec_names)(SEXP);
 SEXP (*vec_set_names)(SEXP, SEXP);
-SEXP (*vec_recycle)(SEXP, R_len_t);
 
 void vctrs_init_api();
 

--- a/src/init.c
+++ b/src/init.c
@@ -197,7 +197,7 @@ void R_init_vctrs(DllInfo *dll)
     R_RegisterCCallable("vctrs", "init_compact_seq", (DL_FUNC) &init_compact_seq);
 
     // Extremely experimental as eventually this might support R_xlen_t
-    R_RegisterCCallable("vctrs", "vec_short_size", (DL_FUNC) &vec_size);
+    R_RegisterCCallable("vctrs", "short_vec_size", (DL_FUNC) &vec_size);
 }
 
 

--- a/src/init.c
+++ b/src/init.c
@@ -188,7 +188,6 @@ void R_init_vctrs(DllInfo *dll)
     R_RegisterCCallable("vctrs", "vec_slice_impl", (DL_FUNC) &vec_slice_impl);
     R_RegisterCCallable("vctrs", "vec_names", (DL_FUNC) &vec_names);
     R_RegisterCCallable("vctrs", "vec_set_names", (DL_FUNC) &vec_set_names);
-    R_RegisterCCallable("vctrs", "vec_recycle", (DL_FUNC) &vec_recycle);
 
     // Extremely experimental
     // Exported but not directly available in the API header
@@ -196,8 +195,9 @@ void R_init_vctrs(DllInfo *dll)
     R_RegisterCCallable("vctrs", "compact_seq", (DL_FUNC) &compact_seq);
     R_RegisterCCallable("vctrs", "init_compact_seq", (DL_FUNC) &init_compact_seq);
 
-    // Extremely experimental as eventually this might support R_xlen_t
+    // Extremely experimental as eventually these might support R_xlen_t
     R_RegisterCCallable("vctrs", "short_vec_size", (DL_FUNC) &vec_size);
+    R_RegisterCCallable("vctrs", "short_vec_recycle", (DL_FUNC) &vec_recycle);
 }
 
 

--- a/src/init.c
+++ b/src/init.c
@@ -80,6 +80,7 @@ extern SEXP vec_init(SEXP, R_len_t);
 extern SEXP vec_assign_impl(SEXP, SEXP, SEXP, bool);
 extern SEXP vec_slice_impl(SEXP, SEXP);
 extern SEXP vec_names(SEXP);
+extern SEXP vec_recycle(SEXP, R_len_t);
 
 // Extremely experimental
 // Exported but not directly available in the API header
@@ -187,6 +188,7 @@ void R_init_vctrs(DllInfo *dll)
     R_RegisterCCallable("vctrs", "vec_slice_impl", (DL_FUNC) &vec_slice_impl);
     R_RegisterCCallable("vctrs", "vec_names", (DL_FUNC) &vec_names);
     R_RegisterCCallable("vctrs", "vec_set_names", (DL_FUNC) &vec_set_names);
+    R_RegisterCCallable("vctrs", "vec_recycle", (DL_FUNC) &vec_recycle);
 
     // Extremely experimental
     // Exported but not directly available in the API header

--- a/src/init.c
+++ b/src/init.c
@@ -183,7 +183,6 @@ void R_init_vctrs(DllInfo *dll)
     // Very experimental
     R_RegisterCCallable("vctrs", "vec_proxy", (DL_FUNC) &vec_proxy);
     R_RegisterCCallable("vctrs", "vec_restore", (DL_FUNC) &vec_restore);
-    R_RegisterCCallable("vctrs", "vec_init", (DL_FUNC) &vec_init);
     R_RegisterCCallable("vctrs", "vec_assign_impl", (DL_FUNC) &vec_assign_impl);
     R_RegisterCCallable("vctrs", "vec_slice_impl", (DL_FUNC) &vec_slice_impl);
     R_RegisterCCallable("vctrs", "vec_names", (DL_FUNC) &vec_names);
@@ -198,6 +197,7 @@ void R_init_vctrs(DllInfo *dll)
     // Extremely experimental as eventually these might support R_xlen_t
     R_RegisterCCallable("vctrs", "short_vec_size", (DL_FUNC) &vec_size);
     R_RegisterCCallable("vctrs", "short_vec_recycle", (DL_FUNC) &vec_recycle);
+    R_RegisterCCallable("vctrs", "short_vec_init", (DL_FUNC) &vec_init);
 }
 
 


### PR DESCRIPTION
One more callable that I will need in {slide}. See [this PR](https://github.com/DavisVaughan/slide/pull/25) if interested in why.

@lionel- does this suffer from the `R_len_t` vs `R_xlen_t` problem like `vec_size()`? If so, should the exported callable for `vec_init()` also be changed?