### PR TITLE
Fix vec_proxy_compare.POSIXlt

### DIFF
--- a/R/type-date-time.R
+++ b/R/type-date-time.R
@@ -79,7 +79,7 @@ vec_proxy.POSIXlt <- function(x, ...) {
 }
 #' @export
 vec_proxy_compare.POSIXlt <- function(x, ..., relax = FALSE) {
-  new_data_frame(vec_data(x), n = length(x))
+  new_data_frame(vec_data(x)[c("year", "mon", "mday", "hour", "min", "sec")], n = length(x))
 }
 
 

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -140,7 +140,7 @@ test_that("vec_proxy_compare() preserves data frames and vectors", {
 
 test_that("vec_proxy_compare() handles data frame with a POSIXlt column", {
   df <- data.frame(times = 1:5, x = 1:5)
-  df$times <- as.POSIXlt(seq.Date(Sys.Date(), length.out = 5, by = "day"))
+  df$times <- as.POSIXlt(seq.Date(as.Date("2019-12-30"), as.Date("2020-01-03"), by = "day"))
 
   df2 <- df
   df2$times <- vec_proxy_compare(df$times)
@@ -149,6 +149,11 @@ test_that("vec_proxy_compare() handles data frame with a POSIXlt column", {
     vec_proxy_compare(df),
     vec_proxy_compare(df2)
   )
+})
+
+test_that("vec_proxy_compare.POSIXlt() correctly orders (#720)", {
+  dates <- as.POSIXlt(seq.Date(as.Date("2019-12-30"), as.Date("2020-01-03"), by = "day"))
+  expect_equal(vec_order(dates), 1:5)
 })
 
 test_that("error is thrown with data frames with 0 columns", {


### PR DESCRIPTION
closes #720

``` r
library(vctrs)

dates <- as.POSIXlt(seq(as.Date("2019-12-30"), as.Date("2020-01-02"), by = "day"))
sort(dates)
#> [1] "2019-12-30 UTC" "2019-12-31 UTC" "2020-01-01 UTC" "2020-01-02 UTC"
vec_sort(dates)
#> [1] "2019-12-30 UTC" "2019-12-31 UTC" "2020-01-01 UTC" "2020-01-02 UTC"
```

<sup>Created on 2019-12-30 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>