### PR TITLE
Don't propagate missingness through list elements in `vec_equal()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # vctrs 0.2.0.9000
 
+* `vec_equal()` no longer propagates missing values when comparing list
+  elements. This means that `vec_equal(list(NULL), list(NULL))` will continue to
+  return `NA` because `NULL` is the missing element for a list, but now
+  `vec_equal(list(NA), list(NA))` returns `TRUE` because the `NA` values are
+  compared directly without checking for missingness.
+
 * Lists of expressions are now supported in `vec_equal()` and functions that
   compare elements, such as `vec_unique()` and `vec_match()`. This ensures that
   they work with the result of modeling functions like `glm()` and `mgcv::gam()`

--- a/R/equal.R
+++ b/R/equal.R
@@ -72,6 +72,6 @@ vec_duplicate_all <- function(x) {
   .Call(vctrs_duplicate_all, x)
 }
 
-obj_equal <- function(x, y, na_equal = TRUE) {
-  .Call(vctrs_equal_object, x, y, na_equal)
+obj_equal <- function(x, y) {
+  .Call(vctrs_equal_object, x, y)
 }

--- a/src/equal.c
+++ b/src/equal.c
@@ -253,7 +253,7 @@ static int df_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal, 
   }                                                       \
   while (0)
 
-static inline int vec_equal_attrib(SEXP x, SEXP y);
+static inline bool vec_equal_attrib(SEXP x, SEXP y);
 
 // [[ include("vctrs.h") ]]
 bool equal_object(SEXP x, SEXP y) {
@@ -375,7 +375,7 @@ SEXP vctrs_equal_object(SEXP x, SEXP y) {
 
 // TODO: Sort attributes by tag before comparison
 
-static inline int vec_equal_attrib(SEXP x, SEXP y) {
+static inline bool vec_equal_attrib(SEXP x, SEXP y) {
   SEXP x_attrs = ATTRIB(x);
   SEXP y_attrs = ATTRIB(y);
 

--- a/src/equal.c
+++ b/src/equal.c
@@ -201,7 +201,14 @@ static int chr_equal_scalar(const SEXP* x, const SEXP* y, bool na_equal) {
 }
 
 static int list_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
-  return equal_object(VECTOR_ELT(x, i), VECTOR_ELT(y, j), na_equal);
+  const SEXP xi = VECTOR_ELT(x, i);
+  const SEXP yj = VECTOR_ELT(y, j);
+
+  if (na_equal) {
+    return equal_object(xi, yj);
+  } else {
+    return (xi == R_NilValue || yj == R_NilValue) ? NA_LOGICAL : equal_object(xi, yj);
+  }
 }
 
 static int df_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal, int n_col) {
@@ -218,46 +225,47 @@ static int df_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal, 
 
 // -----------------------------------------------------------------------------
 
+// Missingness is never propagated through objects,
+// so `na_equal` is always `true` in these macros
+
 #define EQUAL_ALL(CTYPE, CONST_DEREF, SCALAR_EQUAL)       \
   do {                                                    \
     const CTYPE* p_x = CONST_DEREF(x);                    \
     const CTYPE* p_y = CONST_DEREF(y);                    \
                                                           \
     for (R_len_t i = 0; i < n; ++i, ++p_x, ++p_y) {       \
-      eq = SCALAR_EQUAL(p_x, p_y, na_equal);              \
-      if (eq <= 0) {                                      \
-        break;                                            \
+      if (!SCALAR_EQUAL(p_x, p_y, true)) {                \
+        return false;                                     \
       }                                                   \
     }                                                     \
+    return true;                                          \
   }                                                       \
   while (0)
 
 #define EQUAL_ALL_BARRIER(SCALAR_EQUAL)                   \
   do {                                                    \
     for (R_len_t i = 0; i < n; ++i) {                     \
-      eq = SCALAR_EQUAL(x, i, y, i, na_equal);            \
-      if (eq <= 0) {                                      \
-        break;                                            \
+      if (!SCALAR_EQUAL(x, i, y, i, true)) {              \
+        return false;                                     \
       }                                                   \
     }                                                     \
+    return true;                                          \
   }                                                       \
   while (0)
 
-static inline bool obj_equal_attrib(SEXP x, SEXP y);
-static inline int vec_equal_attrib(SEXP x, SEXP y, bool na_equal);
+static inline int vec_equal_attrib(SEXP x, SEXP y);
 
 // [[ include("vctrs.h") ]]
-int equal_object(SEXP x, SEXP y, bool na_equal) {
+bool equal_object(SEXP x, SEXP y) {
   SEXPTYPE type = TYPEOF(x);
 
   if (type != TYPEOF(y)) {
     return false;
   }
 
-  // Pointer comparison is safe for these types
+  // Pointer comparison is all that is required for these types
   switch (type) {
   case NILSXP:
-    return x == y ? (na_equal ? true : NA_LOGICAL) : false;
   case SYMSXP:
   case SPECIALSXP:
   case BUILTINSXP:
@@ -267,9 +275,9 @@ int equal_object(SEXP x, SEXP y, bool na_equal) {
     return x == y;
   }
 
-  // For other types, pointer comparison is only relevant when missing
-  // values are not propagated
-  if (na_equal && x == y) {
+  // For other types, try a pointer comparison first before
+  // performing an in depth equality check
+  if (x == y) {
     return true;
   }
 
@@ -288,41 +296,35 @@ int equal_object(SEXP x, SEXP y, bool na_equal) {
   case LANGSXP:
   case LISTSXP:
   case BCODESXP: {
-    if (!obj_equal_attrib(x, y)) {
+    if (!equal_object(ATTRIB(x), ATTRIB(y))) {
       return false;
     }
 
-    int eq;
-    eq = equal_object(CAR(x), CAR(y), na_equal);
-    if (eq <= 0) {
-      return eq;
+    if (!equal_object(CAR(x), CAR(y))) {
+      return false;
     }
 
     x = CDR(x);
     y = CDR(y);
 
-    if (x == R_NilValue && y == R_NilValue) {
-      return true;
+    if (!equal_object(x, y)) {
+      return false;
     }
 
-    eq = equal_object(x, y, na_equal);
-    if (eq <= 0) {
-      return eq;
-    }
     return true;
   }
 
   case CLOSXP:
-    if (!obj_equal_attrib(x, y)) {
+    if (!equal_object(ATTRIB(x), ATTRIB(y))) {
       return false;
     }
-    if (!equal_object(BODY(x), BODY(y), true)) {
+    if (!equal_object(BODY(x), BODY(y))) {
       return false;
     }
-    if (!equal_object(CLOENV(x), CLOENV(y), true)) {
+    if (!equal_object(CLOENV(x), CLOENV(y))) {
       return false;
     }
-    if (!equal_object(FORMALS(x), FORMALS(y), true)) {
+    if (!equal_object(FORMALS(x), FORMALS(y))) {
       return false;
     }
     return true;
@@ -346,46 +348,34 @@ int equal_object(SEXP x, SEXP y, bool na_equal) {
     return false;
   }
 
-  int eq_attr = vec_equal_attrib(x, y, na_equal);
-  if (eq_attr <= 0) {
-    return eq_attr;
+  if (!vec_equal_attrib(x, y)) {
+    return false;
   }
-
-  int eq = true;
 
   switch (type) {
-  case LGLSXP:  EQUAL_ALL(int, LOGICAL_RO, lgl_equal_scalar); break;
-  case INTSXP:  EQUAL_ALL(int, INTEGER_RO, int_equal_scalar); break;
-  case REALSXP: EQUAL_ALL(double, REAL_RO, dbl_equal_scalar); break;
-  case STRSXP:  EQUAL_ALL(SEXP, STRING_PTR_RO, chr_equal_scalar); break;
-  case RAWSXP:  EQUAL_ALL(Rbyte, RAW_RO, raw_equal_scalar); break;
-  case CPLXSXP: EQUAL_ALL(Rcomplex, COMPLEX_RO, cpl_equal_scalar); break;
+  case LGLSXP:  EQUAL_ALL(int, LOGICAL_RO, lgl_equal_scalar);
+  case INTSXP:  EQUAL_ALL(int, INTEGER_RO, int_equal_scalar);
+  case REALSXP: EQUAL_ALL(double, REAL_RO, dbl_equal_scalar);
+  case STRSXP:  EQUAL_ALL(SEXP, STRING_PTR_RO, chr_equal_scalar);
+  case RAWSXP:  EQUAL_ALL(Rbyte, RAW_RO, raw_equal_scalar);
+  case CPLXSXP: EQUAL_ALL(Rcomplex, COMPLEX_RO, cpl_equal_scalar);
   case EXPRSXP:
-  case VECSXP:  EQUAL_ALL_BARRIER(list_equal_scalar); break;
+  case VECSXP:  EQUAL_ALL_BARRIER(list_equal_scalar);
   default:      Rf_errorcall(R_NilValue, "Internal error: Unexpected type in `equal_object()`");
   }
-
-  return eq;
 }
 
 #undef EQUAL_ALL
 #undef EQUAL_ALL_BARRIER
 
 // [[ register() ]]
-SEXP vctrs_equal_object(SEXP x, SEXP y, SEXP na_equal) {
-  return Rf_ScalarLogical(equal_object(x, y, Rf_asLogical(na_equal)));
+SEXP vctrs_equal_object(SEXP x, SEXP y) {
+  return Rf_ScalarLogical(equal_object(x, y));
 }
 
 // TODO: Sort attributes by tag before comparison
 
-// We don't propagate missingness from attributes because any missing
-// values in there are probably actual data
-static inline bool obj_equal_attrib(SEXP x, SEXP y) {
-  return equal_object(ATTRIB(x), ATTRIB(y), true);
-}
-
-// Same as `obj_` variant but propagates NA only for names
-static inline int vec_equal_attrib(SEXP x, SEXP y, bool na_equal) {
+static inline int vec_equal_attrib(SEXP x, SEXP y) {
   SEXP x_attrs = ATTRIB(x);
   SEXP y_attrs = ATTRIB(y);
 
@@ -401,14 +391,8 @@ static inline int vec_equal_attrib(SEXP x, SEXP y, bool na_equal) {
       return false;
     }
 
-    int eq;
-    if (x_tag == R_NamesSymbol) {
-      eq = equal_object(CAR(x_attrs), CAR(y_attrs), na_equal);
-    } else {
-      eq = equal_object(CAR(x_attrs), CAR(y_attrs), true);
-    }
-    if (eq <= 0) {
-      return(eq);
+    if (!equal_object(CAR(x_attrs), CAR(y_attrs))) {
+      return false;
     }
 
     x_attrs = CDR(x_attrs);
@@ -424,7 +408,7 @@ bool equal_names(SEXP x, SEXP y) {
   SEXP x_names = PROTECT(Rf_getAttrib(x, R_NamesSymbol));
   SEXP y_names = PROTECT(Rf_getAttrib(y, R_NamesSymbol));
 
-  bool out = equal_object(x_names, y_names, true);
+  bool out = equal_object(x_names, y_names);
 
   UNPROTECT(2);
   return out;

--- a/src/init.c
+++ b/src/init.c
@@ -17,7 +17,7 @@ extern SEXP vctrs_fields(SEXP);
 extern SEXP vctrs_n_fields(SEXP);
 extern SEXP vctrs_hash(SEXP);
 extern SEXP vctrs_hash_object(SEXP);
-extern SEXP vctrs_equal_object(SEXP, SEXP, SEXP);
+extern SEXP vctrs_equal_object(SEXP, SEXP);
 extern SEXP vctrs_in(SEXP, SEXP);
 extern SEXP vctrs_duplicated(SEXP);
 extern SEXP vctrs_unique_loc(SEXP);
@@ -105,7 +105,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_n_fields",                   (DL_FUNC) &vctrs_n_fields, 1},
   {"vctrs_hash",                       (DL_FUNC) &vctrs_hash, 1},
   {"vctrs_hash_object",                (DL_FUNC) &vctrs_hash_object, 1},
-  {"vctrs_equal_object",               (DL_FUNC) &vctrs_equal_object, 3},
+  {"vctrs_equal_object",               (DL_FUNC) &vctrs_equal_object, 2},
   {"vctrs_in",                         (DL_FUNC) &vctrs_in, 2},
   {"vctrs_unique_loc",                 (DL_FUNC) &vctrs_unique_loc, 1},
   {"vctrs_duplicated",                 (DL_FUNC) &vctrs_duplicated, 1},

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -245,9 +245,9 @@ SEXP chr_assign(SEXP out, SEXP index, SEXP value, bool clone);
 SEXP list_assign(SEXP out, SEXP index, SEXP value, bool clone);
 SEXP df_assign(SEXP out, SEXP index, SEXP value, bool clone);
 
-// Most vector predicates return `int` because missing values are
-// propagated as `NA_LOGICAL`
-int equal_object(SEXP x, SEXP y, bool na_equal);
+// equal_object() never propagates missingness, so
+// it can return a `bool`
+bool equal_object(SEXP x, SEXP y);
 bool equal_names(SEXP x, SEXP y);
 
 /**


### PR DESCRIPTION
Closes #662 

Before:

``` r
library(vctrs)

vec_equal(list(NULL), list(NULL))
#> [1] NA
vec_equal(list(NULL), list(NULL), na_equal = TRUE)
#> [1] TRUE

# this was a bug on my part from a previous PR, oops
vec_equal(list(NULL), list(1))
#> [1] FALSE

vec_equal(list(list(NULL)), list(list(NULL)))
#> [1] NA
vec_equal(list(list(NULL)), list(list(NULL)), na_equal = TRUE)
#> [1] TRUE

vec_equal(list(NA), list(NA))
#> [1] NA
vec_equal(list(NA), list(NA), na_equal = TRUE)
#> [1] TRUE

x <- structure(1, names = NA_character_)
vec_equal(list(x), list(x))
#> [1] NA
```

After:

``` r
library(vctrs)

vec_equal(list(NULL), list(NULL))
#> [1] NA
vec_equal(list(NULL), list(NULL), na_equal = TRUE)
#> [1] TRUE

# fixed!
vec_equal(list(NULL), list(1))
#> [1] NA

vec_equal(list(list(NULL)), list(list(NULL)))
#> [1] TRUE
vec_equal(list(list(NULL)), list(list(NULL)), na_equal = TRUE)
#> [1] TRUE

vec_equal(list(NA), list(NA))
#> [1] TRUE
vec_equal(list(NA), list(NA), na_equal = TRUE)
#> [1] TRUE

x <- structure(1, names = NA_character_)
vec_equal(list(x), list(x))
#> [1] TRUE
```