### PR TITLE
Support Altvec objects in vec_slice

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # vctrs 0.2.0.9000
 
+* `vec_slice()` now support Altvec vectors (@jimhester).
+
 * `vec_proxy_equal()` is now applied recursively across the columns of
   data frames (#641).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # vctrs 0.2.0.9000
 
-* `vec_slice()` now support Altvec vectors (@jimhester).
+* `vec_slice()` now support Altvec vectors (@jimhester, #696).
 
 * `vec_proxy_equal()` is now applied recursively across the columns of
   data frames (#641).

--- a/src/altrep-rle.c
+++ b/src/altrep-rle.c
@@ -2,6 +2,18 @@
 #include "altrep-rle.h"
 #include "altrep.h"
 
+#if (R_VERSION < R_Version(3, 5, 0))
+
+void vctrs_init_altrep_rle(DllInfo* dll) { }
+
+SEXP altrep_rle_Make(SEXP input) {
+  Rf_error("Need R 3.5+ for Altrep support.");
+
+  return R_NilValue;
+}
+
+#else
+
 SEXP altrep_rle_Make(SEXP input) {
 
   SEXP res = R_new_altrep(altrep_rle_class, input, R_NilValue);
@@ -160,3 +172,5 @@ void vctrs_init_altrep_rle(DllInfo* dll) {
   // altstring
   R_set_altstring_Elt_method(altrep_rle_class, altrep_rle_string_Elt);
 }
+
+#endif

--- a/src/altrep-rle.c
+++ b/src/altrep-rle.c
@@ -1,0 +1,162 @@
+#include "vctrs.h"
+#include "altrep-rle.h"
+#include "altrep.h"
+
+SEXP altrep_rle_Make(SEXP input) {
+
+  SEXP res = R_new_altrep(altrep_rle_class, input, R_NilValue);
+
+  MARK_NOT_MUTABLE(res);
+
+  return res;
+}
+
+// ALTREP methods -------------------
+// The length of the object
+inline R_xlen_t altrep_rle_Length(SEXP vec) {
+  SEXP data2 = R_altrep_data2(vec);
+  if (data2 != R_NilValue) {
+    return Rf_xlength(data2);
+  }
+  R_xlen_t sz = 0;
+  SEXP rle = R_altrep_data1(vec);
+  int* rle_p = INTEGER(rle);
+
+  for (R_xlen_t i = 0; i < Rf_xlength(rle); ++i) {
+    sz += rle_p[i];
+  }
+
+  return sz;
+}
+
+// What gets printed when .Internal(inspect()) is used
+Rboolean altrep_rle_Inspect(
+    SEXP x,
+    int pre,
+    int deep,
+    int pvec,
+    void (*inspect_subtree)(SEXP, int, int, int)) {
+  Rprintf(
+      "vroom_rle (len=%d, materialized=%s)\n",
+      altrep_rle_Length(x),
+      R_altrep_data2(x) != R_NilValue ? "T" : "F");
+  return TRUE;
+}
+
+// ALTSTRING methods -----------------
+
+// the element at the index `i`
+SEXP altrep_rle_string_Elt(SEXP vec, R_xlen_t i) {
+  SEXP data2 = R_altrep_data2(vec);
+  if (data2 != R_NilValue) {
+    return STRING_ELT(data2, i);
+  }
+
+  SEXP rle = R_altrep_data1(vec);
+  int* rle_p = INTEGER(rle);
+  SEXP nms = Rf_getAttrib(rle, Rf_install("names"));
+
+  R_xlen_t idx = 0;
+  while (i >= 0 && idx < Rf_xlength(rle)) {
+    i -= rle_p[idx++];
+  }
+
+  return STRING_ELT(nms, idx - 1);
+}
+
+R_xlen_t find_rle_index(int* rle_data, R_xlen_t i, R_xlen_t size) {
+  R_xlen_t idx = 0;
+  while (i >= 0 && idx < size) {
+    i -= rle_data[idx++];
+  }
+  return idx - 1;
+}
+
+
+// This is a simple implementation, a more complex one would produce a
+// altrep_rle object as well
+SEXP altrep_rle_Extract_subset(SEXP x, SEXP indx, SEXP call) {
+  SEXP data2 = R_altrep_data2(x);
+  // If the vector is already materialized, just fall back to the default
+  // implementation
+  if (data2 != R_NilValue) {
+    return NULL;
+  }
+
+  SEXP data1 = R_altrep_data1(x);
+
+  int* index_data = INTEGER(indx);
+  R_xlen_t index_n = Rf_length(indx);
+
+  int* rle_data = INTEGER(data1);
+  R_xlen_t rle_n = Rf_length(data1);
+
+  SEXP nms = Rf_getAttrib(data1, Rf_install("names"));
+
+  SEXP out = PROTECT(Rf_allocVector(STRSXP, index_n));
+
+  for (R_len_t i = 0; i < index_n; ++i) {
+    R_xlen_t rle_idx = find_rle_index(rle_data, index_data[i], rle_n);
+    SET_STRING_ELT(out, i, STRING_ELT(nms, rle_idx));
+  }
+
+  UNPROTECT(1);
+
+  return out;
+}
+
+// --- Altvec
+SEXP altrep_rle_string_Materialize(SEXP vec) {
+  SEXP data2 = R_altrep_data2(vec);
+  if (data2 != R_NilValue) {
+    return data2;
+  }
+
+  R_xlen_t sz = altrep_rle_Length(vec);
+  SEXP rle = R_altrep_data1(vec);
+  int* rle_p = INTEGER(rle);
+
+  SEXP out = PROTECT(Rf_allocVector(STRSXP, sz));
+
+  R_xlen_t idx = 0;
+  SEXP nms = Rf_getAttrib(rle, Rf_install("names"));
+  for (R_xlen_t i = 0; i < Rf_xlength(rle); ++i) {
+    for (R_xlen_t j = 0; j < rle_p[i]; ++j) {
+      SET_STRING_ELT(out, idx++, STRING_ELT(nms, i));
+    }
+  }
+
+  UNPROTECT(1);
+  R_set_altrep_data2(vec, out);
+
+  return out;
+}
+
+void* altrep_rle_Dataptr(SEXP vec, Rboolean writeable) {
+  return STDVEC_DATAPTR(altrep_rle_string_Materialize(vec));
+}
+
+const void* altrep_rle_Dataptr_or_null(SEXP vec) {
+  SEXP data2 = R_altrep_data2(vec);
+  if (data2 == R_NilValue)
+    return NULL;
+
+  return STDVEC_DATAPTR(data2);
+}
+
+// -------- initialize the altrep class with the methods above
+void vctrs_init_altrep_rle(DllInfo* dll) {
+  altrep_rle_class = R_make_altstring_class("altrep_rle", "vctrs", dll);
+
+  // altrep
+  R_set_altrep_Length_method(altrep_rle_class, altrep_rle_Length);
+  R_set_altrep_Inspect_method(altrep_rle_class, altrep_rle_Inspect);
+
+  // altvec
+  R_set_altvec_Dataptr_method(altrep_rle_class, altrep_rle_Dataptr);
+  R_set_altvec_Dataptr_or_null_method(altrep_rle_class, altrep_rle_Dataptr_or_null);
+  R_set_altvec_Extract_subset_method(altrep_rle_class, altrep_rle_Extract_subset);
+
+  // altstring
+  R_set_altstring_Elt_method(altrep_rle_class, altrep_rle_string_Elt);
+}

--- a/src/altrep-rle.c
+++ b/src/altrep-rle.c
@@ -4,6 +4,8 @@
 
 #if (R_VERSION < R_Version(3, 5, 0))
 
+#include <R_ext/Rdynload.h>
+
 void vctrs_init_altrep_rle(DllInfo* dll) { }
 
 SEXP altrep_rle_Make(SEXP input) {

--- a/src/altrep-rle.h
+++ b/src/altrep-rle.h
@@ -3,6 +3,8 @@
 
 #include "altrep.h"
 
+#if (R_VERSION >= R_Version(3, 5, 0))
+
 SEXP altrep_rle_Make(SEXP input);
 R_xlen_t altrep_rle_Length(SEXP vec);
 Rboolean altrep_rle_Inspect(
@@ -19,5 +21,7 @@ const void* altrep_rle_Dataptr_or_null(SEXP vec);
 void vctrs_init_altrep_rle(DllInfo* dll);
 
 static R_altrep_class_t altrep_rle_class;
+
+#endif
 
 #endif

--- a/src/altrep-rle.h
+++ b/src/altrep-rle.h
@@ -1,0 +1,23 @@
+#ifndef ALTREP_RLE_H
+#define ALTREP_RLE_H
+
+#include "altrep.h"
+
+SEXP altrep_rle_Make(SEXP input);
+R_xlen_t altrep_rle_Length(SEXP vec);
+Rboolean altrep_rle_Inspect(
+    SEXP x,
+    int pre,
+    int deep,
+    int pvec,
+    void (*inspect_subtree)(SEXP, int, int, int));
+SEXP altrep_rle_string_Elt(SEXP vec, R_xlen_t i);
+SEXP altrep_rle_Extract_subset(SEXP x, SEXP indx, SEXP call);
+SEXP altrep_rle_string_Materialize(SEXP vec);
+void* altrep_rle_Dataptr(SEXP vec, Rboolean writeable);
+const void* altrep_rle_Dataptr_or_null(SEXP vec);
+void vctrs_init_altrep_rle(DllInfo* dll);
+
+static R_altrep_class_t altrep_rle_class;
+
+#endif

--- a/src/altrep.h
+++ b/src/altrep.h
@@ -1,5 +1,7 @@
-#ifndef API_PROXY_H
-#define API_PROXY_H
+#ifndef ALTREP_H
+#define ALTREP_H
+
+#include "Rversion.h"
 
 #if (R_VERSION < R_Version(3, 5, 0))
 
@@ -47,7 +49,7 @@ typedef struct { ALTVEC_METHODS; } altvec_methods_t;
 #define ALTREP_DISPATCH(fun, ...) DO_DISPATCH(ALTREP, fun, __VA_ARGS__)
 #define ALTVEC_DISPATCH(fun, ...) DO_DISPATCH(ALTVEC, fun, __VA_ARGS__)
 
-SEXP ALTVEC_EXTRACT_SUBSET_PROXY(SEXP x, SEXP indx, SEXP call) {
+static SEXP ALTVEC_EXTRACT_SUBSET_PROXY(SEXP x, SEXP indx, SEXP call) {
   return ALTVEC_DISPATCH(Extract_subset, x, indx, call);
 }
 

--- a/src/altrep.h
+++ b/src/altrep.h
@@ -1,0 +1,56 @@
+#ifndef API_PROXY_H
+#define API_PROXY_H
+
+#if (R_VERSION < R_Version(3, 5, 0))
+
+# define ALTREP(x) false
+# define ALTVEC_EXTRACT_SUBSET_PROXY(x, indx, call) NULL
+
+#else
+
+#include "R_ext/Altrep.h"
+
+#define ALTREP_METHODS                                 \
+  R_altrep_UnserializeEX_method_t UnserializeEX;       \
+  R_altrep_Unserialize_method_t Unserialize;           \
+  R_altrep_Serialized_state_method_t Serialized_state; \
+  R_altrep_DuplicateEX_method_t DuplicateEX;           \
+  R_altrep_Duplicate_method_t Duplicate;               \
+  R_altrep_Coerce_method_t Coerce;                     \
+  R_altrep_Inspect_method_t Inspect;                   \
+  R_altrep_Length_method_t Length
+
+#define ALTVEC_METHODS                               \
+  ALTREP_METHODS;                                    \
+  R_altvec_Dataptr_method_t Dataptr;                 \
+  R_altvec_Dataptr_or_null_method_t Dataptr_or_null; \
+  R_altvec_Extract_subset_method_t Extract_subset
+
+typedef struct { ALTREP_METHODS; } altrep_methods_t;
+typedef struct { ALTVEC_METHODS; } altvec_methods_t;
+
+#define CLASS_METHODS_TABLE(type_class) STDVEC_DATAPTR(type_class)
+
+#define GENERIC_METHODS_TABLE(x, type_class) \
+  ((type_class##_methods_t *) CLASS_METHODS_TABLE(ALTREP_CLASS(x)))
+
+
+#define ALTREP_METHODS_TABLE(x) GENERIC_METHODS_TABLE(x, altrep)
+#define ALTVEC_METHODS_TABLE(x) GENERIC_METHODS_TABLE(x, altvec)
+
+#define DISPATCH_TARGET_HELPER(x, ...) x
+#define DISPATCH_TARGET(...) DISPATCH_TARGET_HELPER(__VA_ARGS__, dummy)
+
+#define DO_DISPATCH(type, fun, ...)					\
+  type##_METHODS_TABLE(DISPATCH_TARGET(__VA_ARGS__))->fun(__VA_ARGS__)
+
+#define ALTREP_DISPATCH(fun, ...) DO_DISPATCH(ALTREP, fun, __VA_ARGS__)
+#define ALTVEC_DISPATCH(fun, ...) DO_DISPATCH(ALTVEC, fun, __VA_ARGS__)
+
+SEXP ALTVEC_EXTRACT_SUBSET_PROXY(SEXP x, SEXP indx, SEXP call) {
+  return ALTVEC_DISPATCH(Extract_subset, x, indx, call);
+}
+
+#endif
+
+#endif

--- a/src/init.c
+++ b/src/init.c
@@ -3,6 +3,7 @@
 #include <stdlib.h> // for NULL
 #include <stdbool.h> // for bool
 #include <R_ext/Rdynload.h>
+#include "altrep-rle.h"
 
 /* FIXME:
    Check these declarations against the C/Fortran source code.
@@ -104,6 +105,10 @@ extern bool vec_is_vector(SEXP);
 // Defined below
 SEXP vctrs_init_library(SEXP);
 
+// Defined in altrep-rle.h
+extern SEXP altrep_rle_Make(SEXP);
+void vctrs_init_altrep_rle(DllInfo* dll);
+
 static const R_CallMethodDef CallEntries[] = {
   {"vctrs_list_get",                   (DL_FUNC) &vctrs_list_get, 2},
   {"vctrs_list_set",                   (DL_FUNC) &vctrs_list_set, 3},
@@ -179,6 +184,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_proxy_recursive",            (DL_FUNC) &vctrs_proxy_recursive, 2},
   {"vctrs_maybe_translate_encoding",   (DL_FUNC) &vctrs_maybe_translate_encoding, 1},
   {"vctrs_maybe_translate_encoding2",  (DL_FUNC) &vctrs_maybe_translate_encoding2, 2},
+  {"vctrs_rle",                        (DL_FUNC) &altrep_rle_Make, 1},
   {NULL, NULL, 0}
 };
 
@@ -228,6 +234,9 @@ void R_init_vctrs(DllInfo *dll)
 
     // Extremely experimental (for dplyr)
     R_RegisterCCallable("vctrs", "vec_is_vector", (DL_FUNC) &vec_is_vector);
+
+    // Altrep classes
+    vctrs_init_altrep_rle(dll);
 }
 
 

--- a/src/slice.c
+++ b/src/slice.c
@@ -1,6 +1,7 @@
 #include "vctrs.h"
 #include "utils.h"
 #include "slice.h"
+#include "altrep.h"
 
 // Initialised at load time
 SEXP syms_vec_slice_fallback = NULL;
@@ -96,7 +97,7 @@ static void stop_index_oob_names(SEXP i, SEXP names) {
 #define SLICE(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE)          \
   if (ALTREP(x)) {                                                 \
     SEXP out;                                                      \
-    out = ALTVEC_EXTRACT_SUBSET(x, index, R_NilValue);             \
+    out = ALTVEC_EXTRACT_SUBSET_PROXY(x, index, R_NilValue);       \
     if (out != NULL) {                                             \
       return out;                                                  \
     }                                                              \

--- a/src/slice.c
+++ b/src/slice.c
@@ -94,6 +94,13 @@ static void stop_index_oob_names(SEXP i, SEXP names) {
   return out
 
 #define SLICE(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE)          \
+  if (ALTREP(x)) {                                                 \
+    SEXP out;                                                      \
+    out = ALTVEC_EXTRACT_SUBSET(x, index, R_NilValue);             \
+    if (out != NULL) {                                             \
+      return out;                                                  \
+    }                                                              \
+  }                                                                \
   if (is_compact_rep(index)) {                                     \
     SLICE_COMPACT_REP(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE); \
   } else if (is_compact_seq(index)) {                              \

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -409,4 +409,6 @@ void stop_recycle_incompatible_size(R_len_t x_size, R_len_t size)
 # define COMPLEX_RO(x) ((const Rcomplex*) COMPLEX(x))
 # define STRING_PTR_RO(x) ((const SEXP*) STRING_PTR(x))
 # define RAW_RO(x) ((const Rbyte*) RAW(x))
+# define ALTREP(x) false
+# define ALTVEC_EXTRACT_SUBSET(x, indx, call) NULL
 #endif

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -410,5 +410,5 @@ void stop_recycle_incompatible_size(R_len_t x_size, R_len_t size)
 # define STRING_PTR_RO(x) ((const SEXP*) STRING_PTR(x))
 # define RAW_RO(x) ((const Rbyte*) RAW(x))
 # define ALTREP(x) false
-# define ALTVEC_EXTRACT_SUBSET(x, indx, call) NULL
+# define ALTVEC_EXTRACT_SUBSET_PROXY(x, indx, call) NULL
 #endif

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -409,6 +409,4 @@ void stop_recycle_incompatible_size(R_len_t x_size, R_len_t size)
 # define COMPLEX_RO(x) ((const Rcomplex*) COMPLEX(x))
 # define STRING_PTR_RO(x) ((const SEXP*) STRING_PTR(x))
 # define RAW_RO(x) ((const Rbyte*) RAW(x))
-# define ALTREP(x) false
-# define ALTVEC_EXTRACT_SUBSET_PROXY(x, indx, call) NULL
 #endif

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -991,6 +991,8 @@ test_that("vec_coerce_position() handles `allow_types`", {
 })
 
 test_that("vec_splice() works with Altrep classes with custom extract methods", {
+  skip_if(getRversion() < "3.5")
+
   x <- .Call(vctrs_rle, c(foo = 10L, bar = 5L))
 
   idx <- c(1, 3, 15)

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -989,3 +989,10 @@ test_that("vec_coerce_position() handles `allow_types`", {
     vec_coerce_position(TRUE, allow_types = c("position", "name"))
   })
 })
+
+test_that("vec_splice() works with Altrep classes with custom extract methods", {
+  x <- .Call(vctrs_rle, c(foo = 10L, bar = 5L))
+
+  idx <- c(1, 3, 15)
+  expect_equal(vec_slice(x, idx), x[idx])
+})


### PR DESCRIPTION
This dispatches to ALTVEC_EXTRACT_SUBSET for altvec objects,
falling back to the normal slicing code if the Altvec object does not
declare a extract_subset method.

For versions of R prior to the introduction of Altvec (< 3.5.0) stub
macros are defined resulting in a dead conditional, which should be
removed by dead code optimizer in the compiler.