### PR TITLE
Only run actions on PRs or the master branch

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,4 +1,10 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 name: R-CMD-check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,7 +4,7 @@ on:
       - master
   pull_request:
     branches:
-      - master
+      - '**'
 
 name: R-CMD-check
 


### PR DESCRIPTION
Instead of running checks on both the feature branch and the pull request this will only  them on pull requests against the master branch and commits to the master