### PR TITLE
Use base primitives in `equal_object()`

### DIFF
--- a/src/equal.c
+++ b/src/equal.c
@@ -23,15 +23,16 @@ int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
   case STRSXP: return chr_equal_scalar(STRING_PTR(x) + i, STRING_PTR(y) + j, na_equal);
   case RAWSXP: return raw_equal_scalar(RAW(x) + i, RAW(y) + j, na_equal);
   case CPLXSXP: return cpl_equal_scalar(COMPLEX(x) + i, COMPLEX(y) + j, na_equal);
-  case VECSXP: {
-    if (is_data_frame(x)) {
-      return df_equal_scalar(x, i, y, j, na_equal);
-    }
+  default: break;
+  }
 
-    return list_equal_scalar(x, i, y, j, na_equal);
+  switch (vec_proxy_typeof(x)) {
+  case vctrs_type_list: return list_equal_scalar(x, i, y, j, na_equal);
+  case vctrs_type_dataframe: return df_equal_scalar(x, i, y, j, na_equal);
+  default: break;
   }
-  default: vctrs_stop_unsupported_type(vec_typeof(x), "equal_scalar()");
-  }
+
+  vctrs_stop_unsupported_type(vec_typeof(x), "equal_scalar()");
 }
 
 

--- a/src/equal.c
+++ b/src/equal.c
@@ -23,16 +23,15 @@ int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
   case STRSXP: return chr_equal_scalar(STRING_PTR(x) + i, STRING_PTR(y) + j, na_equal);
   case RAWSXP: return raw_equal_scalar(RAW(x) + i, RAW(y) + j, na_equal);
   case CPLXSXP: return cpl_equal_scalar(COMPLEX(x) + i, COMPLEX(y) + j, na_equal);
-  default: break;
-  }
+  case VECSXP: {
+    if (is_data_frame(x)) {
+      return df_equal_scalar(x, i, y, j, na_equal);
+    }
 
-  switch (vec_proxy_typeof(x)) {
-  case vctrs_type_list: return list_equal_scalar(x, i, y, j, na_equal);
-  case vctrs_type_dataframe: return df_equal_scalar(x, i, y, j, na_equal);
-  default: break;
+    return list_equal_scalar(x, i, y, j, na_equal);
   }
-
-  vctrs_stop_unsupported_type(vec_typeof(x), "equal_scalar()");
+  default: vctrs_stop_unsupported_type(vec_typeof(x), "equal_scalar()");
+  }
 }
 
 

--- a/src/equal.c
+++ b/src/equal.c
@@ -199,6 +199,30 @@ static int df_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) 
   return true;
 }
 
+#define EQUAL_ALL(CTYPE, CONST_DEREF, SCALAR_EQUAL)       \
+  do {                                                    \
+    const CTYPE* xp = CONST_DEREF(x);                     \
+    const CTYPE* yp = CONST_DEREF(y);                     \
+                                                          \
+    for (R_len_t i = 0; i < n; ++i, ++xp, ++yp) {         \
+      eq = SCALAR_EQUAL(xp, yp, na_equal);                \
+      if (eq <= 0) {                                      \
+        break;                                            \
+      }                                                   \
+    }                                                     \
+  }                                                       \
+  while (0)
+
+#define EQUAL_ALL_BARRIER(SCALAR_EQUAL)                   \
+  do {                                                    \
+    for (R_len_t i = 0; i < n; ++i) {                     \
+      eq = SCALAR_EQUAL(x, i, y, i, na_equal);            \
+      if (eq <= 0) {                                      \
+        break;                                            \
+      }                                                   \
+    }                                                     \
+  }                                                       \
+  while (0)
 
 static inline bool obj_equal_attrib(SEXP x, SEXP y);
 static inline int vec_equal_attrib(SEXP x, SEXP y, bool na_equal);
