### PR TITLE
Improve `vec_split_id()`

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -436,7 +436,7 @@ SEXP vec_split_id(SEXP x) {
 
   R_len_t g = 0;
 
-  // Locate groups, this is essentially `vec_group()`
+  // Identify groups, this is essentially `vec_group_id()`
   for (int i = 0; i < n; ++i) {
     int32_t hash = dict_hash_scalar(&d, i);
     R_len_t key = d.key[hash];

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -444,7 +444,7 @@ SEXP vec_split_id(SEXP x) {
     if (key == DICT_EMPTY) {
       dict_put(&d, hash, i);
       p_groups[i] = g;
-      g++;
+      ++g;
     } else {
       p_groups[i] = p_groups[key];
     }

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -473,13 +473,13 @@ SEXP vec_split_id(SEXP x) {
     p_counts[group]++;
   }
 
-  SEXP out_id = PROTECT_N(Rf_allocVector(VECSXP, n_groups), &nprot);
-  init_list_of(out_id, vctrs_shared_empty_int);
+  SEXP out_pos = PROTECT_N(Rf_allocVector(VECSXP, n_groups), &nprot);
+  init_list_of(out_pos, vctrs_shared_empty_int);
 
-  // Initialize `out_id` to a list of integers with sizes corresponding
+  // Initialize `out_pos` to a list of integers with sizes corresponding
   // to the number of elements in that group
   for (int i = 0; i < n_groups; ++i) {
-    SET_VECTOR_ELT(out_id, i, Rf_allocVector(INTSXP, p_counts[i]));
+    SET_VECTOR_ELT(out_pos, i, Rf_allocVector(INTSXP, p_counts[i]));
   }
 
   // The current position we are updating, each group has its own counter
@@ -491,7 +491,7 @@ SEXP vec_split_id(SEXP x) {
   for (int i = 0; i < n; ++i) {
     int group = p_groups[i];
     int position = p_positions[group];
-    INTEGER(VECTOR_ELT(out_id, group))[position] = i + 1;
+    INTEGER(VECTOR_ELT(out_pos, group))[position] = i + 1;
     p_positions[group]++;
   }
 
@@ -500,10 +500,12 @@ SEXP vec_split_id(SEXP x) {
   // Construct output data frame
   SEXP out = PROTECT_N(Rf_allocVector(VECSXP, 2), &nprot);
   SET_VECTOR_ELT(out, 0, out_key);
-  SET_VECTOR_ELT(out, 1, out_id);
+  SET_VECTOR_ELT(out, 1, out_pos);
 
   SEXP names = PROTECT_N(Rf_allocVector(STRSXP, 2), &nprot);
   SET_STRING_ELT(names, 0, strings_key);
+  // TODO - Change to `strings_pos` when we change
+  // `vec_split_id()` -> `vec_group_pos()`
   SET_STRING_ELT(names, 1, strings_id);
 
   Rf_setAttrib(out, R_NamesSymbol, names);


### PR DESCRIPTION
Working on `vec_group_id()` gave me some insight into a better implementation of `vec_split_id()` that uses the `vec_group_id()` approach of constructing group identifiers. It uses less memory and is faster. It also feels more readable now.

``` r
library(vctrs)
vec_split_id_old <- vctrs2:::vec_split_id
```

2000 groups, 10 mil elements

```r
g1 <- rep(1:2000, length = 1e7)

bench::mark(
  vec_split_id(g1),
  vec_split_id_old(g1),
  iterations = 30
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 x 6
#>   expression                min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>           <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split_id(g1)        257ms    295ms      3.37     179MB     3.25
#> 2 vec_split_id_old(g1)    379ms    400ms      2.46     307MB     2.54
```

20000 groups, 10 mil elements

```r
g2 <- rep(1:20000, length = 1e7)

bench::mark(
  vec_split_id(g2),
  vec_split_id_old(g2),
  iterations = 20
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 x 6
#>   expression                min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>           <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split_id(g2)        341ms    390ms      2.56     180MB     2.81
#> 2 vec_split_id_old(g2)    617ms    713ms      1.41     308MB     2.82
```

1 million rows, 26000 groups

```r
set.seed(123)

# 1 million rows, ~26000 groups
df <- data.frame(
  x = sample(1000, 1000000, replace = TRUE),
  y = sample(letters, 1000000, replace = TRUE)
)

vec_unique_count(df)
#> [1] 26000

bench::mark(
  vec_split_id(df),
  vec_split_id_old(df),
  iterations = 40
)
#> # A tibble: 2 x 6
#>   expression                min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>           <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_split_id(df)        142ms    161ms      6.02    20.7MB    0.488
#> 2 vec_split_id_old(df)    174ms    217ms      4.72    36.6MB    0.525
```