### PR TITLE
Remove data frame check in `df_equal_scalar()`

### DIFF
--- a/src/equal.c
+++ b/src/equal.c
@@ -174,10 +174,6 @@ static int list_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal
 }
 
 static int df_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
-  if (!is_data_frame(y)) {
-    return false;
-  }
-
   int p = Rf_length(x);
   if (p != Rf_length(y)) {
     return false;

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -43,13 +43,18 @@ test_that("can compare data frames", {
 })
 
 test_that("data frames must have same size and columns", {
-  expect_false(.Call(vctrs_equal,
+  expect_error(.Call(vctrs_equal,
     data.frame(x = 1),
     data.frame(x = 1, y = 2),
     TRUE
-  ))
+    ),
+    "must have the same number of columns"
+  )
 
-  expect_false(.Call(vctrs_equal,
+  # Names are not checked, as `vec_cast_common()` should take care of the type.
+  # So if `vec_cast_common()` is not called, or is improperly specified, then
+  # this could result in false equality.
+  expect_true(.Call(vctrs_equal,
     data.frame(x = 1),
     data.frame(y = 1),
     TRUE


### PR DESCRIPTION
Because of the checks we do elsewhere, it is essentially impossible for a non-data frame `y` to get into `df_equal_scalar()`. Because of this, we are doing an expensive check of `is_data_frame()` a large number of times (once per row!) when I don't think we need to. Removing it has nice performance improvements for `vec_equal()` and the dictionary functions, which call `equal_scalar()` internally.

``` r
df <- data.frame(x = 1:1e6, y = 1:1e6)
```

```r
# before
bench::mark(
  vec_equal(df, df, na_equal = TRUE),
  iterations = 300
)
#> # A tibble: 1 x 6
#>   expression                            min median `itr/sec` mem_alloc
#>   <bch:expr>                         <bch:> <bch:>     <dbl> <bch:byt>
#> 1 vec_equal(df, df, na_equal = TRUE) 84.2ms   90ms      11.1    11.5MB
#> # … with 1 more variable: `gc/sec` <dbl>

# after
bench::mark(
  vec_equal(df, df, na_equal = TRUE),
  iterations = 300
)
#> # A tibble: 1 x 6
#>   expression                            min median `itr/sec` mem_alloc
#>   <bch:expr>                         <bch:> <bch:>     <dbl> <bch:byt>
#> 1 vec_equal(df, df, na_equal = TRUE) 69.6ms 73.8ms      13.5    11.5MB
#> # … with 1 more variable: `gc/sec` <dbl>
```

```r
# before
bench::mark(
  vec_unique_loc(df),
  iterations = 300
)
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_unique_loc(df)   83.3ms   96.3ms      10.4    23.6MB     21.1

# after
bench::mark(
  vec_unique_loc(df),
  iterations = 300
)
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_unique_loc(df)   77.6ms   87.7ms      11.4    23.6MB     27.9
```