### PR TITLE
Simplify `dbl_equal_scalar()` NA checks

### DIFF
--- a/src/equal.c
+++ b/src/equal.c
@@ -121,8 +121,7 @@ static int dbl_equal_scalar(const double* x, const double* y, bool na_equal) {
   if (na_equal) {
     if (R_IsNA(xi)) return R_IsNA(yj);
     if (R_IsNaN(xi)) return R_IsNaN(yj);
-    if (R_IsNA(yj)) return false;
-    if (R_IsNaN(yj)) return false;
+    if (ISNAN(yj)) return false;
   } else {
     if (isnan(xi) || isnan(yj)) return NA_LOGICAL;
   }

--- a/src/equal.c
+++ b/src/equal.c
@@ -121,7 +121,7 @@ static int dbl_equal_scalar(const double* x, const double* y, bool na_equal) {
   if (na_equal) {
     if (R_IsNA(xi)) return R_IsNA(yj);
     if (R_IsNaN(xi)) return R_IsNaN(yj);
-    if (ISNAN(yj)) return false;
+    if (isnan(yj)) return false;
   } else {
     if (isnan(xi) || isnan(yj)) return NA_LOGICAL;
   }


### PR DESCRIPTION
While doing some benchmarking, I came across a strange performance result with `dbl_equal_scalar()`. First off, I compile with Apple's clang and use the default settings, with `-O2`.

When `inline` is added to `dbl_equal_scalar()`, it significantly improves the performance. In this benchmark, `vec_equal()` uses `inline` for `dbl_equal_scalar()`.

``` r
library(vctrs)
x <- rep(1, 1e8)
vec_equal_no_inline <- vctrs2::vec_equal

bench::mark(vec_equal(x, x), vec_equal_no_inline(x, x), iterations = 20)
#> # A tibble: 2 x 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal(x, x)              245ms    270ms      3.76     381MB    1.25 
#> 2 vec_equal_no_inline(x, x)    346ms    352ms      2.82     381MB    0.704
```

This _only_ seemed to apply to `dbl_equal_scalar()`.

After a bit of manual tweaking, I found that, for whatever reason, by commenting _any_ of these 4 if branches out we get the performance improvement even without the `inline`. Note that `na_equal = FALSE` by default so this code is not being run and commenting them out should not be affecting performance.

https://github.com/r-lib/vctrs/blob/1fea78461baa14d091a6a70fe7f261945f05e677/src/equal.c#L122-L125

Condensing the last two if branches with `R_isNA(yj)` and `R_IsNaN(yj)` into a single check with `ISNAN(yj)` (which checks for both, see [this R source comment](https://github.com/wch/r-source/blob/5a156a0865362bb8381dcd69ac335f5174a4f60c/src/include/R_ext/Arith.h#L66)) seems to recover the speed with no need for `inline`ing. This benchmark uses this PR branch, and is not using `inline`.

``` r
library(vctrs)
x <- rep(1, 1e8)
vec_equal_old <- vctrs2::vec_equal

bench::mark(
  vec_equal(x, x), 
  vec_equal_old(x, x), 
  iterations = 20
)
#> # A tibble: 2 x 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal(x, x)        237ms    258ms      3.88     381MB    1.29 
#> 2 vec_equal_old(x, x)    359ms    385ms      2.59     381MB    0.648
```

Whether or not we generally try and optimize for these compiler things, I think this change makes sense because we are reducing the number of `if` statements from 4 to 3 in the `na_equal = TRUE` case. So with this last benchmark I think we are getting double benefits, one from whatever is improving the compiler optimizations, and one from the reduced number of if branches.

``` r
library(vctrs)
x <- rep(1, 1e8)
vec_equal_old <- vctrs2::vec_equal

bench::mark(
  vec_equal(x, x, na_equal = TRUE), 
  vec_equal_old(x, x, na_equal = TRUE), 
  iterations = 20
)
#> # A tibble: 2 x 6
#>   expression                                min   median `itr/sec`
#>   <bch:expr>                           <bch:tm> <bch:tm>     <dbl>
#> 1 vec_equal(x, x, na_equal = TRUE)     541.73ms 558.68ms     1.77 
#> 2 vec_equal_old(x, x, na_equal = TRUE)    1.04s    1.07s     0.931
#> # … with 2 more variables: mem_alloc <bch:byt>, `gc/sec` <dbl>
```