### PR TITLE
Materialize compact subscripts when slicing ALTREP objects

### DIFF
--- a/src/altrep-rle.c
+++ b/src/altrep-rle.c
@@ -110,7 +110,14 @@ SEXP altrep_rle_Extract_subset(SEXP x, SEXP indx, SEXP call) {
   SEXP out = PROTECT(Rf_allocVector(STRSXP, index_n));
 
   for (R_len_t i = 0; i < index_n; ++i) {
-    R_xlen_t rle_idx = find_rle_index(rle_data, index_data[i], rle_n);
+    int index_elt = index_data[i];
+
+    if (index_elt == NA_INTEGER) {
+      SET_STRING_ELT(out, i, NA_STRING);
+      continue;
+    }
+
+    R_xlen_t rle_idx = find_rle_index(rle_data, index_elt, rle_n);
     SET_STRING_ELT(out, i, STRING_ELT(nms, rle_idx));
   }
 

--- a/src/altrep-rle.c
+++ b/src/altrep-rle.c
@@ -117,6 +117,8 @@ SEXP altrep_rle_Extract_subset(SEXP x, SEXP indx, SEXP call) {
       continue;
     }
 
+    --index_elt;
+
     R_xlen_t rle_idx = find_rle_index(rle_data, index_elt, rle_n);
     SET_STRING_ELT(out, i, STRING_ELT(nms, rle_idx));
   }

--- a/src/slice.c
+++ b/src/slice.c
@@ -72,20 +72,21 @@ SEXP vec_slice_impl(SEXP x, SEXP subscript);
   UNPROTECT(1);                                                 \
   return out
 
-#define SLICE(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE)               \
-  if (ALTREP(x)) {                                                      \
-    SEXP out;                                                           \
-    out = ALTVEC_EXTRACT_SUBSET_PROXY(x, subscript, R_NilValue);        \
-    if (out != NULL) {                                                  \
-      return out;                                                       \
-    }                                                                   \
-  }                                                                     \
-  if (is_compact_rep(subscript)) {                                      \
-    SLICE_COMPACT_REP(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE);      \
-  } else if (is_compact_seq(subscript)) {                               \
-    SLICE_COMPACT_SEQ(RTYPE, CTYPE, DEREF, CONST_DEREF);                \
-  } else {                                                              \
-    SLICE_SUBSCRIPT(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE);        \
+#define SLICE(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE)                   \
+  if (ALTREP(x)) {                                                          \
+    SEXP alt_subscript = PROTECT(compact_materialize(subscript));           \
+    SEXP out = ALTVEC_EXTRACT_SUBSET_PROXY(x, alt_subscript, R_NilValue);   \
+    UNPROTECT(1);                                                           \
+    if (out != NULL) {                                                      \
+      return out;                                                           \
+    }                                                                       \
+  }                                                                         \
+  if (is_compact_rep(subscript)) {                                          \
+    SLICE_COMPACT_REP(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE);          \
+  } else if (is_compact_seq(subscript)) {                                   \
+    SLICE_COMPACT_SEQ(RTYPE, CTYPE, DEREF, CONST_DEREF);                    \
+  } else {                                                                  \
+    SLICE_SUBSCRIPT(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE);            \
   }
 
 static SEXP lgl_slice(SEXP x, SEXP subscript) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -417,7 +417,7 @@ SEXP compact_materialize(SEXP x) {
   } else if (is_compact_seq(x)) {
     return compact_seq_materialize(x);
   } else {
-    Rf_errorcall(R_NilValue, "Internal error: `x` must be a compact seq or rep.");
+    return x;
   }
 }
 

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -449,6 +449,14 @@ test_that("vec_init() asserts vectorness (#301)", {
   expect_error(vec_init(NULL, 1L), class = "vctrs_error_scalar_type")
 })
 
+test_that("vec_init() works with Altrep classes", {
+  skip_if(getRversion() < "3.5")
+
+  x <- .Call(vctrs_rle, c(foo = 1L, bar = 2L))
+
+  expect_equal(vec_init(x, 2), rep(NA_character_, 2))
+})
+
 # vec_chop ----------------------------------------------------------------
 
 test_that("vec_chop() throws error with non-vector inputs", {
@@ -643,6 +651,14 @@ test_that("names are repaired correctly with compact reps and `NA_integer_`", {
   expect_equal(vec_slice_rep(x, NA_integer_, 2L), expect)
 })
 
+test_that("vec_slice() with compact_reps work with Altrep classes", {
+  skip_if(getRversion() < "3.5")
+
+  x <- .Call(vctrs_rle, c(foo = 10L, bar = 5L))
+
+  expect_equal(vec_slice_rep(x, 10L, 3L), rep("foo", 3))
+})
+
 # vec_slice + compact_seq -------------------------------------------------
 
 # `start` is 0-based
@@ -762,6 +778,14 @@ test_that("can subset S3 objects using the fallback method with compact seqs", {
   expect_equal(vec_slice_seq(x, 0L, 1L), vec_slice(x, 1L))
   expect_equal(vec_slice_seq(x, 2L, 2L), vec_slice(x, 3:4))
   expect_equal(vec_slice_seq(x, 3L, 2L, FALSE), vec_slice(x, 4:3))
+})
+
+test_that("vec_slice() with compact_seqs work with Altrep classes", {
+  skip_if(getRversion() < "3.5")
+
+  x <- .Call(vctrs_rle, c(foo = 2L, bar = 3L))
+
+  expect_equal(vec_slice_seq(x, 1L, 3L), c("foo", "bar", "bar"))
 })
 
 # vec_chop + compact_seq --------------------------------------------------

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -806,6 +806,6 @@ test_that("vec_slice() works with Altrep classes with custom extract methods", {
 
   x <- .Call(vctrs_rle, c(foo = 10L, bar = 5L))
 
-  idx <- c(1, 3, 15)
-  expect_equal(vec_slice(x, idx), x[idx])
+  idx <- c(9, 10, 11)
+  expect_equal(vec_slice(x, idx), c("foo", "foo", "bar"))
 })


### PR DESCRIPTION
Closes #744 

Also adds `NA_integer_` subscript support to the `altrep_rle` class so we can add tests, and fixes a small off by one bug with it.

Now, with this PR and dev vroom:

``` r
library(vctrs)
library(vroom)

x <- vroom("x,y\n1,2\n")
#> Rows: 1
#> Columns: 2
#> Delimiter: ","
#> dbl [2]: x, y
#> 
#> Use `spec()` to retrieve the guessed column specification
#> Pass a specification to the `col_types` argument to quiet this message
vec_rbind(x)
#> # A tibble: 1 x 2
#>       x     y
#>   <dbl> <dbl>
#> 1     1     2

x <- vroom("x,y\n1,2\n")
#> Rows: 1
#> Columns: 2
#> Delimiter: ","
#> dbl [2]: x, y
#> 
#> Use `spec()` to retrieve the guessed column specification
#> Pass a specification to the `col_types` argument to quiet this message
vec_init(x, 2)
#> # A tibble: 2 x 2
#>       x     y
#>   <dbl> <dbl>
#> 1    NA    NA
#> 2    NA    NA
```

<sup>Created on 2020-01-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>