### PR TITLE
Add 'list' class to list_of vctrs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Suggests:
     covr,
     crayon,
     generics,
+    jsonlite,
     knitr,
     pillar (>= 1.4.1),
     pkgdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 * Equality and ordering methods are now implemented for raw and
   complex vectors (@romainfrancois).
 
+* `list_of` vctrs now include a 'list' class for compatibility with 
+   legacy S4 list methods, including jsonlite.
 
 # vctrs 0.2.0
 

--- a/R/type-list-of.R
+++ b/R/type-list-of.R
@@ -62,7 +62,10 @@ new_list_of <- function(x = list(), ptype = logical(), ..., class = character())
   stopifnot(is.list(x))
   stopifnot(vec_size(ptype) == 0)
 
-  new_vctr(x, ..., ptype = ptype, class = c(class, "vctrs_list_of"))
+  # Append 'list' class after 'vctrs_vctr'
+  out <- new_vctr(x, ..., ptype = ptype, class = c(class, "vctrs_list_of"))
+  class(out) <- c(class(out), "list")
+  out
 }
 
 #' @export

--- a/src/utils.c
+++ b/src/utils.c
@@ -1029,13 +1029,14 @@ void vctrs_init_utils(SEXP ns) {
   SET_STRING_ELT(classes_tibble, 2, strings_data_frame);
 
 
-  classes_list_of = Rf_allocVector(STRSXP, 2);
+  classes_list_of = Rf_allocVector(STRSXP, 3);
   R_PreserveObject(classes_list_of);
 
   strings_vctrs_list_of = Rf_mkChar("vctrs_list_of");
   SET_STRING_ELT(classes_list_of, 0, strings_vctrs_list_of);
 
   SET_STRING_ELT(classes_list_of, 1, strings_vctrs_vctr);
+  SET_STRING_ELT(classes_list_of, 2, Rf_mkChar("list"));
 
 
   vctrs_shared_empty_lgl = Rf_allocVector(LGLSXP, 0);

--- a/tests/testthat/test-type-list-of.R
+++ b/tests/testthat/test-type-list-of.R
@@ -181,3 +181,8 @@ test_that("list_of() has as.character() method (tidyverse/tidyr#654)", {
   exp <- rep(paste0("<", vec_ptype_abbr(mtcars), ">"), 2)
   expect_identical(as.character(list_of(mtcars, mtcars)), exp)
 })
+
+test_that("list_of can be serialized as list", {
+  json <- jsonlite::toJSON(new_list_of(list(1, "a", 3)), auto_unbox = TRUE)
+  expect_equal(unclass(json), '[1,"a",3]')
+})


### PR DESCRIPTION
This adds the `list` class to `list_of` vctrs. This solves the issue with jsonlite (and possibly other packages implementing S4 list methods):

 - https://github.com/tidyverse/tidyr/issues/750
 - https://github.com/jeroen/jsonlite/issues/292

Perhaps jsonlite is ill-behaved, but I think adding the `list` class to `list_of` makes sense?