### PR TITLE
Export `vec_is_vector()` not `vctrs_is_vector()`

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -96,6 +96,9 @@ extern SEXP vec_recycle(SEXP, R_len_t);
 extern SEXP compact_seq(R_len_t, R_len_t, bool);
 extern SEXP init_compact_seq(int*, R_len_t, R_len_t, bool);
 
+// Extremely experimental (for dplyr)
+extern bool vec_is_vector(SEXP);
+
 // Defined below
 SEXP vctrs_init_library(SEXP);
 
@@ -220,7 +223,7 @@ void R_init_vctrs(DllInfo *dll)
     R_RegisterCCallable("vctrs", "short_vec_init", (DL_FUNC) &vec_init);
 
     // Extremely experimental (for dplyr)
-    R_RegisterCCallable("vctrs", "vctrs_is_vector", (DL_FUNC) &vctrs_is_vector);
+    R_RegisterCCallable("vctrs", "vec_is_vector", (DL_FUNC) &vec_is_vector);
 }
 
 


### PR DESCRIPTION
I spoke with @romainfrancois and it seems he wants `vec_is_vector()` not `vctrs_is_vector()` (so it can just return a bool not a SEXP)

Used here where he does the reverse dance back to a bool
https://github.com/tidyverse/dplyr/pull/4646/files#diff-f5eb4fcb92142d5a2359648c78adb5ffR98