### PR TITLE
Use `R_len_t n` in `vec_restore()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vctrs
 Title: Vector Helpers
-Version: 0.2.0.9007
+Version: 0.2.0.9008
 Authors@R: 
     c(person(given = "Hadley",
              family = "Wickham",

--- a/inst/include/vctrs.c
+++ b/inst/include/vctrs.c
@@ -1,7 +1,6 @@
 #include "vctrs.h"
 
 SEXP (*vec_proxy)(SEXP) = NULL;
-SEXP (*vec_restore)(SEXP, SEXP, SEXP) = NULL;
 SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool) = NULL;
 SEXP (*vec_slice_impl)(SEXP, SEXP) = NULL;
 SEXP (*vec_names)(SEXP) = NULL;
@@ -9,7 +8,6 @@ SEXP (*vec_set_names)(SEXP, SEXP) = NULL;
 
 void vctrs_init_api() {
   vec_proxy = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_proxy");
-  vec_restore = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vec_restore");
   vec_assign_impl = (SEXP (*)(SEXP, SEXP, SEXP, bool)) R_GetCCallable("vctrs", "vec_assign_impl");
   vec_slice_impl = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_slice_impl");
   vec_names = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_names");

--- a/inst/include/vctrs.h
+++ b/inst/include/vctrs.h
@@ -6,7 +6,6 @@
 #include <stdbool.h>
 
 SEXP (*vec_proxy)(SEXP);
-SEXP (*vec_restore)(SEXP, SEXP, SEXP);
 SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool);
 SEXP (*vec_slice_impl)(SEXP, SEXP);
 SEXP (*vec_names)(SEXP);

--- a/src/bind.c
+++ b/src/bind.c
@@ -305,7 +305,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, enum name_repair_arg name_
   names = PROTECT(vec_as_names(names, name_repair, false));
   Rf_setAttrib(out, R_NamesSymbol, names);
 
-  out = vec_restore(out, type, R_NilValue);
+  out = vec_restore(out, type, VCTRS_UNKNOWN_SIZE);
 
   UNPROTECT(8);
   return out;

--- a/src/bind.c
+++ b/src/bind.c
@@ -305,7 +305,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, enum name_repair_arg name_
   names = PROTECT(vec_as_names(names, name_repair, false));
   Rf_setAttrib(out, R_NamesSymbol, names);
 
-  out = vec_restore(out, type, VCTRS_UNKNOWN_SIZE);
+  out = vec_restore(out, type, NA_INTEGER);
 
   UNPROTECT(8);
   return out;

--- a/src/c.c
+++ b/src/c.c
@@ -108,7 +108,7 @@ static SEXP vec_c(SEXP xs,
     UNPROTECT(1);
   }
 
-  out = vec_restore(out, ptype, R_NilValue);
+  out = vec_restore(out, ptype, VCTRS_UNKNOWN_SIZE);
 
   if (has_names) {
     out_names = PROTECT(vec_as_names(out_names, name_repair, false));

--- a/src/c.c
+++ b/src/c.c
@@ -108,7 +108,7 @@ static SEXP vec_c(SEXP xs,
     UNPROTECT(1);
   }
 
-  out = vec_restore(out, ptype, VCTRS_UNKNOWN_SIZE);
+  out = vec_restore(out, ptype, NA_INTEGER);
 
   if (has_names) {
     out_names = PROTECT(vec_as_names(out_names, name_repair, false));

--- a/src/cast.c
+++ b/src/cast.c
@@ -522,7 +522,7 @@ SEXP vec_restore(SEXP x, SEXP to, R_len_t n) {
     // first restore data frames as such before calling the restore
     // method, if any
     SEXP out = PROTECT(vctrs_df_restore(x, to, n));
-    out = vec_restore_dispatch(x, to, n);
+    out = vec_restore_dispatch(out, to, n);
     UNPROTECT(1);
     return out;
   }}

--- a/src/cast.c
+++ b/src/cast.c
@@ -258,7 +258,7 @@ static SEXP df_as_dataframe(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vct
   // `to` might not have any columns to compute the original size.
   init_data_frame(out, size);
 
-  out = PROTECT(vec_restore(out, to, VCTRS_UNKNOWN_SIZE));
+  out = PROTECT(vec_restore(out, to, NA_INTEGER));
 
   R_len_t extra_len = Rf_length(x) - common_len;
   if (extra_len) {
@@ -480,7 +480,7 @@ SEXP vctrs_df_restore(SEXP x, SEXP to, R_len_t n) {
                  Rf_type2char(TYPEOF(x)));
   }
 
-  if (n == VCTRS_UNKNOWN_SIZE) {
+  if (n == NA_INTEGER) {
     n = df_raw_size(x);
   }
 
@@ -507,8 +507,7 @@ SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size) {
 
 static SEXP vec_restore_dispatch(SEXP x, SEXP to, R_len_t n);
 
-// If `n = -1`, the size is considered to be unknown.
-// This is better specified as `n = VCTRS_UNKNOWN_SIZE`.
+// If `n = NA_INTEGER`, the size is considered to be unknown.
 
 // [[ include("vctrs.h") ]]
 SEXP vec_restore(SEXP x, SEXP to, R_len_t n) {
@@ -530,12 +529,12 @@ SEXP vec_restore(SEXP x, SEXP to, R_len_t n) {
 
 // [[ register() ]]
 SEXP vctrs_restore(SEXP x, SEXP to, SEXP n_) {
-  R_len_t n = (n_ == R_NilValue) ? VCTRS_UNKNOWN_SIZE : r_int_get(n_, 0);
+  R_len_t n = (n_ == R_NilValue) ? NA_INTEGER : r_int_get(n_, 0);
   return vec_restore(x, to, n);
 }
 
 static SEXP vec_restore_dispatch(SEXP x, SEXP to, R_len_t n) {
-  SEXP n_ = (n == VCTRS_UNKNOWN_SIZE) ? R_NilValue : r_int(n);
+  SEXP n_ = (n == NA_INTEGER) ? R_NilValue : r_int(n);
   PROTECT(n_);
 
   SEXP out = vctrs_dispatch3(

--- a/src/init.c
+++ b/src/init.c
@@ -48,7 +48,7 @@ extern SEXP vctrs_slice(SEXP, SEXP);
 extern SEXP vctrs_chop(SEXP, SEXP);
 extern SEXP vec_slice_seq(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_slice_rep(SEXP, SEXP, SEXP);
-extern SEXP vec_restore(SEXP, SEXP, SEXP);
+extern SEXP vctrs_restore(SEXP, SEXP, SEXP);
 extern SEXP vec_restore_default(SEXP, SEXP);
 extern SEXP vec_proxy(SEXP);
 extern SEXP vctrs_unspecified(SEXP);
@@ -88,6 +88,7 @@ extern SEXP vec_assign_impl(SEXP, SEXP, SEXP, bool);
 extern SEXP vec_slice_impl(SEXP, SEXP);
 extern SEXP vec_names(SEXP);
 extern SEXP vec_recycle(SEXP, R_len_t);
+extern SEXP vec_restore(SEXP, SEXP, R_len_t);
 
 // Extremely experimental
 // Exported but not directly available in the API header
@@ -138,7 +139,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_chop",                       (DL_FUNC) &vctrs_chop, 2},
   {"vctrs_slice_seq",                  (DL_FUNC) &vec_slice_seq, 4},
   {"vctrs_slice_rep",                  (DL_FUNC) &vec_slice_rep, 3},
-  {"vctrs_restore",                    (DL_FUNC) &vec_restore, 3},
+  {"vctrs_restore",                    (DL_FUNC) &vctrs_restore, 3},
   {"vctrs_restore_default",            (DL_FUNC) &vec_restore_default, 2},
   {"vctrs_proxy",                      (DL_FUNC) &vec_proxy, 1},
   {"vctrs_unspecified",                (DL_FUNC) &vctrs_unspecified, 1},
@@ -198,7 +199,6 @@ void R_init_vctrs(DllInfo *dll)
 
     // Very experimental
     R_RegisterCCallable("vctrs", "vec_proxy", (DL_FUNC) &vec_proxy);
-    R_RegisterCCallable("vctrs", "vec_restore", (DL_FUNC) &vec_restore);
     R_RegisterCCallable("vctrs", "vec_assign_impl", (DL_FUNC) &vec_assign_impl);
     R_RegisterCCallable("vctrs", "vec_slice_impl", (DL_FUNC) &vec_slice_impl);
     R_RegisterCCallable("vctrs", "vec_names", (DL_FUNC) &vec_names);
@@ -214,6 +214,7 @@ void R_init_vctrs(DllInfo *dll)
     R_RegisterCCallable("vctrs", "short_vec_size", (DL_FUNC) &vec_size);
     R_RegisterCCallable("vctrs", "short_vec_recycle", (DL_FUNC) &vec_recycle);
     R_RegisterCCallable("vctrs", "short_vec_init", (DL_FUNC) &vec_init);
+    R_RegisterCCallable("vctrs", "short_vec_restore", (DL_FUNC) &vec_restore);
 }
 
 

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -45,12 +45,12 @@ SEXP vec_assign(SEXP x, SEXP index, SEXP value) {
   SEXP out;
   if (vec_requires_fallback(x, info) || has_dim(x)) {
     // Restore the value before falling back to `[<-`
-    value = PROTECT(vec_restore(value_proxy, value_orig, R_NilValue));
+    value = PROTECT(vec_restore(value_proxy, value_orig, VCTRS_UNKNOWN_SIZE));
     out = vec_assign_fallback(x, index, value);
     UNPROTECT(1);
   } else {
     out = PROTECT(vec_assign_impl(info.proxy, index, value_proxy, true));
-    out = vec_restore(out, x, R_NilValue);
+    out = vec_restore(out, x, VCTRS_UNKNOWN_SIZE);
     UNPROTECT(1);
   }
 
@@ -237,7 +237,7 @@ SEXP df_assign(SEXP x, SEXP index, SEXP value, bool clone) {
     value_elt = PROTECT(vec_proxy(value_elt));
 
     SEXP assigned = PROTECT(vec_assign_impl(proxy_elt, index, value_elt, clone));
-    assigned = vec_restore(assigned, out_elt, R_NilValue);
+    assigned = vec_restore(assigned, out_elt, VCTRS_UNKNOWN_SIZE);
 
     SET_VECTOR_ELT(out, i, assigned);
     UNPROTECT(3);

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -242,7 +242,7 @@ SEXP df_assign(SEXP x, SEXP index, SEXP value, bool clone) {
     value_elt = PROTECT(vec_proxy(value_elt));
 
     SEXP assigned = PROTECT(vec_assign_impl(proxy_elt, index, value_elt, clone));
-    assigned = vec_restore(assigned, out_elt, VCTRS_UNKNOWN_SIZE);
+    assigned = vec_restore(assigned, out_elt, NA_INTEGER);
 
     SET_VECTOR_ELT(out, i, assigned);
     UNPROTECT(3);

--- a/src/slice.c
+++ b/src/slice.c
@@ -314,7 +314,7 @@ static SEXP slice_rownames(SEXP names, SEXP index) {
 SEXP vec_slice_impl(SEXP x, SEXP index) {
   int nprot = 0;
 
-  SEXP restore_size = PROTECT_N(r_int(vec_index_size(index)), &nprot);
+  R_len_t restore_size = vec_index_size(index);
 
   struct vctrs_proxy_info info = vec_proxy_info(x);
   PROTECT_PROXY_INFO(&info, &nprot);
@@ -694,8 +694,7 @@ SEXP vctrs_as_index(SEXP i, SEXP n, SEXP names, SEXP convert_negative) {
  */
 struct vctrs_chop_info {
   struct vctrs_proxy_info proxy_info;
-  SEXP restore_size;
-  int* p_restore_size;
+  R_len_t restore_size;
   SEXP index;
   int* p_index;
   bool has_indices;
@@ -705,10 +704,9 @@ struct vctrs_chop_info {
 
 #define PROTECT_CHOP_INFO(info, n) do {       \
   PROTECT_PROXY_INFO(&(info)->proxy_info, n); \
-  PROTECT((info)->restore_size);              \
   PROTECT((info)->index);                     \
   PROTECT((info)->out);                       \
-  *n += 3;                                    \
+  *n += 2;                                    \
 } while (0)                                   \
 
 static struct vctrs_chop_info init_chop_info(SEXP x, SEXP indices) {
@@ -719,8 +717,8 @@ static struct vctrs_chop_info init_chop_info(SEXP x, SEXP indices) {
   info.proxy_info = vec_proxy_info(x);
   PROTECT_PROXY_INFO(&info.proxy_info, &nprot);
 
-  info.restore_size = PROTECT_N(r_int(1), &nprot);
-  info.p_restore_size = INTEGER(info.restore_size);
+  // Default to the size required if `indices = NULL`
+  info.restore_size = 1;
 
   info.index = PROTECT_N(r_int(0), &nprot);
   info.p_index = INTEGER(info.index);
@@ -836,7 +834,7 @@ static SEXP chop(SEXP x, SEXP indices, struct vctrs_chop_info info) {
   for (R_len_t i = 0; i < info.out_size; ++i) {
     if (info.has_indices) {
       info.index = VECTOR_ELT(indices, i);
-      *info.p_restore_size = vec_size(info.index);
+      info.restore_size = vec_size(info.index);
     } else {
       ++(*info.p_index);
     }
@@ -906,7 +904,7 @@ static SEXP chop_df(SEXP x, SEXP indices, struct vctrs_chop_info info) {
   // Restore each data frame
   for (int i = 0; i < info.out_size; ++i) {
     if (info.has_indices) {
-      *info.p_restore_size = vec_size(VECTOR_ELT(indices, i));
+      info.restore_size = vec_size(VECTOR_ELT(indices, i));
     }
 
     elt = VECTOR_ELT(info.out, i);
@@ -931,7 +929,7 @@ static SEXP chop_shaped(SEXP x, SEXP indices, struct vctrs_chop_info info) {
   for (R_len_t i = 0; i < info.out_size; ++i) {
     if (info.has_indices) {
       info.index = VECTOR_ELT(indices, i);
-      *info.p_restore_size = vec_size(info.index);
+      info.restore_size = vec_size(info.index);
     } else {
       ++(*info.p_index);
     }
@@ -980,7 +978,7 @@ static SEXP chop_fallback(SEXP x, SEXP indices, struct vctrs_chop_info info) {
   for (R_len_t i = 0; i < info.out_size; ++i) {
     if (info.has_indices) {
       info.index = VECTOR_ELT(indices, i);
-      *info.p_restore_size = vec_size(info.index);
+      info.restore_size = vec_size(info.index);
 
       // Update `i` binding with the new index value
       Rf_defineVar(syms_i, info.index, env);

--- a/src/utils.c
+++ b/src/utils.c
@@ -217,7 +217,7 @@ SEXP map(SEXP x, SEXP (*fn)(SEXP)) {
 
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
-  out = vctrs_df_restore(out, df, vctrs_shared_zero_int);
+  out = vctrs_df_restore(out, df, 0);
 
   UNPROTECT(1);
   return out;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -10,6 +10,7 @@ typedef R_xlen_t r_ssize_t;
 
 #define VCTRS_ASSERT(condition) ((void)sizeof(char[1 - 2*!(condition)]))
 
+#define VCTRS_UNKNOWN_SIZE -1
 
 // Vector types -------------------------------------------------
 
@@ -203,7 +204,7 @@ enum vctrs_proxy_kind {
 SEXP vec_proxy(SEXP x);
 SEXP vec_proxy_equal(SEXP x);
 SEXP vec_proxy_recursive(SEXP x, enum vctrs_proxy_kind kind);
-SEXP vec_restore(SEXP x, SEXP to, SEXP i);
+SEXP vec_restore(SEXP x, SEXP to, R_len_t n);
 R_len_t vec_size(SEXP x);
 R_len_t vec_size_common(SEXP xs, R_len_t absent);
 SEXP vec_dim(SEXP x);
@@ -239,7 +240,7 @@ bool is_record(SEXP x);
 R_len_t df_size(SEXP x);
 R_len_t df_rownames_size(SEXP x);
 R_len_t df_raw_size(SEXP x);
-SEXP vctrs_df_restore(SEXP x, SEXP to, SEXP n);
+SEXP vctrs_df_restore(SEXP x, SEXP to, R_len_t n);
 SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size);
 
 SEXP chr_assign(SEXP out, SEXP index, SEXP value, bool clone);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -10,7 +10,6 @@ typedef R_xlen_t r_ssize_t;
 
 #define VCTRS_ASSERT(condition) ((void)sizeof(char[1 - 2*!(condition)]))
 
-#define VCTRS_UNKNOWN_SIZE -1
 
 // Vector types -------------------------------------------------
 


### PR DESCRIPTION
Closes #650 

The main benefits from `vec_restore()` taking a `R_len_t n` value are that `vec_slice_impl()` and `vec_chop()` are slightly simpler because they don't have to manage a `SEXP` value for `n`.

There are two changes that were made to support this:
- `VCTRS_UNKNOWN_SIZE` is the replacement for passing `R_NilValue` to `vec_restore()`, and is set to `-1`
- We export `short_vec_restore()` as a callable (for slide) rather than `vec_restore()`

In the third commit I also found a pre-existing bug, and I'm not sure how it wasn't breaking things already.