### PR TITLE
Implement column wise `vec_equal()` for data frames

### DIFF
--- a/R/equal.R
+++ b/R/equal.R
@@ -54,6 +54,7 @@ vec_proxy_equal.default <- function(x, ...) {
 #' vec_equal(df, data.frame(x = 1, y = 2))
 #' vec_equal_na(df)
 vec_equal <- function(x, y, na_equal = FALSE, .ptype = NULL) {
+  vec_assert(na_equal, ptype = logical(), size = 1L)
   args <- vec_recycle_common(x, y)
   args <- vec_cast_common(!!!args, .to = .ptype)
   .Call(vctrs_equal, args[[1]], args[[2]], na_equal)

--- a/src/compare.c
+++ b/src/compare.c
@@ -303,8 +303,8 @@ do {                                                                 \
   const CTYPE* p_x = CONST_DEREF(x);                                 \
   const CTYPE* p_y = CONST_DEREF(y);                                 \
                                                                      \
-  for (R_len_t i = 0; i < n_row; ++i, ++p_row_known, ++p_x, ++p_y) { \
-    if (*p_row_known) {                                              \
+  for (R_len_t i = 0; i < n_row; ++i, ++p_x, ++p_y) {                \
+    if (p_row_known[i]) {                                            \
       continue;                                                      \
     }                                                                \
                                                                      \
@@ -312,7 +312,7 @@ do {                                                                 \
                                                                      \
     if (cmp != 0) {                                                  \
       p_out[i] = cmp;                                                \
-      *p_row_known = true;                                           \
+      p_row_known[i] = true;                                         \
       --info.remaining;                                              \
                                                                      \
       if (info.remaining == 0) {                                     \

--- a/src/equal.c
+++ b/src/equal.c
@@ -441,8 +441,8 @@ static struct vctrs_df_rowwise_info init_rowwise_equal_info(R_len_t n_row) {
   info.out = PROTECT(Rf_allocVector(LGLSXP, n_row));
   int* p_out = LOGICAL(info.out);
 
-  for (R_len_t i = 0; i < n_row; ++i, ++p_out) {
-    *p_out = 1;
+  for (R_len_t i = 0; i < n_row; ++i) {
+    p_out[i] = 1;
   }
 
   // To begin with, no rows have a known comparison value

--- a/src/equal.c
+++ b/src/equal.c
@@ -49,7 +49,7 @@ int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
     const CTYPE* xp = CONST_DEREF(x);                   \
     const CTYPE* yp = CONST_DEREF(y);                   \
                                                         \
-    for (R_len_t i = 0; i < n; ++i, ++xp, ++yp) {       \
+    for (R_len_t i = 0; i < size; ++i, ++xp, ++yp) {    \
       p[i] = SCALAR_EQUAL(xp, yp, na_equal);            \
     }                                                   \
   }                                                     \
@@ -57,7 +57,7 @@ int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
 
 #define EQUAL_BARRIER(SCALAR_EQUAL)                     \
   do {                                                  \
-    for (R_len_t i = 0; i < n; ++i) {                   \
+    for (R_len_t i = 0; i < size; ++i) {                \
       p[i] = SCALAR_EQUAL(x, i, y, i, na_equal);        \
     }                                                   \
   }                                                     \
@@ -71,7 +71,7 @@ int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
       Rf_errorcall(R_NilValue, "`x` and `y` must have the same number of columns"); \
     }                                                                               \
                                                                                     \
-    for (R_len_t i = 0; i < n; ++i) {                                               \
+    for (R_len_t i = 0; i < size; ++i) {                                            \
       p[i] = SCALAR_EQUAL(x, i, y, i, na_equal, n_col);                             \
     }                                                                               \
   }                                                                                 \
@@ -89,8 +89,8 @@ SEXP vctrs_equal(SEXP x, SEXP y, SEXP na_equal_) {
 
   bool na_equal = Rf_asLogical(na_equal_);
 
-  R_len_t n = vec_size(x);
-  SEXP out = PROTECT(Rf_allocVector(LGLSXP, n));
+  R_len_t size = vec_size(x);
+  SEXP out = PROTECT(Rf_allocVector(LGLSXP, size));
   int32_t* p = LOGICAL(out);
 
   switch (type) {

--- a/src/equal.c
+++ b/src/equal.c
@@ -110,14 +110,14 @@ SEXP vctrs_equal(SEXP x, SEXP y, SEXP na_equal_) {
   bool na_equal = Rf_asLogical(na_equal_);
 
   switch (type) {
-  case vctrs_type_logical:   EQUAL(int, LOGICAL_RO, lgl_equal_scalar); break;
-  case vctrs_type_integer:   EQUAL(int, INTEGER_RO, int_equal_scalar); break;
-  case vctrs_type_double:    EQUAL(double, REAL_RO, dbl_equal_scalar); break;
-  case vctrs_type_raw:       EQUAL(Rbyte, RAW_RO, raw_equal_scalar); break;
-  case vctrs_type_complex:   EQUAL(Rcomplex, COMPLEX_RO, cpl_equal_scalar); break;
-  case vctrs_type_character: EQUAL(SEXP, STRING_PTR_RO, chr_equal_scalar); break;
-  case vctrs_type_list:      EQUAL_BARRIER(list_equal_scalar); break;
-  case vctrs_type_dataframe: EQUAL_DF(df_equal_scalar); break;
+  case vctrs_type_logical:   EQUAL(int, LOGICAL_RO, lgl_equal_scalar);
+  case vctrs_type_integer:   EQUAL(int, INTEGER_RO, int_equal_scalar);
+  case vctrs_type_double:    EQUAL(double, REAL_RO, dbl_equal_scalar);
+  case vctrs_type_raw:       EQUAL(Rbyte, RAW_RO, raw_equal_scalar);
+  case vctrs_type_complex:   EQUAL(Rcomplex, COMPLEX_RO, cpl_equal_scalar);
+  case vctrs_type_character: EQUAL(SEXP, STRING_PTR_RO, chr_equal_scalar);
+  case vctrs_type_list:      EQUAL_BARRIER(list_equal_scalar);
+  case vctrs_type_dataframe: EQUAL_DF(df_equal_scalar);
   case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_equal()`");
   default:                   Rf_error("Unimplemented type in `vctrs_equal()`");
   }

--- a/src/equal.c
+++ b/src/equal.c
@@ -504,8 +504,8 @@ do {                                                                 \
   const CTYPE* p_x = CONST_DEREF(x);                                 \
   const CTYPE* p_y = CONST_DEREF(y);                                 \
                                                                      \
-  for (R_len_t i = 0; i < n_row; ++i, ++p_row_known, ++p_x, ++p_y) { \
-    if (*p_row_known) {                                              \
+  for (R_len_t i = 0; i < n_row; ++i, ++p_x, ++p_y) {                \
+    if (p_row_known[i]) {                                            \
       continue;                                                      \
     }                                                                \
                                                                      \
@@ -513,7 +513,7 @@ do {                                                                 \
                                                                      \
     if (eq <= 0) {                                                   \
       p_out[i] = eq;                                                 \
-      *p_row_known = true;                                           \
+      p_row_known[i] = true;                                         \
       --info.remaining;                                              \
                                                                      \
       if (info.remaining == 0) {                                     \
@@ -531,8 +531,8 @@ do {                                                   \
   int* p_out = LOGICAL(info.out);                      \
   int* p_row_known = LOGICAL(info.row_known);          \
                                                        \
-  for (R_len_t i = 0; i < n_row; ++i, ++p_row_known) { \
-    if (*p_row_known) {                                \
+  for (R_len_t i = 0; i < n_row; ++i) {                \
+    if (p_row_known[i]) {                              \
       continue;                                        \
     }                                                  \
                                                        \
@@ -540,7 +540,7 @@ do {                                                   \
                                                        \
     if (eq <= 0) {                                     \
       p_out[i] = eq;                                   \
-      *p_row_known = true;                             \
+      p_row_known[i] = true;                           \
       --info.remaining;                                \
                                                        \
       if (info.remaining == 0) {                       \

--- a/src/equal.c
+++ b/src/equal.c
@@ -50,13 +50,13 @@ static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t n_row);
 #define EQUAL(CTYPE, CONST_DEREF, SCALAR_EQUAL)         \
   do {                                                  \
     SEXP out = PROTECT(Rf_allocVector(LGLSXP, size));   \
-    int32_t* p = LOGICAL(out);                          \
+    int32_t* p_out = LOGICAL(out);                      \
                                                         \
-    const CTYPE* xp = CONST_DEREF(x);                   \
-    const CTYPE* yp = CONST_DEREF(y);                   \
+    const CTYPE* p_x = CONST_DEREF(x);                  \
+    const CTYPE* p_y = CONST_DEREF(y);                  \
                                                         \
-    for (R_len_t i = 0; i < size; ++i, ++xp, ++yp) {    \
-      p[i] = SCALAR_EQUAL(xp, yp, na_equal);            \
+    for (R_len_t i = 0; i < size; ++i, ++p_x, ++p_y) {  \
+      p_out[i] = SCALAR_EQUAL(p_x, p_y, na_equal);      \
     }                                                   \
                                                         \
     UNPROTECT(3);                                       \
@@ -67,10 +67,10 @@ static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t n_row);
 #define EQUAL_BARRIER(SCALAR_EQUAL)                     \
   do {                                                  \
     SEXP out = PROTECT(Rf_allocVector(LGLSXP, size));   \
-    int32_t* p = LOGICAL(out);                          \
+    int32_t* p_out = LOGICAL(out);                      \
                                                         \
     for (R_len_t i = 0; i < size; ++i) {                \
-      p[i] = SCALAR_EQUAL(x, i, y, i, na_equal);        \
+      p_out[i] = SCALAR_EQUAL(x, i, y, i, na_equal);    \
     }                                                   \
                                                         \
     UNPROTECT(3);                                       \
@@ -220,11 +220,11 @@ static int df_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal, 
 
 #define EQUAL_ALL(CTYPE, CONST_DEREF, SCALAR_EQUAL)       \
   do {                                                    \
-    const CTYPE* xp = CONST_DEREF(x);                     \
-    const CTYPE* yp = CONST_DEREF(y);                     \
+    const CTYPE* p_x = CONST_DEREF(x);                    \
+    const CTYPE* p_y = CONST_DEREF(y);                    \
                                                           \
-    for (R_len_t i = 0; i < n; ++i, ++xp, ++yp) {         \
-      eq = SCALAR_EQUAL(xp, yp, na_equal);                \
+    for (R_len_t i = 0; i < n; ++i, ++p_x, ++p_y) {       \
+      eq = SCALAR_EQUAL(p_x, p_y, na_equal);              \
       if (eq <= 0) {                                      \
         break;                                            \
       }                                                   \

--- a/src/equal.c
+++ b/src/equal.c
@@ -50,7 +50,7 @@ static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t n_row);
 #define EQUAL(CTYPE, CONST_DEREF, SCALAR_EQUAL)         \
   do {                                                  \
     SEXP out = PROTECT(Rf_allocVector(LGLSXP, size));   \
-    int32_t* p_out = LOGICAL(out);                      \
+    int* p_out = LOGICAL(out);                          \
                                                         \
     const CTYPE* p_x = CONST_DEREF(x);                  \
     const CTYPE* p_y = CONST_DEREF(y);                  \
@@ -67,7 +67,7 @@ static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t n_row);
 #define EQUAL_BARRIER(SCALAR_EQUAL)                     \
   do {                                                  \
     SEXP out = PROTECT(Rf_allocVector(LGLSXP, size));   \
-    int32_t* p_out = LOGICAL(out);                      \
+    int* p_out = LOGICAL(out);                          \
                                                         \
     for (R_len_t i = 0; i < size; ++i) {                \
       p_out[i] = SCALAR_EQUAL(x, i, y, i, na_equal);    \

--- a/src/equal.c
+++ b/src/equal.c
@@ -82,14 +82,15 @@ SEXP vctrs_equal(SEXP x, SEXP y, SEXP na_equal_) {
   x = PROTECT(vec_proxy_recursive(x, vctrs_proxy_equal));
   y = PROTECT(vec_proxy_recursive(y, vctrs_proxy_equal));
 
+  R_len_t size = vec_size(x);
+
   enum vctrs_type type = vec_proxy_typeof(x);
-  if (type != vec_proxy_typeof(y) || vec_size(x) != vec_size(y)) {
+  if (type != vec_proxy_typeof(y) || size != vec_size(y)) {
     Rf_errorcall(R_NilValue, "`x` and `y` must have same types and lengths");
   }
 
   bool na_equal = Rf_asLogical(na_equal_);
 
-  R_len_t size = vec_size(x);
   SEXP out = PROTECT(Rf_allocVector(LGLSXP, size));
   int32_t* p = LOGICAL(out);
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -276,13 +276,12 @@ bool duplicated_any(SEXP names);
 /**
  * @member out A vector of size `n_row` containing the output of the
  *   row wise data frame operation.
- * @member row_known A boolean array of size `n_row`. It is intended to be
- *   constructed from and managed by a RAWSXP. Initially, all values are
- *   initialized to `false`. As we iterate along the columns, we flip the
- *   corresponding row's `row_known` value to `true` if we can determine the
- *   `out` value for that row from the current columns. Once a row's `row_known`
- *   value is `true`, we never check that row again as we continue through the
- *   columns.
+ * @member row_known A boolean array of size `n_row`. Allocated on the R heap.
+ *   Initially, all values are initialized to `false`. As we iterate along the
+ *   columns, we flip the corresponding row's `row_known` value to `true` if we
+ *   can determine the `out` value for that row from the current columns.
+ *   Once a row's `row_known` value is `true`, we never check that row again
+ *   as we continue through the columns.
  * @member p_row_known A pointer to the boolean array stored in `row_known`.
  *   Initialized with `(bool*) RAW(info.row_known)`.
  * @member remaining The number of `row_known` values that are still `false`.

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -276,19 +276,23 @@ bool duplicated_any(SEXP names);
 /**
  * @member out A vector of size `n_row` containing the output of the
  *   row wise data frame operation.
- * @member row_known A logical vector of size `n_row`. Initially, all values
- *   are initialized to `FALSE`. As we iterate along the columns, we flip the
- *   corresponding row's `row_known` value to `TRUE` if we can determine the
+ * @member row_known A boolean array of size `n_row`. It is intended to be
+ *   constructed from and managed by a RAWSXP. Initially, all values are
+ *   initialized to `false`. As we iterate along the columns, we flip the
+ *   corresponding row's `row_known` value to `true` if we can determine the
  *   `out` value for that row from the current columns. Once a row's `row_known`
- *   value is `TRUE`, we never check that row again as we continue through the
+ *   value is `true`, we never check that row again as we continue through the
  *   columns.
- * @member remaining The number of `row_known` values that are still `FALSE`.
+ * @member p_row_known A pointer to the boolean array stored in `row_known`.
+ *   Initialized with `(bool*) RAW(info.row_known)`.
+ * @member remaining The number of `row_known` values that are still `false`.
  *   If this hits `0` before we traverse the entire data frame, we can exit
  *   immediately because all `out` values are already known.
  */
 struct vctrs_df_rowwise_info {
   SEXP out;
   SEXP row_known;
+  bool* p_row_known;
   R_len_t remaining;
 };
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -267,6 +267,37 @@ void hash_fill(uint32_t* p, R_len_t n, SEXP x);
 
 bool duplicated_any(SEXP names);
 
+// Rowwise operations -------------------------------------------
+
+// Used in functions that treat data frames as vectors of rows, but
+// iterate over them column wise. Examples are `vec_equal()` and
+// `vec_compare()`.
+
+/**
+ * @member out A vector of size `n_row` containing the output of the
+ *   row wise data frame operation.
+ * @member row_known A logical vector of size `n_row`. Initially, all values
+ *   are initialized to `FALSE`. As we iterate along the columns, we flip the
+ *   corresponding row's `row_known` value to `TRUE` if we can determine the
+ *   `out` value for that row from the current columns. Once a row's `row_known`
+ *   value is `TRUE`, we never check that row again as we continue through the
+ *   columns.
+ * @member remaining The number of `row_known` values that are still `FALSE`.
+ *   If this hits `0` before we traverse the entire data frame, we can exit
+ *   immediately because all `out` values are already known.
+ */
+struct vctrs_df_rowwise_info {
+  SEXP out;
+  SEXP row_known;
+  R_len_t remaining;
+};
+
+#define PROTECT_DF_ROWWISE_INFO(info, n) do {  \
+  PROTECT((info)->out);                        \
+  PROTECT((info)->row_known);                  \
+  *n += 2;                                     \
+} while (0)
+
 // Missing values -----------------------------------------------
 
 // Annex F of C99 specifies that `double` should conform to the IEEE 754


### PR DESCRIPTION
Uses the same approach as `vec_compare()`

Before

``` r
library(vctrs)
library(nycflights13)

bench::mark(
  vec_equal(flights, flights)
)
#> # A tibble: 1 x 6
#>   expression                       min  median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                  <bch:tm> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal(flights, flights)    113ms   118ms      8.56     138MB        0

flights_sort <- dplyr::arrange(flights, dep_time)

bench::mark(
  vec_equal(flights, flights_sort)
)
#> # A tibble: 1 x 6
#>   expression                          min median `itr/sec` mem_alloc
#>   <bch:expr>                       <bch:> <bch:>     <dbl> <bch:byt>
#> 1 vec_equal(flights, flights_sort) 7.91ms 8.85ms      112.    1.29MB
#> # … with 1 more variable: `gc/sec` <dbl>
```

After:

``` r
library(vctrs)
library(nycflights13)

bench::mark(
  vec_equal(flights, flights)
)
#> # A tibble: 1 x 6
#>   expression                       min  median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                  <bch:tm> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal(flights, flights)   9.54ms  10.5ms      91.1     134MB     2.07

flights_sort <- dplyr::arrange(flights, dep_time)

bench::mark(
  vec_equal(flights, flights_sort)
)
#> # A tibble: 1 x 6
#>   expression                          min median `itr/sec` mem_alloc
#>   <bch:expr>                       <bch:> <bch:>     <dbl> <bch:byt>
#> 1 vec_equal(flights, flights_sort) 2.34ms  2.6ms      353.    2.57MB
#> # … with 1 more variable: `gc/sec` <dbl>
```

Also:

- Validates `na_equal`
- Fleshes out test coverage a bit
- Recognized that the structs we use in `vec_equal()` and `vec_compare()` are identical, so I pulled it out into `vctrs.h`. Let me know what you think about the name (`vctrs_df_rowwise_info`). It will also be used to vectorize `vec_equal_na()` and `vec_duplicate_all()` for data frames using the same approach so I thought it made sense to pull it out. It's nice because the `init_*()` functions can set the `info.out` SEXP to whatever type is required for that particular function. `vec_compare()` uses an integer, `vec_equal()` uses a logical.