### PR TITLE
Improve base type matching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # vctrs 0.2.0.9000
 
+* `vec_ptype()` has relaxed default behaviour for base types; now if two
+  vectors both inherit from (e.g.) "character", the common type is also
+  "character" (#497).
+
 * Positive and negative 0 are now considered equivalent by all functions that
   check for equality or uniqueness (#637).
 

--- a/R/shape.R
+++ b/R/shape.R
@@ -11,15 +11,6 @@ new_shape <- function(type, shape = NULL) {
   }
 }
 
-shape_match <- function(type, x, y) {
-  if (!is.object(x) && !is.object(y)) {
-    shape <- shape_common(x, y)
-    new_shape(type, shape)
-  } else {
-    type
-  }
-}
-
 shape_common <- function(x, y) {
   shape <- n_dim2(shape(x), shape(y))
   map2_int(shape$x, shape$y, axis2)

--- a/R/shape.R
+++ b/R/shape.R
@@ -12,8 +12,12 @@ new_shape <- function(type, shape = NULL) {
 }
 
 shape_match <- function(type, x, y) {
-  shape <- shape_common(x, y)
-  new_shape(type, shape)
+  if (!is.object(x) && !is.object(y)) {
+    shape <- shape_common(x, y)
+    new_shape(type, shape)
+  } else {
+    type
+  }
 }
 
 shape_common <- function(x, y) {
@@ -78,10 +82,6 @@ shape_broadcast <- function(x, to) {
 # Helpers -----------------------------------------------------------------
 
 shape <- function(x) {
-  if (is.object(x)) {
-    abort("Only bare vectors have shapes.")
-  }
-
   vec_dim(x)[-1]
 }
 

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -407,3 +407,12 @@ lossy_floor <- function(x, to, x_arg = "x", to_arg = "to") {
   lossy <- x != x_floor
   maybe_lossy_cast(x_floor, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
+
+shape_match <- function(type, x, y) {
+  if (!is.object(x) && !is.object(y)) {
+    shape <- shape_common(x, y)
+    new_shape(type, shape)
+  } else {
+    type
+  }
+}

--- a/tests/testthat/test-shape.R
+++ b/tests/testthat/test-shape.R
@@ -4,13 +4,32 @@ int <- function(...) {
   array(NA_integer_, c(...))
 }
 
-# common shape ------------------------------------------------------------
+# shape_match -------------------------------------------------------------
+
+test_that("array dimensions are preserved", {
+  mat1 <- matrix(lgl(), nrow = 1, ncol = 1)
+  mat2 <- matrix(lgl(), nrow = 2, ncol = 2)
+  mat3 <- matrix(lgl(), nrow = 2, ncol = 3)
+
+  expect_equal(vec_ptype2(mat1, mat1), matrix(lgl(), nrow = 0, ncol = 1))
+  expect_equal(vec_ptype2(mat1, mat2), matrix(lgl(), nrow = 0, ncol = 2))
+  expect_error(vec_ptype2(mat2, mat3), "Incompatible")
+})
+
+test_that("extensions of base vectors collapse to base type", {
+  x <- structure("x", class = c("foo", "character"))
+  expect_equal(vec_ptype2(x, x), character())
+  expect_equal(vec_ptype2(x, character()), character())
+  expect_equal(vec_ptype2(character(), x), character())
+})
 
 test_that("shape_match()", {
   expect_identical(shape_match(integer(), int(5), int(10)), new_shape(integer()))
   expect_identical(shape_match(integer(), int(5, 1), int(10, 1)), new_shape(integer(), 1))
   expect_identical(shape_match(integer(), int(5, 1, 2), int(10, 1, 2)), new_shape(integer(), 1:2))
 })
+
+# common shape ------------------------------------------------------------
 
 test_that("length is ignored", {
   expect_equal(shape_common(int(5), int(10)), integer())
@@ -81,13 +100,5 @@ test_that("recycling rules applied", {
     shape_broadcast(array(1L, c(1, 0)), int(1, 1)),
     "Non-recyclable dimensions",
     class = "vctrs_error_incompatible_cast"
-  )
-})
-
-test_that("shape of vector not supported", {
-  expect_error(
-    shape(new_vctr(1:4)),
-    "Only bare vectors have shapes.",
-    fixed = TRUE
   )
 })

--- a/tests/testthat/test-shape.R
+++ b/tests/testthat/test-shape.R
@@ -4,31 +4,6 @@ int <- function(...) {
   array(NA_integer_, c(...))
 }
 
-# shape_match -------------------------------------------------------------
-
-test_that("array dimensions are preserved", {
-  mat1 <- matrix(lgl(), nrow = 1, ncol = 1)
-  mat2 <- matrix(lgl(), nrow = 2, ncol = 2)
-  mat3 <- matrix(lgl(), nrow = 2, ncol = 3)
-
-  expect_equal(vec_ptype2(mat1, mat1), matrix(lgl(), nrow = 0, ncol = 1))
-  expect_equal(vec_ptype2(mat1, mat2), matrix(lgl(), nrow = 0, ncol = 2))
-  expect_error(vec_ptype2(mat2, mat3), "Incompatible")
-})
-
-test_that("extensions of base vectors collapse to base type", {
-  x <- structure("x", class = c("foo", "character"))
-  expect_equal(vec_ptype2(x, x), character())
-  expect_equal(vec_ptype2(x, character()), character())
-  expect_equal(vec_ptype2(character(), x), character())
-})
-
-test_that("shape_match()", {
-  expect_identical(shape_match(integer(), int(5), int(10)), new_shape(integer()))
-  expect_identical(shape_match(integer(), int(5, 1), int(10, 1)), new_shape(integer(), 1))
-  expect_identical(shape_match(integer(), int(5, 1, 2), int(10, 1, 2)), new_shape(integer(), 1:2))
-})
-
 # common shape ------------------------------------------------------------
 
 test_that("length is ignored", {

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -1,5 +1,29 @@
 context("test-type-bare")
 
+# shape_match -------------------------------------------------------------
+
+test_that("array dimensions are preserved", {
+  mat1 <- matrix(lgl(), nrow = 1, ncol = 1)
+  mat2 <- matrix(lgl(), nrow = 2, ncol = 2)
+  mat3 <- matrix(lgl(), nrow = 2, ncol = 3)
+
+  expect_equal(vec_ptype2(mat1, mat1), matrix(lgl(), nrow = 0, ncol = 1))
+  expect_equal(vec_ptype2(mat1, mat2), matrix(lgl(), nrow = 0, ncol = 2))
+  expect_error(vec_ptype2(mat2, mat3), "Incompatible")
+})
+
+test_that("extensions of base vectors collapse to base type", {
+  x <- structure("x", class = c("foo", "character"))
+  expect_equal(vec_ptype2(x, x), character())
+  expect_equal(vec_ptype2(x, character()), character())
+  expect_equal(vec_ptype2(character(), x), character())
+})
+
+test_that("shape_match()", {
+  expect_identical(shape_match(integer(), int(5), int(10)), new_shape(integer()))
+  expect_identical(shape_match(integer(), int(5, 1), int(10, 1)), new_shape(integer(), 1))
+  expect_identical(shape_match(integer(), int(5, 1, 2), int(10, 1, 2)), new_shape(integer(), 1:2))
+})
 
 # vec_cast() --------------------------------------------------------------
 

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -20,6 +20,8 @@ test_that("extensions of base vectors collapse to base type", {
 })
 
 test_that("shape_match()", {
+  int <- function(...) array(NA_integer_, c(...))
+
   expect_identical(shape_match(integer(), int(5), int(10)), new_shape(integer()))
   expect_identical(shape_match(integer(), int(5, 1), int(10, 1)), new_shape(integer(), 1))
   expect_identical(shape_match(integer(), int(5, 1, 2), int(10, 1, 2)), new_shape(integer(), 1:2))


### PR DESCRIPTION
* If neither x nor y are objects, preserve their shape
* Otherwise preserve the underlying base type

I think this is correct because if the class vector includes (e.g.) "character", that's an assertion that the object is a character vector. To preserve attributes and class, you'd need to provide a vec_ptype2 method.

Fixes #497