### PR TITLE
Ensure that `NA` names are repaired when slicing with `compact_rep`s

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -679,3 +679,8 @@ vec_chop <- function(x, indices = NULL) {
 vec_slice_seq <- function(x, start, size, increasing = TRUE) {
   .Call(vctrs_slice_seq, x, start, size, increasing)
 }
+
+# Exposed for testing (`i` is 1-based)
+vec_slice_rep <- function(x, i, n) {
+  .Call(vctrs_slice_rep, x, i, n)
+}

--- a/src/init.c
+++ b/src/init.c
@@ -47,6 +47,7 @@ extern SEXP vctrs_as_index(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_slice(SEXP, SEXP);
 extern SEXP vctrs_chop(SEXP, SEXP);
 extern SEXP vec_slice_seq(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vec_slice_rep(SEXP, SEXP, SEXP);
 extern SEXP vec_restore(SEXP, SEXP, SEXP);
 extern SEXP vec_restore_default(SEXP, SEXP);
 extern SEXP vec_proxy(SEXP);
@@ -136,6 +137,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 2},
   {"vctrs_chop",                       (DL_FUNC) &vctrs_chop, 2},
   {"vctrs_slice_seq",                  (DL_FUNC) &vec_slice_seq, 4},
+  {"vctrs_slice_rep",                  (DL_FUNC) &vec_slice_rep, 3},
   {"vctrs_restore",                    (DL_FUNC) &vec_restore, 3},
   {"vctrs_restore_default",            (DL_FUNC) &vec_restore_default, 2},
   {"vctrs_proxy",                      (DL_FUNC) &vec_proxy, 1},

--- a/src/slice.c
+++ b/src/slice.c
@@ -247,8 +247,13 @@ static SEXP vec_slice_base(enum vctrs_type type, SEXP x, SEXP index) {
 
 // Replace any `NA` name caused by `NA` index with the empty
 // string. It's ok mutate the names vector since it is freshly
-// created (and the empty string is persistently protected anyway).
+// created, but we make an additional check for that anyways
+// (and the empty string is persistently protected anyway).
 static void repair_na_names(SEXP names, SEXP index) {
+  if (!NO_REFERENCES(names)) {
+    Rf_errorcall(R_NilValue, "Internal error: `names` must not be referenced.");
+  }
+
   // No possible way to have `NA_integer_` in a compact seq
   if (is_compact_seq(index)) {
     return;

--- a/src/slice.c
+++ b/src/slice.c
@@ -249,6 +249,11 @@ static SEXP vec_slice_base(enum vctrs_type type, SEXP x, SEXP index) {
 // string. It's ok mutate the names vector since it is freshly
 // created (and the empty string is persistently protected anyway).
 static void repair_na_names(SEXP names, SEXP index) {
+  // No possible way to have `NA_integer_` in a compact seq
+  if (is_compact_seq(index)) {
+    return;
+  }
+
   R_len_t n = Rf_length(names);
 
   if (n == 0) {

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -632,6 +632,17 @@ test_that("vec_chop() falls back to `[` for shaped objects with no proxy when in
   expect_equal(result, x)
 })
 
+# vec_slice + compact_rep -------------------------------------------------
+
+# `i` is 1-based
+
+test_that("names are repaired correctly with compact reps and `NA_integer_`", {
+  x <- list(a = 1L, b = 2L)
+  expect <- set_names(list(NULL, NULL), c("", ""))
+
+  expect_equal(vec_slice_rep(x, NA_integer_, 2L), expect)
+})
+
 # vec_slice + compact_seq -------------------------------------------------
 
 # `start` is 0-based


### PR DESCRIPTION
Closes #676 
Closes tidyverse/tidyr#802

`slice_names()`'s name repair for `NA` names didn't handle `compact_rep` objects, so the internal `vec_init()` calls in `vec_rbind()` and `vec_c()` were generating incorrectly repaired names.

It handles them correctly now, and we also have `vec_slice_rep()` exported to the R side for testing.

Before

``` r
library(vctrs)

problem <- list(name1 = 1L, name2 = 2L)
x <- vctrs:::data_frame(col = problem)

vec_c(x)$col
#> [[1]]
#> [1] 1
#> 
#> $<NA>
#> [1] 2

vec_rbind(x)$col
#> [[1]]
#> [1] 1
#> 
#> $<NA>
#> [1] 2
```

<sup>Created on 2019-11-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>

After

``` r
library(vctrs)

problem <- list(name1 = 1L, name2 = 2L)
x <- vctrs:::data_frame(col = problem)

vec_c(x)$col
#> [[1]]
#> [1] 1
#> 
#> [[2]]
#> [1] 2

vec_rbind(x)$col
#> [[1]]
#> [1] 1
#> 
#> [[2]]
#> [1] 2

vctrs:::vec_slice_rep(problem, NA_integer_, 2L)
#> [[1]]
#> NULL
#> 
#> [[2]]
#> NULL
```

<sup>Created on 2019-11-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>