### PR TITLE
Implement native `vec_recycle_common()`

### DIFF
--- a/R/recycle.R
+++ b/R/recycle.R
@@ -46,12 +46,5 @@ vec_recycle <- function(x, size) {
 #' @export
 #' @rdname vec_recycle
 vec_recycle_common <- function(..., .size = NULL) {
-  args <- list2(...)
-  size <- vec_size_common(!!!args, .size = .size, .absent = na_int)
-
-  if (identical(size, na_int)) {
-    args
-  } else {
-    map(args, vec_recycle, size = size)
-  }
+  .External2(vctrs_recycle_common, .size)
 }

--- a/src/init.c
+++ b/src/init.c
@@ -160,6 +160,7 @@ static const R_CallMethodDef CallEntries[] = {
 
 extern SEXP vctrs_type_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_size_common(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_recycle_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cast_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_rbind(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cbind(SEXP, SEXP, SEXP, SEXP);
@@ -168,6 +169,7 @@ extern SEXP vctrs_c(SEXP, SEXP, SEXP, SEXP);
 static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_type_common",                (DL_FUNC) &vctrs_type_common, 1},
   {"vctrs_size_common",                (DL_FUNC) &vctrs_size_common, 2},
+  {"vctrs_recycle_common",             (DL_FUNC) &vctrs_recycle_common, 1},
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 1},
   {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 3},
   {"vctrs_cbind",                      (DL_FUNC) &vctrs_cbind, 3},

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -220,6 +220,7 @@ SEXP vec_type(SEXP x);
 SEXP vec_type_finalise(SEXP x);
 bool vec_is_unspecified(SEXP x);
 SEXP vec_recycle(SEXP x, R_len_t size);
+SEXP vec_recycle_common(SEXP xs, R_len_t size);
 SEXP vec_names(SEXP x);
 
 SEXP vec_type2(SEXP x,


### PR DESCRIPTION
This is a C version of `vec_recycle_common()`, because I thought it would be nice if it was faster.

I tried to make it so that the C `vec_recycle_common()` can be used on its own at the C level, like `vec_size_common()` can. Notably, there is a `size < 0` check in there that should play nicely if we call `vec_size_common()` from C first, and then pass the resulting size on to `vec_recycle_common()`.

A few simple benchmarks. We get a nice speedup when there was nothing to do (all inputs were the same size), and we are about twice as fast when there is some work to do.

``` r
library(vctrs)
library(purrr)

bench::mark(
  vec_recycle_common(),
  vec_recycle_common_old()
)
#> # A tibble: 2 x 6
#>   expression                    min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>               <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_recycle_common()        538ns    762ns  1264239.    6.52KB     126.
#> 2 vec_recycle_common_old()   2.84µs   4.33µs   206676.   30.26KB       0

bench::mark(
  vec_recycle_common(1),
  vec_recycle_common_old(1)
)
#> # A tibble: 2 x 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_recycle_common(1)       1.01µs   1.22µs   745976.        0B      0  
#> 2 vec_recycle_common_old(1)   5.97µs   6.86µs   137671.    11.7KB     27.5

bench::mark(
  vec_recycle_common(1, mtcars),
  vec_recycle_common_old(1, mtcars)
)
#> # A tibble: 2 x 6
#>   expression                            min  median `itr/sec` mem_alloc
#>   <bch:expr>                        <bch:t> <bch:t>     <dbl> <bch:byt>
#> 1 vec_recycle_common(1, mtcars)      4.45µs  5.62µs   169317.    17.1KB
#> 2 vec_recycle_common_old(1, mtcars) 10.08µs 11.66µs    82060.      304B
#> # … with 1 more variable: `gc/sec` <dbl>
```

It will be useful in `unnest()`, where we do something like this `pmap()` in `unchop()`.

```r
x <- rep(list(data.frame(x = 1)), 5000)

lst_x <- list(x)

bench::mark(
  pmap(lst_x, vec_recycle_common),
  pmap(lst_x, vec_recycle_common_old),
  iterations = 100
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 x 6
#>   expression                             min median `itr/sec` mem_alloc
#>   <bch:expr>                          <bch:> <bch:>     <dbl> <bch:byt>
#> 1 pmap(lst_x, vec_recycle_common)     20.4ms 34.8ms      27.4   113.6KB
#> 2 pmap(lst_x, vec_recycle_common_old) 49.6ms 76.3ms      12.9    39.1KB
#> # … with 1 more variable: `gc/sec` <dbl>

lst_x_x <- list(x, x)

bench::mark(
  pmap(lst_x_x, vec_recycle_common),
  pmap(lst_x_x, vec_recycle_common_old),
  iterations = 100
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 x 6
#>   expression                               min  median `itr/sec` mem_alloc
#>   <bch:expr>                            <bch:> <bch:t>     <dbl> <bch:byt>
#> 1 pmap(lst_x_x, vec_recycle_common)     42.9ms  60.2ms     14.9     39.1KB
#> 2 pmap(lst_x_x, vec_recycle_common_old) 71.7ms 111.5ms      8.84    39.1KB
#> # … with 1 more variable: `gc/sec` <dbl>
```

<sup>Created on 2019-09-25 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>