### PR TITLE
Issue 594

### DIFF
--- a/src/size-common.c
+++ b/src/size-common.c
@@ -8,9 +8,9 @@ SEXP vctrs_size_common(SEXP call, SEXP op, SEXP args, SEXP env) {
 
   SEXP size = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
   if (size != R_NilValue) {
-    size_validate(size, ".size");
+    R_len_t out = size_validate(size, ".size");
     UNPROTECT(1);
-    return size;
+    return r_int(out);
   }
 
   SEXP absent = PROTECT(Rf_eval(CAR(args), env));

--- a/tests/testthat/test-size.R
+++ b/tests/testthat/test-size.R
@@ -88,6 +88,9 @@ test_that("can pass size", {
   expect_identical(vec_size_common(1:2, 1:3, .size = 5L), 5L)
 })
 
+test_that("provided size is cast to an integer", {
+  expect_identical(vec_size_common(.size = 1), 1L)
+})
 
 # sequences ---------------------------------------------------------------
 


### PR DESCRIPTION
Closes #594 

We now return the validated size from `size_validate()`, which has been cast to an integer.