### PR TITLE
Clarify unique repair of `...` + a sequence of digits

### DIFF
--- a/R/names.R
+++ b/R/names.R
@@ -15,7 +15,7 @@
 #'   `minimal`.
 #'
 #' * `unique` names are `minimal`, have no duplicates, and can be used
-#'   where a variable name is expected.  Empty names, and `...` or
+#'   where a variable name is expected.  Empty names, and
 #'   `..` followed by a sequence of digits are banned.
 #'
 #'   - All columns can be accessed by name via `df[["name"]]` and
@@ -77,9 +77,9 @@
 #'
 #' `unique` names are `minimal`, have no duplicates, and can be used
 #'  (possibly with backticks) in contexts where a variable is
-#'  expected. Empty names, and `...` or `..` followed by a sequence of
-#'  digits are banned If a data frame has `unique` names, you can
-#'  index it by name, and also access the columns by name.  In
+#'  expected. Empty names, and `..` followed by a sequence of
+#'  digits are banned. If a data frame has `unique` names, you can
+#'  index it by name, and also access the columns by name. In
 #'  particular, `df[["name"]]` and `` df$`name` `` and also ``with(df,
 #'  `name`)`` always work.
 #'

--- a/R/names.R
+++ b/R/names.R
@@ -15,7 +15,7 @@
 #'   `minimal`.
 #'
 #' * `unique` names are `minimal`, have no duplicates, and can be used
-#'   where a variable name is expected.  Empty names, and
+#'   where a variable name is expected. Empty names, `...`, and
 #'   `..` followed by a sequence of digits are banned.
 #'
 #'   - All columns can be accessed by name via `df[["name"]]` and
@@ -77,7 +77,7 @@
 #'
 #' `unique` names are `minimal`, have no duplicates, and can be used
 #'  (possibly with backticks) in contexts where a variable is
-#'  expected. Empty names, and `..` followed by a sequence of
+#'  expected. Empty names, `...`, and `..` followed by a sequence of
 #'  digits are banned. If a data frame has `unique` names, you can
 #'  index it by name, and also access the columns by name. In
 #'  particular, `df[["name"]]` and `` df$`name` `` and also ``with(df,

--- a/man/vec_as_names.Rd
+++ b/man/vec_as_names.Rd
@@ -48,7 +48,7 @@ name of an unnamed element is \code{""} and never \code{NA}. For instance,
 created by the tibble package have names that are, at least,
 \code{minimal}.
 \item \code{unique} names are \code{minimal}, have no duplicates, and can be used
-where a variable name is expected.  Empty names, and \code{...} or
+where a variable name is expected.  Empty names, and
 \code{..} followed by a sequence of digits are banned.
 \itemize{
 \item All columns can be accessed by name via \code{df[["name"]]} and
@@ -84,9 +84,9 @@ Examples:\preformatted{Original names of a vector with length 3: NULL
 
 \code{unique} names are \code{minimal}, have no duplicates, and can be used
 (possibly with backticks) in contexts where a variable is
-expected. Empty names, and \code{...} or \code{..} followed by a sequence of
-digits are banned If a data frame has \code{unique} names, you can
-index it by name, and also access the columns by name.  In
+expected. Empty names, and \code{..} followed by a sequence of
+digits are banned. If a data frame has \code{unique} names, you can
+index it by name, and also access the columns by name. In
 particular, \code{df[["name"]]} and \code{df$`name`} and also \code{with(df, `name`)} always work.
 
 There are many ways to make names \code{unique}. We append a suffix of the form

--- a/man/vec_as_names.Rd
+++ b/man/vec_as_names.Rd
@@ -48,7 +48,7 @@ name of an unnamed element is \code{""} and never \code{NA}. For instance,
 created by the tibble package have names that are, at least,
 \code{minimal}.
 \item \code{unique} names are \code{minimal}, have no duplicates, and can be used
-where a variable name is expected.  Empty names, and
+where a variable name is expected. Empty names, \code{...}, and
 \code{..} followed by a sequence of digits are banned.
 \itemize{
 \item All columns can be accessed by name via \code{df[["name"]]} and
@@ -84,7 +84,7 @@ Examples:\preformatted{Original names of a vector with length 3: NULL
 
 \code{unique} names are \code{minimal}, have no duplicates, and can be used
 (possibly with backticks) in contexts where a variable is
-expected. Empty names, and \code{..} followed by a sequence of
+expected. Empty names, \code{...}, and \code{..} followed by a sequence of
 digits are banned. If a data frame has \code{unique} names, you can
 index it by name, and also access the columns by name. In
 particular, \code{df[["name"]]} and \code{df$`name`} and also \code{with(df, `name`)} always work.


### PR DESCRIPTION
I was slightly confused by the `vec_as_names()` docs because it states that for `unique` repair:

"Empty names, and `...` or `..` followed by a sequence of digits are banned."

Are `...1` and `...2` really banned as named? It does not seem like it.

```r
library(vctrs)

vec_as_names(c("..1", "..2"), repair = "unique")
#> New names:
#> * `..1` -> ...1
#> * `..2` -> ...2
#> [1] "...1" "...2"

vec_as_names(c("...1", "...2"), repair = "unique")
#> [1] "...1" "...2"
```