### PR TITLE
Use `new_date()` not `date()`

### DIFF
--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -270,7 +270,7 @@ as.list.vctrs_vctr <- function(x, ...) {
 
 #' @export
 as.Date.vctrs_vctr <- function(x, ...) {
-  vec_cast(x, date())
+  vec_cast(x, new_date())
 }
 
 #' @export


### PR DESCRIPTION
`base::date()` returns a character. We wanted `new_date()`.