### PR TITLE
Optimize hashing doubles by avoiding expensive NA checks

### DIFF
--- a/src/compare.c
+++ b/src/compare.c
@@ -44,29 +44,29 @@ int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
   case REALSXP: {
     double xi = REAL(x)[i], yj = REAL(y)[j];
     if (na_equal) {
-      enum vctrs_indicator x_indicator = dbl_missing_indicator(xi);
-      enum vctrs_indicator y_indicator = dbl_missing_indicator(yj);
+      enum vctrs_missingness x_missingness = dbl_missingness(xi);
+      enum vctrs_missingness y_missingness = dbl_missingness(yj);
 
-      switch (x_indicator) {
-      case vctrs_indicator_exists: {
-        switch (y_indicator) {
-        case vctrs_indicator_exists: return dcmp(xi, yj);
-        case vctrs_indicator_na: return 1L;
-        case vctrs_indicator_nan: return 1L;
+      switch (x_missingness) {
+      case vctrs_missingness_none: {
+        switch (y_missingness) {
+        case vctrs_missingness_none: return dcmp(xi, yj);
+        case vctrs_missingness_na: return 1L;
+        case vctrs_missingness_nan: return 1L;
         }
       }
-      case vctrs_indicator_na: {
-        switch (y_indicator) {
-        case vctrs_indicator_exists: return -1;
-        case vctrs_indicator_na: return 0;
-        case vctrs_indicator_nan: return 1;
+      case vctrs_missingness_na: {
+        switch (y_missingness) {
+        case vctrs_missingness_none: return -1;
+        case vctrs_missingness_na: return 0;
+        case vctrs_missingness_nan: return 1;
         }
       }
-      case vctrs_indicator_nan: {
-        switch (y_indicator) {
-        case vctrs_indicator_exists: return -1;
-        case vctrs_indicator_na: return -1;
-        case vctrs_indicator_nan: return 0;
+      case vctrs_missingness_nan: {
+        switch (y_missingness) {
+        case vctrs_missingness_none: return -1;
+        case vctrs_missingness_na: return -1;
+        case vctrs_missingness_nan: return 0;
         }
       }
       }

--- a/src/compare.c
+++ b/src/compare.c
@@ -44,29 +44,29 @@ int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
   case REALSXP: {
     double xi = REAL(x)[i], yj = REAL(y)[j];
     if (na_equal) {
-      enum vctrs_missingness x_missingness = dbl_missingness(xi);
-      enum vctrs_missingness y_missingness = dbl_missingness(yj);
+      enum vctrs_dbl_type x_type = dbl_type(xi);
+      enum vctrs_dbl_type y_type = dbl_type(yj);
 
-      switch (x_missingness) {
-      case vctrs_missingness_none: {
-        switch (y_missingness) {
-        case vctrs_missingness_none: return dcmp(xi, yj);
-        case vctrs_missingness_na: return 1L;
-        case vctrs_missingness_nan: return 1L;
+      switch (x_type) {
+      case vctrs_dbl_number: {
+        switch (y_type) {
+        case vctrs_dbl_number: return dcmp(xi, yj);
+        case vctrs_dbl_missing: return 1L;
+        case vctrs_dbl_nan: return 1L;
         }
       }
-      case vctrs_missingness_na: {
-        switch (y_missingness) {
-        case vctrs_missingness_none: return -1;
-        case vctrs_missingness_na: return 0;
-        case vctrs_missingness_nan: return 1;
+      case vctrs_dbl_missing: {
+        switch (y_type) {
+        case vctrs_dbl_number: return -1;
+        case vctrs_dbl_missing: return 0;
+        case vctrs_dbl_nan: return 1;
         }
       }
-      case vctrs_missingness_nan: {
-        switch (y_missingness) {
-        case vctrs_missingness_none: return -1;
-        case vctrs_missingness_na: return -1;
-        case vctrs_missingness_nan: return 0;
+      case vctrs_dbl_nan: {
+        switch (y_type) {
+        case vctrs_dbl_number: return -1;
+        case vctrs_dbl_missing: return -1;
+        case vctrs_dbl_nan: return 0;
         }
       }
       }

--- a/src/compare.c
+++ b/src/compare.c
@@ -44,26 +44,26 @@ int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
   case REALSXP: {
     double xi = REAL(x)[i], yj = REAL(y)[j];
     if (na_equal) {
-      enum vctrs_dbl_type x_type = dbl_classify(xi);
-      enum vctrs_dbl_type y_type = dbl_classify(yj);
+      enum vctrs_dbl_class x_class = dbl_classify(xi);
+      enum vctrs_dbl_class y_class = dbl_classify(yj);
 
-      switch (x_type) {
+      switch (x_class) {
       case vctrs_dbl_number: {
-        switch (y_type) {
+        switch (y_class) {
         case vctrs_dbl_number: return dcmp(xi, yj);
         case vctrs_dbl_missing: return 1L;
         case vctrs_dbl_nan: return 1L;
         }
       }
       case vctrs_dbl_missing: {
-        switch (y_type) {
+        switch (y_class) {
         case vctrs_dbl_number: return -1;
         case vctrs_dbl_missing: return 0;
         case vctrs_dbl_nan: return 1;
         }
       }
       case vctrs_dbl_nan: {
-        switch (y_type) {
+        switch (y_class) {
         case vctrs_dbl_number: return -1;
         case vctrs_dbl_missing: return -1;
         case vctrs_dbl_nan: return 0;

--- a/src/compare.c
+++ b/src/compare.c
@@ -47,23 +47,23 @@ int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
       enum vctrs_indicator x_indicator = dbl_missing_indicator(xi);
       enum vctrs_indicator y_indicator = dbl_missing_indicator(yj);
 
-      switch(x_indicator) {
+      switch (x_indicator) {
       case vctrs_indicator_exists: {
-        switch(y_indicator) {
+        switch (y_indicator) {
         case vctrs_indicator_exists: return dcmp(xi, yj);
         case vctrs_indicator_na: return 1L;
         case vctrs_indicator_nan: return 1L;
         }
       }
       case vctrs_indicator_na: {
-        switch(y_indicator) {
+        switch (y_indicator) {
         case vctrs_indicator_exists: return -1;
         case vctrs_indicator_na: return 0;
         case vctrs_indicator_nan: return 1;
         }
       }
       case vctrs_indicator_nan: {
-        switch(y_indicator) {
+        switch (y_indicator) {
         case vctrs_indicator_exists: return -1;
         case vctrs_indicator_na: return -1;
         case vctrs_indicator_nan: return 0;

--- a/src/compare.c
+++ b/src/compare.c
@@ -44,8 +44,8 @@ int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
   case REALSXP: {
     double xi = REAL(x)[i], yj = REAL(y)[j];
     if (na_equal) {
-      enum vctrs_dbl_type x_type = dbl_type(xi);
-      enum vctrs_dbl_type y_type = dbl_type(yj);
+      enum vctrs_dbl_type x_type = dbl_classify(xi);
+      enum vctrs_dbl_type y_type = dbl_classify(yj);
 
       switch (x_type) {
       case vctrs_dbl_number: {

--- a/src/equal.c
+++ b/src/equal.c
@@ -120,10 +120,10 @@ static int dbl_equal_scalar(const double* x, const double* y, bool na_equal) {
   const double yj = *y;
 
   if (na_equal) {
-    switch (dbl_missingness(xi)) {
-    case vctrs_missingness_none: break;
-    case vctrs_missingness_na: return dbl_missingness(yj) == vctrs_missingness_na;
-    case vctrs_missingness_nan: return dbl_missingness(yj) == vctrs_missingness_nan;
+    switch (dbl_type(xi)) {
+    case vctrs_dbl_number: break;
+    case vctrs_dbl_missing: return dbl_type(yj) == vctrs_dbl_missing;
+    case vctrs_dbl_nan: return dbl_type(yj) == vctrs_dbl_nan;
     }
 
     if (isnan(yj)) {

--- a/src/equal.c
+++ b/src/equal.c
@@ -120,10 +120,10 @@ static int dbl_equal_scalar(const double* x, const double* y, bool na_equal) {
   const double yj = *y;
 
   if (na_equal) {
-    switch (dbl_type(xi)) {
+    switch (dbl_classify(xi)) {
     case vctrs_dbl_number: break;
-    case vctrs_dbl_missing: return dbl_type(yj) == vctrs_dbl_missing;
-    case vctrs_dbl_nan: return dbl_type(yj) == vctrs_dbl_nan;
+    case vctrs_dbl_missing: return dbl_classify(yj) == vctrs_dbl_missing;
+    case vctrs_dbl_nan: return dbl_classify(yj) == vctrs_dbl_nan;
     }
 
     if (isnan(yj)) {

--- a/src/equal.c
+++ b/src/equal.c
@@ -120,10 +120,10 @@ static int dbl_equal_scalar(const double* x, const double* y, bool na_equal) {
   const double yj = *y;
 
   if (na_equal) {
-    switch (dbl_missing_indicator(xi)) {
-    case vctrs_indicator_exists: break;
-    case vctrs_indicator_na: return dbl_missing_indicator(yj) == vctrs_indicator_na;
-    case vctrs_indicator_nan: return dbl_missing_indicator(yj) == vctrs_indicator_nan;
+    switch (dbl_missingness(xi)) {
+    case vctrs_missingness_none: break;
+    case vctrs_missingness_na: return dbl_missingness(yj) == vctrs_missingness_na;
+    case vctrs_missingness_nan: return dbl_missingness(yj) == vctrs_missingness_nan;
     }
 
     if (isnan(yj)) {

--- a/src/equal.c
+++ b/src/equal.c
@@ -118,10 +118,17 @@ static int raw_equal_scalar(const Rbyte* x, const Rbyte* y, bool na_equal) {
 static int dbl_equal_scalar(const double* x, const double* y, bool na_equal) {
   const double xi = *x;
   const double yj = *y;
+
   if (na_equal) {
-    if (R_IsNA(xi)) return R_IsNA(yj);
-    if (R_IsNaN(xi)) return R_IsNaN(yj);
-    if (isnan(yj)) return false;
+    switch(dbl_missing_indicator(xi)) {
+    case vctrs_indicator_exists: break;
+    case vctrs_indicator_na: return dbl_missing_indicator(yj) == vctrs_indicator_na;
+    case vctrs_indicator_nan: return dbl_missing_indicator(yj) == vctrs_indicator_nan;
+    }
+
+    if (isnan(yj)) {
+      return false;
+    }
   } else {
     if (isnan(xi) || isnan(yj)) return NA_LOGICAL;
   }

--- a/src/equal.c
+++ b/src/equal.c
@@ -120,7 +120,7 @@ static int dbl_equal_scalar(const double* x, const double* y, bool na_equal) {
   const double yj = *y;
 
   if (na_equal) {
-    switch(dbl_missing_indicator(xi)) {
+    switch (dbl_missing_indicator(xi)) {
     case vctrs_indicator_exists: break;
     case vctrs_indicator_na: return dbl_missing_indicator(yj) == vctrs_indicator_na;
     case vctrs_indicator_nan: return dbl_missing_indicator(yj) == vctrs_indicator_nan;

--- a/src/hash.c
+++ b/src/hash.c
@@ -69,15 +69,14 @@ static uint32_t int_hash_scalar(const int* x) {
 }
 static uint32_t dbl_hash_scalar(const double* x) {
   double val = *x;
+
   // Hash all NAs and NaNs to same value (i.e. ignoring significand)
-  // Avoid calling both expensive `R_IsNA()` and `R_IsNaN()` checks
-  if (isnan(val)) {
-    if (R_IsNA(val)) {
-      val = NA_REAL;
-    } else {
-      val = R_NaN;
-    }
+  switch(dbl_missing_indicator(val)) {
+  case vctrs_indicator_exists: break;
+  case vctrs_indicator_na: val = NA_REAL; break;
+  case vctrs_indicator_nan: val = R_NaN; break;
   }
+
   return hash_double(val);
 }
 static uint32_t cpl_hash_scalar(const Rcomplex* x) {

--- a/src/hash.c
+++ b/src/hash.c
@@ -71,7 +71,7 @@ static uint32_t dbl_hash_scalar(const double* x) {
   double val = *x;
 
   // Hash all NAs and NaNs to same value (i.e. ignoring significand)
-  switch (dbl_type(val)) {
+  switch (dbl_classify(val)) {
   case vctrs_dbl_number: break;
   case vctrs_dbl_missing: val = NA_REAL; break;
   case vctrs_dbl_nan: val = R_NaN; break;

--- a/src/hash.c
+++ b/src/hash.c
@@ -71,10 +71,10 @@ static uint32_t dbl_hash_scalar(const double* x) {
   double val = *x;
 
   // Hash all NAs and NaNs to same value (i.e. ignoring significand)
-  switch (dbl_missingness(val)) {
-  case vctrs_missingness_none: break;
-  case vctrs_missingness_na: val = NA_REAL; break;
-  case vctrs_missingness_nan: val = R_NaN; break;
+  switch (dbl_type(val)) {
+  case vctrs_dbl_number: break;
+  case vctrs_dbl_missing: val = NA_REAL; break;
+  case vctrs_dbl_nan: val = R_NaN; break;
   }
 
   return hash_double(val);

--- a/src/hash.c
+++ b/src/hash.c
@@ -71,7 +71,7 @@ static uint32_t dbl_hash_scalar(const double* x) {
   double val = *x;
 
   // Hash all NAs and NaNs to same value (i.e. ignoring significand)
-  switch(dbl_missing_indicator(val)) {
+  switch (dbl_missing_indicator(val)) {
   case vctrs_indicator_exists: break;
   case vctrs_indicator_na: val = NA_REAL; break;
   case vctrs_indicator_nan: val = R_NaN; break;

--- a/src/hash.c
+++ b/src/hash.c
@@ -70,10 +70,13 @@ static uint32_t int_hash_scalar(const int* x) {
 static uint32_t dbl_hash_scalar(const double* x) {
   double val = *x;
   // Hash all NAs and NaNs to same value (i.e. ignoring significand)
-  if (R_IsNA(val)) {
-    val = NA_REAL;
-  } else if (R_IsNaN(val)) {
-    val = R_NaN;
+  // Avoid calling both expensive `R_IsNA()` and `R_IsNaN()` checks
+  if (isnan(val)) {
+    if (R_IsNA(val)) {
+      val = NA_REAL;
+    } else {
+      val = R_NaN;
+    }
   }
   return hash_double(val);
 }

--- a/src/hash.c
+++ b/src/hash.c
@@ -71,10 +71,10 @@ static uint32_t dbl_hash_scalar(const double* x) {
   double val = *x;
 
   // Hash all NAs and NaNs to same value (i.e. ignoring significand)
-  switch (dbl_missing_indicator(val)) {
-  case vctrs_indicator_exists: break;
-  case vctrs_indicator_na: val = NA_REAL; break;
-  case vctrs_indicator_nan: val = R_NaN; break;
+  switch (dbl_missingness(val)) {
+  case vctrs_missingness_none: break;
+  case vctrs_missingness_na: val = NA_REAL; break;
+  case vctrs_missingness_nan: val = R_NaN; break;
   }
 
   return hash_double(val);

--- a/src/utils.c
+++ b/src/utils.c
@@ -286,7 +286,7 @@ SEXP s3_find_method(const char* generic, SEXP x) {
 }
 
 // [[ include("vctrs.h") ]]
-enum vctrs_dbl_type dbl_type(double x) {
+enum vctrs_dbl_type dbl_classify(double x) {
   if (!isnan(x)) {
     return vctrs_dbl_number;
   }

--- a/src/utils.c
+++ b/src/utils.c
@@ -287,18 +287,18 @@ SEXP s3_find_method(const char* generic, SEXP x) {
 
 // [[ include("vctrs.h") ]]
 enum vctrs_indicator dbl_missing_indicator(double x) {
-  if (isnan(x)) {
-    vctrs_indicator_t indicator;
-    indicator.value = x;
-
-    if (indicator.key[vctrs_indicator_pos] == 1954) {
-      return vctrs_indicator_na;
-    }
-
-    return vctrs_indicator_nan;
+  if (!isnan(x)) {
+    return vctrs_indicator_exists;
   }
 
-  return vctrs_indicator_exists;
+  vctrs_indicator_t indicator;
+  indicator.value = x;
+
+  if (indicator.key[vctrs_indicator_pos] == 1954) {
+    return vctrs_indicator_na;
+  } else {
+    return vctrs_indicator_nan;
+  }
 }
 
 // Initialised at load time

--- a/src/utils.c
+++ b/src/utils.c
@@ -295,7 +295,7 @@ enum vctrs_dbl_type dbl_type(double x) {
   VCTRS_ASSERT(sizeof(double) == sizeof(int64_t));
   VCTRS_ASSERT(sizeof(double) == 2 * sizeof(int));
 
-  vctrs_dbl_indicator indicator;
+  union vctrs_dbl_indicator indicator;
   indicator.value = x;
 
   if (indicator.key[vctrs_indicator_pos] == 1954) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -286,7 +286,7 @@ SEXP s3_find_method(const char* generic, SEXP x) {
 }
 
 // [[ include("vctrs.h") ]]
-enum vctrs_dbl_type dbl_classify(double x) {
+enum vctrs_dbl_class dbl_classify(double x) {
   if (!isnan(x)) {
     return vctrs_dbl_number;
   }

--- a/src/utils.c
+++ b/src/utils.c
@@ -291,10 +291,6 @@ enum vctrs_dbl_type dbl_type(double x) {
     return vctrs_dbl_number;
   }
 
-  // We assume the following in `union vctrs_dbl_indicator`
-  VCTRS_ASSERT(sizeof(double) == sizeof(int64_t));
-  VCTRS_ASSERT(sizeof(double) == 2 * sizeof(int));
-
   union vctrs_dbl_indicator indicator;
   indicator.value = x;
 
@@ -1234,4 +1230,8 @@ void vctrs_init_utils(SEXP ns) {
   compact_rep_attrib = Rf_cons(R_NilValue, R_NilValue);
   R_PreserveObject(compact_rep_attrib);
   SET_TAG(compact_rep_attrib, Rf_install("vctrs_compact_rep"));
+
+  // We assume the following in `union vctrs_dbl_indicator`
+  VCTRS_ASSERT(sizeof(double) == sizeof(int64_t));
+  VCTRS_ASSERT(sizeof(double) == 2 * sizeof(int));
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -291,6 +291,10 @@ enum vctrs_dbl_type dbl_type(double x) {
     return vctrs_dbl_number;
   }
 
+  // We assume the following in `union vctrs_dbl_indicator`
+  VCTRS_ASSERT(sizeof(double) == sizeof(int64_t));
+  VCTRS_ASSERT(sizeof(double) == 2 * sizeof(int));
+
   vctrs_dbl_indicator indicator;
   indicator.value = x;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -286,18 +286,18 @@ SEXP s3_find_method(const char* generic, SEXP x) {
 }
 
 // [[ include("vctrs.h") ]]
-enum vctrs_missingness dbl_missingness(double x) {
+enum vctrs_dbl_type dbl_type(double x) {
   if (!isnan(x)) {
-    return vctrs_missingness_none;
+    return vctrs_dbl_number;
   }
 
-  vctrs_missingness_indicator_t indicator;
+  vctrs_dbl_indicator indicator;
   indicator.value = x;
 
   if (indicator.key[vctrs_indicator_pos] == 1954) {
-    return vctrs_missingness_na;
+    return vctrs_dbl_missing;
   } else {
-    return vctrs_missingness_nan;
+    return vctrs_dbl_nan;
   }
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -285,6 +285,21 @@ SEXP s3_find_method(const char* generic, SEXP x) {
   return R_NilValue;
 }
 
+// [[ include("vctrs.h") ]]
+enum vctrs_indicator dbl_missing_indicator(double x) {
+  if (isnan(x)) {
+    vctrs_indicator_t indicator;
+    indicator.value = x;
+
+    if (indicator.key[vctrs_indicator_pos] == 1954) {
+      return vctrs_indicator_na;
+    }
+
+    return vctrs_indicator_nan;
+  }
+
+  return vctrs_indicator_exists;
+}
 
 // Initialised at load time
 SEXP compact_seq_attrib = NULL;

--- a/src/utils.c
+++ b/src/utils.c
@@ -286,18 +286,18 @@ SEXP s3_find_method(const char* generic, SEXP x) {
 }
 
 // [[ include("vctrs.h") ]]
-enum vctrs_indicator dbl_missing_indicator(double x) {
+enum vctrs_missingness dbl_missingness(double x) {
   if (!isnan(x)) {
-    return vctrs_indicator_exists;
+    return vctrs_missingness_none;
   }
 
-  vctrs_indicator_t indicator;
+  vctrs_missingness_indicator_t indicator;
   indicator.value = x;
 
   if (indicator.key[vctrs_indicator_pos] == 1954) {
-    return vctrs_indicator_na;
+    return vctrs_missingness_na;
   } else {
-    return vctrs_indicator_nan;
+    return vctrs_missingness_nan;
   }
 }
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -282,7 +282,7 @@ bool duplicated_any(SEXP names);
 // integer array of size 2. On little endian systems, this is flipped
 // and the NA marker is in the first element.
 //
-// The type assumptions made here are asserted in `dbl_classify()`
+// The type assumptions made here are asserted in `vctrs_init_utils()`
 
 #ifdef WORDS_BIGENDIAN
 static const int vctrs_indicator_pos = 1;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -267,7 +267,8 @@ bool duplicated_any(SEXP names);
 
 // Missing values -----------------------------------------------
 
-// IEEE 754 defines binary64 as
+// Annex F of C99 specifies that `double` should conform to the IEEE 754
+// type `binary64`, which is defined as:
 // * 1  bit : sign
 // * 11 bits: exponent
 // * 52 bits: significand

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -290,10 +290,10 @@ static const int vctrs_indicator_pos = 1;
 static const int vctrs_indicator_pos = 0;
 #endif
 
-typedef union {
+union vctrs_dbl_indicator {
   double value;        // 8 bytes
   unsigned int key[2]; // 4 * 2 bytes
-} vctrs_dbl_indicator;
+};
 
 enum vctrs_dbl_type {
   vctrs_dbl_number,

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -295,13 +295,13 @@ union vctrs_dbl_indicator {
   unsigned int key[2]; // 4 * 2 bytes
 };
 
-enum vctrs_dbl_type {
+enum vctrs_dbl_class {
   vctrs_dbl_number,
   vctrs_dbl_missing,
   vctrs_dbl_nan
 };
 
-enum vctrs_dbl_type dbl_classify(double x);
+enum vctrs_dbl_class dbl_classify(double x);
 
 // Names --------------------------------------------------------
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -8,6 +8,8 @@
 
 typedef R_xlen_t r_ssize_t;
 
+#define VCTRS_ASSERT(condition) ((void)sizeof(char[1 - 2*!(condition)]))
+
 
 // Vector types -------------------------------------------------
 
@@ -279,6 +281,8 @@ bool duplicated_any(SEXP names);
 // On big endian systems, this corresponds to the second element of an
 // integer array of size 2. On little endian systems, this is flipped
 // and the NA marker is in the first element.
+//
+// The type assumptions made here are asserted in `dbl_type()`
 
 #ifdef WORDS_BIGENDIAN
 static const int vctrs_indicator_pos = 1;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -289,15 +289,15 @@ static const int vctrs_indicator_pos = 0;
 typedef union {
   double value;        // 8 bytes
   unsigned int key[2]; // 4 * 2 bytes
-} vctrs_indicator_t;
+} vctrs_missingness_indicator_t;
 
-enum vctrs_indicator {
-  vctrs_indicator_exists,
-  vctrs_indicator_na,
-  vctrs_indicator_nan
+enum vctrs_missingness {
+  vctrs_missingness_none,
+  vctrs_missingness_na,
+  vctrs_missingness_nan
 };
 
-enum vctrs_indicator dbl_missing_indicator(double x);
+enum vctrs_missingness dbl_missingness(double x);
 
 // Names --------------------------------------------------------
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -265,6 +265,38 @@ void hash_fill(uint32_t* p, R_len_t n, SEXP x);
 
 bool duplicated_any(SEXP names);
 
+// Missing values -----------------------------------------------
+
+// IEEE 754 defines binary64 as
+// * 1  bit : sign
+// * 11 bits: exponent
+// * 52 bits: significand
+//
+// R stores the value "1954" in the last 32 bits: this payload marks
+// the value as a NA, not a regular NaN.
+//
+// On big endian systems, this corresponds to the second element of an
+// integer array of size 2. On little endian systems, this is flipped
+// and the NA marker is in the first element.
+
+#ifdef WORDS_BIGENDIAN
+static const int vctrs_indicator_pos = 1;
+#else
+static const int vctrs_indicator_pos = 0;
+#endif
+
+typedef union {
+  double value;        // 8 bytes
+  unsigned int key[2]; // 4 * 2 bytes
+} vctrs_indicator_t;
+
+enum vctrs_indicator {
+  vctrs_indicator_exists,
+  vctrs_indicator_na,
+  vctrs_indicator_nan
+};
+
+enum vctrs_indicator dbl_missing_indicator(double x);
 
 // Names --------------------------------------------------------
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -282,7 +282,7 @@ bool duplicated_any(SEXP names);
 // integer array of size 2. On little endian systems, this is flipped
 // and the NA marker is in the first element.
 //
-// The type assumptions made here are asserted in `dbl_type()`
+// The type assumptions made here are asserted in `dbl_classify()`
 
 #ifdef WORDS_BIGENDIAN
 static const int vctrs_indicator_pos = 1;
@@ -301,7 +301,7 @@ enum vctrs_dbl_type {
   vctrs_dbl_nan
 };
 
-enum vctrs_dbl_type dbl_type(double x);
+enum vctrs_dbl_type dbl_classify(double x);
 
 // Names --------------------------------------------------------
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -289,15 +289,15 @@ static const int vctrs_indicator_pos = 0;
 typedef union {
   double value;        // 8 bytes
   unsigned int key[2]; // 4 * 2 bytes
-} vctrs_missingness_indicator_t;
+} vctrs_dbl_indicator;
 
-enum vctrs_missingness {
-  vctrs_missingness_none,
-  vctrs_missingness_na,
-  vctrs_missingness_nan
+enum vctrs_dbl_type {
+  vctrs_dbl_number,
+  vctrs_dbl_missing,
+  vctrs_dbl_nan
 };
 
-enum vctrs_missingness dbl_missingness(double x);
+enum vctrs_dbl_type dbl_type(double x);
 
 // Names --------------------------------------------------------
 


### PR DESCRIPTION
Today I learned how profile compiled C code using Apple's built in Instruments. I've got a few speed improvement PRs to submit based on my results. This is the first.

In `dbl_hash_scalar()` we call `R_IsNA()` and then `R_IsNaN()`, which is rather expensive. A more efficient approach is to use `isnan()` to first determine if a value is any of `NA` or `NaN`, and only call `R_IsNA()` to tell them apart after that.

This almost 2x's the hashing speed for doubles, which directly translates into improvements for the dictionary functions.

``` r
library(vctrs)
library(nycflights13)

vec_hash <- vctrs:::vec_hash

vec_unique_loc_old <- vctrs2::vec_unique_loc
vec_hash_old <- vctrs2:::vec_hash

# only double columns for the test
flights_dbl <- flights[, vapply(flights, is.double, logical(1))]
flights_dbl$time_hour <- NULL

bench::mark(
  vec_hash(flights_dbl),
  vec_hash_old(flights_dbl),
  iterations = 200
)
#> # A tibble: 2 x 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_hash(flights_dbl)       3.85ms   4.37ms      225.    1.29MB     6.95
#> 2 vec_hash_old(flights_dbl)   8.89ms   9.59ms      103.    1.29MB     3.18

bench::mark(
  vec_unique_loc(flights_dbl),
  vec_unique_loc_old(flights_dbl),
  iterations = 200
)
#> # A tibble: 2 x 6
#>   expression                         min median `itr/sec` mem_alloc
#>   <bch:expr>                      <bch:> <bch:>     <dbl> <bch:byt>
#> 1 vec_unique_loc(flights_dbl)     34.5ms 39.1ms      24.8    8.56MB
#> 2 vec_unique_loc_old(flights_dbl)   41ms 47.1ms      20.9    8.55MB
#> # … with 1 more variable: `gc/sec` <dbl>
```

<sup>Created on 2019-11-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>

If you are curious, calling `vec_unique_loc()` looks like this with Instruments 

<img width="581" alt="Screen Shot 2019-11-05 at 3 24 14 PM" src="https://user-images.githubusercontent.com/19150088/68243387-64c68600-ffe0-11e9-9aa8-7eac02f61a0a.png">
