### PR TITLE
Document with roxygen 7.0.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,4 +51,4 @@ Encoding: UTF-8
 Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.1

--- a/man/new_date.Rd
+++ b/man/new_date.Rd
@@ -20,8 +20,7 @@ new_date(x = double())
 
 new_datetime(x = double(), tzone = "")
 
-new_duration(x = double(), units = c("secs", "mins", "hours", "days",
-  "weeks"))
+new_duration(x = double(), units = c("secs", "mins", "hours", "days", "weeks"))
 
 \method{vec_ptype2}{Date}(x, y, ...)
 

--- a/man/new_factor.Rd
+++ b/man/new_factor.Rd
@@ -8,8 +8,7 @@
 \alias{vec_cast.factor}
 \title{Factor/ordered factor S3 class}
 \usage{
-new_factor(x = integer(), levels = character(), ...,
-  class = character())
+new_factor(x = integer(), levels = character(), ..., class = character())
 
 new_ordered(x = integer(), levels = character())
 

--- a/man/new_vctr.Rd
+++ b/man/new_vctr.Rd
@@ -33,8 +33,8 @@ you as they've been carefully planned to be internally consistent.
 \itemize{
 \item \code{[[} and \code{[} use \code{NextMethod()} dispatch to the underlying base function,
 then restore attributes with \code{vec_restore()}.
-\code{rep()} and \code{length<-} work similarly.
-\item \code{[[<-} and \code{[<-} cast \code{value} to same type as \code{x}, then call
+\code{rep()} and \verb{length<-} work similarly.
+\item \verb{[[<-} and \verb{[<-} cast \code{value} to same type as \code{x}, then call
 \code{NextMethod()}.
 \item \code{as.logical()}, \code{as.integer()}, \code{as.numeric()}, \code{as.character()},
 \code{as.Date()} and \code{as.POSIXct()} methods call \code{vec_cast()}.
@@ -55,8 +55,8 @@ use \code{\link[=vec_arith]{vec_arith()}}.
 \code{sum()}, \code{any()}, \code{all()}), the Math group generics (\code{abs()}, \code{sign()},
 etc), \code{mean()}, \code{is.nan()}, \code{is.finite()}, and \code{is.infinite()}
 use \code{\link[=vec_math]{vec_math()}}.
-\item \code{dims()}, \code{dims<-}, \code{dimnames()}, \code{dimnames<-}, \code{levels()}, and
-\code{levels<-} methods throw errors.
+\item \code{dims()}, \verb{dims<-}, \code{dimnames()}, \verb{dimnames<-}, \code{levels()}, and
+\verb{levels<-} methods throw errors.
 }
 }
 

--- a/man/obj_print.Rd
+++ b/man/obj_print.Rd
@@ -35,7 +35,7 @@ obj_str_footer(x, ...)
 }
 \description{
 These are constructed to be more easily extensible since you can override
-the \code{_header()}, \code{_data()} or \code{_footer()} components individually. The
+the \verb{_header()}, \verb{_data()} or \verb{_footer()} components individually. The
 default methods are built on top of \code{format()}.
 }
 \keyword{internal}

--- a/man/s3_register.Rd
+++ b/man/s3_register.Rd
@@ -24,7 +24,7 @@ the old namespace. This might cause crashes because of dangling
 \description{
 Generally, the recommend way to register an S3 method is to use the
 \code{S3Method()} namespace directive (often generated automatically by the
-\code{@export} roxygen2 tag). However, this technique requires that the generic
+\verb{@export} roxygen2 tag). However, this technique requires that the generic
 be in an imported package, and sometimes you want to suggest a package,
 and only provide a method when that package is loaded. \code{s3_register()}
 can be called from your package's \code{.onLoad()} to dynamically register
@@ -37,9 +37,9 @@ For R 3.5.0 and later, \code{s3_register()} is also useful when demonstrating
 class creation in a vignette, since method lookup no longer always involves
 the lexical scope. For R 3.6.0 and later, you can achieve a similar effect
 by using "delayed method registration", i.e. placing the following in your
-\code{NAMESPACE} file:\preformatted{if (getRversion() >= "3.6.0") {
+\code{NAMESPACE} file:\preformatted{if (getRversion() >= "3.6.0") \{
   S3method(package::generic, class)
-}
+\}
 }
 }
 \examples{

--- a/man/vctrs-conditions.Rd
+++ b/man/vctrs-conditions.Rd
@@ -10,21 +10,65 @@
 \alias{allow_lossy_cast}
 \title{Custom conditions for vctrs package}
 \usage{
-stop_incompatible_type(x, y, x_arg = "", y_arg = "", details = NULL,
-  ..., message = NULL, .subclass = NULL)
+stop_incompatible_type(
+  x,
+  y,
+  x_arg = "",
+  y_arg = "",
+  details = NULL,
+  ...,
+  message = NULL,
+  .subclass = NULL
+)
 
-stop_incompatible_cast(x, y, details = NULL, ..., x_arg = "",
-  to_arg = "", message = NULL, .subclass = NULL)
+stop_incompatible_cast(
+  x,
+  y,
+  details = NULL,
+  ...,
+  x_arg = "",
+  to_arg = "",
+  message = NULL,
+  .subclass = NULL
+)
 
-stop_incompatible_op(op, x, y, details = NULL, ..., message = NULL,
-  .subclass = NULL)
+stop_incompatible_op(
+  op,
+  x,
+  y,
+  details = NULL,
+  ...,
+  message = NULL,
+  .subclass = NULL
+)
 
-stop_incompatible_size(x, y, x_size, y_size, x_arg = "", y_arg = "",
-  details = NULL, ..., message = NULL, .subclass = NULL)
+stop_incompatible_size(
+  x,
+  y,
+  x_size,
+  y_size,
+  x_arg = "",
+  y_arg = "",
+  details = NULL,
+  ...,
+  message = NULL,
+  .subclass = NULL
+)
 
-maybe_lossy_cast(result, x, to, lossy = NULL, locations = NULL,
-  details = NULL, ..., x_arg = "", to_arg = "", message = NULL,
-  .subclass = NULL, .deprecation = FALSE)
+maybe_lossy_cast(
+  result,
+  x,
+  to,
+  lossy = NULL,
+  locations = NULL,
+  details = NULL,
+  ...,
+  x_arg = "",
+  to_arg = "",
+  message = NULL,
+  .subclass = NULL,
+  .deprecation = FALSE
+)
 
 allow_lossy_cast(expr, x_ptype = NULL, to_ptype = NULL)
 }
@@ -60,7 +104,7 @@ or \code{to} match these \link[=vec_ptype]{prototypes}.}
 \item{subclass}{Use if you want to further customise the class}
 }
 \value{
-\code{stop_incompatible_*()} unconditionally raise an error of class
+\verb{stop_incompatible_*()} unconditionally raise an error of class
 \code{"vctrs_error_incompatible_*"} and \code{"vctrs_error_incompatible"}.
 }
 \description{

--- a/man/vec_as_index.Rd
+++ b/man/vec_as_index.Rd
@@ -5,11 +5,17 @@
 \alias{vec_as_position}
 \title{Create an index vector or a position}
 \usage{
-vec_as_index(i, n, names = NULL, ..., allow_types = c("indicator",
-  "position", "name"), convert_values = "negative", arg = "i")
+vec_as_index(
+  i,
+  n,
+  names = NULL,
+  ...,
+  allow_types = c("indicator", "position", "name"),
+  convert_values = "negative",
+  arg = "i"
+)
 
-vec_as_position(i, n, names = NULL, ..., allow_values = NULL,
-  arg = "i")
+vec_as_position(i, n, names = NULL, ..., allow_values = NULL, arg = "i")
 }
 \arguments{
 \item{i}{An integer, character or logical vector specifying the positions or

--- a/man/vec_as_names.Rd
+++ b/man/vec_as_names.Rd
@@ -4,8 +4,12 @@
 \alias{vec_as_names}
 \title{Retrieve and repair names}
 \usage{
-vec_as_names(names, ..., repair = c("minimal", "unique", "universal",
-  "check_unique"), quiet = FALSE)
+vec_as_names(
+  names,
+  ...,
+  repair = c("minimal", "unique", "universal", "check_unique"),
+  quiet = FALSE
+)
 }
 \arguments{
 \item{names}{A character vector.}
@@ -112,7 +116,7 @@ repair.
 \item Have no duplicates (inherited from \code{unique}).
 \item Are not \code{...}. Do not have the form \code{..i}, where \code{i} is a
 number (inherited from \code{unique}).
-\item Consist of letters, numbers, and the dot \code{.} or underscore \code{_}
+\item Consist of letters, numbers, and the dot \code{.} or underscore \verb{_}
 characters.
 \item Start with a letter or start with the dot \code{.} not followed by a
 number.

--- a/man/vec_assert.Rd
+++ b/man/vec_assert.Rd
@@ -5,8 +5,7 @@
 \alias{vec_is}
 \title{Assert an argument has known prototype and/or size}
 \usage{
-vec_assert(x, ptype = NULL, size = NULL,
-  arg = as_label(substitute(x)))
+vec_assert(x, ptype = NULL, size = NULL, arg = as_label(substitute(x)))
 
 vec_is(x, ptype = NULL, size = NULL)
 }

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -6,11 +6,19 @@
 \alias{vec_cbind}
 \title{Combine many data frames into one data frame}
 \usage{
-vec_rbind(..., .ptype = NULL, .names_to = NULL,
-  .name_repair = c("unique", "universal", "check_unique"))
+vec_rbind(
+  ...,
+  .ptype = NULL,
+  .names_to = NULL,
+  .name_repair = c("unique", "universal", "check_unique")
+)
 
-vec_cbind(..., .ptype = NULL, .size = NULL,
-  .name_repair = c("unique", "universal", "check_unique", "minimal"))
+vec_cbind(
+  ...,
+  .ptype = NULL,
+  .size = NULL,
+  .name_repair = c("unique", "universal", "check_unique", "minimal")
+)
 }
 \arguments{
 \item{...}{Data frames or vectors.

--- a/man/vec_c.Rd
+++ b/man/vec_c.Rd
@@ -4,8 +4,12 @@
 \alias{vec_c}
 \title{Combine many vectors into one vector}
 \usage{
-vec_c(..., .ptype = NULL, .name_spec = NULL,
-  .name_repair = c("minimal", "unique", "check_unique", "universal"))
+vec_c(
+  ...,
+  .ptype = NULL,
+  .name_spec = NULL,
+  .name_repair = c("minimal", "unique", "check_unique", "universal")
+)
 }
 \arguments{
 \item{...}{Vectors to coerce.}

--- a/man/vec_chop.Rd
+++ b/man/vec_chop.Rd
@@ -16,7 +16,7 @@ its individual elements, equivalent to using an \code{indices} of
 \code{as.list(vec_seq_along(x))}.}
 }
 \value{
-A vector of type \code{list_of<vec_ptype(x)>} and size \code{vec_size(indices)}
+A vector of type \verb{list_of<vec_ptype(x)>} and size \code{vec_size(indices)}
 or, if \code{indices == NULL}, \code{vec_size(x)}.
 }
 \description{

--- a/man/vec_coerce_index.Rd
+++ b/man/vec_coerce_index.Rd
@@ -5,11 +5,14 @@
 \alias{vec_coerce_position}
 \title{Coerce to the base type of a position}
 \usage{
-vec_coerce_index(i, ..., allow_types = c("indicator", "position",
-  "name"), arg = "i")
+vec_coerce_index(
+  i,
+  ...,
+  allow_types = c("indicator", "position", "name"),
+  arg = "i"
+)
 
-vec_coerce_position(i, ..., allow_types = c("position", "name"),
-  arg = "i")
+vec_coerce_position(i, ..., allow_types = c("position", "name"), arg = "i")
 }
 \arguments{
 \item{i}{An integer, character or logical vector specifying the positions or

--- a/man/vec_data.Rd
+++ b/man/vec_data.Rd
@@ -56,15 +56,15 @@ for S3 lists. In vctrs, S3 lists are treated as scalars by
 default. This way we don't treat objects like model fits as
 vectors. To prevent vctrs from treating your S3 list as a scalar,
 unclass it in the \code{vec_proxy()} method. For instance, here is the
-definition for \code{list_of}:\preformatted{vec_proxy.vctrs_list_of <- function(x) {
+definition for \code{list_of}:\preformatted{vec_proxy.vctrs_list_of <- function(x) \{
   unclass(x)
-}
+\}
 }
 
 Another case where you need to implement a proxy is \link[=new_rcrd]{record types}. Record types should return a data frame, as in
-the \code{POSIXlt} method:\preformatted{vec_proxy.POSIXlt <- function(x) {
+the \code{POSIXlt} method:\preformatted{vec_proxy.POSIXlt <- function(x) \{
   new_data_frame(unclass(x))
-}
+\}
 }
 
 Note that you don't need to implement \code{vec_proxy()} when your class

--- a/man/vec_group.Rd
+++ b/man/vec_group.Rd
@@ -23,7 +23,7 @@ vec_group_rle(x)
 \code{vec_size(vec_unique(x))}.
 \itemize{
 \item A \code{key} column of type \code{vec_ptype(x)}
-\item A \code{pos} column of type \code{list_of<integer>}
+\item A \code{pos} column of type \verb{list_of<integer>}
 }
 \item \code{vec_group_rle()}: A \code{vctrs_group_rle} rcrd object with two integer
 vector fields: \code{group} and \code{length}.

--- a/man/vec_order.Rd
+++ b/man/vec_order.Rd
@@ -5,11 +5,9 @@
 \alias{vec_sort}
 \title{Order and sort vectors}
 \usage{
-vec_order(x, direction = c("asc", "desc"), na_value = c("largest",
-  "smallest"))
+vec_order(x, direction = c("asc", "desc"), na_value = c("largest", "smallest"))
 
-vec_sort(x, direction = c("asc", "desc"), na_value = c("largest",
-  "smallest"))
+vec_sort(x, direction = c("asc", "desc"), na_value = c("largest", "smallest"))
 }
 \arguments{
 \item{x}{A vector}

--- a/man/vec_slice.Rd
+++ b/man/vec_slice.Rd
@@ -53,7 +53,7 @@ cause an error if they don't implement a \code{\link[=vec_proxy]{vec_proxy()}} m
 \item \code{vec_slice()} only slices along one dimension. For
 two-dimensional types, the first dimension is subsetted.
 \item \code{vec_slice()} preserves attributes by default.
-\item \code{vec_slice<-()} is type-stable and always returns the same type
+\item \verb{vec_slice<-()} is type-stable and always returns the same type
 as the LHS.
 }
 }

--- a/man/vec_split.Rd
+++ b/man/vec_split.Rd
@@ -14,7 +14,7 @@ vec_split(x, by)
 \value{
 A data frame with two columns and size equal to
 \code{vec_size(vec_unique(by))}. The \code{key} column has the same type as
-\code{by}, and the \code{val} column has type \code{list_of<vec_ptype(x)>}.
+\code{by}, and the \code{val} column has type \verb{list_of<vec_ptype(x)>}.
 
 Note for complex types, the default \code{data.frame} print method will be
 suboptimal, and you will want to coerce into a tibble to better


### PR DESCRIPTION
It's interesting to see what has been converted to verb still. Notably `\verb{length<-}` and `\verb{@export}` and this (even with parentheses) `\verb{vec_slice<-()}`. Maybe it needs backticks because it's not syntactic?