### PR TITLE
Use `iconv()` for portable encoding conversions

### DIFF
--- a/tests/testthat/helper-encoding.R
+++ b/tests/testthat/helper-encoding.R
@@ -5,8 +5,16 @@ encodings <- function() {
   unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
   latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
+  list(utf = utf, unknown = unknown, latin1 = latin1)
+}
+
+encoding_bytes <- function() {
+  string <- "\u00B0C"
+
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+
   bytes <- unknown
   Encoding(bytes) <- "bytes"
 
-  list(utf = utf, unknown = unknown, latin1 = latin1, bytes = bytes)
+  bytes
 }

--- a/tests/testthat/helper-encoding.R
+++ b/tests/testthat/helper-encoding.R
@@ -1,11 +1,11 @@
 encodings <- function() {
   string <- "\u00B0C"
 
-  utf <- iconv(string, from = Encoding(string), to = "UTF-8")
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
   unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
   latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
-  list(utf = utf, unknown = unknown, latin1 = latin1)
+  list(utf8 = utf8, unknown = unknown, latin1 = latin1)
 }
 
 encoding_bytes <- function() {

--- a/tests/testthat/helper-encoding.R
+++ b/tests/testthat/helper-encoding.R
@@ -1,12 +1,12 @@
 encodings <- function() {
   string <- "\u00B0C"
 
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  utf <- iconv(string, from = Encoding(string), to = "UTF-8")
   unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
   latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
   bytes <- unknown
   Encoding(bytes) <- "bytes"
 
-  list(utf8 = utf8, unknown = unknown, latin1 = latin1, bytes = bytes)
+  list(utf = utf, unknown = unknown, latin1 = latin1, bytes = bytes)
 }

--- a/tests/testthat/helper-encoding.R
+++ b/tests/testthat/helper-encoding.R
@@ -1,0 +1,12 @@
+encodings <- function() {
+  string <- "\u00B0C"
+
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
+
+  bytes <- unknown
+  Encoding(bytes) <- "bytes"
+
+  list(utf8 = utf8, unknown = unknown, latin1 = latin1, bytes = bytes)
+}

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -109,42 +109,29 @@ test_that("unique functions take the equality proxy (#375)", {
 })
 
 test_that("vec_unique() can detect uniqueness with the same string in various encodings (#553)", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
-  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
-
-  x <- c(unknown, utf8, latin1)
+  enc <- encodings()
+  x <- c(enc$unknown, enc$utf8, enc$latin1)
 
   expect_equal(vec_unique(x), x[1])
   expect_equal(vec_unique(x), unique(x))
 })
 
 test_that("vec_unique() returns differently encoded strings in the order they appear", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
-
-  x <- c(unknown, utf8)
-  y <- c(utf8, unknown)
+  enc <- encodings()
+  x <- c(enc$unknown, enc$utf8)
+  y <- c(enc$utf8, enc$unknown)
 
   expect_equal(Encoding(vec_unique(x)), "unknown")
   expect_equal(Encoding(vec_unique(y)), "UTF-8")
 })
 
 test_that("vec_unique() can determine uniqueness when the encoding is the same", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
-  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
+  enc <- encodings()
 
-  bytes <- unknown
-  Encoding(bytes) <- "bytes"
-
-  x <- c(unknown, unknown)
-  y <- c(latin1, latin1)
-  z <- c(utf8, utf8)
-  w <- c(bytes, bytes)
+  x <- c(enc$unknown, enc$unknown)
+  y <- c(enc$latin1, enc$latin1)
+  z <- c(enc$utf8, enc$utf8)
+  w <- c(enc$bytes, enc$bytes)
 
   expect_equal(vec_unique(x), x[1])
   expect_equal(vec_unique(x), unique(x))
@@ -160,17 +147,11 @@ test_that("vec_unique() can determine uniqueness when the encoding is the same",
 })
 
 test_that("vec_unique() fails purposefully with bytes strings and other encodings", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
-  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
+  enc <- encodings()
 
-  bytes <- utf8
-  Encoding(bytes) <- "bytes"
-
-  bytes_utf8 <- c(bytes, utf8)
-  bytes_unknown <- c(bytes, unknown)
-  bytes_latin1 <- c(bytes, latin1)
+  bytes_utf8 <- c(enc$bytes, enc$utf8)
+  bytes_unknown <- c(enc$bytes, enc$unknown)
+  bytes_latin1 <- c(enc$bytes, enc$latin1)
 
   expect_error(vec_unique(bytes_utf8), '"bytes" encoding is not allowed')
   expect_error(vec_unique(bytes_unknown), '"bytes" encoding is not allowed')

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -110,7 +110,7 @@ test_that("unique functions take the equality proxy (#375)", {
 
 test_that("vec_unique() can detect uniqueness with the same string in various encodings (#553)", {
   enc <- encodings()
-  x <- c(enc$unknown, enc$utf8, enc$latin1)
+  x <- c(enc$unknown, enc$utf, enc$latin1)
 
   expect_equal(vec_unique(x), x[1])
   expect_equal(vec_unique(x), unique(x))
@@ -118,8 +118,8 @@ test_that("vec_unique() can detect uniqueness with the same string in various en
 
 test_that("vec_unique() returns differently encoded strings in the order they appear", {
   enc <- encodings()
-  x <- c(enc$unknown, enc$utf8)
-  y <- c(enc$utf8, enc$unknown)
+  x <- c(enc$unknown, enc$utf)
+  y <- c(enc$utf, enc$unknown)
 
   expect_equal(Encoding(vec_unique(x)), "unknown")
   expect_equal(Encoding(vec_unique(y)), "UTF-8")
@@ -130,7 +130,7 @@ test_that("vec_unique() can determine uniqueness when the encoding is the same",
 
   x <- c(enc$unknown, enc$unknown)
   y <- c(enc$latin1, enc$latin1)
-  z <- c(enc$utf8, enc$utf8)
+  z <- c(enc$utf, enc$utf)
   w <- c(enc$bytes, enc$bytes)
 
   expect_equal(vec_unique(x), x[1])
@@ -149,11 +149,11 @@ test_that("vec_unique() can determine uniqueness when the encoding is the same",
 test_that("vec_unique() fails purposefully with bytes strings and other encodings", {
   enc <- encodings()
 
-  bytes_utf8 <- c(enc$bytes, enc$utf8)
+  bytes_utf <- c(enc$bytes, enc$utf)
   bytes_unknown <- c(enc$bytes, enc$unknown)
   bytes_latin1 <- c(enc$bytes, enc$latin1)
 
-  expect_error(vec_unique(bytes_utf8), '"bytes" encoding is not allowed')
+  expect_error(vec_unique(bytes_utf), '"bytes" encoding is not allowed')
   expect_error(vec_unique(bytes_unknown), '"bytes" encoding is not allowed')
   expect_error(vec_unique(bytes_latin1), '"bytes" encoding is not allowed')
 })
@@ -208,27 +208,27 @@ test_that("can take the unique loc of 1d arrays (#461)", {
 
 test_that("can use matching functions with strings with different encodings", {
   enc <- encodings()
-  utf8 <- enc$utf8
+  utf <- enc$utf
   unknown <- enc$unknown
   latin1 <- enc$latin1
 
-  expect_equal(vec_match(utf8, unknown), 1L)
-  expect_equal(vec_match(utf8, unknown), match(utf8, unknown))
+  expect_equal(vec_match(utf, unknown), 1L)
+  expect_equal(vec_match(utf, unknown), match(utf, unknown))
 
-  expect_equal(vec_match(utf8, latin1), 1L)
-  expect_equal(vec_match(utf8, latin1), match(utf8, latin1))
+  expect_equal(vec_match(utf, latin1), 1L)
+  expect_equal(vec_match(utf, latin1), match(utf, latin1))
 
-  expect_equal(vec_in(utf8, unknown), TRUE)
-  expect_equal(vec_in(utf8, unknown), utf8 %in% unknown)
+  expect_equal(vec_in(utf, unknown), TRUE)
+  expect_equal(vec_in(utf, unknown), utf %in% unknown)
 
-  expect_equal(vec_in(utf8, latin1), TRUE)
-  expect_equal(vec_in(utf8, latin1), utf8 %in% latin1)
+  expect_equal(vec_in(utf, latin1), TRUE)
+  expect_equal(vec_in(utf, latin1), utf %in% latin1)
 })
 
 test_that("can use matching functions when one string has multiple encodings", {
   enc <- encodings()
 
-  x <- c(enc$utf8, enc$unknown)
+  x <- c(enc$utf, enc$unknown)
   latin1 <- enc$latin1
 
   expect_equal(vec_match(x, latin1), c(1L, 1L))
@@ -237,7 +237,7 @@ test_that("can use matching functions when one string has multiple encodings", {
 
 test_that("can use matching functions within the same encoding", {
   enc <- encodings()
-  utf8 <- enc$utf8
+  utf <- enc$utf
   unknown <- enc$unknown
   latin1 <- enc$latin1
   bytes <- enc$bytes
@@ -248,8 +248,8 @@ test_that("can use matching functions within the same encoding", {
   expect_equal(vec_match(latin1, latin1), 1L)
   expect_equal(vec_match(latin1, latin1), match(latin1, latin1))
 
-  expect_equal(vec_match(utf8, utf8), 1L)
-  expect_equal(vec_match(utf8, utf8), match(utf8, utf8))
+  expect_equal(vec_match(utf, utf), 1L)
+  expect_equal(vec_match(utf, utf), match(utf, utf))
 
   expect_equal(vec_match(bytes, bytes), 1L)
   expect_equal(vec_match(bytes, bytes), match(bytes, bytes))
@@ -260,8 +260,8 @@ test_that("can use matching functions within the same encoding", {
   expect_equal(vec_in(latin1, latin1), TRUE)
   expect_equal(vec_in(latin1, latin1), latin1 %in% latin1)
 
-  expect_equal(vec_in(utf8, utf8), TRUE)
-  expect_equal(vec_in(utf8, utf8), utf8 %in% utf8)
+  expect_equal(vec_in(utf, utf), TRUE)
+  expect_equal(vec_in(utf, utf), utf %in% utf)
 
   expect_equal(vec_in(bytes, bytes), TRUE)
   expect_equal(vec_in(bytes, bytes), bytes %in% bytes)
@@ -269,80 +269,80 @@ test_that("can use matching functions within the same encoding", {
 
 test_that("can use matching functions with lists of characters with different encodings", {
   enc <- encodings()
-  utf8 <- enc$utf8
+  utf <- enc$utf
   latin1 <- enc$latin1
 
   lst_ascii <- list("ascii")
   lst_latin1 <- list(latin1)
   lst_ascii_latin1 <- c(lst_ascii, lst_latin1)
-  lst_utf8 <- list(utf8)
+  lst_utf <- list(utf)
 
-  lst_of_lst_utf8 <- list(lst_utf8)
+  lst_of_lst_utf <- list(lst_utf)
   lst_of_lst_ascii_latin1 <- list(lst_ascii, lst_latin1)
 
   expect_equal(vec_match(lst_ascii, lst_ascii), 1L)
   expect_equal(vec_in(lst_ascii, lst_ascii), TRUE)
 
-  expect_equal(vec_match(lst_utf8, lst_ascii_latin1), 2L)
-  expect_equal(vec_in(lst_utf8, lst_ascii_latin1), TRUE)
+  expect_equal(vec_match(lst_utf, lst_ascii_latin1), 2L)
+  expect_equal(vec_in(lst_utf, lst_ascii_latin1), TRUE)
 
-  expect_equal(vec_match(lst_utf8, lst_ascii_latin1), match(lst_utf8, lst_ascii_latin1))
-  expect_equal(vec_in(lst_utf8, lst_ascii_latin1), lst_utf8 %in% lst_ascii_latin1)
+  expect_equal(vec_match(lst_utf, lst_ascii_latin1), match(lst_utf, lst_ascii_latin1))
+  expect_equal(vec_in(lst_utf, lst_ascii_latin1), lst_utf %in% lst_ascii_latin1)
 
-  expect_equal(vec_match(lst_of_lst_utf8, lst_of_lst_ascii_latin1), 2L)
-  expect_equal(vec_in(lst_of_lst_utf8, lst_of_lst_ascii_latin1), TRUE)
+  expect_equal(vec_match(lst_of_lst_utf, lst_of_lst_ascii_latin1), 2L)
+  expect_equal(vec_in(lst_of_lst_utf, lst_of_lst_ascii_latin1), TRUE)
 
-  expect_equal(vec_match(lst_of_lst_utf8, lst_of_lst_ascii_latin1), match(lst_of_lst_utf8, lst_of_lst_ascii_latin1))
-  expect_equal(vec_in(lst_of_lst_utf8, lst_of_lst_ascii_latin1), lst_of_lst_utf8 %in% lst_of_lst_ascii_latin1)
+  expect_equal(vec_match(lst_of_lst_utf, lst_of_lst_ascii_latin1), match(lst_of_lst_utf, lst_of_lst_ascii_latin1))
+  expect_equal(vec_in(lst_of_lst_utf, lst_of_lst_ascii_latin1), lst_of_lst_utf %in% lst_of_lst_ascii_latin1)
 })
 
 test_that("can use matching functions with data frames with string columns", {
   enc <- encodings()
-  utf8 <- enc$utf8
+  utf <- enc$utf
   unknown <- enc$unknown
 
-  df_utf8 <- data_frame(x = utf8, y = 2)
+  df_utf <- data_frame(x = utf, y = 2)
   df_unknown <- data_frame(x = c(unknown, unknown), y = c(1, 2))
 
   expect_equal(vec_match(df_unknown, df_unknown), 1:2)
   expect_equal(vec_in(df_unknown, df_unknown), c(TRUE, TRUE))
 
-  expect_equal(vec_match(df_utf8, df_unknown), 2L)
-  expect_equal(vec_in(df_utf8, df_unknown), TRUE)
+  expect_equal(vec_match(df_utf, df_unknown), 2L)
+  expect_equal(vec_in(df_utf, df_unknown), TRUE)
 })
 
 test_that("can use matching functions with data frame subclasses with string columns", {
   enc <- encodings()
-  utf8 <- enc$utf8
+  utf <- enc$utf
   unknown <- enc$unknown
 
-  df_utf8 <- new_data_frame(list(x = utf8, y = 2), class = "subclass")
+  df_utf <- new_data_frame(list(x = utf, y = 2), class = "subclass")
   df_unknown <- new_data_frame(list(x = c(unknown, unknown), y = c(1, 2)), class = "subclass")
 
   expect_equal(vec_match(df_unknown, df_unknown), 1:2)
   expect_equal(vec_in(df_unknown, df_unknown), c(TRUE, TRUE))
 
-  expect_equal(vec_match(df_utf8, df_unknown), 2L)
-  expect_equal(vec_in(df_utf8, df_unknown), TRUE)
+  expect_equal(vec_match(df_utf, df_unknown), 2L)
+  expect_equal(vec_in(df_utf, df_unknown), TRUE)
 })
 
 test_that("can use matching functions with lists of data frames with string columns", {
   enc <- encodings()
-  utf8 <- enc$utf8
+  utf <- enc$utf
   unknown <- enc$unknown
 
-  df_utf8 <- data_frame(x = utf8, y = 2)
+  df_utf <- data_frame(x = utf, y = 2)
   df_unknown_1 <- data_frame(x = unknown, y = 1)
   df_unknown_2 <- data_frame(x = unknown, y = 2)
 
-  lst_of_df_utf8 <- list(df_utf8)
+  lst_of_df_utf <- list(df_utf)
   lst_of_df_unknown <- list(df_unknown_1, df_unknown_2)
 
   expect_equal(vec_match(lst_of_df_unknown, lst_of_df_unknown), 1:2)
   expect_equal(vec_in(lst_of_df_unknown, lst_of_df_unknown), c(TRUE, TRUE))
 
-  expect_equal(vec_match(lst_of_df_utf8, lst_of_df_unknown), 2L)
-  expect_equal(vec_in(lst_of_df_utf8, lst_of_df_unknown), TRUE)
+  expect_equal(vec_match(lst_of_df_utf, lst_of_df_unknown), 2L)
+  expect_equal(vec_in(lst_of_df_utf, lst_of_df_unknown), TRUE)
 })
 
 # splits ------------------------------------------------------------------

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -109,12 +109,10 @@ test_that("unique functions take the equality proxy (#375)", {
 })
 
 test_that("vec_unique() can detect uniqueness with the same string in various encodings (#553)", {
-  utf8 <- "\u00B0C"
-
-  unknown <- utf8
-  Encoding(unknown) <- "unknown"
-
-  latin1 <- iconv(utf8, "UTF-8", "latin1")
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
   x <- c(unknown, utf8, latin1)
 
@@ -123,10 +121,9 @@ test_that("vec_unique() can detect uniqueness with the same string in various en
 })
 
 test_that("vec_unique() returns differently encoded strings in the order they appear", {
-  utf8 <- "\u00B0C"
-
-  unknown <- utf8
-  Encoding(unknown) <- "unknown"
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
 
   x <- c(unknown, utf8)
   y <- c(utf8, unknown)
@@ -136,12 +133,10 @@ test_that("vec_unique() returns differently encoded strings in the order they ap
 })
 
 test_that("vec_unique() can determine uniqueness when the encoding is the same", {
-  unknown <- "fa\xE7ile"
-
-  latin1 <- unknown
-  Encoding(latin1) <- "latin1"
-
-  utf8 <- enc2utf8(latin1)
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
   bytes <- unknown
   Encoding(bytes) <- "bytes"
@@ -165,15 +160,13 @@ test_that("vec_unique() can determine uniqueness when the encoding is the same",
 })
 
 test_that("vec_unique() fails purposefully with bytes strings and other encodings", {
-  utf8 <- "\u00B0C"
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
   bytes <- utf8
   Encoding(bytes) <- "bytes"
-
-  unknown <- utf8
-  Encoding(unknown) <- "unknown"
-
-  latin1 <- iconv(utf8, "UTF-8", "latin1")
 
   bytes_utf8 <- c(bytes, utf8)
   bytes_unknown <- c(bytes, unknown)
@@ -233,12 +226,10 @@ test_that("can take the unique loc of 1d arrays (#461)", {
 })
 
 test_that("can use matching functions with strings with different encodings", {
-  utf8 <- "\u00B0C"
-
-  unknown <- utf8
-  Encoding(unknown) <- "unknown"
-
-  latin1 <- iconv(utf8, "UTF-8", "latin1")
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
   expect_equal(vec_match(utf8, unknown), 1L)
   expect_equal(vec_match(utf8, unknown), match(utf8, unknown))
@@ -254,12 +245,10 @@ test_that("can use matching functions with strings with different encodings", {
 })
 
 test_that("can use matching functions when one string has multiple encodings", {
-  utf8 <- "\u00B0C"
-
-  unknown <- utf8
-  Encoding(unknown) <- "unknown"
-
-  latin1 <- iconv(utf8, "UTF-8", "latin1")
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
   x <- c(utf8, unknown)
 
@@ -268,12 +257,10 @@ test_that("can use matching functions when one string has multiple encodings", {
 })
 
 test_that("can use matching functions within the same encoding", {
-  unknown <- "fa\xE7ile"
-
-  latin1 <- unknown
-  Encoding(latin1) <- "latin1"
-
-  utf8 <- enc2utf8(latin1)
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
   bytes <- unknown
   Encoding(bytes) <- "bytes"
@@ -304,10 +291,9 @@ test_that("can use matching functions within the same encoding", {
 })
 
 test_that("can use matching functions with lists of characters with different encodings", {
-  latin1 <- "fa\xE7ile"
-  Encoding(latin1) <- "latin1"
-
-  utf8 <- enc2utf8(latin1)
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
   lst_ascii <- list("ascii")
   lst_latin1 <- list(latin1)
@@ -334,10 +320,9 @@ test_that("can use matching functions with lists of characters with different en
 })
 
 test_that("can use matching functions with data frames with string columns", {
-  utf8 <- "\u00B0C"
-
-  unknown <- utf8
-  Encoding(unknown) <- "unknown"
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
 
   df_utf8 <- data_frame(x = utf8, y = 2)
   df_unknown <- data_frame(x = c(unknown, unknown), y = c(1, 2))
@@ -350,10 +335,9 @@ test_that("can use matching functions with data frames with string columns", {
 })
 
 test_that("can use matching functions with data frame subclasses with string columns", {
-  utf8 <- "\u00B0C"
-
-  unknown <- utf8
-  Encoding(unknown) <- "unknown"
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
 
   df_utf8 <- new_data_frame(list(x = utf8, y = 2), class = "subclass")
   df_unknown <- new_data_frame(list(x = c(unknown, unknown), y = c(1, 2)), class = "subclass")
@@ -366,10 +350,9 @@ test_that("can use matching functions with data frame subclasses with string col
 })
 
 test_that("can use matching functions with lists of data frames with string columns", {
-  utf8 <- "\u00B0C"
-
-  unknown <- utf8
-  Encoding(unknown) <- "unknown"
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
 
   df_utf8 <- data_frame(x = utf8, y = 2)
   df_unknown_1 <- data_frame(x = unknown, y = 1)

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -226,10 +226,10 @@ test_that("can take the unique loc of 1d arrays (#461)", {
 })
 
 test_that("can use matching functions with strings with different encodings", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
-  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
+  enc <- encodings()
+  utf8 <- enc$utf8
+  unknown <- enc$unknown
+  latin1 <- enc$latin1
 
   expect_equal(vec_match(utf8, unknown), 1L)
   expect_equal(vec_match(utf8, unknown), match(utf8, unknown))
@@ -245,25 +245,21 @@ test_that("can use matching functions with strings with different encodings", {
 })
 
 test_that("can use matching functions when one string has multiple encodings", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
-  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
+  enc <- encodings()
 
-  x <- c(utf8, unknown)
+  x <- c(enc$utf8, enc$unknown)
+  latin1 <- enc$latin1
 
   expect_equal(vec_match(x, latin1), c(1L, 1L))
   expect_equal(vec_match(x, latin1), match(x, latin1))
 })
 
 test_that("can use matching functions within the same encoding", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
-  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
-
-  bytes <- unknown
-  Encoding(bytes) <- "bytes"
+  enc <- encodings()
+  utf8 <- enc$utf8
+  unknown <- enc$unknown
+  latin1 <- enc$latin1
+  bytes <- enc$bytes
 
   expect_equal(vec_match(unknown, unknown), 1L)
   expect_equal(vec_match(unknown, unknown), match(unknown, unknown))
@@ -291,9 +287,9 @@ test_that("can use matching functions within the same encoding", {
 })
 
 test_that("can use matching functions with lists of characters with different encodings", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
+  enc <- encodings()
+  utf8 <- enc$utf8
+  latin1 <- enc$latin1
 
   lst_ascii <- list("ascii")
   lst_latin1 <- list(latin1)
@@ -320,9 +316,9 @@ test_that("can use matching functions with lists of characters with different en
 })
 
 test_that("can use matching functions with data frames with string columns", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  enc <- encodings()
+  utf8 <- enc$utf8
+  unknown <- enc$unknown
 
   df_utf8 <- data_frame(x = utf8, y = 2)
   df_unknown <- data_frame(x = c(unknown, unknown), y = c(1, 2))
@@ -335,9 +331,9 @@ test_that("can use matching functions with data frames with string columns", {
 })
 
 test_that("can use matching functions with data frame subclasses with string columns", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  enc <- encodings()
+  utf8 <- enc$utf8
+  unknown <- enc$unknown
 
   df_utf8 <- new_data_frame(list(x = utf8, y = 2), class = "subclass")
   df_unknown <- new_data_frame(list(x = c(unknown, unknown), y = c(1, 2)), class = "subclass")
@@ -350,9 +346,9 @@ test_that("can use matching functions with data frame subclasses with string col
 })
 
 test_that("can use matching functions with lists of data frames with string columns", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  enc <- encodings()
+  utf8 <- enc$utf8
+  unknown <- enc$unknown
 
   df_utf8 <- data_frame(x = utf8, y = 2)
   df_unknown_1 <- data_frame(x = unknown, y = 1)

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -117,8 +117,8 @@ test_that("vec_unique() can detect uniqueness with the same string in various en
 
 test_that("vec_unique() returns differently encoded strings in the order they appear", {
   enc <- encodings()
-  x <- c(enc$unknown, enc$utf)
-  y <- c(enc$utf, enc$unknown)
+  x <- c(enc$unknown, enc$utf8)
+  y <- c(enc$utf8, enc$unknown)
 
   expect_equal(Encoding(vec_unique(x)), "unknown")
   expect_equal(Encoding(vec_unique(y)), "UTF-8")
@@ -231,10 +231,10 @@ test_that("cannot use matching functions when mixing bytes with other encodings"
 test_that("can use matching functions when one string has multiple encodings", {
   encs <- encodings()
 
-  utf_unknown <- c(encs$utf, encs$unknown)
+  utf8_unknown <- c(encs$utf8, encs$unknown)
 
-  expect_equal(vec_match(utf_unknown, encs$latin1), c(1L, 1L))
-  expect_equal(vec_match(utf_unknown, encs$latin1), match(utf_unknown, encs$latin1))
+  expect_equal(vec_match(utf8_unknown, encs$latin1), c(1L, 1L))
+  expect_equal(vec_match(utf8_unknown, encs$latin1), match(utf8_unknown, encs$latin1))
 })
 
 test_that("can use matching functions with lists of characters with different encodings", {
@@ -243,68 +243,68 @@ test_that("can use matching functions with lists of characters with different en
   lst_ascii <- list("ascii")
   lst_latin1 <- list(encs$latin1)
   lst_ascii_latin1 <- c(lst_ascii, lst_latin1)
-  lst_utf <- list(encs$utf)
+  lst_utf8 <- list(encs$utf8)
 
-  lst_of_lst_utf <- list(lst_utf)
+  lst_of_lst_utf8 <- list(lst_utf8)
   lst_of_lst_ascii_latin1 <- list(lst_ascii, lst_latin1)
 
   expect_equal(vec_match(lst_ascii, lst_ascii), 1L)
   expect_equal(vec_in(lst_ascii, lst_ascii), TRUE)
 
-  expect_equal(vec_match(lst_utf, lst_ascii_latin1), 2L)
-  expect_equal(vec_in(lst_utf, lst_ascii_latin1), TRUE)
+  expect_equal(vec_match(lst_utf8, lst_ascii_latin1), 2L)
+  expect_equal(vec_in(lst_utf8, lst_ascii_latin1), TRUE)
 
-  expect_equal(vec_match(lst_utf, lst_ascii_latin1), match(lst_utf, lst_ascii_latin1))
-  expect_equal(vec_in(lst_utf, lst_ascii_latin1), lst_utf %in% lst_ascii_latin1)
+  expect_equal(vec_match(lst_utf8, lst_ascii_latin1), match(lst_utf8, lst_ascii_latin1))
+  expect_equal(vec_in(lst_utf8, lst_ascii_latin1), lst_utf8 %in% lst_ascii_latin1)
 
-  expect_equal(vec_match(lst_of_lst_utf, lst_of_lst_ascii_latin1), 2L)
-  expect_equal(vec_in(lst_of_lst_utf, lst_of_lst_ascii_latin1), TRUE)
+  expect_equal(vec_match(lst_of_lst_utf8, lst_of_lst_ascii_latin1), 2L)
+  expect_equal(vec_in(lst_of_lst_utf8, lst_of_lst_ascii_latin1), TRUE)
 
-  expect_equal(vec_match(lst_of_lst_utf, lst_of_lst_ascii_latin1), match(lst_of_lst_utf, lst_of_lst_ascii_latin1))
-  expect_equal(vec_in(lst_of_lst_utf, lst_of_lst_ascii_latin1), lst_of_lst_utf %in% lst_of_lst_ascii_latin1)
+  expect_equal(vec_match(lst_of_lst_utf8, lst_of_lst_ascii_latin1), match(lst_of_lst_utf8, lst_of_lst_ascii_latin1))
+  expect_equal(vec_in(lst_of_lst_utf8, lst_of_lst_ascii_latin1), lst_of_lst_utf8 %in% lst_of_lst_ascii_latin1)
 })
 
 test_that("can use matching functions with data frames with string columns", {
   encs <- encodings()
 
-  df_utf <- data_frame(x = encs$utf, y = 2)
+  df_utf8 <- data_frame(x = encs$utf8, y = 2)
   df_unknown <- data_frame(x = rep(encs$unknown, 2), y = c(1, 2))
 
   expect_equal(vec_match(df_unknown, df_unknown), 1:2)
   expect_equal(vec_in(df_unknown, df_unknown), c(TRUE, TRUE))
 
-  expect_equal(vec_match(df_utf, df_unknown), 2L)
-  expect_equal(vec_in(df_utf, df_unknown), TRUE)
+  expect_equal(vec_match(df_utf8, df_unknown), 2L)
+  expect_equal(vec_in(df_utf8, df_unknown), TRUE)
 })
 
 test_that("can use matching functions with data frame subclasses with string columns", {
   encs <- encodings()
 
-  df_utf <- new_data_frame(list(x = encs$utf, y = 2), class = "subclass")
+  df_utf8 <- new_data_frame(list(x = encs$utf8, y = 2), class = "subclass")
   df_unknown <- new_data_frame(list(x = rep(encs$unknown, 2), y = c(1, 2)), class = "subclass")
 
   expect_equal(vec_match(df_unknown, df_unknown), 1:2)
   expect_equal(vec_in(df_unknown, df_unknown), c(TRUE, TRUE))
 
-  expect_equal(vec_match(df_utf, df_unknown), 2L)
-  expect_equal(vec_in(df_utf, df_unknown), TRUE)
+  expect_equal(vec_match(df_utf8, df_unknown), 2L)
+  expect_equal(vec_in(df_utf8, df_unknown), TRUE)
 })
 
 test_that("can use matching functions with lists of data frames with string columns", {
   encs <- encodings()
 
-  df_utf <- data_frame(x = encs$utf, y = 2)
+  df_utf8 <- data_frame(x = encs$utf8, y = 2)
   df_unknown_1 <- data_frame(x = encs$unknown, y = 1)
   df_unknown_2 <- data_frame(x = encs$unknown, y = 2)
 
-  lst_of_df_utf <- list(df_utf)
+  lst_of_df_utf8 <- list(df_utf8)
   lst_of_df_unknown <- list(df_unknown_1, df_unknown_2)
 
   expect_equal(vec_match(lst_of_df_unknown, lst_of_df_unknown), 1:2)
   expect_equal(vec_in(lst_of_df_unknown, lst_of_df_unknown), c(TRUE, TRUE))
 
-  expect_equal(vec_match(lst_of_df_utf, lst_of_df_unknown), 2L)
-  expect_equal(vec_in(lst_of_df_utf, lst_of_df_unknown), TRUE)
+  expect_equal(vec_match(lst_of_df_utf8, lst_of_df_unknown), 2L)
+  expect_equal(vec_in(lst_of_df_utf8, lst_of_df_unknown), TRUE)
 })
 
 # splits ------------------------------------------------------------------

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -71,26 +71,26 @@ test_that("data frames must have same size and columns", {
 
 test_that("can determine equality of strings with different encodings (#553)", {
   enc <- encodings()
-  utf8 <- enc$utf8
+  utf <- enc$utf
   unknown <- enc$unknown
   latin1 <- enc$latin1
 
-  expect_true(vec_equal(utf8, unknown))
-  expect_equal(vec_equal(utf8, unknown), utf8 == unknown)
+  expect_true(vec_equal(utf, unknown))
+  expect_equal(vec_equal(utf, unknown), utf == unknown)
 
-  expect_true(vec_equal(utf8, latin1))
-  expect_equal(vec_equal(utf8, latin1), utf8 == latin1)
+  expect_true(vec_equal(utf, latin1))
+  expect_equal(vec_equal(utf, latin1), utf == latin1)
 })
 
 test_that("equality can be determined when strings have identical encodings", {
   enc <- encodings()
-  utf8 <- enc$utf8
+  utf <- enc$utf
   unknown <- enc$unknown
   latin1 <- enc$latin1
   bytes <- enc$bytes
 
-  expect_true(vec_equal(utf8, utf8))
-  expect_equal(vec_equal(utf8, utf8), utf8 == utf8)
+  expect_true(vec_equal(utf, utf))
+  expect_equal(vec_equal(utf, utf), utf == utf)
 
   expect_true(vec_equal(latin1, latin1))
   expect_equal(vec_equal(latin1, latin1), latin1 == latin1)
@@ -104,12 +104,12 @@ test_that("equality can be determined when strings have identical encodings", {
 
 test_that("equality is known to fail when comparing bytes to other encodings", {
   enc <- encodings()
-  utf8 <- enc$utf8
+  utf <- enc$utf
   unknown <- enc$unknown
   latin1 <- enc$latin1
   bytes <- enc$bytes
 
-  expect_error(vec_equal(bytes, utf8), '"bytes" encoding is not allowed')
+  expect_error(vec_equal(bytes, utf), '"bytes" encoding is not allowed')
   expect_error(vec_equal(bytes, unknown), '"bytes" encoding is not allowed')
   expect_error(vec_equal(bytes, latin1), '"bytes" encoding is not allowed')
 })

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -70,10 +70,10 @@ test_that("data frames must have same size and columns", {
 })
 
 test_that("can determine equality of strings with different encodings (#553)", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
-  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
+  enc <- encodings()
+  utf8 <- enc$utf8
+  unknown <- enc$unknown
+  latin1 <- enc$latin1
 
   expect_true(vec_equal(utf8, unknown))
   expect_equal(vec_equal(utf8, unknown), utf8 == unknown)
@@ -83,13 +83,11 @@ test_that("can determine equality of strings with different encodings (#553)", {
 })
 
 test_that("equality can be determined when strings have identical encodings", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
-  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
-
-  bytes <- unknown
-  Encoding(bytes) <- "bytes"
+  enc <- encodings()
+  utf8 <- enc$utf8
+  unknown <- enc$unknown
+  latin1 <- enc$latin1
+  bytes <- enc$bytes
 
   expect_true(vec_equal(utf8, utf8))
   expect_equal(vec_equal(utf8, utf8), utf8 == utf8)
@@ -105,13 +103,11 @@ test_that("equality can be determined when strings have identical encodings", {
 })
 
 test_that("equality is known to fail when comparing bytes to other encodings", {
-  string <- "\u00B0C"
-  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
-  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
-
-  bytes <- unknown
-  Encoding(bytes) <- "bytes"
+  enc <- encodings()
+  utf8 <- enc$utf8
+  unknown <- enc$unknown
+  latin1 <- enc$latin1
+  bytes <- enc$bytes
 
   expect_error(vec_equal(bytes, utf8), '"bytes" encoding is not allowed')
   expect_error(vec_equal(bytes, unknown), '"bytes" encoding is not allowed')

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -70,48 +70,30 @@ test_that("data frames must have same size and columns", {
 })
 
 test_that("can determine equality of strings with different encodings (#553)", {
-  enc <- encodings()
-  utf <- enc$utf
-  unknown <- enc$unknown
-  latin1 <- enc$latin1
-
-  expect_true(vec_equal(utf, unknown))
-  expect_equal(vec_equal(utf, unknown), utf == unknown)
-
-  expect_true(vec_equal(utf, latin1))
-  expect_equal(vec_equal(utf, latin1), utf == latin1)
+  for (x_encoding in encodings()) {
+    for (y_encoding in encodings()) {
+      expect_equal(vec_equal(x_encoding, y_encoding), TRUE)
+      expect_equal(vec_equal(x_encoding, y_encoding), x_encoding == y_encoding)
+    }
+  }
 })
 
 test_that("equality can be determined when strings have identical encodings", {
-  enc <- encodings()
-  utf <- enc$utf
-  unknown <- enc$unknown
-  latin1 <- enc$latin1
-  bytes <- enc$bytes
+  encs <- c(encodings(), list(bytes = encoding_bytes()))
 
-  expect_true(vec_equal(utf, utf))
-  expect_equal(vec_equal(utf, utf), utf == utf)
-
-  expect_true(vec_equal(latin1, latin1))
-  expect_equal(vec_equal(latin1, latin1), latin1 == latin1)
-
-  expect_true(vec_equal(unknown, unknown))
-  expect_equal(vec_equal(unknown, unknown), unknown == unknown)
-
-  expect_true(vec_equal(bytes, bytes))
-  expect_equal(vec_equal(bytes, bytes), bytes == bytes)
+  for (enc in encs) {
+    expect_true(vec_equal(enc, enc))
+    expect_equal(vec_equal(enc, enc), enc == enc)
+  }
 })
 
 test_that("equality is known to fail when comparing bytes to other encodings", {
-  enc <- encodings()
-  utf <- enc$utf
-  unknown <- enc$unknown
-  latin1 <- enc$latin1
-  bytes <- enc$bytes
+  error <- "translating strings with \"bytes\" encoding"
 
-  expect_error(vec_equal(bytes, utf), '"bytes" encoding is not allowed')
-  expect_error(vec_equal(bytes, unknown), '"bytes" encoding is not allowed')
-  expect_error(vec_equal(bytes, latin1), '"bytes" encoding is not allowed')
+  for (enc in encodings()) {
+    expect_error(vec_equal(encoding_bytes(), enc), error)
+    expect_error(vec_equal(enc, encoding_bytes()), error)
+  }
 })
 
 # object ------------------------------------------------------------------

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -70,12 +70,10 @@ test_that("data frames must have same size and columns", {
 })
 
 test_that("can determine equality of strings with different encodings (#553)", {
-  utf8 <- "\u00B0C"
-
-  unknown <- utf8
-  Encoding(unknown) <- "unknown"
-
-  latin1 <- iconv(utf8, "UTF-8", "latin1")
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
   expect_true(vec_equal(utf8, unknown))
   expect_equal(vec_equal(utf8, unknown), utf8 == unknown)
@@ -85,35 +83,35 @@ test_that("can determine equality of strings with different encodings (#553)", {
 })
 
 test_that("equality can be determined when strings have identical encodings", {
-  x <- "fa\xE7ile"
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
-  # unknown
-  expect_true(vec_equal(x, x))
-  expect_equal(vec_equal(x, x), x == x)
+  bytes <- unknown
+  Encoding(bytes) <- "bytes"
 
-  Encoding(x) <- "latin1"
-  expect_true(vec_equal(x, x))
-  expect_equal(vec_equal(x, x), x == x)
+  expect_true(vec_equal(utf8, utf8))
+  expect_equal(vec_equal(utf8, utf8), utf8 == utf8)
 
-  x <- iconv(x, "latin1", "UTF-8")
-  expect_true(vec_equal(x, x))
-  expect_equal(vec_equal(x, x), x == x)
+  expect_true(vec_equal(latin1, latin1))
+  expect_equal(vec_equal(latin1, latin1), latin1 == latin1)
 
-  Encoding(x) <- "bytes"
-  expect_true(vec_equal(x, x))
-  expect_equal(vec_equal(x, x), x == x)
+  expect_true(vec_equal(unknown, unknown))
+  expect_equal(vec_equal(unknown, unknown), unknown == unknown)
+
+  expect_true(vec_equal(bytes, bytes))
+  expect_equal(vec_equal(bytes, bytes), bytes == bytes)
 })
 
 test_that("equality is known to fail when comparing bytes to other encodings", {
-  utf8 <- "\u00B0C"
+  string <- "\u00B0C"
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
-  bytes <- utf8
+  bytes <- unknown
   Encoding(bytes) <- "bytes"
-
-  unknown <- utf8
-  Encoding(unknown) <- "unknown"
-
-  latin1 <- iconv(utf8, "UTF-8", "latin1")
 
   expect_error(vec_equal(bytes, utf8), '"bytes" encoding is not allowed')
   expect_error(vec_equal(bytes, unknown), '"bytes" encoding is not allowed')

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -132,9 +132,9 @@ test_that("Subclasses of `tbl_df` have `tbl_df` common type (#481)", {
 })
 
 test_that("Column name encodings are handled correctly in the common type (#553)", {
-  name_utf8 <- "\u00B0C"
-  name_unknown <- name_utf8
-  Encoding(name_unknown) <- "unknown"
+  string <- "\u00B0C"
+  name_utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  name_unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
 
   data <- list(chr())
 

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -136,8 +136,8 @@ test_that("Column name encodings are handled correctly in the common type (#553)
 
   data <- list(chr())
 
-  df_utf <- tibble::as_tibble(set_names(data, encs$utf))
+  df_utf8 <- tibble::as_tibble(set_names(data, encs$utf8))
   df_unknown <- tibble::as_tibble(set_names(data, encs$unknown))
 
-  expect_identical(vec_ptype2(df_utf, df_unknown), df_utf)
+  expect_identical(vec_ptype2(df_utf8, df_unknown), df_utf8)
 })

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -132,9 +132,9 @@ test_that("Subclasses of `tbl_df` have `tbl_df` common type (#481)", {
 })
 
 test_that("Column name encodings are handled correctly in the common type (#553)", {
-  string <- "\u00B0C"
-  name_utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
-  name_unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  enc <- encodings()
+  name_utf8 <- enc$utf8
+  name_unknown <- enc$unknown
 
   data <- list(chr())
 

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -133,13 +133,13 @@ test_that("Subclasses of `tbl_df` have `tbl_df` common type (#481)", {
 
 test_that("Column name encodings are handled correctly in the common type (#553)", {
   enc <- encodings()
-  name_utf8 <- enc$utf8
+  name_utf <- enc$utf
   name_unknown <- enc$unknown
 
   data <- list(chr())
 
-  df_utf8 <- tibble::as_tibble(set_names(data, name_utf8))
+  df_utf <- tibble::as_tibble(set_names(data, name_utf))
   df_unknown <- tibble::as_tibble(set_names(data, name_unknown))
 
-  expect_identical(vec_ptype2(df_utf8, df_unknown), df_utf8)
+  expect_identical(vec_ptype2(df_utf, df_unknown), df_utf)
 })

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -132,14 +132,12 @@ test_that("Subclasses of `tbl_df` have `tbl_df` common type (#481)", {
 })
 
 test_that("Column name encodings are handled correctly in the common type (#553)", {
-  enc <- encodings()
-  name_utf <- enc$utf
-  name_unknown <- enc$unknown
+  encs <- encodings()
 
   data <- list(chr())
 
-  df_utf <- tibble::as_tibble(set_names(data, name_utf))
-  df_unknown <- tibble::as_tibble(set_names(data, name_unknown))
+  df_utf <- tibble::as_tibble(set_names(data, encs$utf))
+  df_unknown <- tibble::as_tibble(set_names(data, encs$unknown))
 
   expect_identical(vec_ptype2(df_utf, df_unknown), df_utf)
 })


### PR DESCRIPTION
Closes #589 

This PR fixes the failures experienced on Windows due to tests not anticipating that `Encoding(x) <- "unknown"` does different things than it does on Mac/Linux.

We now always use `iconv()` to generate the differently encoded variables required for the tests (except bytes, which requires `Encoding<-` still as far as I can tell).