### PR TITLE
Remove extra call to `vec_type()`

### DIFF
--- a/src/type.c
+++ b/src/type.c
@@ -117,8 +117,6 @@ SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype) {
 
 
 static SEXP vctrs_type2_common(SEXP current, SEXP next, struct counters* counters) {
-  next = PROTECT(vec_type(next));
-
   int left;
   current = vec_type2(current, next, counters->curr_arg, counters->next_arg, &left);
 
@@ -128,7 +126,6 @@ static SEXP vctrs_type2_common(SEXP current, SEXP next, struct counters* counter
     counters_shift(counters);
   }
 
-  UNPROTECT(1);
   return current;
 }
 


### PR DESCRIPTION
There is a call to `vec_type()` in `vctrs_type2_common()` that I think is extraneous. Removing it does not break any tests, and looking at `vec_type2()` I don't see why it would be required to call this here.

Decent benefits for `vec_ptype_common()` from this.

``` r
library(vctrs)
library(tibble)

x <- 1

lst_of_x <- rep_len(list(x), 1e4)

df <- data.frame(x = 1, y = 2, z = 3)
tbl <- as_tibble(df)

lst_of_df <- rep_len(list(df), 1e4)
lst_of_tbl <- rep_len(list(tbl), 1e4)
```

```r
bench::mark(
  vec_ptype_common(!!! lst_of_x),
  iterations = 5000
)

# before

#> # A tibble: 1 x 6
#>   expression                        min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                    <bch:t> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype_common(!!!lst_of_x)   474µs  509µs     1887.     6.5KB    0.377

# after

#> # A tibble: 1 x 6
#>   expression                        min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                    <bch:t> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype_common(!!!lst_of_x)   298µs  336µs     2900.     6.5KB    0.580
```

```r
bench::mark(
  vec_ptype_common(!!! lst_of_df),
  iterations = 500
)

# before 

#> # A tibble: 1 x 6
#>   expression                        min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype_common(!!!lst_of_df) 19.8ms 27.3ms      37.0        0B     32.3

# after

#> # A tibble: 1 x 6
#>   expression                        min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype_common(!!!lst_of_df) 14.4ms   17ms      57.9        0B     25.1
```

```r
bench::mark(
  vec_ptype_common(!!! lst_of_tbl),
  iterations = 500
)

# before

#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 x 6
#>   expression                        min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                      <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype_common(!!!lst_of_tbl) 101ms  117ms      8.51    16.7KB     17.4

# after 

#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 x 6
#>   expression                         min median `itr/sec` mem_alloc
#>   <bch:expr>                      <bch:> <bch:>     <dbl> <bch:byt>
#> 1 vec_ptype_common(!!!lst_of_tbl) 73.8ms 90.1ms      11.2    16.7KB
#> # … with 1 more variable: `gc/sec` <dbl>
```