### PR TITLE
Ensure that only 1 or 0 is returned when checking if doubles are `NA`

### DIFF
--- a/src/equal.c
+++ b/src/equal.c
@@ -454,7 +454,9 @@ static int int_equal_na_scalar(const int* x) {
 
 static int dbl_equal_na_scalar(const double* x) {
   // is.na(NaN) is TRUE
-  return isnan(*x);
+  // isnan() does not consistently return 1 and 0 on all platforms,
+  // but R's ISNAN() does
+  return ISNAN(*x);
 }
 
 static int chr_equal_na_scalar(const SEXP* x) {


### PR DESCRIPTION
Closes #587 

Bench marks show that performance isn't affected much, which is great.

``` r
library(vctrs)
x <- rep(c(1, NA), times = 500000)

# before
bench::mark(vec_equal_na(x), iterations = 10000)
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(x)    376µs    742µs     1316.    3.82MB     132.

# after
bench::mark(vec_equal_na(x), iterations = 10000)
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(x)    472µs    749µs     1286.    3.82MB     129.
```