@@ -230,32 +254,14 @@ int equal_object(SEXP x, SEXP y, bool na_equal) {
   }
 
   switch(type) {
+  // Handled below
   case LGLSXP:
   case INTSXP:
   case REALSXP:
   case STRSXP:
   case RAWSXP:
   case CPLXSXP:
-  case VECSXP: {
-    R_len_t n = vec_size(x);
-    if (n != vec_size(y)) {
-      return false;
-    }
-
-    int eq_attr = vec_equal_attrib(x, y, na_equal);
-    if (eq_attr <= 0) {
-      return eq_attr;
-    }
-
-    for (R_len_t i = 0; i < n; ++i) {
-      int eq = equal_scalar(x, i, y, i, na_equal);
-      if (eq <= 0) {
-        return eq;
-      }
-    }
-
-    return true;
-  }
+  case VECSXP: break;
 
   case DOTSXP:
   case LANGSXP:
@@ -306,8 +312,34 @@ int equal_object(SEXP x, SEXP y, bool na_equal) {
     Rf_errorcall(R_NilValue, "Unsupported type %s", Rf_type2char(TYPEOF(x)));
   }
 
-  return true;
+  R_len_t n = Rf_length(x);
+  if (n != Rf_length(y)) {
+    return false;
+  }
+
+  int eq_attr = vec_equal_attrib(x, y, na_equal);
+  if (eq_attr <= 0) {
+    return eq_attr;
+  }
+
+  int eq = true;
+
+  switch (type) {
+  case LGLSXP:  EQUAL_ALL(int, LOGICAL_RO, lgl_equal_scalar); break;
+  case INTSXP:  EQUAL_ALL(int, INTEGER_RO, int_equal_scalar); break;
+  case REALSXP: EQUAL_ALL(double, REAL_RO, dbl_equal_scalar); break;
+  case STRSXP:  EQUAL_ALL(SEXP, STRING_PTR_RO, chr_equal_scalar); break;
+  case RAWSXP:  EQUAL_ALL(Rbyte, RAW_RO, raw_equal_scalar); break;
+  case CPLXSXP: EQUAL_ALL(Rcomplex, COMPLEX_RO, cpl_equal_scalar); break;
+  case VECSXP:  EQUAL_ALL_BARRIER(list_equal_scalar); break;
+  default:      Rf_errorcall(R_NilValue, "Internal error: Unexpected type in `equal_object()`");
+  }
+
+  return eq;
 }
+
+#undef EQUAL_ALL
+#undef EQUAL_ALL_BARRIER
 
 // [[ register() ]]
 SEXP vctrs_equal_object(SEXP x, SEXP y, SEXP na_equal) {

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -69,6 +69,20 @@ test_that("data frames must have same size and columns", {
 
 })
 
+test_that("can compare lists of scalars (#643)", {
+  lst <- list(new_sclr(x = 1))
+  expect_true(vec_equal(lst, lst))
+
+  lst <- list(new_sclr(y = NA))
+  expect_equal(vec_equal(lst, lst), NA)
+  expect_true(vec_equal(lst, lst, na_equal = TRUE))
+
+  df <- data.frame(x = c(1, 4, 3), y = c(2, 8, 9))
+  model <- lm(y ~ x, df)
+  lst <- list(model)
+  expect_true(vec_equal(lst, lst))
+})
+
 test_that("can determine equality of strings with different encodings (#553)", {
   for (x_encoding in encodings()) {
     for (y_encoding in encodings()) {


### PR DESCRIPTION
Related to #643 

- We now use `Rf_length()` rather than `vec_size()` in `equal_object()`
- This effectively treats data frames as lists, which is correct when it is viewed as an "object" (i.e. in the case of `list(<data_frame>)`)
- The previous usage of `equal_scalar()` would now be invalid, because it treats data frames as vectors of rows. So I changed it to a macro approach that treats data frames as lists.

The last point has major performance improvements for lists.

``` r
library(vctrs)
vec_equal_old <- vctrs2::vec_equal

x <- rep("a", 1000000)
lst <- list(x)

bench::mark(
  new = vec_equal(lst, lst),
  old = vec_equal_old(lst, lst)
)
#> # A tibble: 2 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new          6.06ms   6.48ms     153.     91.2KB        0
#> 2 old         10.67ms  11.39ms      87.5    79.5KB        0
```

This means that data frames with list columns have a ridiculous improvement.

``` r
library(vctrs)
library(nycflights13)

nested <- tidyr::nest(flights, data = c(-year, -month))

nested
#> # A tibble: 12 x 3
#>     year month            data
#>    <int> <int> <list<df[,17]>>
#>  1  2013     1   [27,004 × 17]
#>  2  2013    10   [28,889 × 17]
#>  3  2013    11   [27,268 × 17]
#>  4  2013    12   [28,135 × 17]
#>  5  2013     2   [24,951 × 17]
#>  6  2013     3   [28,834 × 17]
#>  7  2013     4   [28,330 × 17]
#>  8  2013     5   [28,796 × 17]
#>  9  2013     6   [28,243 × 17]
#> 10  2013     7   [29,425 × 17]
#> 11  2013     8   [29,327 × 17]
#> 12  2013     9   [27,574 × 17]

# before
bench::mark(
  vec_equal(nested, nested, na_equal = TRUE)
)
#> # A tibble: 1 x 6
#>   expression                                   min median `itr/sec`
#>   <bch:expr>                                 <bch> <bch:>     <dbl>
#> 1 vec_equal(nested, nested, na_equal = TRUE) 188ms  192ms      5.21
#> # … with 2 more variables: mem_alloc <bch:byt>, `gc/sec` <dbl>

# after
bench::mark(
  vec_equal(nested, nested, na_equal = TRUE)
)
#> # A tibble: 1 x 6
#>   expression                                    min median `itr/sec`
#>   <bch:expr>                                 <bch:> <bch:>     <dbl>
#> 1 vec_equal(nested, nested, na_equal = TRUE) 4.15ms 4.42ms      226.
#> # … with 2 more variables: mem_alloc <bch:byt>, `gc/sec` <dbl>
```
