### PR TITLE
Remove backports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ BugReports: https://github.com/r-lib/vctrs/issues
 Depends: 
     R (>= 3.2)
 Imports: 
-    backports,
     ellipsis (>= 0.2.0),
     digest,
     glue,

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,9 @@
+str_dup <- function(x, times) {
+  paste0(rep(x, times = times), collapse = "")
+}
+
 indent <- function(x, n) {
-  pad <- strrep(" ", n)
+  pad <- str_dup(" ", n)
   map_chr(x, gsub, pattern = "(\n+)", replacement = paste0("\\1", pad))
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,7 +1,5 @@
 # nocov start
 .onLoad <- function(libname, pkgname) {
-  backports::import(pkgname, "strrep")
-
   s3_register("generics::as.factor", "vctrs_vctr")
   s3_register("generics::as.ordered", "vctrs_vctr")
   s3_register("generics::as.difftime", "vctrs_vctr")

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -57,7 +57,7 @@ test_that("vec_ptype_common() includes index in argument tag", {
   df2 <- tibble(x = tibble(y = tibble(z = "a")))
 
   # Create a column name too large for default buffer
-  nm <- strrep("foobarfoobar", 10)
+  nm <- str_dup("foobarfoobar", 10)
   large_df1 <- set_names(df1, nm)
   large_df2 <- set_names(df2, nm)
 


### PR DESCRIPTION
I could make `str_dup()` more robust, but for our limited use I figured this was good enough.