### PR TITLE
Use `is_unspecified()` in `vec_cast.list.default()`

### DIFF
--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -413,7 +413,7 @@ vec_cast.list.list <- function(x, to, ...) {
 #' @export
 #' @method vec_cast.list default
 vec_cast.list.default <- function(x, to, ...) {
-  if (inherits(x, "vctrs_unspecified")) {
+  if (is_unspecified(x)) {
     return(vec_init(to, length(x)))
   }
 

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -419,6 +419,8 @@ vec_cast.list.default <- function(x, to, ...) {
 
   out <- lapply(seq_along(x), function(i) x[[i]])
 
+  vec_slice(out, vec_equal_na(x)) <- list(NULL)
+
   if (!is.object(to)) {
     out <- shape_broadcast(out, to)
   }
@@ -433,6 +435,9 @@ vec_cast.list.data.frame <- function(x, to, ...) {
   # equivalent for `vec_get()`
   row.names(x) <- NULL
   out <- vec_chop(x)
+
+  vec_slice(out, vec_equal_na(x)) <- list(NULL)
+
   out
 }
 

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -438,6 +438,10 @@ vec_cast.list.data.frame <- function(x, to, ...) {
 
   vec_slice(out, vec_equal_na(x)) <- list(NULL)
 
+  if (!is.object(to)) {
+    out <- shape_broadcast(out, to)
+  }
+
   out
 }
 

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -320,6 +320,18 @@ test_that("data frames are cast to list row wise (#639)", {
   expect_equal(vec_cast(x, list()), expect)
 })
 
+test_that("Casting atomic `NA` values to list results in a `NULL`", {
+  x <- c(NA, 1)
+  expect <- list(NULL, 1)
+  expect_equal(vec_cast(x, list()), expect)
+})
+
+test_that("Casting data frame `NA` rows to list results in a `NULL`", {
+  x <- data.frame(x = c(NA, NA, 1), y = c(NA, 1, 2))
+  expect <- list(NULL, vec_slice(x, 2), vec_slice(x, 3))
+  expect_equal(vec_cast(x, list()), expect)
+})
+
 # Unspecified
 
 test_that("unspecified can be cast to bare methods", {

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -320,6 +320,16 @@ test_that("data frames are cast to list row wise (#639)", {
   expect_equal(vec_cast(x, list()), expect)
 })
 
+test_that("data frames can be cast to shaped lists", {
+  to <- array(list(), dim = c(0, 2, 1))
+  x <- data.frame(x = 1:2, y = 3:4)
+
+  expect <- list(vec_slice(x, 1), vec_slice(x, 2))
+  expect <- array(expect, dim = c(2, 2, 1))
+
+  expect_equal(vec_cast(x, to), expect)
+})
+
 test_that("Casting atomic `NA` values to list results in a `NULL`", {
   x <- c(NA, 1)
   expect <- list(NULL, 1)

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -302,7 +302,7 @@ test_that("can sort raw", {
 
 test_that("safe casts work as expected", {
   expect_equal(vec_cast(NULL, list()), NULL)
-  expect_equal(vec_cast(NA, list()), list(NA))
+  expect_equal(vec_cast(NA, list()), list(NULL))
   expect_equal(vec_cast(1:2, list()), list(1L, 2L))
   expect_equal(vec_cast(list(1L, 2L), list()), list(1L, 2L))
 })


### PR DESCRIPTION
Before:

``` r
vctrs::vec_cast(NA, list())
#> [[1]]
#> [1] NA
```

After:

``` r
vctrs::vec_cast(NA, list())
#> [[1]]
#> NULL
```

We had a test for the `list(NA)` result, but I'm not sure that's correct?

Open question, what should this return?

``` r
vctrs::vec_cast(c(NA, 1), list())
#> [[1]]
#> [1] NA
#> 
#> [[2]]
#> [1] 1
```

I feel like this should be `list(NULL, 1)`? It would still be reversible, i.e. `vec_cast()`ing back to a double would give the original result.