### PR TITLE
Prevent `vec_ptype2()` methods from being inherited

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,20 @@
 
 # vctrs 0.2.99.9000
 
+* `vec_ptype2()` methods for base classes now prevent
+  inheritance. This makes sense because the subtyping graph created by
+  `vec_ptype2()` methods is generally not the same as the inheritance
+  relationships defined by S3 classes. For instance, subclasses are
+  often a richer type than their superclasses, and should often be
+  declared as supertypes (e.g. `vec_ptype2()` should return the
+  subclass).
+
+  We introduced this breaking change in a patch release because
+  `new_vctr()` now adds the base type to the class vector by default,
+  which caused `vec_ptype2()` to dispatch erroneously to the methods
+  for base types. We'll finish switching to this approach in vctrs
+  0.3.0 for the rest of the base S3 classes (dates, data frames, ...).
+
 * `vec_equal_na()` now works with complex vectors.
 
 * `vec_as_index()` has been renamed to `vec_as_location()`.

--- a/R/assert.R
+++ b/R/assert.R
@@ -117,6 +117,9 @@ is_same_type <- function(x, ptype) {
     )
   }
 
+  x <- vec_slice(x, integer())
+  ptype <- vec_slice(ptype, integer())
+
   # FIXME: Remove row names for matrices and arrays, and handle empty
   # but existing dimnames
   x <- vec_set_names(x, NULL)

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -1,110 +1,257 @@
 # Type2 -------------------------------------------------------------------
 
-# Numeric-ish
+# Left generics -----------------------------------------------------------
 
 #' @rdname vec_ptype2
 #' @export vec_ptype2.logical
 #' @method vec_ptype2 logical
 #' @export
-vec_ptype2.logical <- function(x, y, ...) UseMethod("vec_ptype2.logical", y)
+vec_ptype2.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(x)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    UseMethod("vec_ptype2.logical", y)
+  }
+}
 #' @rdname vec_ptype2
 #' @export vec_ptype2.integer
 #' @method vec_ptype2 integer
 #' @export
-vec_ptype2.integer <- function(x, y, ...) UseMethod("vec_ptype2.integer", y)
+vec_ptype2.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(x)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    UseMethod("vec_ptype2.integer", y)
+  }
+}
 #' @rdname vec_ptype2
 #' @export vec_ptype2.double
 #' @method vec_ptype2 double
 #' @export
-vec_ptype2.double <- function(x, y, ...) UseMethod("vec_ptype2.double", y)
+vec_ptype2.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(x)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    UseMethod("vec_ptype2.double", y)
+  }
+}
 #' @rdname vec_ptype2
 #' @export vec_ptype2.complex
 #' @method vec_ptype2 complex
 #' @export
-vec_ptype2.complex <- function(x, y, ...) UseMethod("vec_ptype2.complex", y)
+vec_ptype2.complex <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(x)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    UseMethod("vec_ptype2.complex", y)
+  }
+}
+#' @rdname vec_ptype2
+#' @export vec_ptype2.character
+#' @method vec_ptype2 character
+#' @export
+vec_ptype2.character <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(x)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    UseMethod("vec_ptype2.character", y)
+  }
+}
+#' @rdname vec_ptype2
+#' @export vec_ptype2.raw
+#' @method vec_ptype2 raw
+#' @export
+vec_ptype2.raw <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(x)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    UseMethod("vec_ptype2.raw", y)
+  }
+}
+#' @rdname vec_ptype2
+#' @export vec_ptype2.list
+#' @method vec_ptype2 list
+#' @export
+vec_ptype2.list <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(x)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    UseMethod("vec_ptype2.list", y)
+  }
+}
+
+
+# Numeric-ish
 
 #' @method vec_ptype2.logical logical
 #' @export
-vec_ptype2.logical.logical <- function(x, y, ...) shape_match(logical(), x, y)
+vec_ptype2.logical.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(logical(), x, y)
+  }
+}
 
 #' @export
 #' @method vec_ptype2.integer integer
-vec_ptype2.integer.integer <- function(x, y, ...) shape_match(integer(), x, y)
+vec_ptype2.integer.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(integer(), x, y)
+  }
+}
 #' @export
 #' @method vec_ptype2.logical integer
-vec_ptype2.logical.integer <- function(x, y, ...) shape_match(integer(), x, y)
+vec_ptype2.logical.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(integer(), x, y)
+  }
+}
 #' @export
 #' @method vec_ptype2.integer logical
