### PR TITLE
Improve `vec_compare()`

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -75,6 +75,7 @@ vec_proxy_compare_default <- function(x, relax = FALSE) {
 vec_compare <- function(x, y, na_equal = FALSE, .ptype = NULL) {
   vec_assert(x)
   vec_assert(y)
+  vec_assert(na_equal, ptype = logical(), size = 1L)
 
   args <- vec_recycle_common(x, y)
   args <- vec_cast_common(!!!args, .to = .ptype)

--- a/src/compare.c
+++ b/src/compare.c
@@ -259,13 +259,9 @@ static SEXP df_compare_impl(SEXP x, SEXP y, bool na_equal, SEXP info, R_len_t n)
 
 #define COMPARE_COL(CTYPE, CONST_DEREF, SCALAR_COMPARE)     \
 do {                                                        \
-  SEXP out = VECTOR_ELT(info, 0);                           \
-  SEXP skip = VECTOR_ELT(info, 1);                          \
-  SEXP count = VECTOR_ELT(info, 2);                         \
-                                                            \
-  int* p_out = INTEGER(out);                                \
-  int* p_skip = LOGICAL(skip);                              \
-  int* p_count = INTEGER(count);                            \
+  int* p_out = INTEGER(VECTOR_ELT(info, 0));                \
+  int* p_skip = LOGICAL(VECTOR_ELT(info, 1));               \
+  int* p_count = INTEGER(VECTOR_ELT(info, 2));              \
                                                             \
   const CTYPE* p_x = CONST_DEREF(x);                        \
   const CTYPE* p_y = CONST_DEREF(y);                        \
@@ -287,10 +283,6 @@ do {                                                        \
       }                                                     \
     }                                                       \
   }                                                         \
-                                                            \
-  SET_VECTOR_ELT(info, 0, out);                             \
-  SET_VECTOR_ELT(info, 1, skip);                            \
-  SET_VECTOR_ELT(info, 2, count);                           \
                                                             \
   return info;                                              \
 }                                                           \

