### PR TITLE
Recursively proxy in the dictionary functions

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -333,6 +333,7 @@ SEXP vctrs_count(SEXP x) {
 
   R_len_t n = vec_size(x);
 
+  x = PROTECT_N(vec_proxy_equal(x), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
   dictionary d;

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -21,6 +21,10 @@ int32_t ceil2(int32_t x) {
 
 // Dictonary object ------------------------------------------------------------
 
+// Dictionary functions assume that `x` has been proxied recursively because:
+// - `dict_init_impl()` uses `hash_fill()`
+// - `dict_hash_with()` uses `equal_scalar()`
+
 static void dict_init_impl(dictionary* d, SEXP x, bool partial);
 
 // Dictionaries must be protected and unprotected in consistent stack
@@ -33,7 +37,7 @@ void dict_init_partial(dictionary* d, SEXP x) {
 }
 
 static void dict_init_impl(dictionary* d, SEXP x, bool partial) {
-  d->vec = PROTECT(vec_proxy_recursive(x, vctrs_proxy_equal));
+  d->vec = x;
   d->used = 0;
 
   if (partial) {
@@ -60,8 +64,6 @@ static void dict_init_impl(dictionary* d, SEXP x, bool partial) {
     memset(d->hash, 0, n * sizeof(R_len_t));
     hash_fill(d->hash, n, x);
   }
-
-  UNPROTECT(1);
 }
 
 uint32_t dict_hash_with(dictionary* d, dictionary* x, R_len_t i) {
@@ -114,7 +116,7 @@ SEXP vctrs_unique_loc(SEXP x) {
 
   R_len_t n = vec_size(x);
 
-  x = PROTECT_N(vec_proxy_equal(x), &nprot);
+  x = PROTECT_N(vec_proxy_recursive(x, vctrs_proxy_equal), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
   dictionary d;
@@ -151,7 +153,7 @@ bool duplicated_any(SEXP x) {
 
   R_len_t n = vec_size(x);
 
-  x = PROTECT_N(vec_proxy_equal(x), &nprot);
+  x = PROTECT_N(vec_proxy_recursive(x, vctrs_proxy_equal), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
   dictionary d;
@@ -180,7 +182,7 @@ SEXP vctrs_n_distinct(SEXP x) {
 
   R_len_t n = vec_size(x);
 
-  x = PROTECT_N(vec_proxy_equal(x), &nprot);
+  x = PROTECT_N(vec_proxy_recursive(x, vctrs_proxy_equal), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
   dictionary d;
@@ -203,7 +205,7 @@ SEXP vctrs_id(SEXP x) {
 
   R_len_t n = vec_size(x);
 
-  x = PROTECT_N(vec_proxy_equal(x), &nprot);
+  x = PROTECT_N(vec_proxy_recursive(x, vctrs_proxy_equal), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
   dictionary d;
@@ -235,8 +237,8 @@ SEXP vctrs_match(SEXP needles, SEXP haystack) {
   needles = PROTECT_N(vec_cast(needles, type, args_empty, args_empty), &nprot);
   haystack = PROTECT_N(vec_cast(haystack, type, args_empty, args_empty), &nprot);
 
-  needles = PROTECT_N(vec_proxy_equal(needles), &nprot);
-  haystack = PROTECT_N(vec_proxy_equal(haystack), &nprot);
+  needles = PROTECT_N(vec_proxy_recursive(needles, vctrs_proxy_equal), &nprot);
+  haystack = PROTECT_N(vec_proxy_recursive(haystack, vctrs_proxy_equal), &nprot);
 
   R_len_t n_haystack = vec_size(haystack);
   R_len_t n_needle = vec_size(needles);
@@ -288,8 +290,8 @@ SEXP vctrs_in(SEXP needles, SEXP haystack) {
   needles = PROTECT_N(vec_cast(needles, type, args_empty, args_empty), &nprot);
   haystack = PROTECT_N(vec_cast(haystack, type, args_empty, args_empty), &nprot);
 
-  needles = PROTECT_N(vec_proxy_equal(needles), &nprot);
-  haystack = PROTECT_N(vec_proxy_equal(haystack), &nprot);
+  needles = PROTECT_N(vec_proxy_recursive(needles, vctrs_proxy_equal), &nprot);
+  haystack = PROTECT_N(vec_proxy_recursive(haystack, vctrs_proxy_equal), &nprot);
 
   R_len_t n_haystack = vec_size(haystack);
   R_len_t n_needle = vec_size(needles);
@@ -333,7 +335,7 @@ SEXP vctrs_count(SEXP x) {
 
   R_len_t n = vec_size(x);
 
-  x = PROTECT_N(vec_proxy_equal(x), &nprot);
+  x = PROTECT_N(vec_proxy_recursive(x, vctrs_proxy_equal), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
   dictionary d;
@@ -386,7 +388,7 @@ SEXP vctrs_duplicated(SEXP x) {
 
   R_len_t n = vec_size(x);
 
-  x = PROTECT_N(vec_proxy_equal(x), &nprot);
+  x = PROTECT_N(vec_proxy_recursive(x, vctrs_proxy_equal), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
   dictionary d;

--- a/src/group.c
+++ b/src/group.c
@@ -8,7 +8,7 @@ SEXP vctrs_group_id(SEXP x) {
 
   R_len_t n = vec_size(x);
 
-  x = PROTECT_N(vec_proxy_equal(x), &nprot);
+  x = PROTECT_N(vec_proxy_recursive(x, vctrs_proxy_equal), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
   dictionary d;
@@ -50,7 +50,7 @@ SEXP vctrs_group_rle(SEXP x) {
 
   R_len_t n = vec_size(x);
 
-  x = PROTECT_N(vec_proxy_equal(x), &nprot);
+  x = PROTECT_N(vec_proxy_recursive(x, vctrs_proxy_equal), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
   dictionary d;
@@ -142,7 +142,7 @@ SEXP vec_group_pos(SEXP x) {
 
   R_len_t n = vec_size(x);
 
-  SEXP proxy = PROTECT_N(vec_proxy_equal(x), &nprot);
+  SEXP proxy = PROTECT_N(vec_proxy_recursive(x, vctrs_proxy_equal), &nprot);
   proxy = PROTECT_N(obj_maybe_translate_encoding(proxy, n), &nprot);
 
   dictionary d;

--- a/src/translate.c
+++ b/src/translate.c
@@ -214,6 +214,9 @@ static SEXP df_translate_encoding(SEXP x, R_len_t size) {
 //   translation of every element in the list.
 // - If `x` is a data frame, translate the columns one by one, independently.
 
+// Notes:
+// - Assumes that `x` has been proxied recursively.
+
 static SEXP chr_maybe_translate_encoding(SEXP x, R_len_t size);
 static SEXP list_maybe_translate_encoding(SEXP x, R_len_t size);
 static SEXP df_maybe_translate_encoding(SEXP x, R_len_t size);
@@ -263,6 +266,7 @@ static SEXP df_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t
 
 // Notes:
 // - Assumes that `x` and `y` are the same type from calling `vec_cast()`.
+// - Assumes that `x` and `y` have been recursively proxied.
 // - Does not assume that `x` and `y` are the same size.
 // - Returns a list holding `x` and `y` translated to their common encoding.
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -355,7 +355,12 @@ static SEXP df_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t
 
 // [[ register() ]]
 SEXP vctrs_maybe_translate_encoding(SEXP x) {
-  return obj_maybe_translate_encoding(x, vec_size(x));
+  x = PROTECT(vec_proxy_recursive(x, vctrs_proxy_equal));
+
+  SEXP out = PROTECT(obj_maybe_translate_encoding(x, vec_size(x)));
+
+  UNPROTECT(2);
+  return out;
 }
 
 // [[ register() ]]
@@ -370,8 +375,8 @@ SEXP vctrs_maybe_translate_encoding2(SEXP x, SEXP y) {
   x = PROTECT(vec_cast(x, type, args_empty, args_empty));
   y = PROTECT(vec_cast(y, type, args_empty, args_empty));
 
-  x = PROTECT(vec_proxy_equal(x));
-  y = PROTECT(vec_proxy_equal(y));
+  x = PROTECT(vec_proxy_recursive(x, vctrs_proxy_equal));
+  y = PROTECT(vec_proxy_recursive(y, vctrs_proxy_equal));
 
   UNPROTECT(5);
   return obj_maybe_translate_encoding2(x, vec_size(x), y, vec_size(y));

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -35,6 +35,16 @@ test_that("vec_count works with different encodings", {
   expect_equal(x, new_data_frame(list(key = encodings()[1], count = 3L)))
 })
 
+test_that("vec_count recursively takes the equality proxy", {
+  scoped_comparable_tuple()
+
+  x <- tuple(c(1, 1, 2), 1:3)
+  df <- data_frame(x = x)
+  expect <- data_frame(key = vec_slice(df, c(1, 3)), count = c(2L, 1L))
+
+  expect_equal(vec_count(df), expect)
+})
+
 # duplicates and uniques --------------------------------------------------
 
 test_that("vec_duplicated reports on duplicates regardless of position", {
@@ -110,6 +120,28 @@ test_that("unique functions take the equality proxy (#375)", {
 
   expect_true(vec_in(tuple(2, 100), x))
   expect_identical(vec_match(tuple(2, 100), x), 2L)
+})
+
+test_that("unique functions take the equality proxy recursively", {
+  scoped_comparable_tuple()
+
+  x <- tuple(c(1, 1, 2), 1:3)
+  df <- data_frame(x = x)
+
+  expect_equal(vec_unique(df), vec_slice(df, c(1, 3)))
+  expect_equal(vec_unique_count(df), 2L)
+  expect_equal(vec_unique_loc(df), c(1, 3))
+})
+
+test_that("duplicate functions take the equality proxy recursively", {
+  scoped_comparable_tuple()
+
+  x <- tuple(c(1, 1, 2), 1:3)
+  df <- data_frame(x = x)
+
+  expect_equal(vec_duplicate_any(df), TRUE)
+  expect_equal(vec_duplicate_detect(df), c(TRUE, TRUE, FALSE))
+  expect_equal(vec_duplicate_id(df), c(1, 1, 3))
 })
 
 test_that("unique functions work with different encodings", {
@@ -190,4 +222,17 @@ test_that("matching functions work with different encodings", {
 
   expect_equal(vec_match(encs, encs[1]), rep(1, 3))
   expect_equal(vec_in(encs, encs[1]), rep(TRUE, 3))
+})
+
+test_that("matching functions take the equality proxy recursively", {
+  scoped_comparable_tuple()
+
+  x <- tuple(c(1, 2), 1:2)
+  df <- data_frame(x = x)
+
+  y <- tuple(c(2, 3), c(3, 3))
+  df2 <- data_frame(x = y)
+
+  expect_equal(vec_match(df, df2), c(NA, 1))
+  expect_equal(vec_in(df, df2), c(FALSE, TRUE))
 })

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -335,6 +335,19 @@ test_that("data frames are compared row wise", {
   expect_false(vec_duplicate_all(df2))
 })
 
+test_that("the equality proxy is taken recursively", {
+  scoped_comparable_tuple()
+
+  x <- tuple(c(1, 1, 2), 1:3)
+  df <- data_frame(x = x)
+
+  y <- tuple(c(1, 1, 1), 1:3)
+  df2 <- data_frame(y = y)
+
+  expect_equal(vec_duplicate_all(df), FALSE)
+  expect_equal(vec_duplicate_all(df2), TRUE)
+})
+
 test_that("can detect duplicates among strings with different encodings", {
   for (x_encoding in encodings()) {
     for (y_encoding in encodings()) {

--- a/tests/testthat/test-group.R
+++ b/tests/testthat/test-group.R
@@ -49,6 +49,17 @@ test_that("vec_group_id takes the equality proxy", {
   expect_equal(vec_group_id(x), expect)
 })
 
+test_that("vec_group_id takes the equality proxy recursively", {
+  scoped_comparable_tuple()
+
+  x <- tuple(c(1, 2, 1, 1), 1:4)
+  df <- data_frame(x = x)
+
+  expect <- structure(c(1L, 2L, 1L, 1L), n = 2L)
+
+  expect_equal(vec_group_id(df), expect)
+})
+
 # group rle ---------------------------------------------------------------
 
 test_that("vec_group_rle returns a `vctrs_group_rle` object", {
@@ -94,6 +105,17 @@ test_that("vec_group_rle takes the equality proxy", {
 test_that("vec_group_rle works row wise on data frames", {
   df <- data.frame(x = c(1, 1, 2, 1), y = c(2, 2, 3, 2))
   expect <- new_group_rle(c(1L, 2L, 1L), c(2L, 1L, 1L), 2L)
+  expect_equal(vec_group_rle(df), expect)
+})
+
+test_that("vec_group_rle takes the equality proxy recursively", {
+  scoped_comparable_tuple()
+
+  x <- tuple(c(1, 2, 1, 1), 1:4)
+  df <- data_frame(x = x)
+
+  expect <- new_group_rle(c(1L, 2L, 1L), c(1L, 1L, 2L), 2L)
+
   expect_equal(vec_group_rle(df), expect)
 })
 
@@ -160,6 +182,17 @@ test_that("vec_group_pos takes the equality proxy", {
   x <- as.POSIXlt(new_datetime(c(1, 2, 1)))
   expect_equal(vec_group_pos(x)$key, x[1:2])
   expect_equal(vec_group_pos(x)$pos, list_of(c(1L, 3L), 2L))
+})
+
+test_that("vec_group_pos takes the equality proxy recursively", {
+  scoped_comparable_tuple()
+
+  x <- tuple(c(1, 2, 1, 1), 1:4)
+  df <- data_frame(x = x)
+
+  expect <- data_frame(key = vec_slice(df, c(1, 2)), pos = list_of(c(1L, 3L, 4L), 2L))
+
+  expect_equal(vec_group_pos(df), expect)
 })
 
 test_that("vec_group_pos works with different encodings", {


### PR DESCRIPTION
Closes #630  

* `vec_count()` didn't take the proxy at all. It does now.

* Removed the recursive proxy call from `dict_init_impl()`, it now assumes that `x` has already been recursively proxied. I think this is reasonable, since the functions that build a dictionary probably want to recursively proxy `x` for their own purposes.

* Any function that uses the dictionary now calls `vec_proxy_recursive()` rather than just `vec_proxy_equal()`.

* Added tests for each dictionary function (along with `vec_duplicate_all()`) to ensure that we are taking the proxy recursively.

I'm curious about what @lionel- thinks about this approach. The alternative might be to make sure that both `dict_init_impl()` and the translation helpers do the recursive proxy themselves, but then you'd be doing it twice.