### PR TITLE
Fix assign action

### DIFF
--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -1,4 +1,5 @@
 #include "vctrs.h"
+#include "subscript-loc.h"
 #include "utils.h"
 
 // Initialised at load time
@@ -19,6 +20,11 @@ static SEXP raw_assign(SEXP x, SEXP index, SEXP value, bool clone);
 SEXP list_assign(SEXP x, SEXP index, SEXP value, bool clone);
 SEXP df_assign(SEXP x, SEXP index, SEXP value, bool clone);
 
+const struct vec_as_location_opts default_assign_loc_opts = {
+  .action = SUBSCRIPT_ACTION_ASSIGN,
+  .loc_negative = LOC_NEGATIVE_INVERT,
+  .loc_oob = LOC_OOB_ERROR
+};
 
 // [[ register(); include("vctrs.h") ]]
 SEXP vec_assign(SEXP x, SEXP index, SEXP value) {
@@ -37,7 +43,10 @@ SEXP vec_assign(SEXP x, SEXP index, SEXP value) {
   SEXP value_proxy = PROTECT(vec_proxy(value));
 
   // Recycle the proxy of `value`
-  index = PROTECT(vec_as_location(index, vec_size(x), PROTECT(vec_names(x))));
+  index = PROTECT(vec_as_location_opts(index,
+                                       vec_size(x),
+                                       PROTECT(vec_names(x)),
+                                       &default_assign_loc_opts));
   value_proxy = PROTECT(vec_recycle(value_proxy, vec_size(index), &value_arg));
 
   struct vctrs_proxy_info info = vec_proxy_info(x);

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -103,13 +103,9 @@ static SEXP int_invert_location(SEXP subscript, R_len_t n,
 
     j = -j;
     if (j > n) {
-      if (opts->action == SUBSCRIPT_ACTION_DEFAULT) {
-        struct vec_as_location_opts updated_opts = *opts;
-        updated_opts.action = SUBSCRIPT_ACTION_NEGATE;
-        stop_subscript_oob_location(subscript, n, &updated_opts);
-      } else {
-        stop_subscript_oob_location(subscript, n, opts);
-      }
+      struct vec_as_location_opts updated_opts = *opts;
+      updated_opts.action = SUBSCRIPT_ACTION_NEGATE;
+      stop_subscript_oob_location(subscript, n, &updated_opts);
     }
 
     sel_data[j - 1] = 0;

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -377,9 +377,11 @@ static void stop_subscript_oob_location(SEXP i, R_len_t size,
 }
 static void stop_subscript_oob_name(SEXP i, SEXP names,
                                     const struct vec_as_location_opts* opts) {
-  vctrs_eval_mask2(Rf_install("stop_subscript_oob_name"),
+  SEXP action = get_opts_action(opts);
+  vctrs_eval_mask3(Rf_install("stop_subscript_oob_name"),
                    syms_i, i,
                    syms_names, names,
+                   syms_subscript_action, action,
                    vctrs_ns_env);
   never_reached("stop_subscript_oob_name");
 }

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -2,12 +2,15 @@
 #include "utils.h"
 #include "subscript-loc.h"
 
-static SEXP int_invert_location(SEXP subscript, R_len_t n);
+static SEXP int_invert_location(SEXP subscript, R_len_t n,
+                                const struct vec_as_location_opts* opts);
 static SEXP int_filter_zero(SEXP subscript, R_len_t n_zero);
 static void int_check_consecutive(SEXP subscript, R_len_t n);
 
-static void stop_subscript_oob_location(SEXP i, R_len_t size, bool negate);
-static void stop_subscript_oob_name(SEXP i, SEXP names);
+static void stop_subscript_oob_location(SEXP i, R_len_t size,
+                                        const struct vec_as_location_opts* opts);
+static void stop_subscript_oob_name(SEXP i, SEXP names,
+                                    const struct vec_as_location_opts* opts);
 static void stop_location_negative(SEXP i);
 static void stop_indicator_size(SEXP i, SEXP n);
 static void stop_location_negative_missing(SEXP i);
@@ -15,8 +18,15 @@ static void stop_location_negative_positive(SEXP i);
 static void stop_location_oob_non_consecutive(SEXP i, R_len_t size);
 
 
+const struct vec_as_location_opts default_opts = {
+  .action = SUBSCRIPT_ACTION_DEFAULT,
+  .loc_negative = LOC_NEGATIVE_INVERT,
+  .loc_oob = LOC_OOB_ERROR
+};
+
+
 static SEXP int_as_location(SEXP subscript, R_len_t n,
-                            struct vec_as_location_opts* opts) {
+                            const struct vec_as_location_opts* opts) {
   const int* data = INTEGER_RO(subscript);
   R_len_t loc_n = Rf_length(subscript);
 
@@ -33,7 +43,7 @@ static SEXP int_as_location(SEXP subscript, R_len_t n,
     if (elt != NA_INTEGER) {
       if (elt < 0) {
         switch (opts->loc_negative) {
-        case LOC_NEGATIVE_INVERT: return int_invert_location(subscript, n);
+        case LOC_NEGATIVE_INVERT: return int_invert_location(subscript, n, opts);
         case LOC_NEGATIVE_ERROR: stop_location_negative(subscript);
         case LOC_NEGATIVE_IGNORE: break;
         }
@@ -43,7 +53,7 @@ static SEXP int_as_location(SEXP subscript, R_len_t n,
         ++n_zero;
       } else if (abs(elt) > n) {
         if (opts->loc_oob == LOC_OOB_ERROR) {
-          stop_subscript_oob_location(subscript, n, false);
+          stop_subscript_oob_location(subscript, n, opts);
         }
         extended = true;
       }
@@ -64,9 +74,11 @@ static SEXP int_as_location(SEXP subscript, R_len_t n,
 }
 
 
-static SEXP lgl_as_location(SEXP subscript, R_len_t n);
+static SEXP lgl_as_location(SEXP subscript, R_len_t n,
+                            const struct vec_as_location_opts* opts);
 
-static SEXP int_invert_location(SEXP subscript, R_len_t n) {
+static SEXP int_invert_location(SEXP subscript, R_len_t n,
+                                const struct vec_as_location_opts* opts) {
   const int* data = INTEGER_RO(subscript);
   R_len_t loc_n = Rf_length(subscript);
 
@@ -91,13 +103,19 @@ static SEXP int_invert_location(SEXP subscript, R_len_t n) {
 
     j = -j;
     if (j > n) {
-      stop_subscript_oob_location(subscript, n, true);
+      if (opts->action == SUBSCRIPT_ACTION_DEFAULT) {
+        struct vec_as_location_opts updated_opts = *opts;
+        updated_opts.action = SUBSCRIPT_ACTION_NEGATE;
+        stop_subscript_oob_location(subscript, n, &updated_opts);
+      } else {
+        stop_subscript_oob_location(subscript, n, opts);
+      }
     }
 
     sel_data[j - 1] = 0;
   }
 
-  SEXP out = lgl_as_location(sel, n);
+  SEXP out = lgl_as_location(sel, n, opts);
 
   UNPROTECT(1);
   return out;
@@ -155,7 +173,8 @@ static void int_check_consecutive(SEXP subscript, R_len_t n) {
   UNPROTECT(1);
 }
 
-static SEXP dbl_as_location(SEXP subscript, R_len_t n, struct vec_as_location_opts* opts) {
+static SEXP dbl_as_location(SEXP subscript, R_len_t n,
+                            const struct vec_as_location_opts* opts) {
   subscript = PROTECT(vec_cast(subscript, vctrs_shared_empty_int, args_empty, args_empty));
   subscript = int_as_location(subscript, n, opts);
 
@@ -163,7 +182,8 @@ static SEXP dbl_as_location(SEXP subscript, R_len_t n, struct vec_as_location_op
   return subscript;
 }
 
-static SEXP lgl_as_location(SEXP subscript, R_len_t n) {
+static SEXP lgl_as_location(SEXP subscript, R_len_t n,
+                            const struct vec_as_location_opts* opts) {
   R_len_t subscript_n = Rf_length(subscript);
 
   if (subscript_n == n) {
@@ -221,7 +241,8 @@ static SEXP lgl_as_location(SEXP subscript, R_len_t n) {
   never_reached("lgl_as_location");
 }
 
-static SEXP chr_as_location(SEXP subscript, SEXP names) {
+static SEXP chr_as_location(SEXP subscript, SEXP names,
+                            const struct vec_as_location_opts* opts) {
   if (names == R_NilValue) {
     Rf_errorcall(R_NilValue, "Can't use character names to index an unnamed vector.");
   }
@@ -237,7 +258,7 @@ static SEXP chr_as_location(SEXP subscript, SEXP names) {
 
   for (R_len_t k = 0; k < n; ++k) {
     if (p[k] == NA_INTEGER && ip[k] != NA_STRING) {
-      stop_subscript_oob_name(subscript, names);
+      stop_subscript_oob_name(subscript, names, opts);
     }
   }
 
@@ -248,15 +269,11 @@ static SEXP chr_as_location(SEXP subscript, SEXP names) {
 }
 
 SEXP vec_as_location(SEXP subscript, R_len_t n, SEXP names) {
-  struct vec_as_location_opts opts = {
-    .loc_negative = LOC_NEGATIVE_INVERT,
-    .loc_oob = LOC_OOB_ERROR
-  };
-  return vec_as_location_opts(subscript, n, names, &opts);
+  return vec_as_location_opts(subscript, n, names, &default_opts);
 }
 
 SEXP vec_as_location_opts(SEXP subscript, R_len_t n, SEXP names,
-                          struct vec_as_location_opts* opts) {
+                          const struct vec_as_location_opts* opts) {
 
   if (vec_dim_n(subscript) != 1) {
     Rf_errorcall(R_NilValue, "`i` must have one dimension, not %d.", vec_dim_n(subscript));
@@ -266,8 +283,8 @@ SEXP vec_as_location_opts(SEXP subscript, R_len_t n, SEXP names,
   case NILSXP: return vctrs_shared_empty_int;
   case INTSXP: return int_as_location(subscript, n, opts);
   case REALSXP: return dbl_as_location(subscript, n, opts);
-  case LGLSXP: return lgl_as_location(subscript, n);
-  case STRSXP: return chr_as_location(subscript, names);
+  case LGLSXP: return lgl_as_location(subscript, n, opts);
+  case STRSXP: return chr_as_location(subscript, names, opts);
 
   default: Rf_errorcall(R_NilValue, "`i` must be an integer, character, or logical vector, not a %s.",
                         Rf_type2char(TYPEOF(subscript)));
@@ -349,9 +366,10 @@ static void stop_location_negative_positive(SEXP i) {
   never_reached("stop_location_negative_positive");
 }
 
-static void stop_subscript_oob_location(SEXP i, R_len_t size, bool negate) {
+static void stop_subscript_oob_location(SEXP i, R_len_t size,
+                                        const struct vec_as_location_opts* opts) {
   SEXP size_obj = PROTECT(r_int(size));
-  SEXP action = negate ? chrs_negate : chrs_subset;
+  SEXP action = get_opts_action(opts);
   vctrs_eval_mask3(Rf_install("stop_subscript_oob_location"),
                    syms_i, i,
                    syms_size, size_obj,
@@ -361,7 +379,8 @@ static void stop_subscript_oob_location(SEXP i, R_len_t size, bool negate) {
   UNPROTECT(1);
   never_reached("stop_subscript_oob_location");
 }
-static void stop_subscript_oob_name(SEXP i, SEXP names) {
+static void stop_subscript_oob_name(SEXP i, SEXP names,
+                                    const struct vec_as_location_opts* opts) {
   vctrs_eval_mask2(Rf_install("stop_subscript_oob_name"),
                    syms_i, i,
                    syms_names, names,

--- a/src/subscript-loc.h
+++ b/src/subscript-loc.h
@@ -1,6 +1,8 @@
 #ifndef VCTRS_SUBSCRIPT_LOC_H
 #define VCTRS_SUBSCRIPT_LOC_H
 
+#include "utils.h"
+
 
 enum subscript_action {
   SUBSCRIPT_ACTION_DEFAULT,

--- a/src/subscript-loc.h
+++ b/src/subscript-loc.h
@@ -2,6 +2,15 @@
 #define VCTRS_SUBSCRIPT_LOC_H
 
 
+enum subscript_action {
+  SUBSCRIPT_ACTION_DEFAULT,
+  SUBSCRIPT_ACTION_SUBSET,
+  SUBSCRIPT_ACTION_EXTRACT,
+  SUBSCRIPT_ACTION_ASSIGN,
+  SUBSCRIPT_ACTION_RENAME,
+  SUBSCRIPT_ACTION_REMOVE,
+  SUBSCRIPT_ACTION_NEGATE
+};
 enum num_as_location_loc_negative {
   LOC_NEGATIVE_INVERT,
   LOC_NEGATIVE_ERROR,
@@ -13,12 +22,27 @@ enum num_as_location_loc_oob {
 };
 
 struct vec_as_location_opts {
+  enum subscript_action action;
   enum num_as_location_loc_negative loc_negative;
   enum num_as_location_loc_oob loc_oob;
 };
 
 SEXP vec_as_location(SEXP i, R_len_t n, SEXP names);
-SEXP vec_as_location_opts(SEXP i, R_len_t n, SEXP names, struct vec_as_location_opts* opts);
+SEXP vec_as_location_opts(SEXP i, R_len_t n, SEXP names,
+                          const struct vec_as_location_opts* opts);
+
+static inline SEXP get_opts_action(const struct vec_as_location_opts* opts) {
+  switch (opts->action) {
+  case SUBSCRIPT_ACTION_DEFAULT: return R_NilValue;
+  case SUBSCRIPT_ACTION_SUBSET: return chrs_subset;
+  case SUBSCRIPT_ACTION_EXTRACT: return chrs_extract;
+  case SUBSCRIPT_ACTION_ASSIGN: return chrs_assign;
+  case SUBSCRIPT_ACTION_RENAME: return chrs_rename;
+  case SUBSCRIPT_ACTION_REMOVE: return chrs_remove;
+  case SUBSCRIPT_ACTION_NEGATE: return chrs_negate;
+  }
+  never_reached("get_opts_action");
+}
 
 
 #endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -998,6 +998,9 @@ SEXP strings_group = NULL;
 SEXP strings_length = NULL;
 
 SEXP chrs_subset = NULL;
+SEXP chrs_extract = NULL;
+SEXP chrs_assign = NULL;
+SEXP chrs_rename = NULL;
 SEXP chrs_remove = NULL;
 SEXP chrs_negate = NULL;
 
@@ -1103,6 +1106,15 @@ void vctrs_init_utils(SEXP ns) {
 
   chrs_subset = Rf_mkString("subset");
   R_PreserveObject(chrs_subset);
+
+  chrs_extract = Rf_mkString("extract");
+  R_PreserveObject(chrs_extract);
+
+  chrs_assign = Rf_mkString("assign");
+  R_PreserveObject(chrs_assign);
+
+  chrs_rename = Rf_mkString("rename");
+  R_PreserveObject(chrs_rename);
 
   chrs_remove = Rf_mkString("remove");
   R_PreserveObject(chrs_remove);

--- a/src/utils.h
+++ b/src/utils.h
@@ -248,6 +248,9 @@ extern SEXP strings_group;
 extern SEXP strings_length;
 
 extern SEXP chrs_subset;
+extern SEXP chrs_extract;
+extern SEXP chrs_assign;
+extern SEXP chrs_rename;
 extern SEXP chrs_remove;
 extern SEXP chrs_negate;
 

--- a/tests/testthat/error/test-slice-assign.txt
+++ b/tests/testthat/error/test-slice-assign.txt
@@ -38,6 +38,6 @@ x Can't negate location 100.
 i There are only 26 elements.
 
 > vec_assign(set_names(letters), "foo", "bar")
-Error: Must subset existing elements.
-x Can't subset element with unknown name `foo`.
+Error: Must assign existing elements.
+x Can't assign element with unknown name `foo`.
 

--- a/tests/testthat/error/test-slice-assign.txt
+++ b/tests/testthat/error/test-slice-assign.txt
@@ -20,3 +20,19 @@ Error: Logical subscripts must match the size of the indexed input.
 i The input has size 32.
 x The subscript has size 2.
 
+
+must assign existing elements
+=============================
+
+> vec_assign(1:3, 5, 10)
+Error: Must assign existing elements.
+x Can't assign location 5.
+i There are only 3 elements.
+
+> vec_assign(1:3, "foo", 10)
+Error: Can't use character names to index an unnamed vector.
+
+> vec_assign(set_names(letters), "foo", "bar")
+Error: Must subset existing elements.
+x Can't subset element with unknown name `foo`.
+

--- a/tests/testthat/error/test-slice-assign.txt
+++ b/tests/testthat/error/test-slice-assign.txt
@@ -32,6 +32,11 @@ i There are only 3 elements.
 > vec_assign(1:3, "foo", 10)
 Error: Can't use character names to index an unnamed vector.
 
+> vec_slice(letters, -100) <- "foo"
+Error: Must negate existing elements.
+x Can't negate location 100.
+i There are only 26 elements.
+
 > vec_assign(set_names(letters), "foo", "bar")
 Error: Must subset existing elements.
 x Can't subset element with unknown name `foo`.

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -357,8 +357,6 @@ test_that("must assign existing elements", {
       vec_slice(letters, -100) <- "foo",
       class = "vctrs_error_subscript_oob"
     )
-
-    # FIXME
     expect_error(
       vec_assign(set_names(letters), "foo", "bar"),
       class = "vctrs_error_subscript_oob"
@@ -379,8 +377,6 @@ test_that("slice and assign have informative errors", {
     vec_assign(1:3, 5, 10)
     vec_assign(1:3, "foo", 10)
     vec_slice(letters, -100) <- "foo"
-
-    # FIXME
     vec_assign(set_names(letters), "foo", "bar")
   })
 })

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -343,6 +343,25 @@ test_that("logical subscripts must match size of indexed vector", {
   })
 })
 
+test_that("must assign existing elements", {
+  verify_errors({
+    expect_error(
+      vec_assign(1:3, 5, 10),
+      class = "vctrs_error_subscript_oob"
+    )
+    expect_error(
+      vec_assign(1:3, "foo", 10),
+      "unnamed vector"
+    )
+
+    # FIXME
+    expect_error(
+      vec_assign(set_names(letters), "foo", "bar"),
+      class = "vctrs_error_subscript_oob"
+    )
+  })
+})
+
 test_that("slice and assign have informative errors", {
   verify_output(test_path("error", "test-slice-assign.txt"), {
     "# `vec_assign()` requires recyclable value"
@@ -351,5 +370,12 @@ test_that("slice and assign have informative errors", {
     "# logical subscripts must match size of indexed vector"
     vec_assign(1:2, c(TRUE, FALSE, TRUE), 5)
     vec_assign(mtcars, c(TRUE, FALSE), mtcars[1, ])
+
+    "# must assign existing elements"
+    vec_assign(1:3, 5, 10)
+    vec_assign(1:3, "foo", 10)
+
+    # FIXME
+    vec_assign(set_names(letters), "foo", "bar")
   })
 })

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -353,6 +353,10 @@ test_that("must assign existing elements", {
       vec_assign(1:3, "foo", 10),
       "unnamed vector"
     )
+    expect_error(
+      vec_slice(letters, -100) <- "foo",
+      class = "vctrs_error_subscript_oob"
+    )
 
     # FIXME
     expect_error(
@@ -374,6 +378,7 @@ test_that("slice and assign have informative errors", {
     "# must assign existing elements"
     vec_assign(1:3, 5, 10)
     vec_assign(1:3, "foo", 10)
+    vec_slice(letters, -100) <- "foo"
 
     # FIXME
     vec_assign(set_names(letters), "foo", "bar")


### PR DESCRIPTION
Branched from #765.

Add subscript action to the internal option struct, and set the action to "assign" when assigning.

Before:

```r
vec_slice(letters, 100) <- "foo"
#> Error: Must subset existing elements.
#> ✖ Can't subset location 100.
#> ℹ There are only 26 elements.

vec_assign(set_names(letters), "foo", "bar")
#> Error: Must subset existing elements.
#> ✖ Can't subset element with unknown name `foo`.
```

After:

```r
vec_slice(letters, 100) <- "foo"
#> Error: Must assign existing elements.
#> ✖ Can't assign location 100.
#> ℹ There are only 26 elements.

vec_assign(set_names(letters), "foo", "bar")
#> Error: Must assign existing elements.
#> ✖ Can't assign element with unknown name `foo`.
```