### PR TITLE
Treat `list(NULL)` as a missing value in `vec_equal()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs 0.2.0.9000
 
+* `vec_equal()` now correctly treats `NULL` as the missing value element for
+  lists (#653).
+
 * Positive and negative 0 are now considered equivalent by all functions that
   check for equality or uniqueness (#637).
 

--- a/src/equal.c
+++ b/src/equal.c
@@ -293,7 +293,15 @@ int equal_object(SEXP x, SEXP y, bool na_equal) {
     if (eq <= 0) {
       return eq;
     }
-    eq = equal_object(CDR(x), CDR(y), na_equal);
+
+    x = CDR(x);
+    y = CDR(y);
+
+    if (x == R_NilValue && y == R_NilValue) {
+      return true;
+    }
+
+    eq = equal_object(x, y, na_equal);
     if (eq <= 0) {
       return eq;
     }

--- a/src/equal.c
+++ b/src/equal.c
@@ -254,6 +254,7 @@ int equal_object(SEXP x, SEXP y, bool na_equal) {
   // Pointer comparison is safe for these types
   switch (type) {
   case NILSXP:
+    return x == y ? (na_equal ? true : NA_LOGICAL) : false;
   case SYMSXP:
   case SPECIALSXP:
   case BUILTINSXP:

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -124,6 +124,7 @@ test_that("equality is known to fail when comparing bytes to other encodings", {
 
 test_that("can compare NULL",{
   expect_true(obj_equal(NULL, NULL))
+  expect_equal(obj_equal(NULL, NULL, na_equal = FALSE), NA)
 })
 
 test_that("can compare objects with reference semantics", {

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -28,6 +28,7 @@ test_that("NAs are equal", {
   expect_true(vec_equal(NA_integer_, NA_integer_, na_equal = TRUE))
   expect_true(vec_equal(NA_real_, NA_real_, na_equal = TRUE))
   expect_true(vec_equal(NA_character_, NA_character_, na_equal = TRUE))
+  expect_true(vec_equal(list(NULL), list(NULL), na_equal = TRUE))
 })
 
 test_that("double special values", {
@@ -35,6 +36,10 @@ test_that("double special values", {
   expect_equal(vec_equal(c(NA, NaN), NA, na_equal = TRUE), c(TRUE, FALSE))
   expect_true(vec_equal(Inf, Inf))
   expect_true(vec_equal(-Inf, -Inf))
+})
+
+test_that("`list(NULL)` is considered a missing value (#653)", {
+  expect_equal(vec_equal(list(NULL), list(NULL)), NA)
 })
 
 test_that("can compare data frames", {

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -137,6 +137,7 @@ test_that("can compare objects with reference semantics", {
 test_that("can compare pairlists", {
   expect_true(obj_equal(quote(x + y), quote(x + y)))
   expect_true(obj_equal(pairlist(x = 1, y = 2), pairlist(x = 1, y = 2)))
+  expect_true(obj_equal(pairlist(x = 1, y = 2), pairlist(x = 1, y = 2), na_equal = FALSE))
 })
 
 test_that("can compare functions", {


### PR DESCRIPTION
Closes #653 

``` r
library(vctrs)

vec_equal(list(NULL), list(NULL))
#> [1] NA

vec_equal(list(NULL), list(NULL), na_equal = TRUE)
#> [1] TRUE
```

<sup>Created on 2019-11-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>