--- a/src/compare.c
+++ b/src/compare.c
@@ -216,6 +216,19 @@ SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal_) {
 
 // -----------------------------------------------------------------------------
 
+/**
+ * @member out An integer vector of size `n_row` containing the output of the
+ *   row wise data frame comparison.
+ * @member row_known A logical vector of size `n_row`. Initially, all values
+ *   are initialized to `FALSE`. As we iterate along the columns, we flip the
+ *   corresponding row's `row_known` value to `TRUE` if we can determine it
+ *   from the current column comparison (i.e. the comparison returns less than
+ *   or greater than). Once a row's `row_known` value is `TRUE`, we never check
+ *   that row again as we continue through the columns.
+ * @member remaining The number of `row_known` values that are still `FALSE`.
+ *   If this hits `0` before we traverse the entire data frame, we can exit
+ *   immediately because all comparison values are already known.
+ */
 struct vctrs_df_compare_info {
   SEXP out;
   SEXP row_known;

--- a/src/compare.c
+++ b/src/compare.c
@@ -258,7 +258,7 @@ static SEXP df_compare_impl(SEXP x, SEXP y, bool na_equal, SEXP info, R_len_t n)
 
   SEXP x_col;
   SEXP y_col;
-  SEXP count;
+  int* p_count;
 
   for (R_len_t i = 0; i < n_col; ++i) {
     x_col = VECTOR_ELT(x, i);
@@ -267,8 +267,8 @@ static SEXP df_compare_impl(SEXP x, SEXP y, bool na_equal, SEXP info, R_len_t n)
     info = vec_compare_col(x_col, y_col, na_equal, info, n);
 
     // If we know all comparison values, break
-    count = VECTOR_ELT(info, 2);
-    if (*INTEGER(count) == 0) {
+    p_count = INTEGER(VECTOR_ELT(info, 2));
+    if (*p_count == 0) {
       break;
     }
   }

--- a/src/compare.c
+++ b/src/compare.c
@@ -257,18 +257,14 @@ static SEXP df_compare_impl(SEXP x, SEXP y, bool na_equal, SEXP info, R_len_t n)
     stop_not_comparable(x, y, "must have the same number of columns");
   }
 
-  SEXP x_col;
-  SEXP y_col;
-  int* p_count;
-
   for (R_len_t i = 0; i < n_col; ++i) {
-    x_col = VECTOR_ELT(x, i);
-    y_col = VECTOR_ELT(y, i);
+    SEXP x_col = VECTOR_ELT(x, i);
+    SEXP y_col = VECTOR_ELT(y, i);
 
     info = vec_compare_col(x_col, y_col, na_equal, info, n);
 
     // If we know all comparison values, break
-    p_count = INTEGER(VECTOR_ELT(info, 2));
+    int* p_count = INTEGER(VECTOR_ELT(info, 2));
     if (*p_count == 0) {
       break;
     }

--- a/src/compare.c
+++ b/src/compare.c
@@ -45,7 +45,7 @@ static int scmp(SEXP x, SEXP y) {
 
 // -----------------------------------------------------------------------------
 
-static int lgl_compare_scalar(const int* x, const int* y, bool na_equal) {
+static inline int lgl_compare_scalar(const int* x, const int* y, bool na_equal) {
   int xi = *x;
   int yj = *y;
 
@@ -56,7 +56,7 @@ static int lgl_compare_scalar(const int* x, const int* y, bool na_equal) {
   }
 }
 
-static int int_compare_scalar(const int* x, const int* y, bool na_equal) {
+static inline int int_compare_scalar(const int* x, const int* y, bool na_equal) {
   int xi = *x;
   int yj = *y;
 
@@ -67,7 +67,7 @@ static int int_compare_scalar(const int* x, const int* y, bool na_equal) {
   }
 }
 
-static int dbl_compare_scalar(const double* x, const double* y, bool na_equal) {
+static inline int dbl_compare_scalar(const double* x, const double* y, bool na_equal) {
   double xi = *x;
   double yj = *y;
 
@@ -103,7 +103,7 @@ static int dbl_compare_scalar(const double* x, const double* y, bool na_equal) {
   }
 }
 
-static int chr_compare_scalar(const SEXP* x, const SEXP* y, bool na_equal) {
+static inline int chr_compare_scalar(const SEXP* x, const SEXP* y, bool na_equal) {
   const SEXP xi = *x;
   const SEXP yj = *y;
 
@@ -118,7 +118,7 @@ static int chr_compare_scalar(const SEXP* x, const SEXP* y, bool na_equal) {
   }
 }
 
-static int df_compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal, int n_col) {
+static inline int df_compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal, int n_col) {
   int cmp;
 
   for (int k = 0; k < n_col; ++k) {

--- a/src/compare.c
+++ b/src/compare.c
@@ -245,6 +245,7 @@ static SEXP df_compare_impl(SEXP x, SEXP y, bool na_equal, SEXP info, R_len_t n)
 
     info = vec_compare_col(x_col, y_col, na_equal, info, n);
 
+    // If we know all comparison values, break
     count = VECTOR_ELT(info, 2);
     if (*INTEGER(count) == 0) {
       break;

--- a/src/compare.c
+++ b/src/compare.c
@@ -170,7 +170,7 @@ int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
 
 // -----------------------------------------------------------------------------
 
-static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t n);
+static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t n_row);
 
 #define COMPARE(CTYPE, CONST_DEREF, SCALAR_COMPARE)     \
 do {                                                    \
@@ -228,21 +228,21 @@ struct vctrs_df_compare_info {
   *n += 2;                                     \
 } while (0)
 
-static struct vctrs_df_compare_info init_compare_info(R_len_t n) {
+static struct vctrs_df_compare_info init_compare_info(R_len_t n_row) {
   struct vctrs_df_compare_info info;
 
   // Initialize to "equality" value
   // and only change if we learn that it differs
-  info.out = PROTECT(Rf_allocVector(INTSXP, n));
+  info.out = PROTECT(Rf_allocVector(INTSXP, n_row));
   int* p_out = INTEGER(info.out);
-  memset(p_out, 0, n * sizeof(int));
+  memset(p_out, 0, n_row * sizeof(int));
 
   // To begin with, no rows have a known comparison value
-  info.row_known = PROTECT(Rf_allocVector(LGLSXP, n));
+  info.row_known = PROTECT(Rf_allocVector(LGLSXP, n_row));
   int* p_row_known = LOGICAL(info.row_known);
-  memset(p_row_known, 0, n * sizeof(int));
+  memset(p_row_known, 0, n_row * sizeof(int));
 
-  info.remaining = n;
+  info.remaining = n_row;
 
   UNPROTECT(2);
   return info;
@@ -254,21 +254,21 @@ static struct vctrs_df_compare_info vec_compare_col(SEXP x,
                                                     SEXP y,
                                                     bool na_equal,
                                                     struct vctrs_df_compare_info info,
-                                                    R_len_t n);
+                                                    R_len_t n_row);
 
 static struct vctrs_df_compare_info df_compare_impl(SEXP x,
                                                     SEXP y,
                                                     bool na_equal,
                                                     struct vctrs_df_compare_info info,
-                                                    R_len_t n);
+                                                    R_len_t n_row);
 
-static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t n) {
+static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t n_row) {
   int nprot = 0;
 
-  struct vctrs_df_compare_info info = init_compare_info(n);
+  struct vctrs_df_compare_info info = init_compare_info(n_row);
   PROTECT_DF_COMPARE_INFO(&info, &nprot);
 
-  info = df_compare_impl(x, y, na_equal, info, n);
+  info = df_compare_impl(x, y, na_equal, info, n_row);
 
   UNPROTECT(nprot);
   return info.out;
@@ -278,7 +278,7 @@ static struct vctrs_df_compare_info df_compare_impl(SEXP x,
                                                     SEXP y,
                                                     bool na_equal,
                                                     struct vctrs_df_compare_info info,
-                                                    R_len_t n) {
+                                                    R_len_t n_row) {
   int n_col = Rf_length(x);
 
   if (n_col == 0) {
@@ -293,7 +293,7 @@ static struct vctrs_df_compare_info df_compare_impl(SEXP x,
     SEXP x_col = VECTOR_ELT(x, i);
     SEXP y_col = VECTOR_ELT(y, i);
 
-    info = vec_compare_col(x_col, y_col, na_equal, info, n);
+    info = vec_compare_col(x_col, y_col, na_equal, info, n_row);
 
     // If we know all comparison values, break
     if (info.remaining == 0) {
@@ -306,47 +306,47 @@ static struct vctrs_df_compare_info df_compare_impl(SEXP x,
 
 // -----------------------------------------------------------------------------
 
-#define COMPARE_COL(CTYPE, CONST_DEREF, SCALAR_COMPARE)          \
-do {                                                             \
-  int* p_out = INTEGER(info.out);                                \
-  int* p_row_known = LOGICAL(info.row_known);                    \
-                                                                 \
-  const CTYPE* p_x = CONST_DEREF(x);                             \
-  const CTYPE* p_y = CONST_DEREF(y);                             \
-                                                                 \
-  for (R_len_t i = 0; i < n; ++i, ++p_row_known, ++p_x, ++p_y) { \
-    if (*p_row_known) {                                          \
-      continue;                                                  \
-    }                                                            \
-                                                                 \
-    int cmp = SCALAR_COMPARE(p_x, p_y, na_equal);                \
-                                                                 \
-    if (cmp != 0) {                                              \
-      p_out[i] = cmp;                                            \
-      *p_row_known = true;                                       \
-      --info.remaining;                                          \
-                                                                 \
-      if (info.remaining == 0) {                                 \
-        break;                                                   \
-      }                                                          \
-    }                                                            \
-  }                                                              \
-                                                                 \
-  return info;                                                   \
-}                                                                \
+#define COMPARE_COL(CTYPE, CONST_DEREF, SCALAR_COMPARE)              \
+do {                                                                 \
+  int* p_out = INTEGER(info.out);                                    \
+  int* p_row_known = LOGICAL(info.row_known);                        \
+                                                                     \
+  const CTYPE* p_x = CONST_DEREF(x);                                 \
+  const CTYPE* p_y = CONST_DEREF(y);                                 \
+                                                                     \
+  for (R_len_t i = 0; i < n_row; ++i, ++p_row_known, ++p_x, ++p_y) { \
+    if (*p_row_known) {                                              \
+      continue;                                                      \
+    }                                                                \
+                                                                     \
+    int cmp = SCALAR_COMPARE(p_x, p_y, na_equal);                    \
+                                                                     \
+    if (cmp != 0) {                                                  \
+      p_out[i] = cmp;                                                \
+      *p_row_known = true;                                           \
+      --info.remaining;                                              \
+                                                                     \
+      if (info.remaining == 0) {                                     \
+        break;                                                       \
+      }                                                              \
+    }                                                                \
+  }                                                                  \
+                                                                     \
+  return info;                                                       \
+}                                                                    \
 while (0)
 
 static struct vctrs_df_compare_info vec_compare_col(SEXP x,
                                                     SEXP y,
                                                     bool na_equal,
                                                     struct vctrs_df_compare_info info,
-                                                    R_len_t n) {
+                                                    R_len_t n_row) {
   switch (vec_proxy_typeof(x)) {
   case vctrs_type_logical:   COMPARE_COL(int, LOGICAL_RO, lgl_compare_scalar);
   case vctrs_type_integer:   COMPARE_COL(int, INTEGER_RO, int_compare_scalar);
   case vctrs_type_double:    COMPARE_COL(double, REAL_RO, dbl_compare_scalar);
   case vctrs_type_character: COMPARE_COL(SEXP, STRING_PTR_RO, chr_compare_scalar);
-  case vctrs_type_dataframe: return df_compare_impl(x, y, na_equal, info, n);
+  case vctrs_type_dataframe: return df_compare_impl(x, y, na_equal, info, n_row);
   case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
   case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
   default:                   Rf_error("Unimplemented type in `vctrs_compare()`");

--- a/src/compare.c
+++ b/src/compare.c
@@ -1,4 +1,5 @@
 #include "vctrs.h"
+#include "utils.h"
 #include <strings.h>
 
 static void stop_not_comparable(SEXP x, SEXP y, const char* message) {
@@ -101,6 +102,8 @@ static inline int dbl_compare_scalar(const double* x, const double* y, bool na_e
   } else {
     return (isnan(xi) || isnan(yj)) ? NA_INTEGER : dcmp(xi, yj);
   }
+
+  never_reached("dbl_compare_scalar");
 }
 
 static inline int chr_compare_scalar(const SEXP* x, const SEXP* y, bool na_equal) {

--- a/src/compare.c
+++ b/src/compare.c
@@ -1,136 +1,207 @@
 #include "vctrs.h"
 #include <strings.h>
 
-void stop_not_comparable(SEXP x, SEXP y, const char* message) {
+static void stop_not_comparable(SEXP x, SEXP y, const char* message) {
   Rf_errorcall(R_NilValue, "`x` and `y` are not comparable: %s", message);
 }
 
 // https://stackoverflow.com/questions/10996418
-int icmp(int x, int y) {
-  return (x > y) - (x < y);
-}
-int dcmp(double x, double y) {
+static int icmp(int x, int y) {
   return (x > y) - (x < y);
 }
 
-int scmp(SEXP x, SEXP y) {
+static int dcmp(double x, double y) {
+  return (x > y) - (x < y);
+}
+
+static int scmp(SEXP x, SEXP y) {
   if (x == y)
     return 0;
   int cmp = strcmp(CHAR(x), CHAR(y));
   return cmp / abs(cmp);
 }
 
-int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
-  if (TYPEOF(x) != TYPEOF(y))
-    stop_not_comparable(x, y, "different types");
+// -----------------------------------------------------------------------------
 
-  switch(TYPEOF(x)) {
-  case LGLSXP: {
-    int xi = LOGICAL(x)[i], yj = LOGICAL(y)[j];
-    if (na_equal) {
-      return icmp(xi, yj);
-    } else {
-      return (xi == NA_LOGICAL || yj == NA_LOGICAL) ? NA_INTEGER : icmp(xi, yj);
-    }
-  }
-  case INTSXP: {
-    int xi = INTEGER(x)[i], yj = INTEGER(y)[j];
-    if (na_equal) {
-      return icmp(xi, yj);
-    } else {
-      return (xi == NA_INTEGER || yj == NA_INTEGER) ? NA_INTEGER : icmp(xi, yj);
-    }
-  }
-  case REALSXP: {
-    double xi = REAL(x)[i], yj = REAL(y)[j];
-    if (na_equal) {
-      if (R_IsNA(xi)) {
-        if (R_IsNaN(yj)) {
-          return 1;
-        } else if (R_IsNA(yj)) {
-          return 0;
-        } else {
-          return -1;
-        }
-      } else if (R_IsNaN(xi)) {
-        if (R_IsNaN(yj)) {
-          return 0;
-        } else if (R_IsNA(yj)) {
-          return -1;
-        } else {
-          return -1;
-        }
-      } else {
-        if (R_IsNaN(yj)) {
-          return 1L;
-        } else if (R_IsNA(yj)) {
-          return 1L;
-        } else {
-          return dcmp(xi, yj);
-        }
-      }
-    } else {
-      return (isnan(xi) || isnan(yj)) ? NA_INTEGER : dcmp(xi, yj);
-    }
-  }
-  case STRSXP: {
-    SEXP xi = STRING_ELT(x, i), yj = STRING_ELT(y, j);
-    if (na_equal) {
-      if (xi == NA_STRING) {
-        return (yj == NA_STRING) ? 0 : -1;
-      } else {
-        return (yj == NA_STRING) ? 1 : scmp(xi, yj);
-      }
-    } else {
-      return (xi == NA_STRING || yj == NA_STRING) ? NA_INTEGER : scmp(xi, yj);
-    }
+static int lgl_compare_scalar(const int* x, const int* y, bool na_equal) {
+  int xi = *x;
+  int yj = *y;
 
-  }
-  case VECSXP:
-    if (is_data_frame(x)) {
-      int p = Rf_length(x);
-      if (p != Rf_length(y))
-        stop_not_comparable(x, y, "different number of columns");
-      if (!equal_names(x, y))
-        stop_not_comparable(x, y, "different column names");
-
-      if (p == 0)
-        stop_not_comparable(x, y, "data frame with zero columns");
-
-      if (p > 1) {
-        for (int k = 0; k < (p - 1); ++k) {
-          SEXP col_x = VECTOR_ELT(x, k);
-          SEXP col_y = VECTOR_ELT(y, k);
-          int cmp = compare_scalar(col_x, i, col_y, j, na_equal);
-
-          if (cmp != 0)
-            return cmp;
-        }
-      }
-
-      SEXP col_x = VECTOR_ELT(x, p - 1);
-      SEXP col_y = VECTOR_ELT(y, p - 1);
-      return compare_scalar(col_x, i, col_y, j, na_equal);
-    } else {
-      stop_not_comparable(x, y, "lists are not comparable");
-    }
-  default:
-    Rf_errorcall(R_NilValue, "Unsupported type %s", Rf_type2char(TYPEOF(x)));
+  if (na_equal) {
+    return icmp(xi, yj);
+  } else {
+    return (xi == NA_LOGICAL || yj == NA_LOGICAL) ? NA_INTEGER : icmp(xi, yj);
   }
 }
 
+static int int_compare_scalar(const int* x, const int* y, bool na_equal) {
+  int xi = *x;
+  int yj = *y;
+
+  if (na_equal) {
+    return icmp(xi, yj);
+  } else {
+    return (xi == NA_INTEGER || yj == NA_INTEGER) ? NA_INTEGER : icmp(xi, yj);
+  }
+}
+
+static int dbl_compare_scalar(const double* x, const double* y, bool na_equal) {
+  double xi = *x;
+  double yj = *y;
+
+  if (na_equal) {
+    if (R_IsNA(xi)) {
+      if (R_IsNaN(yj)) {
+        return 1;
+      } else if (R_IsNA(yj)) {
+        return 0;
+      } else {
+        return -1;
+      }
+    } else if (R_IsNaN(xi)) {
+      if (R_IsNaN(yj)) {
+        return 0;
+      } else if (R_IsNA(yj)) {
+        return -1;
+      } else {
+        return -1;
+      }
+    } else {
+      if (R_IsNaN(yj)) {
+        return 1L;
+      } else if (R_IsNA(yj)) {
+        return 1L;
+      } else {
+        return dcmp(xi, yj);
+      }
+    }
+  } else {
+    return (isnan(xi) || isnan(yj)) ? NA_INTEGER : dcmp(xi, yj);
+  }
+}
+
+// TODO - Handle translations
+static int chr_compare_scalar(const SEXP* x, const SEXP* y, bool na_equal) {
+  const SEXP xi = *x;
+  const SEXP yj = *y;
+
+  if (na_equal) {
+    if (xi == NA_STRING) {
+      return (yj == NA_STRING) ? 0 : -1;
+    } else {
+      return (yj == NA_STRING) ? 1 : scmp(xi, yj);
+    }
+  } else {
+    return (xi == NA_STRING || yj == NA_STRING) ? NA_INTEGER : scmp(xi, yj);
+  }
+}
+
+static int df_compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal, int n_col) {
+  if (n_col == 0) {
+    stop_not_comparable(x, y, "data frame with zero columns");
+  }
+
+  int cmp;
+
+  for (int k = 0; k < n_col; ++k) {
+    SEXP col_x = VECTOR_ELT(x, k);
+    SEXP col_y = VECTOR_ELT(y, k);
+
+    cmp = compare_scalar(col_x, i, col_y, j, na_equal);
+
+    if (cmp != 0) {
+      return cmp;
+    }
+  }
+
+  return cmp;
+}
+
+// -----------------------------------------------------------------------------
+
+// [[ include("vctrs.h") ]]
+int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
+  switch (TYPEOF(x)) {
+  case LGLSXP: return lgl_compare_scalar(LOGICAL(x) + i, LOGICAL(y) + j, na_equal);
+  case INTSXP: return int_compare_scalar(INTEGER(x) + i, INTEGER(y) + j, na_equal);
+  case REALSXP: return dbl_compare_scalar(REAL(x) + i, REAL(y) + j, na_equal);
+  case STRSXP: return chr_compare_scalar(STRING_PTR(x) + i, STRING_PTR(y) + j, na_equal);
+  default: break;
+  }
+
+  switch (vec_proxy_typeof(x)) {
+  case vctrs_type_list: stop_not_comparable(x, y, "lists are not comparable");
+  case vctrs_type_dataframe: {
+    int n_col = Rf_length(x);
+
+    if (n_col != Rf_length(y)) {
+      stop_not_comparable(x, y, "must have the same number of columns");
+    }
+
+    return df_compare_scalar(x, i, y, j, na_equal, n_col);
+  }
+  default: break;
+  }
+
+  Rf_errorcall(R_NilValue, "Unsupported type %s", Rf_type2char(TYPEOF(x)));
+}
+
+// -----------------------------------------------------------------------------
+
+#define COMPARE(CTYPE, CONST_DEREF, SCALAR_COMPARE)     \
+do {                                                    \
+  const CTYPE* xp = CONST_DEREF(x);                     \
+  const CTYPE* yp = CONST_DEREF(y);                     \
+                                                        \
+  for (R_len_t i = 0; i < n; ++i, ++xp, ++yp) {         \
+    p[i] = SCALAR_COMPARE(xp, yp, na_equal);            \
+  }                                                     \
+}                                                       \
+while (0)
+
+#define COMPARE_DF(SCALAR_COMPARE)                                     \
+do {                                                                   \
+  int n_col = Rf_length(x);                                            \
+                                                                       \
+  if (n_col != Rf_length(y)) {                                         \
+    stop_not_comparable(x, y, "must have the same number of columns"); \
+  }                                                                    \
+                                                                       \
+  for (R_len_t i = 0; i < n; ++i) {                                    \
+    p[i] = SCALAR_COMPARE(x, i, y, i, na_equal, n_col);                \
+  }                                                                    \
+}                                                                      \
+while (0)
+
+
 // [[ register() ]]
-SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_compare_) {
-  bool na_compare = Rf_asLogical(na_compare_);
+SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal_) {
+  bool na_equal = Rf_asLogical(na_equal_);
+
   R_len_t n = vec_size(x);
 
-  SEXP out = PROTECT(Rf_allocVector(INTSXP, n));
-  int32_t* p_out = INTEGER(out);
+  enum vctrs_type type = vec_proxy_typeof(x);
+  if (type != vec_proxy_typeof(y) || n != vec_size(y)) {
+    stop_not_comparable(x, y, "must have the same types and lengths");
+  }
 
-  for (R_len_t i = 0; i < n; ++i) {
-    p_out[i] = compare_scalar(x, i, y, i, na_compare);
+  SEXP out = PROTECT(Rf_allocVector(INTSXP, n));
+  int32_t* p = INTEGER(out);
+
+  switch (type) {
+  case vctrs_type_logical:   COMPARE(int, LOGICAL_RO, lgl_compare_scalar); break;
+  case vctrs_type_integer:   COMPARE(int, INTEGER_RO, int_compare_scalar); break;
+  case vctrs_type_double:    COMPARE(double, REAL_RO, dbl_compare_scalar); break;
+  case vctrs_type_character: COMPARE(SEXP, STRING_PTR_RO, chr_compare_scalar); break;
+  case vctrs_type_dataframe: COMPARE_DF(df_compare_scalar); break;
+  case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
+  case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
+  default:                   Rf_error("Unimplemented type in `vctrs_compare()`");
   }
 
   UNPROTECT(1);
   return out;
 }
+
+#undef COMPARE
+#undef COMPARE_DF

--- a/src/compare.c
+++ b/src/compare.c
@@ -79,8 +79,8 @@ static inline int dbl_compare_scalar(const double* x, const double* y, bool na_e
     case vctrs_dbl_number: {
       switch (y_class) {
       case vctrs_dbl_number: return dcmp(xi, yj);
-      case vctrs_dbl_missing: return 1L;
-      case vctrs_dbl_nan: return 1L;
+      case vctrs_dbl_missing: return 1;
+      case vctrs_dbl_nan: return 1;
       }
     }
     case vctrs_dbl_missing: {

--- a/src/compare.c
+++ b/src/compare.c
@@ -174,13 +174,13 @@ static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t n);
 
 #define COMPARE(CTYPE, CONST_DEREF, SCALAR_COMPARE)     \
 do {                                                    \
-  SEXP out = PROTECT(Rf_allocVector(INTSXP, n));        \
+  SEXP out = PROTECT(Rf_allocVector(INTSXP, size));     \
   int* p_out = INTEGER(out);                            \
                                                         \
   const CTYPE* p_x = CONST_DEREF(x);                    \
   const CTYPE* p_y = CONST_DEREF(y);                    \
                                                         \
-  for (R_len_t i = 0; i < n; ++i, ++p_x, ++p_y) {       \
+  for (R_len_t i = 0; i < size; ++i, ++p_x, ++p_y) {    \
     p_out[i] = SCALAR_COMPARE(p_x, p_y, na_equal);      \
   }                                                     \
                                                         \
@@ -193,10 +193,10 @@ while (0)
 SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal_) {
   bool na_equal = Rf_asLogical(na_equal_);
 
-  R_len_t n = vec_size(x);
+  R_len_t size = vec_size(x);
 
   enum vctrs_type type = vec_proxy_typeof(x);
-  if (type != vec_proxy_typeof(y) || n != vec_size(y)) {
+  if (type != vec_proxy_typeof(y) || size != vec_size(y)) {
     stop_not_comparable(x, y, "must have the same types and lengths");
   }
 
@@ -205,7 +205,7 @@ SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal_) {
   case vctrs_type_integer:   COMPARE(int, INTEGER_RO, int_compare_scalar);
   case vctrs_type_double:    COMPARE(double, REAL_RO, dbl_compare_scalar);
   case vctrs_type_character: COMPARE(SEXP, STRING_PTR_RO, chr_compare_scalar);
-  case vctrs_type_dataframe: return df_compare(x, y, na_equal, n);
+  case vctrs_type_dataframe: return df_compare(x, y, na_equal, size);
   case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
   case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
   default:                   Rf_error("Unimplemented type in `vctrs_compare()`");

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -59,7 +59,11 @@ test_that("C code doesn't crash with bad inputs", {
   df <- data.frame(x = c(1, 1, 1), y = c(-1, 0, 1))
 
   expect_error(.Call(vctrs_compare, df, df[1], TRUE), "not comparable")
-  expect_error(.Call(vctrs_compare, df, setNames(df, c("x", "z")), TRUE), "not comparable")
+
+  # Names are not checked, as `vec_cast_common()` should take care of the type.
+  # So if `vec_cast_common()` is not called, or is improperly specified, then
+  # this could result in false equality.
+  expect_equal(.Call(vctrs_compare, df, setNames(df, c("x", "z")), TRUE), c(0, 0, 0))
 })
 
 test_that("xtfrm.vctrs_vctr works for variety of base classes", {

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -55,6 +55,42 @@ test_that("data frames are compared column by column", {
   expect_equal(vec_compare(df1[2:1], df1[2, 2:1]), c(-1, 0, 1))
 })
 
+test_that("can compare data frames with various types of columns", {
+  x1 <- data_frame(x = 1, y = 2)
+  y1 <- data_frame(x = 2, y = 1)
+
+  x2 <- data_frame(x = "a")
+  y2 <- data_frame(x = "b")
+
+  x3 <- data_frame(x = FALSE)
+  y3 <- data_frame(x = TRUE)
+
+  x4 <- data_frame(x = 1L)
+  y4 <- data_frame(x = 2L)
+
+  expect_equal(vec_compare(x1, y1), -1)
+  expect_equal(vec_compare(x2, y2), -1)
+  expect_equal(vec_compare(x3, y3), -1)
+  expect_equal(vec_compare(x4, y4), -1)
+})
+
+test_that("can compare data frames with data frame columns", {
+  df1 <- data_frame(x = data_frame(a = 1))
+  df2 <- data_frame(x = data_frame(a = 2))
+
+  expect_equal(vec_compare(df1, df1), 0)
+  expect_equal(vec_compare(df1, df2), -1)
+})
+
+test_that("can compare data frames with list columns because of `vec_proxy_compare(relax = TRUE)`", {
+  # lists are replaced with `vec_seq_along()`,
+  # so `list(a = 1)` and `list(a = 0)` look equivalent
+  df1 <- data_frame(x = list(a = 1), y = 2)
+  df2 <- data_frame(x = list(a = 0), y = 3)
+
+  expect_equal(vec_compare(df1, df2), -1)
+})
+
 test_that("C code doesn't crash with bad inputs", {
   df <- data.frame(x = c(1, 1, 1), y = c(-1, 0, 1))
 
@@ -111,17 +147,40 @@ test_that("vec_proxy_compare() handles data frame with a POSIXlt column", {
   )
 })
 
+test_that("error is thrown with data frames with 0 columns", {
+  x <- new_data_frame(n = 1L)
+  expect_error(vec_compare(x, x), "data frame with zero columns")
+})
+
+test_that("error is thrown when comparing lists", {
+  expect_error(vec_compare(list(), list()), class = "vctrs_error_unsupported")
+  expect_error(.Call(vctrs_compare, list(), list(), FALSE), "Can't compare lists")
+})
+
+test_that("error is thrown when comparing scalars", {
+  x <- new_sclr(x = 1)
+  expect_error(vec_compare(x, x), class = "vctrs_error_scalar_type")
+  expect_error(.Call(vctrs_compare, x, x, FALSE), class = "vctrs_error_scalar_type")
+})
+
 test_that("`na_equal` is validated", {
   expect_error(vec_compare(1, 1, na_equal = 1), class = "vctrs_error_assert_ptype")
   expect_error(vec_compare(1, 1, na_equal = c(TRUE, FALSE)), class = "vctrs_error_assert_size")
 })
 
-test_that("can compare strings with different encodings", {
+test_that("can compare equal strings with different encodings", {
   for (x_encoding in encodings()) {
     for (y_encoding in encodings()) {
       expect_equal(vec_compare(x_encoding, y_encoding), 0L)
     }
   }
+})
+
+test_that("can compare different strings with different encodings", {
+  x <- "x"
+  y <- encodings()$latin1
+
+  expect_equal(vec_compare(x, y), -1L)
 })
 
 test_that("equality can always be determined when strings have identical encodings", {

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -111,6 +111,11 @@ test_that("vec_proxy_compare() handles data frame with a POSIXlt column", {
   )
 })
 
+test_that("`na_equal` is validated", {
+  expect_error(vec_compare(1, 1, na_equal = 1), class = "vctrs_error_assert_ptype")
+  expect_error(vec_compare(1, 1, na_equal = c(TRUE, FALSE)), class = "vctrs_error_assert_size")
+})
+
 # order/sort --------------------------------------------------------------
 
 test_that("can request NAs sorted first", {

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -116,6 +116,31 @@ test_that("`na_equal` is validated", {
   expect_error(vec_compare(1, 1, na_equal = c(TRUE, FALSE)), class = "vctrs_error_assert_size")
 })
 
+test_that("can compare strings with different encodings", {
+  for (x_encoding in encodings()) {
+    for (y_encoding in encodings()) {
+      expect_equal(vec_compare(x_encoding, y_encoding), 0L)
+    }
+  }
+})
+
+test_that("equality can always be determined when strings have identical encodings", {
+  encs <- c(encodings(), list(bytes = encoding_bytes()))
+
+  for (enc in encs) {
+    expect_equal(vec_compare(enc, enc), 0L)
+  }
+})
+
+test_that("equality is known to fail when comparing bytes to other encodings", {
+  error <- "translating strings with \"bytes\" encoding"
+
+  for (enc in encodings()) {
+    expect_error(vec_compare(encoding_bytes(), enc), error)
+    expect_error(vec_compare(enc, encoding_bytes()), error)
+  }
+})
+
 # order/sort --------------------------------------------------------------
 
 test_that("can request NAs sorted first", {

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -100,6 +100,10 @@ test_that("C code doesn't crash with bad inputs", {
   # So if `vec_cast_common()` is not called, or is improperly specified, then
   # this could result in false equality.
   expect_equal(.Call(vctrs_compare, df, setNames(df, c("x", "z")), TRUE), c(0, 0, 0))
+
+  df1 <- new_data_frame(list(x = 1:3, y = c(1, 1, 1)))
+  df2 <- new_data_frame(list(y = 1:2, x = 1:2))
+  expect_error(.Call(vctrs_compare, df1, df2, TRUE), "must have the same types and lengths")
 })
 
 test_that("xtfrm.vctrs_vctr works for variety of base classes", {
@@ -176,7 +180,7 @@ test_that("can compare equal strings with different encodings", {
   }
 })
 
-test_that("can compare different strings with different encodings", {
+test_that("can compare non-equal strings with different encodings", {
   x <- "x"
   y <- encodings()$latin1
 
@@ -184,7 +188,7 @@ test_that("can compare different strings with different encodings", {
 })
 
 test_that("equality can always be determined when strings have identical encodings", {
-  encs <- c(encodings(), list(bytes = encoding_bytes()))
+  encs <- list2(!!!encodings(), bytes = encoding_bytes())
 
   for (enc in encs) {
     expect_equal(vec_compare(enc, enc), 0L)


### PR DESCRIPTION
Closes #648 

Still working on this, but incredibly promising results with a rewrite of `vec_compare()`. 

It follows the ideas of `vec_equal()` for the most part. But importantly I'm also experimenting with the idea of doing the comparisons column wise on data frames. This is way more efficient than row wise and I think we might be able to port this idea over to `vec_equal()` too.

The way it generally works is that we construct a logical `skip` vector initialized to all false values and with size equal to the number of rows in the data frame. As we go through the data frame columns, we flip the `skip` values to `TRUE` when we "know" the comparison value (i.e. if it is less than or greater than) and we don't ever evaluate that row again when comparing downstream columns. If all `skip` values are ever `TRUE` (as measured by a decreasing `count` that hits `0` when we know everything), we exit immediately.

Before

``` r
library(vctrs)
library(nycflights13)

bench::mark(
  vec_compare(flights$year, flights$year)
)
#> # A tibble: 1 x 6
#>   expression                                 min median `itr/sec` mem_alloc
#>   <bch:expr>                              <bch:> <bch:>     <dbl> <bch:byt>
#> 1 vec_compare(flights$year, flights$year) 5.26ms 6.48ms      156.     135MB
#> # … with 1 more variable: `gc/sec` <dbl>

bench::mark(
  vec_compare(flights, flights)
)
#> # A tibble: 1 x 6
#>   expression                        min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                    <bch:t> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 vec_compare(flights, flights)   189ms  197ms      5.07    58.2MB     2.54

flights_sort <- dplyr::arrange(flights, dep_time)

bench::mark(
  vec_compare(flights, flights_sort)
)
#> # A tibble: 1 x 6
#>   expression                            min median `itr/sec` mem_alloc
#>   <bch:expr>                         <bch:> <bch:>     <dbl> <bch:byt>
#> 1 vec_compare(flights, flights_sort) 39.1ms 42.3ms      23.9    11.6MB
#> # … with 1 more variable: `gc/sec` <dbl>
```

After

``` r
library(vctrs)
library(nycflights13)

# vector speed up
bench::mark(
  vec_compare(flights$year, flights$year)
)
#> # A tibble: 1 x 6
#>   expression                                min median `itr/sec` mem_alloc
#>   <bch:expr>                              <bch> <bch:>     <dbl> <bch:byt>
#> 1 vec_compare(flights$year, flights$year) 351µs  509µs     1700.     133MB
#> # … with 1 more variable: `gc/sec` <dbl>

# all equal "worst case"
bench::mark(
  vec_compare(flights, flights)
)
#> # A tibble: 1 x 6
#>   expression                        min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                    <bch:t> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 vec_compare(flights, flights)  12.3ms   13ms      75.6    2.92MB     2.04

flights_sort <- dplyr::arrange(flights, dep_time)

# not all equal, we compare column wise and skip if we already
# know the result
bench::mark(
  vec_compare(flights, flights_sort)
)
#> # A tibble: 1 x 6
#>   expression                            min median `itr/sec` mem_alloc
#>   <bch:expr>                         <bch:> <bch:>     <dbl> <bch:byt>
#> 1 vec_compare(flights, flights_sort) 2.52ms 3.13ms      306.    2.57MB
#> # … with 1 more variable: `gc/sec` <dbl>
```

<sup>Created on 2019-11-06 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>