### PR TITLE
Preserve names of index vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # vctrs 0.2.0.9000
 
+* `vec_as_index()` now preserves names of its inputs if possible.
+
 * New `vec_duplicate_all()` for detecting if all values in a vector are
   equivalent.
 

--- a/R/slice.R
+++ b/R/slice.R
@@ -189,6 +189,9 @@ vec_maybe_coerce_index <- function(i, arg) {
   if (!vec_is(i)) {
     return(maybe(error = new_error_index_bad_type(i, .arg = arg)))
   }
+
+  nms <- names(i)
+
   if (is.object(i)) {
     if (vec_is_subtype(i, int())) {
       i <- vec_cast(i, int())
@@ -204,6 +207,9 @@ vec_maybe_coerce_index <- function(i, arg) {
   if (!typeof(i) %in% c("integer", "character", "logical")) {
     return(maybe(error = new_error_index_bad_type(i, .arg = arg)))
   }
+
+  # FIXME: Work around lack of name restoration in `vec_cast()`
+  names(i) <- nms
 
   maybe(i)
 }

--- a/src/slice.c
+++ b/src/slice.c
@@ -567,6 +567,8 @@ static SEXP chr_as_index(SEXP i, SEXP names) {
     }
   }
 
+  r_poke_names(matched, PROTECT(r_names(i))); UNPROTECT(1);
+
   UNPROTECT(1);
   return matched;
 }

--- a/src/slice.c
+++ b/src/slice.c
@@ -511,10 +511,20 @@ static SEXP lgl_as_index(SEXP i, R_len_t n) {
   R_len_t index_n = Rf_length(i);
 
   if (index_n == n) {
-    return r_lgl_which(i, true);
+    SEXP out = PROTECT(r_lgl_which(i, true));
+
+    SEXP nms = PROTECT(r_names(i));
+    if (nms != R_NilValue) {
+      nms = PROTECT(vec_slice(nms, out));
+      r_poke_names(out, nms);
+      UNPROTECT(1);
+    }
+
+    UNPROTECT(2);
+    return out;
   }
 
-  /* A single `TRUE` or `FALSE` index is recycled to the full vector
+  /* A single `TRUE` or `FALSE` index is recycled_nms to the full vector
    * size. This means `TRUE` is synonym for missing index (i.e. no
    * subsetting) and `FALSE` is synonym for empty index.
    *
@@ -525,19 +535,28 @@ static SEXP lgl_as_index(SEXP i, R_len_t n) {
    */
   if (index_n == 1) {
     int elt = LOGICAL(i)[0];
+
+    SEXP out;
     if (elt == NA_LOGICAL) {
-      SEXP out = PROTECT(Rf_allocVector(INTSXP, n));
+      out = PROTECT(Rf_allocVector(INTSXP, n));
       r_int_fill(out, NA_INTEGER, n);
-      UNPROTECT(1);
-      return out;
     } else if (elt) {
-      SEXP out = PROTECT(Rf_allocVector(INTSXP, n));
+      out = PROTECT(Rf_allocVector(INTSXP, n));
       r_int_fill_seq(out, 1, n);
-      UNPROTECT(1);
-      return out;
     } else {
       return vctrs_shared_empty_int;
     }
+
+    SEXP nms = PROTECT(r_names(i));
+    if (nms != R_NilValue) {
+      SEXP recycled_nms = PROTECT(Rf_allocVector(STRSXP, n));
+      r_chr_fill(recycled_nms, r_chr_get(nms, 0), n);
+      r_poke_names(out, recycled_nms);
+      UNPROTECT(1);
+    }
+
+    UNPROTECT(2);
+    return out;
   }
 
   Rf_errorcall(R_NilValue,

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -788,6 +788,10 @@ test_that("vec_as_index() preserves names if possible", {
   expect_identical(vec_as_index(c(a = 1, b = 3), 3L), c(a = 1L, b = 3L))
   expect_identical(vec_as_index(c(a = "z", b = "y"), 26L, letters), c(a = 26L, b = 25L))
 
+  expect_identical(vec_as_index(c(foo = TRUE, bar = FALSE, baz = TRUE), 3L), c(foo = 1L, baz = 3L))
+  expect_identical(vec_as_index(c(foo = TRUE), 3L), c(foo = 1L, foo = 2L, foo = 3L))
+  expect_identical(vec_as_index(c(foo = NA), 3L), c(foo = na_int, foo = na_int, foo = na_int))
+
   # Names of negative selections are dropped
   expect_identical(vec_as_index(c(a = -1L, b = -3L), 3L), 2L)
 })

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -782,3 +782,11 @@ test_that("all OOB errors inherit from `vctrs_error_index_oob`", {
   expect_error(vec_as_index(100, 2L), class = "vctrs_error_index_oob")
   expect_error(vec_as_index("foo", 2L, names = c("bar", "baz")), class = "vctrs_error_index_oob")
 })
+
+test_that("vec_as_index() preserves names if possible", {
+  expect_identical(vec_as_index(c(a = 1L, b = 3L), 3L), c(a = 1L, b = 3L))
+  expect_identical(vec_as_index(c(a = 1, b = 3), 3L), c(a = 1L, b = 3L))
+
+  # Names of negative selections are dropped
+  expect_identical(vec_as_index(c(a = -1L, b = -3L), 3L), 2L)
+})

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -786,6 +786,7 @@ test_that("all OOB errors inherit from `vctrs_error_index_oob`", {
 test_that("vec_as_index() preserves names if possible", {
   expect_identical(vec_as_index(c(a = 1L, b = 3L), 3L), c(a = 1L, b = 3L))
   expect_identical(vec_as_index(c(a = 1, b = 3), 3L), c(a = 1L, b = 3L))
+  expect_identical(vec_as_index(c(a = "z", b = "y"), 26L, letters), c(a = 26L, b = 25L))
 
   # Names of negative selections are dropped
   expect_identical(vec_as_index(c(a = -1L, b = -3L), 3L), 2L)


### PR DESCRIPTION
Except for negative indices, names are now preserved:

```r
vec_as_index(c(a = 1, b = 3), 3L)
#> a b
#> 1 3

vec_as_index(c(a = "z", b = "y"), 26L, letters)
#>  a  b
#> 26 25

vec_as_index(c(foo = TRUE, bar = FALSE, baz = TRUE), 3L)
#> foo baz
#>   1   3

vec_as_index(c(foo = TRUE), 3L)
#> foo foo foo
#>   1   2   3

vec_as_index(c(foo = NA), 3L)
#> foo foo foo
#>  NA  NA  NA
```