### PR TITLE
Return a bare list from `vec_chop()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 * `vec_proxy_equal()` is now applied recursively across the columns of
   data frames (#641).
 
+* `vec_split()` no longer returns the `val` column as a `list_of`. It is now
+  returned as a bare list.
+  
 * Complex numbers are coercible with the integer and
   double (#564).
 

--- a/R/group.R
+++ b/R/group.R
@@ -23,7 +23,7 @@
 #'   * `vec_group_pos()`: A two column data frame with size equal to
 #'     `vec_size(vec_unique(x))`.
 #'     * A `key` column of type `vec_ptype(x)`
-#'     * A `pos` column of type `list_of<integer>`
+#'     * A `pos` column of type list, with elements of type integer.
 #'   * `vec_group_rle()`: A `vctrs_group_rle` rcrd object with two integer
 #'     vector fields: `group` and `length`.
 #'

--- a/R/slice.R
+++ b/R/slice.R
@@ -670,8 +670,8 @@ vec_init <- function(x, n = 1L) {
 #'   would be valid as an index in [vec_slice()]. If `NULL`, `x` is split into
 #'   its individual elements, equivalent to using an `indices` of
 #'   `as.list(vec_seq_along(x))`.
-#' @return A vector of type `list_of<vec_ptype(x)>` and size `vec_size(indices)`
-#'   or, if `indices == NULL`, `vec_size(x)`.
+#' @return A list of size `vec_size(indices)` or, if `indices == NULL`,
+#'   `vec_size(x)`.
 #' @export
 #' @examples
 #' vec_chop(1:5)

--- a/R/split.R
+++ b/R/split.R
@@ -8,7 +8,8 @@
 #' @param by Vector whose unique values defines the groups.
 #' @return A data frame with two columns and size equal to
 #'   `vec_size(vec_unique(by))`. The `key` column has the same type as
-#'   `by`, and the `val` column has type `list_of<vec_ptype(x)>`.
+#'   `by`, and the `val` column is a list containing elements of type
+#'   `vec_ptype(x)`.
 #'
 #'   Note for complex types, the default `data.frame` print method will be
 #'   suboptimal, and you will want to coerce into a tibble to better

--- a/man/vec_chop.Rd
+++ b/man/vec_chop.Rd
@@ -16,8 +16,8 @@ its individual elements, equivalent to using an \code{indices} of
 \code{as.list(vec_seq_along(x))}.}
 }
 \value{
-A vector of type \verb{list_of<vec_ptype(x)>} and size \code{vec_size(indices)}
-or, if \code{indices == NULL}, \code{vec_size(x)}.
+A list of size \code{vec_size(indices)} or, if \code{indices == NULL},
+\code{vec_size(x)}.
 }
 \description{
 \code{vec_chop()} provides an efficient method to repeatedly slice a vector. It

--- a/man/vec_group.Rd
+++ b/man/vec_group.Rd
@@ -23,7 +23,7 @@ vec_group_rle(x)
 \code{vec_size(vec_unique(x))}.
 \itemize{
 \item A \code{key} column of type \code{vec_ptype(x)}
-\item A \code{pos} column of type \verb{list_of<integer>}
+\item A \code{pos} column of type list, with elements of type integer.
 }
 \item \code{vec_group_rle()}: A \code{vctrs_group_rle} rcrd object with two integer
 vector fields: \code{group} and \code{length}.

--- a/man/vec_split.Rd
+++ b/man/vec_split.Rd
@@ -14,7 +14,8 @@ vec_split(x, by)
 \value{
 A data frame with two columns and size equal to
 \code{vec_size(vec_unique(by))}. The \code{key} column has the same type as
-\code{by}, and the \code{val} column has type \verb{list_of<vec_ptype(x)>}.
+\code{by}, and the \code{val} column is a list containing elements of type
+\code{vec_ptype(x)}.
 
 Note for complex types, the default \code{data.frame} print method will be
 suboptimal, and you will want to coerce into a tibble to better

--- a/src/bind.c
+++ b/src/bind.c
@@ -171,9 +171,6 @@ static SEXP as_df_row_impl(SEXP x, enum name_repair_arg name_repair, bool quiet)
 
   x = PROTECT_N(vec_chop(x, R_NilValue), &nprot);
 
-  // Clear list_of class info
-  SET_ATTRIB(x, R_NilValue);
-
   r_poke_names(x, nms);
 
   x = new_data_frame(x, 1);

--- a/src/group.c
+++ b/src/group.c
@@ -192,7 +192,6 @@ SEXP vec_group_pos(SEXP x) {
   }
 
   SEXP out_pos = PROTECT_N(Rf_allocVector(VECSXP, n_groups), &nprot);
-  init_list_of(out_pos, vctrs_shared_empty_int);
 
   // Initialize `out_pos` to a list of integers with sizes corresponding
   // to the number of elements in that group

--- a/src/slice.c
+++ b/src/slice.c
@@ -805,14 +805,6 @@ SEXP vctrs_chop(SEXP x, SEXP indices) {
 
 // [[ include("vctrs.h") ]]
 SEXP vec_chop(SEXP x, SEXP indices) {
-  SEXP out = PROTECT(vec_chop_impl(x, indices));
-  init_list_of(out, vec_type(x));
-
-  UNPROTECT(1);
-  return out;
-}
-
-static SEXP vec_chop_impl(SEXP x, SEXP indices) {
   int nprot = 0;
 
   struct vctrs_chop_info info = init_chop_info(x, indices);
@@ -941,7 +933,7 @@ static SEXP chop_df(SEXP x, SEXP indices, struct vctrs_chop_info info) {
   // into the appropriate data frame column in the `out` list
   for (int i = 0; i < n_cols; ++i) {
     SEXP col = VECTOR_ELT(info.proxy_info.proxy, i);
-    SEXP split = PROTECT(vec_chop_impl(col, indices));
+    SEXP split = PROTECT(vec_chop(col, indices));
 
     for (int j = 0; j < info.out_size; ++j) {
       elt = VECTOR_ELT(info.out, j);

--- a/src/split.c
+++ b/src/split.c
@@ -12,6 +12,7 @@ SEXP vec_split(SEXP x, SEXP by) {
   SEXP indices = VECTOR_ELT(out, 1);
 
   SEXP val = vec_chop(x, indices);
+  init_list_of(val, vec_type(x));
   SET_VECTOR_ELT(out, 1, val);
 
   SEXP names = PROTECT(Rf_getAttrib(out, R_NamesSymbol));

--- a/src/split.c
+++ b/src/split.c
@@ -12,7 +12,6 @@ SEXP vec_split(SEXP x, SEXP by) {
   SEXP indices = VECTOR_ELT(out, 1);
 
   SEXP val = vec_chop(x, indices);
-  init_list_of(val, vec_type(x));
   SET_VECTOR_ELT(out, 1, val);
 
   SEXP names = PROTECT(Rf_getAttrib(out, R_NamesSymbol));

--- a/tests/testthat/test-group.R
+++ b/tests/testthat/test-group.R
@@ -143,7 +143,7 @@ test_that("can locate unique groups of an empty vector", {
 
   expect_s3_class(out, "data.frame")
   expect_equal(out$key, integer())
-  expect_equal(out$pos, list_of(.ptype = integer()))
+  expect_equal(out$pos, list())
 })
 
 test_that("can locate unique groups of a data frame", {
@@ -177,11 +177,11 @@ test_that("vec_group_pos takes the equality proxy", {
   local_comparable_tuple()
   x <- tuple(c(1, 2, 1), 1:3)
   expect_equal(vec_group_pos(x)$key, x[1:2])
-  expect_equal(vec_group_pos(x)$pos, list_of(c(1L, 3L), 2L))
+  expect_equal(vec_group_pos(x)$pos, list(c(1L, 3L), 2L))
 
   x <- as.POSIXlt(new_datetime(c(1, 2, 1)))
   expect_equal(vec_group_pos(x)$key, x[1:2])
-  expect_equal(vec_group_pos(x)$pos, list_of(c(1L, 3L), 2L))
+  expect_equal(vec_group_pos(x)$pos, list(c(1L, 3L), 2L))
 })
 
 test_that("vec_group_pos takes the equality proxy recursively", {
@@ -190,7 +190,7 @@ test_that("vec_group_pos takes the equality proxy recursively", {
   x <- tuple(c(1, 2, 1, 1), 1:4)
   df <- data_frame(x = x)
 
-  expect <- data_frame(key = vec_slice(df, c(1, 2)), pos = list_of(c(1L, 3L, 4L), 2L))
+  expect <- data_frame(key = vec_slice(df, c(1, 2)), pos = list(c(1L, 3L, 4L), 2L))
 
   expect_equal(vec_group_pos(df), expect)
 })

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -456,12 +456,12 @@ test_that("vec_chop() throws error with non-vector inputs", {
   expect_error(vec_chop(environment()), class = "vctrs_error_scalar_type")
 })
 
-test_that("atomics are split into a list_of", {
+test_that("atomics are split into a list", {
   x <- 1:5
-  expect_equal(vec_chop(x), as_list_of(as.list(x)))
+  expect_equal(vec_chop(x), as.list(x))
 
   x <- letters[1:5]
-  expect_equal(vec_chop(x), as_list_of(as.list(x)))
+  expect_equal(vec_chop(x), as.list(x))
 })
 
 test_that("atomic names are kept", {
@@ -472,11 +472,11 @@ test_that("atomic names are kept", {
 
 test_that("base R classed objects are split into a list", {
   fctr <- factor(c("a", "b"))
-  expect <- as_list_of(lapply(vec_seq_along(fctr), vec_slice, x = fctr))
+  expect <- lapply(vec_seq_along(fctr), vec_slice, x = fctr)
   expect_equal(vec_chop(fctr), expect)
 
   date <- new_date(c(0, 1))
-  expect <- as_list_of(lapply(vec_seq_along(date), vec_slice, x = date))
+  expect <- lapply(vec_seq_along(date), vec_slice, x = date)
   expect_equal(vec_chop(date), expect)
 })
 
@@ -488,13 +488,13 @@ test_that("base R classed object names are kept", {
 
 test_that("list elements are split", {
   x <- list(1, 2)
-  result <- list_of(vec_slice(x, 1), vec_slice(x, 2))
+  result <- list(vec_slice(x, 1), vec_slice(x, 2))
   expect_equal(vec_chop(x), result)
 })
 
 test_that("data frames are split rowwise", {
   x <- data_frame(x = 1:2, y = c("a", "b"))
-  result <- list_of(vec_slice(x, 1), vec_slice(x, 2))
+  result <- list(vec_slice(x, 1), vec_slice(x, 2))
   expect_equal(vec_chop(x), result)
 })
 
@@ -507,7 +507,7 @@ test_that("data frame row names are kept", {
 
 test_that("matrices / arrays are split rowwise", {
   x <- array(1:12, c(2, 2, 2))
-  result <- list_of(vec_slice(x, 1), vec_slice(x, 2))
+  result <- list(vec_slice(x, 1), vec_slice(x, 2))
   expect_equal(vec_chop(x), result)
 })
 
@@ -557,14 +557,14 @@ test_that("`indices` are validated", {
 })
 
 test_that("size 0 `indices` list is allowed", {
-  expect_equal(vec_chop(1, list()), list_of(.ptype = numeric()))
+  expect_equal(vec_chop(1, list()), list())
 })
 
 test_that("individual index values of size 0 are allowed", {
-  expect_equal(vec_chop(1, list(integer())), list_of(numeric()))
+  expect_equal(vec_chop(1, list(integer())), list(numeric()))
 
   df <- data.frame(a = 1, b = "1")
-  expect_equal(vec_chop(df, list(integer())), list_of(vec_ptype(df)))
+  expect_equal(vec_chop(df, list(integer())), list(vec_ptype(df)))
 })
 
 test_that("data frame row names are kept when `indices` are used", {
@@ -621,7 +621,7 @@ test_that("fallback method with `indices` works", {
 
   expect_equal(
     vec_chop(fctr, indices),
-    as_list_of(map(indices, vec_slice, x = fctr))
+    map(indices, vec_slice, x = fctr)
   )
 })
 

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -771,17 +771,17 @@ test_that("can subset S3 objects using the fallback method with compact seqs", {
 test_that("can chop base vectors with compact seqs", {
   start <- 1L
   size <- 2L
-  expect_identical(vec_chop_seq(lgl(1, 0, 1), start, size), list_of(lgl(0, 1)))
-  expect_identical(vec_chop_seq(int(1, 2, 3), start, size), list_of(int(2, 3)))
-  expect_identical(vec_chop_seq(dbl(1, 2, 3), start, size), list_of(dbl(2, 3)))
-  expect_identical(vec_chop_seq(cpl(1, 2, 3), start, size), list_of(cpl(2, 3)))
-  expect_identical(vec_chop_seq(chr("1", "2", "3"), start, size), list_of(chr("2", "3")))
-  expect_identical(vec_chop_seq(bytes(1, 2, 3), start, size), list_of(bytes(2, 3)))
-  expect_identical(vec_chop_seq(list(1, 2, 3), start, size), list_of(list(2, 3)))
+  expect_identical(vec_chop_seq(lgl(1, 0, 1), start, size), list(lgl(0, 1)))
+  expect_identical(vec_chop_seq(int(1, 2, 3), start, size), list(int(2, 3)))
+  expect_identical(vec_chop_seq(dbl(1, 2, 3), start, size), list(dbl(2, 3)))
+  expect_identical(vec_chop_seq(cpl(1, 2, 3), start, size), list(cpl(2, 3)))
+  expect_identical(vec_chop_seq(chr("1", "2", "3"), start, size), list(chr("2", "3")))
+  expect_identical(vec_chop_seq(bytes(1, 2, 3), start, size), list(bytes(2, 3)))
+  expect_identical(vec_chop_seq(list(1, 2, 3), start, size), list(list(2, 3)))
 })
 
 test_that("can chop with a decreasing compact seq", {
-  expect_equal(vec_chop_seq(int(1, 2, 3), 1L, 2L, FALSE), list_of(int(2, 1)))
+  expect_equal(vec_chop_seq(int(1, 2, 3), 1L, 2L, FALSE), list(int(2, 1)))
 })
 
 test_that("can chop with multiple compact seqs", {
@@ -790,15 +790,15 @@ test_that("can chop with multiple compact seqs", {
 
   expect_equal(
     vec_chop_seq(int(1, 2, 3), start, size),
-    list_of(int(2), int(1, 2, 3))
+    list(int(2), int(1, 2, 3))
   )
 })
 
 test_that("can chop S3 objects using the fallback method with compact seqs", {
   x <- factor(c("a", "b", "c", "d"))
-  expect_equal(vec_chop_seq(x, 0L, 0L), list_of(vec_slice(x, integer())))
-  expect_equal(vec_chop_seq(x, 0L, 1L), list_of(vec_slice(x, 1L)))
-  expect_equal(vec_chop_seq(x, 2L, 2L), list_of(vec_slice(x, 3:4)))
+  expect_equal(vec_chop_seq(x, 0L, 0L), list(vec_slice(x, integer())))
+  expect_equal(vec_chop_seq(x, 0L, 1L), list(vec_slice(x, 1L)))
+  expect_equal(vec_chop_seq(x, 2L, 2L), list(vec_slice(x, 3:4)))
 })
 
 # Position / index coercion -----------------------------------------------

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -5,7 +5,7 @@ test_that("can split empty vector", {
 
   expect_s3_class(out, "data.frame")
   expect_equal(out$key, character())
-  expect_equal(out$val, list_of(.ptype = integer()))
+  expect_equal(out$val, list())
 })
 
 test_that("split data frame with data frame", {
@@ -14,7 +14,7 @@ test_that("split data frame with data frame", {
 
   expect_s3_class(out, "data.frame")
   expect_equal(out$key, data.frame(x = c(1, 2), y = c(1, 1)))
-  expect_equal(out$val, list_of(
+  expect_equal(out$val, list(
     data.frame(x = c(1, 1), y = c(1, 1)),
     data.frame(x = 2, y = 1)
   ))


### PR DESCRIPTION
Closes #660 

There are two other places we use `list_of` output (below). I have not touched these. I'm not sure if they should continue to return `list_of`s or not. They seem slightly less "low level" compared to `vec_chop()`, so it might be okay to continue returning a `list_of`.

``` r
library(vctrs)
library(tibble)

as_tibble(vec_split(c("a", "b", "a"), c(1, 1, 2)))
#> # A tibble: 2 x 2
#>     key         val
#>   <dbl> <list<chr>>
#> 1     1         [2]
#> 2     2         [1]

as_tibble(vec_group_pos(c("a", "b", "a")))
#> # A tibble: 2 x 2
#>   key           pos
#>   <chr> <list<int>>
#> 1 a             [2]
#> 2 b             [1]
```

Note that `tidyr::nest()` returns a `list_of` column because of a usage of `vec_split()`.