### PR TITLE
Fix issue where vctrs functions imported in tibble can't be found

### DIFF
--- a/tests/testthat/helper-s3.R
+++ b/tests/testthat/helper-s3.R
@@ -41,7 +41,9 @@ local_no_stringsAsFactors <- function(frame = caller_env()) {
   local_options(.frame = frame, stringsAsFactors = FALSE)
 }
 
-tibble <- tibble::tibble
+tibble <- function(...) {
+  tibble::tibble(...)
+}
 
 local_foobar_proxy <- function(frame = caller_env()) {
   local_methods(.frame = frame, vec_proxy.vctrs_foobar = identity)


### PR DESCRIPTION
Closes #747 

@lionel- if you have a better solution I'm open to it 🤷‍♂ 

We don't really use the extra args to `tibble()` so I figured just passing dots is ok