-vec_ptype2.integer.logical <- function(x, y, ...) shape_match(integer(), x, y)
+vec_ptype2.integer.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(integer(), x, y)
+  }
+}
 
 #' @export
 #' @method vec_ptype2.double double
-vec_ptype2.double.double <- function(x, y, ...) shape_match(double(), x, y)
+vec_ptype2.double.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(double(), x, y)
+  }
+}
 #' @export
 #' @method vec_ptype2.logical double
-vec_ptype2.logical.double <- function(x, y, ...) shape_match(double(), x, y)
+vec_ptype2.logical.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(double(), x, y)
+  }
+}
 #' @export
 #' @method vec_ptype2.double logical
-vec_ptype2.double.logical <- function(x, y, ...) shape_match(double(), x, y)
+vec_ptype2.double.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(double(), x, y)
+  }
+}
 #' @export
 #' @method vec_ptype2.integer double
-vec_ptype2.integer.double <- function(x, y, ...) shape_match(double(), x, y)
+vec_ptype2.integer.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(double(), x, y)
+  }
+}
 #' @export
 #' @method vec_ptype2.double integer
-vec_ptype2.double.integer <- function(x, y, ...) shape_match(double(), x, y)
+vec_ptype2.double.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(double(), x, y)
+  }
+}
 
 #' @export
 #' @method vec_ptype2.complex complex
-vec_ptype2.complex.complex <- function(x, y, ...) shape_match(complex(), x, y)
+vec_ptype2.complex.complex <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(complex(), x, y)
+  }
+}
 #' @export
 #' @method vec_ptype2.integer complex
-vec_ptype2.integer.complex <- function(x, y, ...) shape_match(complex(), x, y)
+vec_ptype2.integer.complex <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(complex(), x, y)
+  }
+}
 #' @export
 #' @method vec_ptype2.complex integer
-vec_ptype2.complex.integer <- function(x, y, ...) shape_match(complex(), x, y)
+vec_ptype2.complex.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(complex(), x, y)
+  }
+}
 #' @export
 #' @method vec_ptype2.double complex
-vec_ptype2.double.complex <- function(x, y, ...) shape_match(complex(), x, y)
+vec_ptype2.double.complex <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(complex(), x, y)
+  }
+}
 #' @export
 #' @method vec_ptype2.complex double
-vec_ptype2.complex.double <- function(x, y, ...) shape_match(complex(), x, y)
+vec_ptype2.complex.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(complex(), x, y)
+  }
+}
 
 
 
 # Character
 
-#' @rdname vec_ptype2
-#' @export vec_ptype2.character
-#' @method vec_ptype2 character
-#' @export
-vec_ptype2.character <- function(x, y, ...) UseMethod("vec_ptype2.character", y)
 #' @method vec_ptype2.character character
 #' @export
-vec_ptype2.character.character <- function(x, y, ...) shape_match(character(), x, y)
+vec_ptype2.character.character <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(character(), x, y)
+  }
+}
 
 
 # Raw
 
-#' @rdname vec_ptype2
-#' @export vec_ptype2.raw
-#' @method vec_ptype2 raw
-#' @export
-vec_ptype2.raw <- function(x, y, ...) UseMethod("vec_ptype2.raw", y)
 #' @export
 #' @method vec_ptype2.raw raw
-vec_ptype2.raw.raw <- function(x, y, ...) shape_match(raw(), x, y)
+vec_ptype2.raw.raw <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(raw(), x, y)
+  }
+}
 
 
 # Lists
 
-#' @rdname vec_ptype2
-#' @export vec_ptype2.list
-#' @method vec_ptype2 list
-#' @export
-vec_ptype2.list <- function(x, y, ...) UseMethod("vec_ptype2.list", y)
 #' @method vec_ptype2.list list
 #' @export
