### PR TITLE
Use a base type when is OBJECT but class is NULL.

### DIFF
--- a/src/type-info.c
+++ b/src/type-info.c
@@ -114,10 +114,7 @@ SEXP vctrs_is_vector(SEXP x) {
 }
 
 static bool class_is_null(SEXP x) {
-  SEXP class = PROTECT(Rf_getAttrib(x, R_ClassSymbol));
-  bool res = Rf_isNull(class);
-  UNPROTECT(1);
-  return res;
+  return Rf_getAttrib(x, R_ClassSymbol) == R_NilValue;
 }
 
 // [[ include("vctrs.h") ]]

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -113,9 +113,16 @@ SEXP vctrs_is_vector(SEXP x) {
   return Rf_ScalarLogical(vec_is_vector(x));
 }
 
+bool class_is_null(SEXP x) {
+  SEXP class = PROTECT(Rf_getAttrib(x, R_ClassSymbol));
+  bool res = Rf_isNull(class);
+  UNPROTECT(1);
+  return res;
+}
+
 // [[ include("vctrs.h") ]]
 enum vctrs_type vec_typeof(SEXP x) {
-  if (!OBJECT(x)) {
+  if (!OBJECT(x) || class_is_null(x)) {
     return vec_base_typeof(x, false);
   }
 

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -113,7 +113,7 @@ SEXP vctrs_is_vector(SEXP x) {
   return Rf_ScalarLogical(vec_is_vector(x));
 }
 
-bool class_is_null(SEXP x) {
+static bool class_is_null(SEXP x) {
   SEXP class = PROTECT(Rf_getAttrib(x, R_ClassSymbol));
   bool res = Rf_isNull(class);
   UNPROTECT(1);

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -139,3 +139,9 @@ test_that("class_type() detects classes", {
   expect_identical(class_type(NA), "none")
   expect_identical(class_type(foobar()), "unknown")
 })
+
+test_that("vec_ptype() handles class-less yet OBJECT gremlins", {
+  gremlin <- stats::model.frame(freeny)
+  expect_error(vec_ptype(gremlin), NA)
+  expect_error(vec_c(gremlin), NA)
+})


### PR DESCRIPTION
closes #563

For some reason, `model.frame()` makes it first column an "OBJECT" but it has no class. `vec_typeof()` was not aware of that situation. 

``` r
library(vctrs)
library(purrr)

mod <- lm(y ~ ., data = freeny)
data <- model.frame(mod)
map(data, is.object)
#> $y
#> [1] TRUE
#> 
#> $lag.quarterly.revenue
#> [1] FALSE
#> 
#> $price.index
#> [1] FALSE
#> 
#> $income.level
#> [1] FALSE
#> 
#> $market.potential
#> [1] FALSE

vec_ptype(data)
#> [1] y                     lag.quarterly.revenue price.index          
#> [4] income.level          market.potential     
#> <0 rows> (or 0-length row.names)
vec_c(data)
#>          y lag.quarterly.revenue price.index income.level market.potential
#> 1  8.79236               8.79636     4.70997      5.82110          12.9699
#> 2  8.79137               8.79236     4.70217      5.82558          12.9733
#> 3  8.81486               8.79137     4.68944      5.83112          12.9774
#> 4  8.81301               8.81486     4.68558      5.84046          12.9806
#> 5  8.90751               8.81301     4.64019      5.85036          12.9831
#> 6  8.93673               8.90751     4.62553      5.86464          12.9854
#> 7  8.96161               8.93673     4.61991      5.87769          12.9900
#> 8  8.96044               8.96161     4.61654      5.89763          12.9943
#> 9  9.00868               8.96044     4.61407      5.92574          12.9992
#> 10 9.03049               9.00868     4.60766      5.94232          13.0033
#> 11 9.06906               9.03049     4.60227      5.95365          13.0099
#> 12 9.05871               9.06906     4.58960      5.96120          13.0159
#> 13 9.10698               9.05871     4.57592      5.97805          13.0212
#> 14 9.12685               9.10698     4.58661      6.00377          13.0265
#> 15 9.17096               9.12685     4.57997      6.02829          13.0351
#> 16 9.18665               9.17096     4.57176      6.03475          13.0429
#> 17 9.23823               9.18665     4.56104      6.03906          13.0497
#> 18 9.26487               9.23823     4.54906      6.05046          13.0551
#> 19 9.28436               9.26487     4.53957      6.05563          13.0634
#> 20 9.31378               9.28436     4.51018      6.06093          13.0693
#> 21 9.35025               9.31378     4.50352      6.07103          13.0737
#> 22 9.35835               9.35025     4.49360      6.08018          13.0770
#> 23 9.39767               9.35835     4.46505      6.08858          13.0849
#> 24 9.42150               9.39767     4.44924      6.10199          13.0918
#> 25 9.44223               9.42150     4.43966      6.11207          13.0950
#> 26 9.48721               9.44223     4.42025      6.11596          13.0984
#> 27 9.52374               9.48721     4.41060      6.12129          13.1089
#> 28 9.53980               9.52374     4.41151      6.12200          13.1169
#> 29 9.58123               9.53980     4.39810      6.13119          13.1222
#> 30 9.60048               9.58123     4.38513      6.14705          13.1266
#> 31 9.64496               9.60048     4.37320      6.15336          13.1356
#> 32 9.64390               9.64496     4.32770      6.15627          13.1415
#> 33 9.69405               9.64390     4.32023      6.16274          13.1444
#> 34 9.69958               9.69405     4.30909      6.17369          13.1459
#> 35 9.68683               9.69958     4.30909      6.16135          13.1520
#> 36 9.71774               9.68683     4.30552      6.18231          13.1593
#> 37 9.74924               9.71774     4.29627      6.18768          13.1579
#> 38 9.77536               9.74924     4.27839      6.19377          13.1625
#> 39 9.79424               9.77536     4.27789      6.20030          13.1664
```
