### PR TITLE
Treat positive and negative 0 as equivalent when hashing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs 0.2.0.9000
 
+* Positive and negative 0 are now considered equivalent by all functions that
+  check for equality or uniqueness (#637).
+
 * New experimental `vec_group_rle()` for returning run length encoded groups.
 
 * New experimental `vec_group_id()` for constructing group identifiers from a

--- a/src/hash.c
+++ b/src/hash.c
@@ -32,6 +32,11 @@ static uint32_t hash_int64(int64_t x) {
 // Seems like something designed specificaly for doubles should work better
 // but I haven't been able to find anything
 static uint32_t hash_double(double x) {
+  // Treat positive/negative 0 as equivalent
+  if (x == 0.0) {
+    x = 0.0;
+  }
+
   union {
     double d;
     uint64_t i;

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -112,7 +112,7 @@ test_that("unique functions take the equality proxy (#375)", {
   expect_identical(vec_match(tuple(2, 100), x), 2L)
 })
 
-test_that("unique functions treat positive and negative 0 as equivalent", {
+test_that("unique functions treat positive and negative 0 as equivalent (#637)", {
   expect_equal(vec_unique(c(0, -0)), 0)
   expect_equal(vec_unique_count(c(0, -0)), 1)
   expect_equal(vec_unique_loc(c(0, -0)), 1)

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -112,6 +112,12 @@ test_that("unique functions take the equality proxy (#375)", {
   expect_identical(vec_match(tuple(2, 100), x), 2L)
 })
 
+test_that("unique functions treat positive and negative 0 as equivalent", {
+  expect_equal(vec_unique(c(0, -0)), 0)
+  expect_equal(vec_unique_count(c(0, -0)), 1)
+  expect_equal(vec_unique_loc(c(0, -0)), 1)
+})
+
 test_that("unique functions work with different encodings", {
   encs <- encodings()
 

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -135,7 +135,7 @@ test_that("can hash complex vectors", {
   )
 })
 
-test_that("hash treats positive and negative 0 as equivalent", {
+test_that("hash treats positive and negative 0 as equivalent (#637)", {
   expect_equal(vec_hash(-0), vec_hash(0))
 })
 

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -135,6 +135,10 @@ test_that("can hash complex vectors", {
   )
 })
 
+test_that("hash treats positive and negative 0 as equivalent", {
+  expect_equal(vec_hash(-0), vec_hash(0))
+})
+
 # Object ------------------------------------------------------------------
 
 test_that("equal objects hash to same value", {


### PR DESCRIPTION
Closes #637 

We now treat positive and negative 0 as equivalent, similar to how R does
https://github.com/wch/r-source/blob/800fa450bca0bef95d53ce705cbc70f6075fdec0/src/main/unique.c#L115

``` r
vctrs::vec_unique(c(0, -0))
#> [1] 0
```

The way that R does, by creating a tmp variable with `double tmp = (xi == 0.0) ? 0.0 : xi;` is slightly slower than what I do by skipping the re-assignment when the value is not 0.

FYI, integers do not have this problem. `0` and `-0` look the same at the C level.

This has minimal performance implications (it looks like it got faster but I think that's just proof that it doesn't have much of an impact, and you are just seeing noise).

``` r
library(vctrs)
x <- rep(1, times = 1e7)

vec_hash <- vctrs:::vec_hash
```

Before:

``` r
bench::mark(vec_hash(x), iterations = 100)
#> # A tibble: 1 x 6
#>   expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_hash(x)    117ms    131ms      7.28    38.1MB     7.58
```

After:

``` r
bench::mark(vec_hash(x), iterations = 100)
#> # A tibble: 1 x 6
#>   expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_hash(x)    119ms    124ms      8.01    38.1MB     8.34
```