### PR TITLE
Pass on the restored data frame to `vec_restore_dispatch()`

### DIFF
--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -131,7 +131,7 @@ SEXP vec_restore(SEXP x, SEXP to, SEXP n) {
     // first restore data frames as such before calling the restore
     // method, if any
     SEXP out = PROTECT(vctrs_df_restore(x, to, n));
-    out = vec_restore_dispatch(x, to, n);
+    out = vec_restore_dispatch(out, to, n);
     UNPROTECT(1);
     return out;
   }}

--- a/tests/testthat/test-proxy-restore.R
+++ b/tests/testthat/test-proxy-restore.R
@@ -80,3 +80,17 @@ test_that("arguments are not inlined in the dispatch call (#300)", {
   expect_equal(call, quote(vec_restore.vctrs_foobar(x = x, to = to, n = n)))
 })
 
+test_that("restoring to non-bare data frames calls `vctrs_df_restore()` before dispatching", {
+  x <- list(x = numeric())
+  to <- new_data_frame(x, class = "tbl_foobar")
+
+  local_methods(
+    vec_restore.tbl_foobar = function(x, to, ..., n) {
+      if (is.data.frame(x)) {
+        abort(class = "error_df_restore_was_called")
+      }
+    }
+  )
+
+  expect_error(vec_restore(x, to), class = "error_df_restore_was_called")
+})


### PR DESCRIPTION
This was a typo from a while back.

When restoring to non-bare data frames, we first call `vctrs_df_restore()` then call the restore dispatch method, but we weren't passing through that restored df.