### PR TITLE
Dispatch correctly on `y`

### DIFF
--- a/vignettes/s3-vector.Rmd
+++ b/vignettes/s3-vector.Rmd
@@ -378,7 +378,7 @@ x
 Now consider `vec_cast()` and `vec_ptype2()`. I start with the standard recipes:
 
 ```{r}
-vec_ptype2.vctrs_decimal <- function(x, y, ...) UseMethod("vec_ptype2.vctrs_decimal")
+vec_ptype2.vctrs_decimal <- function(x, y, ...) UseMethod("vec_ptype2.vctrs_decimal", y)
 vec_ptype2.vctrs_decimal.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }


### PR DESCRIPTION
The vignette dispatches on `x` in the `vec_ptype2.vctrs_decimal` generic, when it should dispatch on the second argument.