-vec_ptype2.list.list <- function(x, y, ...) shape_match(list(), x, y)
+vec_ptype2.list.list <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (is.object(y)) {
+    vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else {
+    shape_match(list(), x, y)
+  }
+}
 #' @method vec_ptype2.logical list
 #' @export
 vec_ptype2.logical.list <- function(x, y, ..., x_arg = "x", y_arg = "y") {

--- a/R/type2.R
+++ b/R/type2.R
@@ -60,6 +60,9 @@ vec_default_ptype2 <- function(x, y, ..., x_arg = "x", y_arg = "y") {
     vec_assert(x)
     return(vec_ptype(x))
   }
+  if (is_same_type(x, y)) {
+    return(vec_ptype(x))
+  }
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 

--- a/man/vec_ptype2.Rd
+++ b/man/vec_ptype2.Rd
@@ -12,19 +12,19 @@
 \alias{vec_default_ptype2}
 \title{Find the common type for a pair of vector types}
 \usage{
-\method{vec_ptype2}{logical}(x, y, ...)
+\method{vec_ptype2}{logical}(x, y, ..., x_arg = "x", y_arg = "y")
 
-\method{vec_ptype2}{integer}(x, y, ...)
+\method{vec_ptype2}{integer}(x, y, ..., x_arg = "x", y_arg = "y")
 
-\method{vec_ptype2}{double}(x, y, ...)
+\method{vec_ptype2}{double}(x, y, ..., x_arg = "x", y_arg = "y")
 
-\method{vec_ptype2}{complex}(x, y, ...)
+\method{vec_ptype2}{complex}(x, y, ..., x_arg = "x", y_arg = "y")
 
-\method{vec_ptype2}{character}(x, y, ...)
+\method{vec_ptype2}{character}(x, y, ..., x_arg = "x", y_arg = "y")
 
-\method{vec_ptype2}{raw}(x, y, ...)
+\method{vec_ptype2}{raw}(x, y, ..., x_arg = "x", y_arg = "y")
 
-\method{vec_ptype2}{list}(x, y, ...)
+\method{vec_ptype2}{list}(x, y, ..., x_arg = "x", y_arg = "y")
 
 vec_ptype2(x, y, ..., x_arg = "x", y_arg = "y")
 

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -1,5 +1,16 @@
 context("test-type-bare")
 
+
+test_that("ptype2 base methods are not inherited", {
+  for (ptype in base_empty_types[-1]) {
+    x <- new_vctr(ptype, class = "foobar", inherit_base_type = TRUE)
+    expect_is(vec_ptype2(x, x), "foobar")
+    expect_error(vec_ptype2(x, ptype), class = "vctrs_error_incompatible_type")
+    expect_error(vec_ptype2(ptype, x), class = "vctrs_error_incompatible_type")
+  }
+})
+
+
 # shape_match -------------------------------------------------------------
 
 test_that("array dimensions are preserved", {
@@ -10,13 +21,6 @@ test_that("array dimensions are preserved", {
   expect_equal(vec_ptype2(mat1, mat1), matrix(lgl(), nrow = 0, ncol = 1))
   expect_equal(vec_ptype2(mat1, mat2), matrix(lgl(), nrow = 0, ncol = 2))
   expect_error(vec_ptype2(mat2, mat3), "Incompatible")
-})
-
-test_that("extensions of base vectors collapse to base type", {
-  x <- structure("x", class = c("foo", "character"))
-  expect_equal(vec_ptype2(x, x), character())
-  expect_equal(vec_ptype2(x, character()), character())
-  expect_equal(vec_ptype2(character(), x), character())
 })
 
 test_that("shape_match()", {
@@ -341,6 +345,7 @@ test_that("Casting data frame `NA` rows to list results in a `NULL`", {
   expect <- list(NULL, vec_slice(x, 2), vec_slice(x, 3))
   expect_equal(vec_cast(x, list()), expect)
 })
+
 
 # Unspecified
 


### PR DESCRIPTION
I noticed in the tidyr revdeps that the changes for base type inheritance in `new_vctr()` have consequences for the dispatch path.

With CRAN vctrs we have:

```r
x <- new_vctr(list(), class = "foobar", inherit_base_type = TRUE)

vec_ptype2(x, x)
#> <foobar[0]>

vec_ptype2(x, list())
#> Error: No common type for `x` <foobar> and `y` <list>.

vec_ptype2(list(), x)
#> Error: No common type for `x` <list> and `y` <foobar>.
```

With current master:

```r
vec_ptype2(x, x)
#> list()

vec_ptype2(x, list())
#> list()

vec_ptype2(list(), x)
#> list()
```

To fix this, this PR:

1. Prevents inheritance in our ptype2 methods for base types.
2. Adjusts `vec_default_ptype2()` to return the LHS if both inputs have the same type.
3. Adjusts `vec_is()` to take the prototype before making the identity check.