### PR TITLE
Call C level `vctrs_init()` from R level `vec_init()`

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -650,7 +650,10 @@ vec_index <- function(x, i, ...) {
 #' vec_init(Sys.Date(), 5)
 #' vec_init(mtcars, 2)
 vec_init <- function(x, n = 1L) {
-  vec_slice(x, rep_len(NA_integer_, n))
+  n <- vec_cast(n, integer())
+  vec_assert(n, size = 1L)
+
+  .Call(vctrs_init, x, n)
 }
 
 #' Repeatedly slice a vector

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -29,7 +29,7 @@
   ns <- ns_env("vctrs")
   env_bind(ns, vec_set_attributes = vec_set_attributes)
 
-  .Call(vctrs_init, ns_env())
+  .Call(vctrs_init_library, ns_env())
 }
 
 # nocov end

--- a/src/init.c
+++ b/src/init.c
@@ -95,7 +95,7 @@ extern SEXP compact_seq(R_len_t, R_len_t, bool);
 extern SEXP init_compact_seq(int*, R_len_t, R_len_t, bool);
 
 // Defined below
-SEXP vctrs_init(SEXP);
+SEXP vctrs_init_library(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
   {"vctrs_list_get",                   (DL_FUNC) &vctrs_list_get, 2},
@@ -128,7 +128,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_compare",                    (DL_FUNC) &vctrs_compare, 3},
   {"vctrs_match",                      (DL_FUNC) &vctrs_match, 2},
   {"vctrs_typeof",                     (DL_FUNC) &vctrs_typeof, 2},
-  {"vctrs_init",                       (DL_FUNC) &vctrs_init, 1},
+  {"vctrs_init_library",               (DL_FUNC) &vctrs_init_library, 1},
   {"vctrs_is_vector",                  (DL_FUNC) &vctrs_is_vector, 1},
   {"vctrs_type2",                      (DL_FUNC) &vctrs_type2, 4},
   {"vctrs_typeof2",                    (DL_FUNC) &vctrs_typeof2, 2},
@@ -229,7 +229,7 @@ void vctrs_init_type_info(SEXP ns);
 void vctrs_init_unspecified(SEXP ns);
 void vctrs_init_utils(SEXP ns);
 
-SEXP vctrs_init(SEXP ns) {
+SEXP vctrs_init_library(SEXP ns) {
   vctrs_init_cast(ns);
   vctrs_init_data(ns);
   vctrs_init_dictionary(ns);

--- a/src/init.c
+++ b/src/init.c
@@ -45,6 +45,7 @@ extern SEXP vctrs_typeof2(SEXP, SEXP);
 extern SEXP vctrs_cast(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_as_index(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_slice(SEXP, SEXP);
+extern SEXP vctrs_init(SEXP, SEXP);
 extern SEXP vctrs_chop(SEXP, SEXP);
 extern SEXP vec_slice_seq(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_slice_rep(SEXP, SEXP, SEXP);
@@ -135,6 +136,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_cast",                       (DL_FUNC) &vctrs_cast, 4},
   {"vctrs_as_index",                   (DL_FUNC) &vctrs_as_index, 4},
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 2},
+  {"vctrs_init",                       (DL_FUNC) &vctrs_init, 2},
   {"vctrs_chop",                       (DL_FUNC) &vctrs_chop, 2},
   {"vctrs_slice_seq",                  (DL_FUNC) &vec_slice_seq, 4},
   {"vctrs_slice_rep",                  (DL_FUNC) &vec_slice_rep, 3},

--- a/src/slice.c
+++ b/src/slice.c
@@ -421,12 +421,21 @@ SEXP vec_slice(SEXP x, SEXP index) {
 
 // [[ include("vctrs.h") ]]
 SEXP vec_init(SEXP x, R_len_t n) {
+  struct vctrs_arg x_arg = new_wrapper_arg(NULL, "x");
+  vec_assert(x, &x_arg);
+
   SEXP i = PROTECT(compact_rep(NA_INTEGER, n));
 
   SEXP out = vec_slice_impl(x, i);
 
   UNPROTECT(1);
   return out;
+}
+
+// [[ register() ]]
+SEXP vctrs_init(SEXP x, SEXP n) {
+  R_len_t n_ = r_int_get(n, 0);
+  return vec_init(x, n_);
 }
 
 // Exported for testing

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -446,7 +446,7 @@ test_that("na of list-array is 1d slice", {
 })
 
 test_that("vec_init() asserts vectorness (#301)", {
-  expect_error(vec_init(NULL), class = "vctrs_error_scalar_type")
+  expect_error(vec_init(NULL, 1L), class = "vctrs_error_scalar_type")
 })
 
 # vec_chop ----------------------------------------------------------------


### PR DESCRIPTION
This is mainly useful to keep the C and R interfaces in line. It would have been easier for me to find the bug in https://github.com/r-lib/vctrs/pull/677 if the R level `vec_init()` had used a `compact_rep()`.

It does have some performance benefits when initializing atomic vectors (from not having to initialize a vector of `NA`s), less so for more complex objects.

Before:

``` r
library(vctrs)

bench::mark(vec_init(1, 1e5), iterations = 1000)
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_init(1, 1e+05)    270µs    364µs     2587.    1.15MB     58.2

bench::mark(vec_init(mtcars, 1e5), iterations = 200)
#> # A tibble: 1 x 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_init(mtcars, 1e+05)   14.5ms   19.6ms      50.3      13MB     60.2
```

<sup>Created on 2019-11-22 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>

After:

``` r
library(vctrs)

bench::mark(vec_init(1, 1e5), iterations = 1000)
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_init(1, 1e+05)   66.2µs    157µs     4523.     861KB     59.6

bench::mark(vec_init(mtcars, 1e5), iterations = 200)
#> # A tibble: 1 x 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_init(mtcars, 1e+05)   14.4ms     19ms      52.7    12.6MB     75.4
```

<sup>Created on 2019-11-22 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>