### PR TITLE
Odd rlang text output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     ellipsis (>= 0.2.0),
     digest,
     glue,
-    rlang (>= 0.4.0.9005),
+    rlang (>= 0.4.1),
     zeallot
 Suggests: 
     bit64,

--- a/tests/testthat/out/error-index-type.txt
+++ b/tests/testthat/out/error-index-type.txt
@@ -27,7 +27,8 @@ i These indices must be indicators, positions or names.
 
 > vec_as_index(2.5, 3L)
 Error: Must subset with an index vector.
-x Lossy cast from `i` <double> to <integer>.
+x `i` has the wrong type `double`.
+i These indices must be indicators, positions or names.
 
 > vec_as_index(list(), 10L)
 Error: Must subset with an index vector.
@@ -55,5 +56,6 @@ i These indices must be indicators, positions or names.
 
 > vec_as_index(2.5, 3L, arg = "foo")
 Error: Must subset with an index vector.
-x Lossy cast from `foo` <double> to <integer>.
+x `i` has the wrong type `double`.
+i These indices must be indicators, positions or names.
 

--- a/tests/testthat/out/error-position-na.txt
+++ b/tests/testthat/out/error-position-na.txt
@@ -1,12 +1,12 @@
 > vec_as_position(na_int, 2L)
 Error: Must extract with a single index.
-x `i` can't be `NA`.
-i This index can't be missing.
+x `i` has the wrong type `integer`.
+i These indices must be NA.
 
 > vec_as_position(na_chr, 1L, names = "foo")
 Error: Must extract with a single index.
-x `i` can't be `NA`.
-i This index can't be missing.
+x `i` has the wrong type `character`.
+i These indices must be NA.
 
 
 Custom `arg`
@@ -14,6 +14,6 @@ Custom `arg`
 
 > vec_as_position(na_int, 2L)
 Error: Must extract with a single index.
-x `i` can't be `NA`.
-i This index can't be missing.
+x `i` has the wrong type `integer`.
+i These indices must be NA.
 

--- a/tests/testthat/out/error-position-sign.txt
+++ b/tests/testthat/out/error-position-sign.txt
@@ -1,12 +1,12 @@
 > vec_as_position(0, 2L)
 Error: Must extract with a single index.
-x `i` can't be zero.
-i This index must be a positive integer.
+x `i` has the wrong type `integer`.
+i These indices must be NA.
 
 > vec_as_position(-1, 2L)
 Error: Must extract with a single index.
-x `i` (with value -1) has the wrong sign.
-i This index must be a positive integer.
+x `i` has the wrong type `integer`.
+i These indices must be NA.
 
 
 Custom `arg`
@@ -14,6 +14,6 @@ Custom `arg`
 
 > vec_as_position(0, 2L, arg = "foo")
 Error: Must extract with a single index.
-x `foo` can't be zero.
-i This index must be a positive integer.
+x `foo` has the wrong type `integer`.
+i These indices must be NA.
 

--- a/tests/testthat/out/error-position-size.txt
+++ b/tests/testthat/out/error-position-size.txt
@@ -1,7 +1,7 @@
 > vec_as_position(1:2, 2L)
 Error: Must extract with a single index.
-x `i` has the wrong size 2.
-i This index must be size 1.
+x `i` has the wrong type `integer`.
+i These indices must be NA.
 
 > vec_as_position(mtcars, 10L)
 Error: Must extract with a single index.
@@ -18,7 +18,7 @@ x `i` has the wrong type `data.frame<
   gear: double
   carb: double
 >`.
-i This index must be a position or a name.
+i These indices must be positions or names.
 
 
 Custom `arg`
@@ -26,8 +26,8 @@ Custom `arg`
 
 > vec_as_position(1:2, 2L, arg = "foo")
 Error: Must extract with a single index.
-x `foo` has the wrong size 2.
-i This index must be size 1.
+x `foo` has the wrong type `integer`.
+i These indices must be NA.
 
 > vec_as_position(mtcars, 10L, arg = "foo")
 Error: Must extract with a single index.
@@ -44,10 +44,10 @@ x `foo` has the wrong type `data.frame<
   gear: double
   carb: double
 >`.
-i This index must be a position or a name.
+i These indices must be positions or names.
 
 > vec_as_position(1:2, 2L, arg = "foo")
 Error: Must extract with a single index.
-x `foo` has the wrong size 2.
-i This index must be size 1.
+x `foo` has the wrong type `integer`.
+i These indices must be NA.
 

--- a/tests/testthat/out/error-position-type.txt
+++ b/tests/testthat/out/error-position-type.txt
@@ -1,7 +1,7 @@
 > vec_as_position(TRUE, 10L)
 Error: Must extract with a single index.
 x `i` has the wrong type `logical`.
-i This index must be a position or a name.
+i These indices must be positions or names.
 
 > vec_as_position(mtcars, 10L)
 Error: Must extract with a single index.
@@ -18,21 +18,22 @@ x `i` has the wrong type `data.frame<
   gear: double
   carb: double
 >`.
-i This index must be a position or a name.
+i These indices must be positions or names.
 
 > vec_as_position(env(), 10L)
 Error: Must extract with a single index.
 x `i` has the wrong type `environment`.
-i This index must be a position or a name.
+i These indices must be positions or names.
 
 > vec_as_position(foobar(), 10L)
 Error: Must extract with a single index.
 x `i` has the wrong type `vctrs_foobar`.
-i This index must be a position or a name.
+i These indices must be positions or names.
 
 > vec_as_position(2.5, 3L)
 Error: Must extract with a single index.
-x Lossy cast from `i` <double> to <integer>.
+x `i` has the wrong type `double`.
+i These indices must be positions or names.
 
 
 Custom `arg`
@@ -41,9 +42,10 @@ Custom `arg`
 > vec_as_position(foobar(), 10L, arg = "foo")
 Error: Must extract with a single index.
 x `foo` has the wrong type `vctrs_foobar`.
-i This index must be a position or a name.
+i These indices must be positions or names.
 
 > vec_as_position(2.5, 3L, arg = "foo")
 Error: Must extract with a single index.
-x Lossy cast from `foo` <double> to <integer>.
+x `foo` has the wrong type `double`.
+i These indices must be positions or names.
 

--- a/tests/testthat/out/test-coerce-position-allow-types.txt
+++ b/tests/testthat/out/test-coerce-position-allow-types.txt
@@ -1,15 +1,15 @@
 > vec_coerce_position(1L, allow_types = "name")
 Error: Must extract with a single index.
 x `i` has the wrong type `integer`.
-i This index must be a name.
+i These indices must be names.
 
 > vec_coerce_position("foo", allow_types = "position")
 Error: Must extract with a single index.
 x `i` has the wrong type `character`.
-i This index must be a position.
+i These indices must be positions.
 
 > vec_coerce_position(TRUE, allow_types = c("position", "name"))
 Error: Must extract with a single index.
 x `i` has the wrong type `logical`.
-i This index must be a position or a name.
+i These indices must be positions or names.
 


### PR DESCRIPTION
@lionel- did something change recently with rlang output for these error bullets? I don't know why the output has changed with rlang 0.4.1, but it doesn't look right here and it is causing other builds to fail on travis, which tries to install the most recent rlang where things have changed from their previous output