### PR TITLE
Use `intptr_t` rather than `int64_t` to avoid 32-bit pointer->int cast warning

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -42,7 +42,7 @@ static uint32_t hash_double(double x) {
 }
 
 static uint32_t hash_char(SEXP x) {
-  return hash_int64((int64_t) x);
+  return hash_int64((intptr_t) x);
 }
 
 static uint32_t hash_char_translate(SEXP x) {
@@ -53,7 +53,7 @@ static uint32_t hash_char_translate(SEXP x) {
   uint32_t hash = 0;
 
   while(*x_utf8++) {
-    hash = hash_combine(hash, hash_int64((int64_t) *x_utf8));
+    hash = hash_combine(hash, hash_int64((intptr_t) *x_utf8));
   }
 
   vmaxset(vmax);


### PR DESCRIPTION
@lionel- this does fix the Windows warning. I assume what is happening for now is that `intptr_t` is equivalent to `int32_t` on the 32-bit Windows build, which is then converted to `int64_t` when it gets to `hash_int64()`, but that is allowed without a warning.

I'll open another issue related to consistently using unsigned integer types