### PR TITLE
Add a `bytes` option to `encodings()`

### DIFF
--- a/tests/testthat/helper-encoding.R
+++ b/tests/testthat/helper-encoding.R
@@ -1,11 +1,17 @@
-encodings <- function() {
+encodings <- function(bytes = FALSE) {
   string <- "\u00B0C"
 
   utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
   unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
   latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
-  list(utf8 = utf8, unknown = unknown, latin1 = latin1)
+  out <- list(utf8 = utf8, unknown = unknown, latin1 = latin1)
+
+  if (bytes) {
+    out <- list2(!!! out, bytes = encoding_bytes())
+  }
+
+  out
 }
 
 encoding_bytes <- function() {

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -188,7 +188,7 @@ test_that("can compare non-equal strings with different encodings", {
 })
 
 test_that("equality can always be determined when strings have identical encodings", {
-  encs <- list2(!!!encodings(), bytes = encoding_bytes())
+  encs <- encodings(bytes = TRUE)
 
   for (enc in encs) {
     expect_equal(vec_compare(enc, enc), 0L)

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -98,7 +98,7 @@ test_that("can determine equality of strings with different encodings (#553)", {
 })
 
 test_that("equality can be determined when strings have identical encodings", {
-  encs <- c(encodings(), list(bytes = encoding_bytes()))
+  encs <- encodings(bytes = TRUE)
 
   for (enc in encs) {
     expect_true(vec_equal(enc, enc))

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -12,7 +12,7 @@ test_that("can translate a character vector of various encodings (#553)", {
 })
 
 test_that("does not perform translation when encodings are all the same", {
-  encs <- c(encodings(), list(bytes = encoding_bytes()))
+  encs <- encodings(bytes = TRUE)
 
   for (enc in encs) {
     x <- c(enc, enc)


### PR DESCRIPTION
Closes #651 

This gives us slightly cleaner tests when we actually do want the bytes version of `°C` to be included