### PR TITLE
Don't call `vec_size()` on scalar types when translating

### DIFF
--- a/src/translate.c
+++ b/src/translate.c
@@ -93,7 +93,6 @@ static bool obj_any_known_encoding(SEXP x, R_len_t size) {
 // For usage on list elements. They have unknown size, and might be scalars.
 static bool elt_any_known_encoding(SEXP x) {
   switch (vec_proxy_typeof(x)) {
-  case vctrs_type_scalar: return false;
   case vctrs_type_character: return chr_any_known_encoding(x, vec_size(x));
   case vctrs_type_list: return list_any_known_encoding(x, vec_size(x));
   case vctrs_type_dataframe: return df_any_known_encoding(x, vec_size(x));
@@ -163,7 +162,6 @@ static SEXP obj_translate_encoding(SEXP x, R_len_t size) {
 // For usage on list elements. They have unknown size, and might be scalars.
 static SEXP elt_translate_encoding(SEXP x) {
   switch (vec_proxy_typeof(x)) {
-  case vctrs_type_scalar: return x;
   case vctrs_type_character: return chr_translate_encoding(x, vec_size(x));
   case vctrs_type_list: return list_translate_encoding(x, vec_size(x));
   case vctrs_type_dataframe: return df_translate_encoding(x, vec_size(x));

--- a/src/translate.c
+++ b/src/translate.c
@@ -82,21 +82,39 @@ static bool list_any_known_encoding(SEXP x, R_len_t size);
 static bool df_any_known_encoding(SEXP x, R_len_t size);
 
 static bool obj_any_known_encoding(SEXP x, R_len_t size) {
-  switch (vec_proxy_typeof(x)) {
-  case vctrs_type_character: return chr_any_known_encoding(x, size);
-  case vctrs_type_list: return list_any_known_encoding(x, size);
-  case vctrs_type_dataframe: return df_any_known_encoding(x, size);
-  default: return false;
+  switch (TYPEOF(x)) {
+  case STRSXP: {
+    return chr_any_known_encoding(x, size);
+  }
+  case VECSXP: {
+    if (is_data_frame(x)) {
+      return df_any_known_encoding(x, size);
+    } else {
+      return list_any_known_encoding(x, size);
+    }
+  }
+  default: {
+    return false;
+  }
   }
 }
 
 // For usage on list elements. They have unknown size, and might be scalars.
 static bool elt_any_known_encoding(SEXP x) {
-  switch (vec_proxy_typeof(x)) {
-  case vctrs_type_character: return chr_any_known_encoding(x, vec_size(x));
-  case vctrs_type_list: return list_any_known_encoding(x, vec_size(x));
-  case vctrs_type_dataframe: return df_any_known_encoding(x, vec_size(x));
-  default: return false;
+  switch (TYPEOF(x)) {
+  case STRSXP: {
+    return chr_any_known_encoding(x, Rf_length(x));
+  }
+  case VECSXP: {
+    if (is_data_frame(x)) {
+      return df_any_known_encoding(x, vec_size(x));
+    } else {
+      return list_any_known_encoding(x, Rf_length(x));
+    }
+  }
+  default: {
+    return false;
+  }
   }
 }
 
@@ -151,21 +169,39 @@ static SEXP list_translate_encoding(SEXP x, R_len_t size);
 static SEXP df_translate_encoding(SEXP x, R_len_t size);
 
 static SEXP obj_translate_encoding(SEXP x, R_len_t size) {
-  switch (vec_proxy_typeof(x)) {
-  case vctrs_type_character: return chr_translate_encoding(x, size);
-  case vctrs_type_list: return list_translate_encoding(x, size);
-  case vctrs_type_dataframe: return df_translate_encoding(x, size);
-  default: return x;
+  switch (TYPEOF(x)) {
+  case STRSXP: {
+    return chr_translate_encoding(x, size);
+  }
+  case VECSXP: {
+    if (is_data_frame(x)) {
+      return df_translate_encoding(x, size);
+    } else {
+      return list_translate_encoding(x, size);
+    }
+  }
+  default: {
+    return x;
+  }
   }
 }
 
 // For usage on list elements. They have unknown size, and might be scalars.
 static SEXP elt_translate_encoding(SEXP x) {
-  switch (vec_proxy_typeof(x)) {
-  case vctrs_type_character: return chr_translate_encoding(x, vec_size(x));
-  case vctrs_type_list: return list_translate_encoding(x, vec_size(x));
-  case vctrs_type_dataframe: return df_translate_encoding(x, vec_size(x));
-  default: return x;
+  switch (TYPEOF(x)) {
+  case STRSXP: {
+    return chr_translate_encoding(x, Rf_length(x));
+  }
+  case VECSXP: {
+    if (is_data_frame(x)) {
+      return df_translate_encoding(x, vec_size(x));
+    } else {
+      return list_translate_encoding(x, Rf_length(x));
+    }
+  }
+  default: {
+    return x;
+  }
   }
 }
 
@@ -240,11 +276,20 @@ static SEXP df_maybe_translate_encoding(SEXP x, R_len_t size);
 
 // [[ include("vctrs.h") ]]
 SEXP obj_maybe_translate_encoding(SEXP x, R_len_t size) {
-  switch (vec_proxy_typeof(x)) {
-  case vctrs_type_character: return chr_maybe_translate_encoding(x, size);
-  case vctrs_type_list: return list_maybe_translate_encoding(x, size);
-  case vctrs_type_dataframe: return df_maybe_translate_encoding(x, size);
-  default: return x;
+  switch (TYPEOF(x)) {
+  case STRSXP: {
+    return chr_maybe_translate_encoding(x, size);
+  }
+  case VECSXP: {
+    if (is_data_frame(x)) {
+      return df_maybe_translate_encoding(x, size);
+    } else {
+      return list_maybe_translate_encoding(x, size);
+    }
+  }
+  default: {
+    return x;
+  }
   }
 }
 
@@ -288,11 +333,20 @@ static SEXP df_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t
 
 // [[ include("vctrs.h") ]]
 SEXP obj_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
-  switch (vec_proxy_typeof(x)) {
-  case vctrs_type_character: return chr_maybe_translate_encoding2(x, x_size, y, y_size);
-  case vctrs_type_list: return list_maybe_translate_encoding2(x, x_size, y, y_size);
-  case vctrs_type_dataframe: return df_maybe_translate_encoding2(x, x_size, y, y_size);
-  default: return translate_none(x, y);
+  switch (TYPEOF(x)) {
+  case STRSXP: {
+    return chr_maybe_translate_encoding2(x, x_size, y, y_size);
+  }
+  case VECSXP: {
+    if (is_data_frame(x)) {
+      return df_maybe_translate_encoding2(x, x_size, y, y_size);
+    } else {
+      return list_maybe_translate_encoding2(x, x_size, y, y_size);
+    }
+  }
+  default: {
+    return translate_none(x, y);
+  }
   }
 }
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -135,12 +135,8 @@ static bool chr_any_known_encoding(SEXP x, R_len_t size) {
 }
 
 static bool list_any_known_encoding(SEXP x, R_len_t size) {
-  SEXP elt;
-
   for (int i = 0; i < size; ++i) {
-    elt = VECTOR_ELT(x, i);
-
-    if (elt_any_known_encoding(elt)) {
+    if (elt_any_known_encoding(VECTOR_ELT(x, i))) {
       return true;
     }
   }
@@ -215,11 +211,10 @@ static SEXP chr_translate_encoding(SEXP x, R_len_t size) {
   SEXP out = PROTECT(r_maybe_duplicate(x));
   SEXP* p_out = STRING_PTR(out);
 
-  SEXP chr;
   const void *vmax = vmaxget();
 
   for (int i = 0; i < size; ++i, ++p_x, ++p_out) {
-    chr = *p_x;
+    SEXP chr = *p_x;
 
     if (Rf_getCharCE(chr) == CE_UTF8) {
       *p_out = chr;
@@ -235,11 +230,10 @@ static SEXP chr_translate_encoding(SEXP x, R_len_t size) {
 }
 
 static SEXP list_translate_encoding(SEXP x, R_len_t size) {
-  SEXP elt;
   x = PROTECT(r_maybe_duplicate(x));
 
   for (int i = 0; i < size; ++i) {
-    elt = VECTOR_ELT(x, i);
+    SEXP elt = VECTOR_ELT(x, i);
     SET_VECTOR_ELT(x, i, elt_translate_encoding(elt));
   }
 
@@ -248,13 +242,12 @@ static SEXP list_translate_encoding(SEXP x, R_len_t size) {
 }
 
 static SEXP df_translate_encoding(SEXP x, R_len_t size) {
-  SEXP col;
-  x = PROTECT(r_maybe_duplicate(x));
-
   int n_col = Rf_length(x);
 
+  x = PROTECT(r_maybe_duplicate(x));
+
   for (int i = 0; i < n_col; ++i) {
-    col = VECTOR_ELT(x, i);
+    SEXP col = VECTOR_ELT(x, i);
     SET_VECTOR_ELT(x, i, obj_translate_encoding(col, size));
   }
 
@@ -306,10 +299,8 @@ static SEXP df_maybe_translate_encoding(SEXP x, R_len_t size) {
 
   x = PROTECT(r_maybe_duplicate(x));
 
-  SEXP elt;
-
   for (int i = 0; i < n_col; ++i) {
-    elt = VECTOR_ELT(x, i);
+    SEXP elt = VECTOR_ELT(x, i);
     SET_VECTOR_ELT(x, i, obj_maybe_translate_encoding(elt, size));
   }
 
@@ -391,22 +382,18 @@ static SEXP list_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len
 }
 
 static SEXP df_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
-  SEXP x_elt;
-  SEXP y_elt;
-  SEXP translated;
+  int n_col = Rf_length(x);
 
   x = PROTECT(r_maybe_duplicate(x));
   y = PROTECT(r_maybe_duplicate(y));
 
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
 
-  int n_col = Rf_length(x);
-
   for (int i = 0; i < n_col; ++i) {
-    x_elt = VECTOR_ELT(x, i);
-    y_elt = VECTOR_ELT(y, i);
+    SEXP x_elt = VECTOR_ELT(x, i);
+    SEXP y_elt = VECTOR_ELT(y, i);
 
-    translated = PROTECT(obj_maybe_translate_encoding2(x_elt, x_size, y_elt, y_size));
+    SEXP translated = PROTECT(obj_maybe_translate_encoding2(x_elt, x_size, y_elt, y_size));
 
     SET_VECTOR_ELT(x, i, VECTOR_ELT(translated, 0));
     SET_VECTOR_ELT(y, i, VECTOR_ELT(translated, 1));

--- a/src/translate.c
+++ b/src/translate.c
@@ -144,6 +144,9 @@ static bool list_any_known_encoding(SEXP x, R_len_t size) {
   return false;
 }
 
+// Data frames have a separate path from lists here purely for
+// performance reasons. We know the size of each column, and can
+// pass that information through.
 static bool df_any_known_encoding(SEXP x, R_len_t size) {
   int n_col = Rf_length(x);
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -13,8 +13,8 @@
 // - (utf8 + utf8), (latin1 + latin1), (unknown + unknown), (bytes + bytes)
 
 static bool chr_translation_required_impl(const SEXP* x, R_len_t size, cetype_t reference) {
-  for (R_len_t i = 0; i < size; ++i, ++x) {
-    if (Rf_getCharCE(*x) != reference) {
+  for (R_len_t i = 0; i < size; ++i) {
+    if (Rf_getCharCE(x[i]) != reference) {
       return true;
     }
   }
@@ -125,8 +125,8 @@ static bool chr_any_known_encoding(SEXP x, R_len_t size) {
 
   const SEXP* p_x = STRING_PTR_RO(x);
 
-  for (int i = 0; i < size; ++i, ++p_x) {
-    if (Rf_getCharCE(*p_x) != CE_NATIVE) {
+  for (int i = 0; i < size; ++i) {
+    if (Rf_getCharCE(p_x[i]) != CE_NATIVE) {
       return true;
     }
   }
@@ -213,15 +213,15 @@ static SEXP chr_translate_encoding(SEXP x, R_len_t size) {
 
   const void *vmax = vmaxget();
 
-  for (int i = 0; i < size; ++i, ++p_x, ++p_out) {
-    SEXP chr = *p_x;
+  for (int i = 0; i < size; ++i) {
+    SEXP chr = p_x[i];
 
     if (Rf_getCharCE(chr) == CE_UTF8) {
-      *p_out = chr;
+      p_out[i] = chr;
       continue;
     }
 
-    *p_out = Rf_mkCharCE(Rf_translateCharUTF8(chr), CE_UTF8);
+    p_out[i] = Rf_mkCharCE(Rf_translateCharUTF8(chr), CE_UTF8);
   }
 
   vmaxset(vmax);

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -120,6 +120,14 @@ test_that("unique functions work with different encodings", {
   expect_equal(vec_unique_loc(encs), 1L)
 })
 
+test_that("unique functions can handle scalar types in lists", {
+  x <- list(x = a ~ b, y = a ~ b, z = a ~ c)
+  expect_equal(vec_unique(x), vec_slice(x, c(1, 3)))
+
+  x <- list(x = call("x"), y = call("y"), z = call("x"))
+  expect_equal(vec_unique(x), vec_slice(x, c(1, 2)))
+})
+
 test_that("duplicate functions works with different encodings", {
   encs <- encodings()
 

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -55,6 +55,17 @@ test_that("translation can still occur even if a scalar type is in a list", {
   expect_equal(obj_maybe_translate_encoding(x), expect)
 })
 
+test_that("translation occurs inside scalars contained in a list", {
+  encs <- encodings()
+
+  scalar <- structure(list(x = encs$latin1), class = "scalar_list")
+  lst <- list(scalar)
+
+  result <- obj_maybe_translate_encoding(lst)
+
+  expect_equal_encoding(result[[1]]$x, encs$utf8)
+})
+
 # ------------------------------------------------------------------------------
 # obj_maybe_translate_encoding2()
 

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -43,6 +43,18 @@ test_that("attributes are kept on translation (#599)", {
   expect_equal(attributes(obj_maybe_translate_encoding(x)), attributes(x))
 })
 
+test_that("translation is robust against scalar types contained in lists (#633)", {
+  x <- list(a = z ~ y, b = z ~ z)
+  expect_equal(obj_maybe_translate_encoding(x), x)
+})
+
+test_that("translation can still occur even if a scalar type is in a list", {
+  encs <- encodings()
+  x <- list(a = z ~ y, b = encs$utf8, c = encs$latin1)
+  expect <- list(a = z ~ y, b = encs$utf8, c = encs$utf8)
+  expect_equal(obj_maybe_translate_encoding(x), expect)
+})
+
 # ------------------------------------------------------------------------------
 # obj_maybe_translate_encoding2()
 
@@ -187,4 +199,10 @@ test_that("all elements are affected when any translation is required in a list"
   expect_equal_encoding(result1[[1]], encs$utf8)
   expect_equal_encoding(result2[[1]], encs$utf8)
   expect_equal_encoding(result2[[2]]$x, encs$utf8)
+})
+
+test_that("translation is robust against scalar types contained in lists (#633)", {
+  x <- list(a = z ~ y, b = z ~ z)
+  y <- list(a = c ~ d, b = e ~ f)
+  expect_equal(obj_maybe_translate_encoding2(x, y), list(x, y))
 })

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -50,9 +50,11 @@ test_that("translation is robust against scalar types contained in lists (#633)"
 
 test_that("translation can still occur even if a scalar type is in a list", {
   encs <- encodings()
-  x <- list(a = z ~ y, b = encs$utf8, c = encs$latin1)
-  expect <- list(a = z ~ y, b = encs$utf8, c = encs$utf8)
-  expect_equal(obj_maybe_translate_encoding(x), expect)
+  x <- list(a = z ~ y, b = encs$latin1)
+
+  result <- obj_maybe_translate_encoding(x)
+
+  expect_equal_encoding(result$b, encs$utf8)
 })
 
 test_that("translation occurs inside scalars contained in a list", {


### PR DESCRIPTION
Closes #633

We now skip over any scalar types found inside of a list in the translation helpers so we don't accidentally call `vec_size()` on them.

``` r
library(vctrs)

lst <- list(y ~ x, y ~ x)

vctrs:::obj_maybe_translate_encoding(lst)
#> [[1]]
#> y ~ x
#> 
#> [[2]]
#> y ~ x

# so this works again
vec_unique(lst)
#> [[1]]
#> y ~ x
```

The change doesn't need to be made in the data frame functions because a scalar type will never directly be a column of a data frame, and it would pass on the data frame size anyways, rather than trying to call `vec_size()`.

There should be no performance implications.