### PR TITLE
Make `vec_chop()` compatible with `compact_seq()`

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -678,6 +678,12 @@ vec_chop <- function(x, indices = NULL) {
   .Call(vctrs_chop, x, indices)
 }
 
+# Exposed for testing  (`starts` is 0-based)
+vec_chop_seq <- function(x, starts, sizes, increasings = TRUE) {
+  args <- vec_recycle_common(starts, sizes, increasings)
+  .Call(vctrs_chop_seq, x, args[[1]], args[[2]], args[[3]])
+}
+
 # Exposed for testing (`start` is 0-based)
 vec_slice_seq <- function(x, start, size, increasing = TRUE) {
   .Call(vctrs_slice_seq, x, start, size, increasing)

--- a/src/init.c
+++ b/src/init.c
@@ -47,6 +47,7 @@ extern SEXP vctrs_as_index(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_slice(SEXP, SEXP);
 extern SEXP vctrs_init(SEXP, SEXP);
 extern SEXP vctrs_chop(SEXP, SEXP);
+extern SEXP vctrs_chop_seq(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_slice_seq(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_slice_rep(SEXP, SEXP, SEXP);
 extern SEXP vec_restore(SEXP, SEXP, SEXP);
@@ -142,6 +143,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 2},
   {"vctrs_init",                       (DL_FUNC) &vctrs_init, 2},
   {"vctrs_chop",                       (DL_FUNC) &vctrs_chop, 2},
+  {"vctrs_chop_seq",                   (DL_FUNC) &vctrs_chop_seq, 4},
   {"vctrs_slice_seq",                  (DL_FUNC) &vec_slice_seq, 4},
   {"vctrs_slice_rep",                  (DL_FUNC) &vec_slice_rep, 3},
   {"vctrs_restore",                    (DL_FUNC) &vec_restore, 3},

--- a/src/slice.c
+++ b/src/slice.c
@@ -805,6 +805,16 @@ static SEXP vec_chop_base(SEXP x, SEXP indices, struct vctrs_chop_info info) {
       Rf_errorcall(R_NilValue, "Can't slice a scalar");
     }
 
+    if (info.has_indices) {
+      for (int i = 0; i < info.out_size; ++i) {
+        SEXP index = VECTOR_ELT(indices, i);
+
+        if (is_compact(index)) {
+          SET_VECTOR_ELT(indices, i, compact_materialize(index));
+        }
+      }
+    }
+
     if (has_dim(x)) {
       return chop_fallback_shaped(x, indices, info);
     }
@@ -845,7 +855,7 @@ static SEXP chop(SEXP x, SEXP indices, struct vctrs_chop_info info) {
   for (R_len_t i = 0; i < info.out_size; ++i) {
     if (info.has_indices) {
       info.index = VECTOR_ELT(indices, i);
-      *info.p_restore_size = vec_size(info.index);
+      *info.p_restore_size = vec_index_size(info.index);
     } else {
       ++(*info.p_index);
     }
@@ -915,7 +925,7 @@ static SEXP chop_df(SEXP x, SEXP indices, struct vctrs_chop_info info) {
   // Restore each data frame
   for (int i = 0; i < info.out_size; ++i) {
     if (info.has_indices) {
-      *info.p_restore_size = vec_size(VECTOR_ELT(indices, i));
+      *info.p_restore_size = vec_index_size(VECTOR_ELT(indices, i));
     }
 
     elt = VECTOR_ELT(info.out, i);
@@ -940,7 +950,7 @@ static SEXP chop_shaped(SEXP x, SEXP indices, struct vctrs_chop_info info) {
   for (R_len_t i = 0; i < info.out_size; ++i) {
     if (info.has_indices) {
       info.index = VECTOR_ELT(indices, i);
-      *info.p_restore_size = vec_size(info.index);
+      *info.p_restore_size = vec_index_size(info.index);
     } else {
       ++(*info.p_index);
     }

--- a/src/slice.c
+++ b/src/slice.c
@@ -762,6 +762,27 @@ static SEXP vec_chop_base(SEXP x, SEXP indices, struct vctrs_chop_info info);
 static SEXP vec_as_indices(SEXP indices, R_len_t n, SEXP names);
 
 // [[ register() ]]
+SEXP vctrs_chop_seq(SEXP x, SEXP starts, SEXP sizes, SEXP increasings) {
+  int* p_starts = INTEGER(starts);
+  int* p_sizes = INTEGER(sizes);
+  int* p_increasings = LOGICAL(increasings);
+
+  int n = Rf_length(starts);
+
+  SEXP indices = PROTECT(Rf_allocVector(VECSXP, n));
+
+  for (int i = 0; i < n; ++i) {
+    SEXP index = compact_seq(p_starts[i], p_sizes[i], p_increasings[i]);
+    SET_VECTOR_ELT(indices, i, index);
+  }
+
+  SEXP out = PROTECT(vec_chop(x, indices));
+
+  UNPROTECT(2);
+  return out;
+}
+
+// [[ register() ]]
 SEXP vctrs_chop(SEXP x, SEXP indices) {
   R_len_t n = vec_size(x);
   SEXP names = PROTECT(vec_names(x));

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -764,6 +764,8 @@ test_that("can subset S3 objects using the fallback method with compact seqs", {
   expect_equal(vec_slice_seq(x, 3L, 2L, FALSE), vec_slice(x, 4:3))
 })
 
+# Position / index coercion -----------------------------------------------
+
 test_that("vec_as_position() returns a position", {
   expect_identical(vec_as_position(2, 2L), 2L)
   expect_identical(vec_as_position("foo", 2L, c("bar", "foo")), 2L)

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -764,6 +764,43 @@ test_that("can subset S3 objects using the fallback method with compact seqs", {
   expect_equal(vec_slice_seq(x, 3L, 2L, FALSE), vec_slice(x, 4:3))
 })
 
+# vec_chop + compact_seq --------------------------------------------------
+
+# `start` is 0-based
+
+test_that("can chop base vectors with compact seqs", {
+  start <- 1L
+  size <- 2L
+  expect_identical(vec_chop_seq(lgl(1, 0, 1), start, size), list_of(lgl(0, 1)))
+  expect_identical(vec_chop_seq(int(1, 2, 3), start, size), list_of(int(2, 3)))
+  expect_identical(vec_chop_seq(dbl(1, 2, 3), start, size), list_of(dbl(2, 3)))
+  expect_identical(vec_chop_seq(cpl(1, 2, 3), start, size), list_of(cpl(2, 3)))
+  expect_identical(vec_chop_seq(chr("1", "2", "3"), start, size), list_of(chr("2", "3")))
+  expect_identical(vec_chop_seq(bytes(1, 2, 3), start, size), list_of(bytes(2, 3)))
+  expect_identical(vec_chop_seq(list(1, 2, 3), start, size), list_of(list(2, 3)))
+})
+
+test_that("can chop with a decreasing compact seq", {
+  expect_equal(vec_chop_seq(int(1, 2, 3), 1L, 2L, FALSE), list_of(int(2, 1)))
+})
+
+test_that("can chop with multiple compact seqs", {
+  start <- c(1L, 0L)
+  size <- c(1L, 3L)
+
+  expect_equal(
+    vec_chop_seq(int(1, 2, 3), start, size),
+    list_of(int(2), int(1, 2, 3))
+  )
+})
+
+test_that("can chop S3 objects using the fallback method with compact seqs", {
+  x <- factor(c("a", "b", "c", "d"))
+  expect_equal(vec_chop_seq(x, 0L, 0L), list_of(vec_slice(x, integer())))
+  expect_equal(vec_chop_seq(x, 0L, 1L), list_of(vec_slice(x, 1L)))
+  expect_equal(vec_chop_seq(x, 2L, 2L), list_of(vec_slice(x, 3:4)))
+})
+
 # Position / index coercion -----------------------------------------------
 
 test_that("vec_as_position() returns a position", {


### PR DESCRIPTION
I would like to register the C callable for `vec_chop()` and be able to pass in a list of compact seqs. The first step to this is to make `vec_chop()` compatible with compact seqs. It was nearly there, this finishes it off and adds tests.