### PR TITLE
Ignore entire `.github` folder

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,5 +11,4 @@
 ^\.Rproj\.user$
 ^TAGS$
 ^revdep$
-^\.github/workflows/R-CMD-check\.yaml$
-^\.github/workflows/pr-commands\.yaml$
+^\.github$


### PR DESCRIPTION
To keep it from showing up when building the package. Tracked in https://github.com/r-lib/usethis/issues/943