### PR TITLE
Improve consistency of subscript errors customisation

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -497,3 +497,11 @@ arg_as_string <- function(arg) {
     as_label(arg)
   }
 }
+append_arg <- function(x, arg) {
+  if (is_null(arg)) {
+    x
+  } else {
+    arg <- arg_as_string(arg)
+    glue::glue("{x} `{arg}`")
+  }
+}

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -266,22 +266,24 @@ cnd_body_vctrs_error_subscript_type <- function(cnd, ...) {
   ))
 }
 
-stop_location_negative_positive <- function(i) {
+stop_location_negative_positive <- function(i, ...) {
   cnd_signal(new_error_subscript_type(
     i,
+    ...,
     body = cnd_body_vctrs_error_location_negative_positive
   ))
 }
 cnd_body_vctrs_error_location_negative_positive <- function(cnd, ...) {
   positive_loc <- which(cnd$i > 0)
+  arg <- append_arg("The subscript", cnd$arg)
 
   if (length(positive_loc) == 1) {
-    loc <- glue::glue("The subscript has a positive value at location {positive_loc}.")
+    loc <- glue::glue("{arg} has a positive value at location {positive_loc}.")
   } else {
     n_loc <- length(positive_loc)
     positive_loc <- enumerate(positive_loc)
     loc <- glue::glue(
-      "The subscript has {n_loc} missing values at locations {positive_loc}."
+      "{arg} has {n_loc} missing values at locations {positive_loc}."
     )
   }
   format_error_bullets(c(

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -162,7 +162,7 @@ vec_as_location2_result <- function(i,
     parent <- result$err
     return(result(err = new_error_location2_type(
       i = i,
-      arg = arg,
+      subscript_arg = arg,
       # FIXME: Should body fields in parents be automatically inherited?
       body = function(...) cnd_body(parent),
       parent = parent
@@ -175,7 +175,7 @@ vec_as_location2_result <- function(i,
   if (length(i) != 1L) {
     return(result(err = new_error_location2_type(
       i = i,
-      arg = arg,
+      subscript_arg = arg,
       body = cnd_bullets_location2_need_scalar
     )))
   }
@@ -189,7 +189,7 @@ vec_as_location2_result <- function(i,
     if (!allow_missing && is.na(i)) {
       result <- result(err = new_error_location2_type(
         i = i,
-        arg = arg,
+        subscript_arg = arg,
         body = cnd_bullets_location2_need_present
       ))
     } else {
@@ -201,7 +201,7 @@ vec_as_location2_result <- function(i,
   if (i == 0L) {
     return(result(err = new_error_location2_type(
       i = i,
-      arg = arg,
+      subscript_arg = arg,
       body = cnd_bullets_location2_need_positive
     )))
   }
@@ -209,7 +209,7 @@ vec_as_location2_result <- function(i,
   if (!allow_negative && neg) {
     return(result(err = new_error_location2_type(
       i = i,
-      arg = arg,
+      subscript_arg = arg,
       body = cnd_bullets_location2_need_positive
     )))
   }
@@ -234,7 +234,7 @@ vec_as_location2_result <- function(i,
     result(err = new_error_location2_type(
       i = i,
       parent = err,
-      arg = arg
+      subscript_arg = arg
     ))
   }
 }
@@ -249,7 +249,7 @@ stop_location_negative_missing <- function(i, ...) {
 }
 cnd_body_vctrs_error_subscript_type <- function(cnd, ...) {
   missing_loc <- which(is.na(cnd$i))
-  arg <- append_arg("The subscript", cnd$arg)
+  arg <- append_arg("The subscript", cnd$subscript_arg)
 
   if (length(missing_loc) == 1) {
     loc <- glue::glue("{arg} has a missing value at location {missing_loc}.")
@@ -275,7 +275,7 @@ stop_location_negative_positive <- function(i, ...) {
 }
 cnd_body_vctrs_error_location_negative_positive <- function(cnd, ...) {
   positive_loc <- which(cnd$i > 0)
-  arg <- append_arg("The subscript", cnd$arg)
+  arg <- append_arg("The subscript", cnd$subscript_arg)
 
   if (length(positive_loc) == 1) {
     loc <- glue::glue("{arg} has a positive value at location {positive_loc}.")
@@ -295,7 +295,6 @@ cnd_body_vctrs_error_location_negative_positive <- function(cnd, ...) {
 
 new_error_location2_type <- function(i,
                                      ...,
-                                     arg = "i",
                                      class = NULL) {
   new_error_subscript2_type(
     class = class,
@@ -303,26 +302,25 @@ new_error_location2_type <- function(i,
     indicator = "error",
     location = "coerce",
     name = "coerce",
-    arg = arg,
     ...
   )
 }
 cnd_bullets_location2_need_scalar <- function(cnd, ...) {
-  cnd$arg <- append_arg("The subscript", cnd$arg)
+  cnd$subscript_arg <- append_arg("The subscript", cnd$subscript_arg)
   format_error_bullets(c(
-    x = glue::glue_data(cnd, "{arg} has size {length(i)} but must be size 1.")
+    x = glue::glue_data(cnd, "{subscript_arg} has size {length(i)} but must be size 1.")
   ))
 }
 cnd_bullets_location2_need_present <- function(cnd, ...) {
-  cnd$arg <- append_arg("The subscript", cnd$arg)
+  cnd$subscript_arg <- append_arg("The subscript", cnd$subscript_arg)
   format_error_bullets(c(
-    x = glue::glue_data(cnd, "{arg} can't be `NA`.")
+    x = glue::glue_data(cnd, "{subscript_arg} can't be `NA`.")
   ))
 }
 cnd_bullets_location2_need_positive <- function(cnd, ...) {
-  cnd$arg <- append_arg("The subscript", cnd$arg)
+  cnd$subscript_arg <- append_arg("The subscript", cnd$subscript_arg)
   format_error_bullets(c(
-    x = glue::glue_data(cnd, "{arg} has value {i} but must be a positive location.")
+    x = glue::glue_data(cnd, "{subscript_arg} has value {i} but must be a positive location.")
   ))
 }
 
@@ -334,9 +332,9 @@ stop_location_negative <- function(i, ...) {
   ))
 }
 cnd_bullets_location_need_non_negative <- function(cnd, ...) {
-  cnd$arg <- append_arg("The subscript", cnd$arg)
+  cnd$subscript_arg <- append_arg("The subscript", cnd$subscript_arg)
   format_error_bullets(c(
-    x = glue::glue_data(cnd, "{arg} can't contain negative locations.")
+    x = glue::glue_data(cnd, "{subscript_arg} can't contain negative locations.")
   ))
 }
 
@@ -349,11 +347,11 @@ stop_indicator_size <- function(i, n, ...) {
   ))
 }
 cnd_body_vctrs_error_indicator_size <- function(cnd, ...) {
-  cnd$arg <- append_arg("the subscript", cnd$arg)
+  cnd$subscript_arg <- append_arg("the subscript", cnd$subscript_arg)
   glue_data_bullets(
     cnd,
     i = "Logical subscripts must match the size of the indexed input.",
-    x = "The input has size {n} but {arg} has size {vec_size(i)}."
+    x = "The input has size {n} but {subscript_arg} has size {vec_size(i)}."
   )
 }
 
@@ -371,14 +369,13 @@ cnd_header.vctrs_error_subscript_oob <- function(cnd, ...) {
   if (cnd_subscript_oob_non_consecutive(cnd)) {
     return(cnd_header_vctrs_error_subscript_oob_non_consecutive(cnd, ...))
   }
-  arg <- cnd$arg
   elt <- cnd_subscript_element(cnd)
   action <- cnd_subscript_action(cnd)
 
-  if (is_null(arg)) {
+  if (is_null(cnd$subscript_arg)) {
     glue::glue("Must {action} existing {elt[[2]]}.")
   } else {
-    arg <- arg_as_string(arg)
+    arg <- arg_as_string(cnd$subscript_arg)
     glue::glue("Must {action} existing {elt[[2]]} in `{arg}`.")
   }
 }
@@ -461,7 +458,7 @@ cnd_body_vctrs_error_subscript_oob_non_consecutive <- function(cnd, ...) {
 
   non_consecutive <- i[c(TRUE, diff(i) != 1L)]
 
-  arg <- append_arg("The subscript", cnd$arg)
+  arg <- append_arg("The subscript", cnd$subscript_arg)
   if (length(non_consecutive) == 1) {
     x_line <- glue::glue("{arg} contains non-consecutive location {non_consecutive}.")
   } else {

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -347,19 +347,20 @@ cnd_bullets_location_need_non_negative <- function(cnd, ...) {
   ))
 }
 
-stop_indicator_size <- function(i, n, arg = "i") {
+stop_indicator_size <- function(i, n, ...) {
   cnd_signal(new_error_subscript_size(
     i,
     n = n,
-    arg = arg,
+    ...,
     body = cnd_body_vctrs_error_indicator_size
   ))
 }
 cnd_body_vctrs_error_indicator_size <- function(cnd, ...) {
+  cnd$arg <- append_arg("the subscript", cnd$arg)
   glue_data_bullets(
     cnd,
     i = "Logical subscripts must match the size of the indexed input.",
-    x = "The input has size {n} but the subscript has size {vec_size(i)}."
+    x = "The input has size {n} but {arg} has size {vec_size(i)}."
   )
 }
 

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -461,25 +461,18 @@ cnd_body_vctrs_error_subscript_oob_non_consecutive <- function(cnd, ...) {
 
   non_consecutive <- i[c(TRUE, diff(i) != 1L)]
 
-  if (is_null(cnd$arg)) {
-    arg_line <- NULL
-  } else {
-    arg <- append_arg("The subscript", cnd$arg)
-    arg_line <- glue::glue("{arg} contains non-consecutive locations.")
-  }
-
+  arg <- append_arg("The subscript", cnd$arg)
   if (length(non_consecutive) == 1) {
-    x <- glue::glue("The location {non_consecutive} is not consecutive to the end.")
+    x_line <- glue::glue("{arg} contains non-consecutive location {non_consecutive}.")
   } else {
     non_consecutive <- enumerate(non_consecutive)
-    x <- glue::glue("The locations {non_consecutive} are not consecutive.")
+    x_line <- glue::glue("{arg} contains non-consecutive locations {non_consecutive}.")
   }
 
   glue_data_bullets(
     cnd,
     i = "The input has size {size}.",
-    x = arg_line,
-    x = x
+    x = x_line
   )
 }
 

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -303,8 +303,6 @@ new_error_location2_type <- function(i,
     ...
   )
 }
-
-
 cnd_bullets_location2_need_scalar <- function(cnd, ...) {
   cnd$arg <- arg_as_string(cnd$arg %||% "i")
   format_error_bullets(c(
@@ -334,19 +332,18 @@ cnd_bullets_location2_need_non_negative <- function(cnd, ...) {
   ))
 }
 
-cnd_bullets_location_need_non_negative <- function(cnd, ...) {
-  cnd$arg <- arg_as_string(cnd$arg %||% "i")
-  format_error_bullets(c(
-    x = glue::glue_data(cnd, "`{arg}` contains negative locations."),
-    i = "The subscript must contain positive locations."
-  ))
-}
-
 stop_location_negative <- function(i, ..., arg = "i") {
   cnd_signal(new_error_subscript_type(
     i,
     arg = arg,
     body = cnd_bullets_location_need_non_negative
+  ))
+}
+cnd_bullets_location_need_non_negative <- function(cnd, ...) {
+  cnd$arg <- arg_as_string(cnd$arg %||% "i")
+  format_error_bullets(c(
+    x = glue::glue_data(cnd, "`{arg}` contains negative locations."),
+    i = "The subscript must contain positive locations."
   ))
 }
 
@@ -366,36 +363,11 @@ cnd_body_vctrs_error_indicator_size <- function(cnd, ...) {
   )
 }
 
-stop_subscript_oob_location <- function(i, size, ..., class = NULL) {
-  stop_subscript_oob(
-    subscript_type = "location",
-    class = class,
-    i = i,
-    size = size,
-    ...
-  )
-}
-stop_subscript_oob_name <- function(i, names, ..., class = NULL) {
-  stop_subscript_oob(
-    subscript_type = "name",
-    class = class,
-    i = i,
-    names = names,
-    ...
-  )
-}
-stop_subscript_oob <- function(i, subscript_type, ..., class = NULL) {
+stop_subscript_oob <- function(i, subscript_type, ...) {
   stop_subscript(
-    class = c(class, "vctrs_error_subscript_oob"),
+    class = "vctrs_error_subscript_oob",
     i = i,
     subscript_type = subscript_type,
-    ...
-  )
-}
-stop_subscript <- function(i, ..., class = NULL) {
-  abort(
-    class = c(class, "vctrs_error_subscript"),
-    i = i,
     ...
   )
 }

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -332,11 +332,11 @@ cnd_bullets_location2_need_non_negative <- function(cnd, ...) {
   ))
 }
 
-stop_location_negative <- function(i, ..., arg = "i") {
+stop_location_negative <- function(i, ...) {
   cnd_signal(new_error_subscript_type(
     i,
-    arg = arg,
-    body = cnd_bullets_location_need_non_negative
+    body = cnd_bullets_location_need_non_negative,
+    ...
   ))
 }
 cnd_bullets_location_need_non_negative <- function(cnd, ...) {

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -54,7 +54,7 @@ vec_as_location <- function(i,
                             n,
                             names = NULL,
                             ...,
-                            arg = "i") {
+                            arg = NULL) {
   if (!missing(...)) ellipsis::check_dots_empty()
 
   i <- vec_as_subscript(i, arg = arg)
@@ -81,7 +81,7 @@ num_as_location <- function(i,
                             ...,
                             negative = c("invert", "error", "ignore"),
                             oob = c("error", "extend"),
-                            arg = "i") {
+                            arg = NULL) {
   if (!missing(...)) ellipsis::check_dots_empty()
 
   if (!is_integer(i) && !is_double(i)) {
@@ -107,7 +107,7 @@ vec_as_location2 <- function(i,
                              names = NULL,
                              ...,
                              missing = c("error", "ignore"),
-                             arg = "i") {
+                             arg = NULL) {
   if (!missing(...)) ellipsis::check_dots_empty()
   result_get(vec_as_location2_result(
     i,
@@ -127,7 +127,7 @@ num_as_location2 <- function(i,
                              ...,
                              negative = c("error", "ignore"),
                              missing = c("error", "ignore"),
-                             arg = "i") {
+                             arg = NULL) {
   if (!missing(...)) ellipsis::check_dots_empty()
 
   if (!is_integer(i) && !is_double(i)) {

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -462,13 +462,22 @@ stop_location_oob_non_consecutive <- function(i, size, ...) {
 }
 
 cnd_header_vctrs_error_subscript_oob_non_consecutive <- function(cnd, ...) {
-  "Can't index beyond the end with non-consecutive locations."
+  action <- cnd_subscript_action(cnd)
+  elt <- cnd_subscript_element(cnd)
+  glue::glue("Can't {action} {elt[[2]]} beyond the end with non-consecutive locations.")
 }
 cnd_body_vctrs_error_subscript_oob_non_consecutive <- function(cnd, ...) {
   i <- sort(cnd$i)
   i <- i[i > cnd$size]
 
   non_consecutive <- i[c(TRUE, diff(i) != 1L)]
+
+  if (is_null(cnd$arg)) {
+    arg_line <- NULL
+  } else {
+    arg <- append_arg("The subscript", cnd$arg)
+    arg_line <- glue::glue("{arg} contains non-consecutive locations.")
+  }
 
   if (length(non_consecutive) == 1) {
     x <- glue::glue("The location {non_consecutive} is not consecutive to the end.")
@@ -480,6 +489,7 @@ cnd_body_vctrs_error_subscript_oob_non_consecutive <- function(cnd, ...) {
   glue_data_bullets(
     cnd,
     i = "The input has size {size}.",
+    x = arg_line,
     x = x
   )
 }

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -64,7 +64,8 @@ vec_as_location <- function(i,
     n = n,
     names = names,
     loc_negative = "invert",
-    loc_oob = "error"
+    loc_oob = "error",
+    arg = arg
   )
 }
 #' @rdname vec_as_location
@@ -92,7 +93,8 @@ num_as_location <- function(i,
     n = n,
     names = NULL,
     loc_negative = negative,
-    loc_oob = oob
+    loc_oob = oob,
+    arg = arg
   )
 }
 

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -202,7 +202,7 @@ vec_as_location2_result <- function(i,
     return(result(err = new_error_location2_type(
       i = i,
       arg = arg,
-      body = cnd_bullets_location2_need_non_zero
+      body = cnd_bullets_location2_need_positive
     )))
   }
 
@@ -210,7 +210,7 @@ vec_as_location2_result <- function(i,
     return(result(err = new_error_location2_type(
       i = i,
       arg = arg,
-      body = cnd_bullets_location2_need_non_negative
+      body = cnd_bullets_location2_need_positive
     )))
   }
 
@@ -308,31 +308,21 @@ new_error_location2_type <- function(i,
   )
 }
 cnd_bullets_location2_need_scalar <- function(cnd, ...) {
-  cnd$arg <- arg_as_string(cnd$arg %||% "i")
+  cnd$arg <- append_arg("The subscript", cnd$arg)
   format_error_bullets(c(
-    x = glue::glue_data(cnd, "`{arg}` has the wrong size {length(i)}."),
-    i = "This subscript must be size 1."
+    x = glue::glue_data(cnd, "{arg} has size {length(i)} but must be size 1.")
   ))
 }
 cnd_bullets_location2_need_present <- function(cnd, ...) {
-  cnd$arg <- arg_as_string(cnd$arg %||% "i")
+  cnd$arg <- append_arg("The subscript", cnd$arg)
   format_error_bullets(c(
-    x = glue::glue_data(cnd, "`{arg}` can't be `NA`."),
-    i = "This subscript can't be missing."
+    x = glue::glue_data(cnd, "{arg} can't be `NA`.")
   ))
 }
-cnd_bullets_location2_need_non_zero <- function(cnd, ...) {
-  cnd$arg <- arg_as_string(cnd$arg %||% "i")
+cnd_bullets_location2_need_positive <- function(cnd, ...) {
+  cnd$arg <- append_arg("The subscript", cnd$arg)
   format_error_bullets(c(
-    x = glue::glue_data(cnd, "`{arg}` can't be zero."),
-    i = "The subscript must be a positive location."
-  ))
-}
-cnd_bullets_location2_need_non_negative <- function(cnd, ...) {
-  cnd$arg <- arg_as_string(cnd$arg %||% "i")
-  format_error_bullets(c(
-    x = glue::glue_data(cnd, "`{arg}` (with value {i}) has the wrong sign."),
-    i = "The subscript must be a positive location."
+    x = glue::glue_data(cnd, "{arg} has value {i} but must be a positive location.")
   ))
 }
 
@@ -344,10 +334,9 @@ stop_location_negative <- function(i, ...) {
   ))
 }
 cnd_bullets_location_need_non_negative <- function(cnd, ...) {
-  cnd$arg <- arg_as_string(cnd$arg %||% "i")
+  cnd$arg <- append_arg("The subscript", cnd$arg)
   format_error_bullets(c(
-    x = glue::glue_data(cnd, "`{arg}` contains negative locations."),
-    i = "The subscript must contain positive locations."
+    x = glue::glue_data(cnd, "{arg} can't contain negative locations.")
   ))
 }
 

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -304,40 +304,39 @@ new_error_location2_type <- function(i,
 
 
 cnd_bullets_location2_need_scalar <- function(cnd, ...) {
-  arg <- cnd$arg %||% "i"
-  size <- length(cnd$i)
+  cnd$arg <- arg_as_string(cnd$arg %||% "i")
   format_error_bullets(c(
-    x = glue::glue("`{arg}` has the wrong size {size}."),
+    x = glue::glue_data(cnd, "`{arg}` has the wrong size {length(i)}."),
     i = "This subscript must be size 1."
   ))
 }
 cnd_bullets_location2_need_present <- function(cnd, ...) {
-  arg <- cnd$arg %||% "i"
+  cnd$arg <- arg_as_string(cnd$arg %||% "i")
   format_error_bullets(c(
-    x = glue::glue("`{arg}` can't be `NA`."),
+    x = glue::glue_data(cnd, "`{arg}` can't be `NA`."),
     i = "This subscript can't be missing."
   ))
 }
 cnd_bullets_location2_need_non_zero <- function(cnd, ...) {
-  arg <- cnd$arg %||% "i"
+  cnd$arg <- arg_as_string(cnd$arg %||% "i")
   format_error_bullets(c(
-    x = glue::glue("`{arg}` can't be zero."),
-    i = "This subscript must be a positive integer."
+    x = glue::glue_data(cnd, "`{arg}` can't be zero."),
+    i = "The subscript must be a positive location."
   ))
 }
 cnd_bullets_location2_need_non_negative <- function(cnd, ...) {
-  cnd$arg <- cnd$arg %||% "i"
+  cnd$arg <- arg_as_string(cnd$arg %||% "i")
   format_error_bullets(c(
     x = glue::glue_data(cnd, "`{arg}` (with value {i}) has the wrong sign."),
-    i = "This subscript must be a positive integer."
+    i = "The subscript must be a positive location."
   ))
 }
 
 cnd_bullets_location_need_non_negative <- function(cnd, ...) {
-  cnd$arg <- cnd$arg %||% "i"
+  cnd$arg <- arg_as_string(cnd$arg %||% "i")
   format_error_bullets(c(
     x = glue::glue_data(cnd, "`{arg}` contains negative locations."),
-    i = "These subscripts must be positive integers."
+    i = "The subscript must contain positive locations."
   ))
 }
 

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -240,22 +240,24 @@ vec_as_location2_result <- function(i,
 }
 
 
-stop_location_negative_missing <- function(i) {
+stop_location_negative_missing <- function(i, ...) {
   cnd_signal(new_error_subscript_type(
     i,
+    ...,
     body = cnd_body_vctrs_error_subscript_type
   ))
 }
 cnd_body_vctrs_error_subscript_type <- function(cnd, ...) {
   missing_loc <- which(is.na(cnd$i))
+  arg <- append_arg("The subscript", cnd$arg)
 
   if (length(missing_loc) == 1) {
-    loc <- glue::glue("The subscript has a missing value at location {missing_loc}.")
+    loc <- glue::glue("{arg} has a missing value at location {missing_loc}.")
   } else {
     n_loc <- length(missing_loc)
     missing_loc <- enumerate(missing_loc)
     loc <- glue::glue(
-      "The subscript has {n_loc} missing values at locations {missing_loc}."
+      "{arg} has {n_loc} missing values at locations {missing_loc}."
     )
   }
   format_error_bullets(c(

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -30,7 +30,7 @@ vec_as_subscript <- function(i,
                              indicator = c("coerce", "error"),
                              location = c("coerce", "error"),
                              name = c("coerce", "error"),
-                             arg = "i") {
+                             arg = NULL) {
   if (!missing(...)) ellipsis::check_dots_empty()
   result_get(vec_as_subscript_result(
     i,
@@ -142,7 +142,7 @@ vec_as_subscript2 <- function(i,
                               indicator = c("coerce", "error"),
                               location = c("coerce", "error"),
                               name = c("coerce", "error"),
-                              arg = "i") {
+                              arg = NULL) {
   if (!missing(...)) ellipsis::check_dots_empty()
   result_get(vec_as_subscript2_result(
     i,
@@ -238,11 +238,10 @@ stop_subscript <- function(i, ..., class = NULL) {
     ...
   )
 }
-new_error_subscript <- function(class = NULL, i, ..., arg = "i") {
+new_error_subscript <- function(class = NULL, i, ...) {
   error_cnd(
     c(class, "vctrs_error_subscript"),
     i = i,
-    arg = arg,
     ...
   )
 }
@@ -251,7 +250,6 @@ new_error_subscript_type <- function(i,
                                      location = "coerce",
                                      name = "coerce",
                                      ...,
-                                     arg = "i",
                                      class = NULL) {
   new_error_subscript(
     class = c(class, "vctrs_error_subscript_type"),
@@ -259,7 +257,6 @@ new_error_subscript_type <- function(i,
     indicator = indicator,
     location = location,
     name = name,
-    arg = arg,
     ...
   )
 }
@@ -320,14 +317,12 @@ new_error_subscript2_type <- function(i,
                                       indicator,
                                       location,
                                       name,
-                                      ...,
-                                      arg = "i") {
+                                      ...) {
   new_error_subscript_type(
     i = i,
     indicator = indicator,
     location = location,
     name = name,
-    arg = arg,
     subscript_scalar = TRUE,
     ...
   )

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -273,13 +273,13 @@ cnd_header.vctrs_error_subscript_type <- function(cnd) {
 }
 #' @export
 cnd_body.vctrs_error_subscript_type <- function(cnd) {
-  arg <- arg_as_string(cnd$arg %||% "i")
+  arg <- append_arg("The subscript", cnd$arg)
   type <- obj_type(cnd$i)
   expected_types <- collapse_subscript_type(cnd, plural = TRUE)
 
   format_error_bullets(c(
-    x = glue::glue("`{arg}` has the wrong type `{type}`."),
-    i = glue::glue("The subscript must contain {expected_types}.")
+    x = glue::glue("{arg} has the wrong type `{type}`."),
+    i = glue::glue("It must contain {expected_types}.")
   ))
 }
 cnd_bullets_subscript_lossy_cast <- function(cnd, ...) {

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -259,15 +259,17 @@ new_error_subscript_type <- function(i,
 
 #' @export
 cnd_header.vctrs_error_subscript_type <- function(cnd) {
+  action <- cnd_subscript_action(cnd)
+  elt <- cnd_subscript_element(cnd)
   if (cnd_subscript_scalar(cnd)) {
-    "Must extract with a single subscript."
+    glue::glue("Must {action} {elt[[1]]} with a single subscript.")
   } else {
-    "Must subset with a proper subscript vector."
+    glue::glue("Must {action} {elt[[2]]} with a proper subscript vector.")
   }
 }
 #' @export
 cnd_body.vctrs_error_subscript_type <- function(cnd) {
-  arg <- cnd$arg %||% "i"
+  arg <- arg_as_string(cnd$arg %||% "i")
   type <- obj_type(cnd$i)
   expected_types <- collapse_subscript_type(cnd, plural = TRUE)
 
@@ -345,7 +347,15 @@ subscript_actions <- c(
   "subset", "extract", "assign", "rename", "remove", "negate"
 )
 cnd_subscript_action <- function(cnd) {
-  action <- cnd$subscript_action %||% "subset"
+  action <- cnd$subscript_action
+
+  if (is_null(action)) {
+    if (cnd_subscript_scalar(cnd)) {
+      action <- "extract"
+    } else {
+      action <- "subset"
+    }
+  }
 
   if (!is_string(action, subscript_actions)) {
     abort(paste0(

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -231,6 +231,13 @@ as_opts_subscript2_type <- function(x, arg = NULL) {
 }
 
 
+stop_subscript <- function(i, ..., class = NULL) {
+  abort(
+    class = c(class, "vctrs_error_subscript"),
+    i = i,
+    ...
+  )
+}
 new_error_subscript <- function(class = NULL, i, ..., arg = "i") {
   error_cnd(
     c(class, "vctrs_error_subscript"),

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -55,7 +55,7 @@ vec_as_subscript_result <- function(i, arg, indicator, location, name) {
   if (!vec_is(i)) {
     return(result(err = new_error_subscript_type(
       i = i,
-      arg = arg,
+      subscript_arg = arg,
       indicator = indicator,
       location = location,
       name = name
@@ -76,7 +76,7 @@ vec_as_subscript_result <- function(i, arg, indicator, location, name) {
     } else {
       return(result(err = new_error_subscript_type(
         i,
-        arg = arg,
+        subscript_arg = arg,
         indicator = indicator,
         location = location,
         name = name
@@ -122,7 +122,7 @@ vec_as_subscript_result <- function(i, arg, indicator, location, name) {
   if (action == "error") {
     result(err = new_error_subscript_type(
       i = i,
-      arg = arg,
+      subscript_arg = arg,
       indicator = indicator,
       location = location,
       name = name
@@ -183,7 +183,7 @@ vec_as_subscript2_result <- function(i,
       indicator = indicator,
       location = location,
       name = name,
-      arg = arg,
+      subscript_arg = arg,
       body = bullets,
       parent = result$err$parent
     )
@@ -199,7 +199,7 @@ vec_as_subscript2_result <- function(i,
       indicator = indicator,
       location = location,
       name = name,
-      arg = arg,
+      subscript_arg = arg,
       body = cnd_body.vctrs_error_subscript_type
     )))
   }
@@ -273,7 +273,7 @@ cnd_header.vctrs_error_subscript_type <- function(cnd) {
 }
 #' @export
 cnd_body.vctrs_error_subscript_type <- function(cnd) {
-  arg <- append_arg("The subscript", cnd$arg)
+  arg <- append_arg("The subscript", cnd$subscript_arg)
   type <- obj_type(cnd$i)
   expected_types <- collapse_subscript_type(cnd, plural = TRUE)
 

--- a/R/vctrs-deprecated.R
+++ b/R/vctrs-deprecated.R
@@ -78,6 +78,7 @@ vec_as_index <- function(i, n, names = NULL) {
     n = n,
     names = names,
     loc_negative = "invert",
-    loc_oob = "error"
+    loc_oob = "error",
+    arg = NULL
   )
 }

--- a/man/vec_as_location.Rd
+++ b/man/vec_as_location.Rd
@@ -7,7 +7,7 @@
 \alias{num_as_location2}
 \title{Create a vector of locations}
 \usage{
-vec_as_location(i, n, names = NULL, ..., arg = "i")
+vec_as_location(i, n, names = NULL, ..., arg = NULL)
 
 num_as_location(
   i,
@@ -15,7 +15,7 @@ num_as_location(
   ...,
   negative = c("invert", "error", "ignore"),
   oob = c("error", "extend"),
-  arg = "i"
+  arg = NULL
 )
 
 vec_as_location2(
@@ -24,7 +24,7 @@ vec_as_location2(
   names = NULL,
   ...,
   missing = c("error", "ignore"),
-  arg = "i"
+  arg = NULL
 )
 
 num_as_location2(
@@ -33,7 +33,7 @@ num_as_location2(
   ...,
   negative = c("error", "ignore"),
   missing = c("error", "ignore"),
-  arg = "i"
+  arg = NULL
 )
 }
 \arguments{

--- a/man/vec_as_subscript.Rd
+++ b/man/vec_as_subscript.Rd
@@ -11,7 +11,7 @@ vec_as_subscript(
   indicator = c("coerce", "error"),
   location = c("coerce", "error"),
   name = c("coerce", "error"),
-  arg = "i"
+  arg = NULL
 )
 
 vec_as_subscript2(
@@ -20,7 +20,7 @@ vec_as_subscript2(
   indicator = c("coerce", "error"),
   location = c("coerce", "error"),
   name = c("coerce", "error"),
-  arg = "i"
+  arg = NULL
 )
 }
 \arguments{

--- a/src/cast.c
+++ b/src/cast.c
@@ -400,12 +400,8 @@ SEXP vec_coercible_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_a
 
 // [[ register() ]]
 SEXP vctrs_coercible_cast(SEXP x, SEXP to, SEXP x_arg_, SEXP to_arg_) {
-  if (!r_is_string(x_arg_)) {
-    Rf_errorcall(R_NilValue, "`x_arg` must be a string");
-  }
-  if (!r_is_string(to_arg_)) {
-    Rf_errorcall(R_NilValue, "`to_arg` must be a string");
-  }
+  x_arg_ = arg_validate(x_arg_, "x_arg");
+  to_arg_ = arg_validate(to_arg_, "to_arg");
 
   struct vctrs_arg x_arg = new_wrapper_arg(NULL, r_chr_get_c_string(x_arg_, 0));
   struct vctrs_arg to_arg = new_wrapper_arg(NULL, r_chr_get_c_string(to_arg_, 0));

--- a/src/init.c
+++ b/src/init.c
@@ -44,7 +44,7 @@ extern SEXP vctrs_is_vector(SEXP);
 extern SEXP vctrs_type2(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_typeof2(SEXP, SEXP);
 extern SEXP vctrs_cast(SEXP, SEXP, SEXP, SEXP);
-extern SEXP vctrs_as_location(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_as_location(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_slice(SEXP, SEXP);
 extern SEXP vctrs_init(SEXP, SEXP);
 extern SEXP vctrs_chop(SEXP, SEXP);
@@ -145,7 +145,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_type2",                      (DL_FUNC) &vctrs_type2, 4},
   {"vctrs_typeof2",                    (DL_FUNC) &vctrs_typeof2, 2},
   {"vctrs_cast",                       (DL_FUNC) &vctrs_cast, 4},
-  {"vctrs_as_location",                (DL_FUNC) &vctrs_as_location, 5},
+  {"vctrs_as_location",                (DL_FUNC) &vctrs_as_location, 6},
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 2},
   {"vctrs_init",                       (DL_FUNC) &vctrs_init, 2},
   {"vctrs_chop",                       (DL_FUNC) &vctrs_chop, 2},
@@ -247,6 +247,7 @@ void vctrs_init_names(SEXP ns);
 void vctrs_init_proxy_restore(SEXP ns);
 void vctrs_init_slice(SEXP ns);
 void vctrs_init_slice_assign(SEXP ns);
+void vctrs_init_subscript_loc(SEXP ns);
 void vctrs_init_type2(SEXP ns);
 void vctrs_init_type(SEXP ns);
 void vctrs_init_type_info(SEXP ns);
@@ -261,6 +262,7 @@ SEXP vctrs_init_library(SEXP ns) {
   vctrs_init_proxy_restore(ns);
   vctrs_init_slice(ns);
   vctrs_init_slice_assign(ns);
+  vctrs_init_subscript_loc(ns);
   vctrs_init_type2(ns);
   vctrs_init_type(ns);
   vctrs_init_type_info(ns);

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -20,12 +20,6 @@ static SEXP raw_assign(SEXP x, SEXP index, SEXP value, bool clone);
 SEXP list_assign(SEXP x, SEXP index, SEXP value, bool clone);
 SEXP df_assign(SEXP x, SEXP index, SEXP value, bool clone);
 
-const struct vec_as_location_opts default_assign_loc_opts = {
-  .action = SUBSCRIPT_ACTION_ASSIGN,
-  .loc_negative = LOC_NEGATIVE_INVERT,
-  .loc_oob = LOC_OOB_ERROR
-};
-
 // [[ register(); include("vctrs.h") ]]
 SEXP vec_assign(SEXP x, SEXP index, SEXP value) {
   if (x == R_NilValue) {
@@ -46,7 +40,7 @@ SEXP vec_assign(SEXP x, SEXP index, SEXP value) {
   index = PROTECT(vec_as_location_opts(index,
                                        vec_size(x),
                                        PROTECT(vec_names(x)),
-                                       &default_assign_loc_opts));
+                                       vec_as_location_default_assign_opts));
   value_proxy = PROTECT(vec_recycle(value_proxy, vec_size(index), &value_arg));
 
   struct vctrs_proxy_info info = vec_proxy_info(x);

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -349,7 +349,7 @@ SEXP vctrs_as_location(SEXP subscript, SEXP n_, SEXP names,
     .action = SUBSCRIPT_ACTION_DEFAULT,
     .loc_negative = parse_loc_negative(loc_negative),
     .loc_oob = parse_loc_oob(loc_oob),
-    .arg = arg
+    .subscript_arg = arg
   };
 
   return vec_as_location_opts(subscript, n, names, &opts);
@@ -359,7 +359,7 @@ static void stop_location_negative_missing(SEXP i,
                                            const struct vec_as_location_opts* opts) {
   vctrs_eval_mask2(Rf_install("stop_location_negative_missing"),
                    syms_i, i,
-                   syms_arg, opts->arg,
+                   syms_subscript_arg, opts->subscript_arg,
                    vctrs_ns_env);
   never_reached("stop_location_negative_missing");
 }
@@ -367,7 +367,7 @@ static void stop_location_negative_positive(SEXP i,
                                             const struct vec_as_location_opts* opts) {
   vctrs_eval_mask2(Rf_install("stop_location_negative_positive"),
                    syms_i, i,
-                   syms_arg, opts->arg,
+                   syms_subscript_arg, opts->subscript_arg,
                    vctrs_ns_env);
   never_reached("stop_location_negative_positive");
 }
@@ -381,7 +381,7 @@ static void stop_subscript_oob_location(SEXP i, R_len_t size,
                    syms_subscript_type, chrs_location,
                    syms_size, size_obj,
                    syms_subscript_action, action,
-                   syms_arg, opts->arg,
+                   syms_subscript_arg, opts->subscript_arg,
                    vctrs_ns_env);
 
   UNPROTECT(1);
@@ -395,7 +395,7 @@ static void stop_subscript_oob_name(SEXP i, SEXP names,
                    syms_subscript_type, chrs_name,
                    syms_names, names,
                    syms_subscript_action, action,
-                   syms_arg, opts->arg,
+                   syms_subscript_arg, opts->subscript_arg,
                    vctrs_ns_env);
   never_reached("stop_subscript_oob_name");
 }
@@ -406,7 +406,7 @@ static void stop_location_negative(SEXP i,
   vctrs_eval_mask3(Rf_install("stop_location_negative"),
                    syms_i, i,
                    syms_subscript_action, action,
-                   syms_arg, opts->arg,
+                   syms_subscript_arg, opts->subscript_arg,
                    vctrs_ns_env);
   never_reached("stop_location_negative");
 }
@@ -416,7 +416,7 @@ static void stop_indicator_size(SEXP i, SEXP n,
   vctrs_eval_mask3(Rf_install("stop_indicator_size"),
                    syms_i, i,
                    syms_n, n,
-                   syms_arg, opts->arg,
+                   syms_subscript_arg, opts->subscript_arg,
                    vctrs_ns_env);
   never_reached("stop_indicator_size");
 }
@@ -427,7 +427,7 @@ static void stop_location_oob_non_consecutive(SEXP i, R_len_t size,
   vctrs_eval_mask3(Rf_install("stop_location_oob_non_consecutive"),
                    syms_i, i,
                    syms_size, size_obj,
-                   syms_arg, opts->arg,
+                   syms_subscript_arg, opts->subscript_arg,
                    vctrs_ns_env);
 
   UNPROTECT(1);
@@ -442,10 +442,10 @@ void vctrs_init_subscript_loc(SEXP ns) {
   vec_as_location_default_opts_obj.action = SUBSCRIPT_ACTION_DEFAULT;
   vec_as_location_default_opts_obj.loc_negative = LOC_NEGATIVE_INVERT;
   vec_as_location_default_opts_obj.loc_oob = LOC_OOB_ERROR;
-  vec_as_location_default_opts_obj.arg = R_NilValue;
+  vec_as_location_default_opts_obj.subscript_arg = R_NilValue;
 
   vec_as_location_default_assign_opts_obj.action = SUBSCRIPT_ACTION_ASSIGN;
   vec_as_location_default_assign_opts_obj.loc_negative = LOC_NEGATIVE_INVERT;
   vec_as_location_default_assign_opts_obj.loc_oob = LOC_OOB_ERROR;
-  vec_as_location_default_assign_opts_obj.arg = R_NilValue;
+  vec_as_location_default_assign_opts_obj.subscript_arg = R_NilValue;
 }

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -357,17 +357,19 @@ SEXP vctrs_as_location(SEXP subscript, SEXP n_, SEXP names,
 
 static void stop_location_negative_missing(SEXP i,
                                            const struct vec_as_location_opts* opts) {
-  vctrs_eval_mask2(Rf_install("stop_location_negative_missing"),
+  vctrs_eval_mask3(Rf_install("stop_location_negative_missing"),
                    syms_i, i,
                    syms_subscript_arg, opts->subscript_arg,
+                   syms_subscript_action, get_opts_action(opts),
                    vctrs_ns_env);
   never_reached("stop_location_negative_missing");
 }
 static void stop_location_negative_positive(SEXP i,
                                             const struct vec_as_location_opts* opts) {
-  vctrs_eval_mask2(Rf_install("stop_location_negative_positive"),
+  vctrs_eval_mask3(Rf_install("stop_location_negative_positive"),
                    syms_i, i,
                    syms_subscript_arg, opts->subscript_arg,
+                   syms_subscript_action, get_opts_action(opts),
                    vctrs_ns_env);
   never_reached("stop_location_negative_positive");
 }
@@ -375,12 +377,11 @@ static void stop_location_negative_positive(SEXP i,
 static void stop_subscript_oob_location(SEXP i, R_len_t size,
                                         const struct vec_as_location_opts* opts) {
   SEXP size_obj = PROTECT(r_int(size));
-  SEXP action = get_opts_action(opts);
   vctrs_eval_mask5(Rf_install("stop_subscript_oob"),
                    syms_i, i,
                    syms_subscript_type, chrs_location,
                    syms_size, size_obj,
-                   syms_subscript_action, action,
+                   syms_subscript_action, get_opts_action(opts),
                    syms_subscript_arg, opts->subscript_arg,
                    vctrs_ns_env);
 
@@ -389,12 +390,11 @@ static void stop_subscript_oob_location(SEXP i, R_len_t size,
 }
 static void stop_subscript_oob_name(SEXP i, SEXP names,
                                     const struct vec_as_location_opts* opts) {
-  SEXP action = get_opts_action(opts);
   vctrs_eval_mask5(Rf_install("stop_subscript_oob"),
                    syms_i, i,
                    syms_subscript_type, chrs_name,
                    syms_names, names,
-                   syms_subscript_action, action,
+                   syms_subscript_action, get_opts_action(opts),
                    syms_subscript_arg, opts->subscript_arg,
                    vctrs_ns_env);
   never_reached("stop_subscript_oob_name");
@@ -402,10 +402,9 @@ static void stop_subscript_oob_name(SEXP i, SEXP names,
 
 static void stop_location_negative(SEXP i,
                                    const struct vec_as_location_opts* opts) {
-  SEXP action = get_opts_action(opts);
   vctrs_eval_mask3(Rf_install("stop_location_negative"),
                    syms_i, i,
-                   syms_subscript_action, action,
+                   syms_subscript_action, get_opts_action(opts),
                    syms_subscript_arg, opts->subscript_arg,
                    vctrs_ns_env);
   never_reached("stop_location_negative");
@@ -413,9 +412,10 @@ static void stop_location_negative(SEXP i,
 
 static void stop_indicator_size(SEXP i, SEXP n,
                                 const struct vec_as_location_opts* opts) {
-  vctrs_eval_mask3(Rf_install("stop_indicator_size"),
+  vctrs_eval_mask4(Rf_install("stop_indicator_size"),
                    syms_i, i,
                    syms_n, n,
+                   syms_subscript_action, get_opts_action(opts),
                    syms_subscript_arg, opts->subscript_arg,
                    vctrs_ns_env);
   never_reached("stop_indicator_size");
@@ -424,9 +424,10 @@ static void stop_indicator_size(SEXP i, SEXP n,
 static void stop_location_oob_non_consecutive(SEXP i, R_len_t size,
                                               const struct vec_as_location_opts* opts) {
   SEXP size_obj = PROTECT(r_int(size));
-  vctrs_eval_mask3(Rf_install("stop_location_oob_non_consecutive"),
+  vctrs_eval_mask4(Rf_install("stop_location_oob_non_consecutive"),
                    syms_i, i,
                    syms_size, size_obj,
+                   syms_subscript_action, get_opts_action(opts),
                    syms_subscript_arg, opts->subscript_arg,
                    vctrs_ns_env);
 

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -11,7 +11,8 @@ static void stop_subscript_oob_location(SEXP i, R_len_t size,
                                         const struct vec_as_location_opts* opts);
 static void stop_subscript_oob_name(SEXP i, SEXP names,
                                     const struct vec_as_location_opts* opts);
-static void stop_location_negative(SEXP i);
+static void stop_location_negative(SEXP i,
+                                   const struct vec_as_location_opts* opts);
 static void stop_indicator_size(SEXP i, SEXP n);
 static void stop_location_negative_missing(SEXP i);
 static void stop_location_negative_positive(SEXP i);
@@ -37,7 +38,7 @@ static SEXP int_as_location(SEXP subscript, R_len_t n,
       if (elt < 0) {
         switch (opts->loc_negative) {
         case LOC_NEGATIVE_INVERT: return int_invert_location(subscript, n, opts);
-        case LOC_NEGATIVE_ERROR: stop_location_negative(subscript);
+        case LOC_NEGATIVE_ERROR: stop_location_negative(subscript, opts);
         case LOC_NEGATIVE_IGNORE: break;
         }
       }
@@ -389,9 +390,13 @@ static void stop_subscript_oob_name(SEXP i, SEXP names,
   never_reached("stop_subscript_oob_name");
 }
 
-static void stop_location_negative(SEXP i) {
-  vctrs_eval_mask1(Rf_install("stop_location_negative"),
+static void stop_location_negative(SEXP i,
+                                   const struct vec_as_location_opts* opts) {
+  SEXP action = get_opts_action(opts);
+  vctrs_eval_mask3(Rf_install("stop_location_negative"),
                    syms_i, i,
+                   syms_subscript_action, action,
+                   syms_arg, opts->arg,
                    vctrs_ns_env);
   never_reached("stop_location_negative");
 }

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -15,7 +15,8 @@ static void stop_location_negative(SEXP i,
                                    const struct vec_as_location_opts* opts);
 static void stop_indicator_size(SEXP i, SEXP n,
                                 const struct vec_as_location_opts* opts);
-static void stop_location_negative_missing(SEXP i);
+static void stop_location_negative_missing(SEXP i,
+                                           const struct vec_as_location_opts* opts);
 static void stop_location_negative_positive(SEXP i);
 static void stop_location_oob_non_consecutive(SEXP i, R_len_t size);
 
@@ -86,7 +87,7 @@ static SEXP int_invert_location(SEXP subscript, R_len_t n,
     int j = *data;
 
     if (j == NA_INTEGER) {
-      stop_location_negative_missing(subscript);
+      stop_location_negative_missing(subscript, opts);
     }
     if (j >= 0) {
       if (j == 0) {
@@ -350,9 +351,11 @@ SEXP vctrs_as_location(SEXP subscript, SEXP n_, SEXP names,
   return vec_as_location_opts(subscript, n, names, &opts);
 }
 
-static void stop_location_negative_missing(SEXP i) {
-  vctrs_eval_mask1(Rf_install("stop_location_negative_missing"),
+static void stop_location_negative_missing(SEXP i,
+                                           const struct vec_as_location_opts* opts) {
+  vctrs_eval_mask2(Rf_install("stop_location_negative_missing"),
                    syms_i, i,
+                   syms_arg, opts->arg,
                    vctrs_ns_env);
   never_reached("stop_location_negative_missing");
 }

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -365,8 +365,9 @@ static void stop_subscript_oob_location(SEXP i, R_len_t size,
                                         const struct vec_as_location_opts* opts) {
   SEXP size_obj = PROTECT(r_int(size));
   SEXP action = get_opts_action(opts);
-  vctrs_eval_mask4(Rf_install("stop_subscript_oob_location"),
+  vctrs_eval_mask5(Rf_install("stop_subscript_oob"),
                    syms_i, i,
+                   syms_subscript_type, chrs_location,
                    syms_size, size_obj,
                    syms_subscript_action, action,
                    syms_arg, opts->arg,
@@ -378,8 +379,9 @@ static void stop_subscript_oob_location(SEXP i, R_len_t size,
 static void stop_subscript_oob_name(SEXP i, SEXP names,
                                     const struct vec_as_location_opts* opts) {
   SEXP action = get_opts_action(opts);
-  vctrs_eval_mask4(Rf_install("stop_subscript_oob_name"),
+  vctrs_eval_mask5(Rf_install("stop_subscript_oob"),
                    syms_i, i,
+                   syms_subscript_type, chrs_name,
                    syms_names, names,
                    syms_subscript_action, action,
                    syms_arg, opts->arg,

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -17,7 +17,8 @@ static void stop_indicator_size(SEXP i, SEXP n,
                                 const struct vec_as_location_opts* opts);
 static void stop_location_negative_missing(SEXP i,
                                            const struct vec_as_location_opts* opts);
-static void stop_location_negative_positive(SEXP i);
+static void stop_location_negative_positive(SEXP i,
+                                            const struct vec_as_location_opts* opts);
 static void stop_location_oob_non_consecutive(SEXP i, R_len_t size);
 
 
@@ -93,7 +94,7 @@ static SEXP int_invert_location(SEXP subscript, R_len_t n,
       if (j == 0) {
         continue;
       } else {
-        stop_location_negative_positive(subscript);
+        stop_location_negative_positive(subscript, opts);
       }
     }
 
@@ -359,9 +360,11 @@ static void stop_location_negative_missing(SEXP i,
                    vctrs_ns_env);
   never_reached("stop_location_negative_missing");
 }
-static void stop_location_negative_positive(SEXP i) {
-  vctrs_eval_mask1(Rf_install("stop_location_negative_positive"),
+static void stop_location_negative_positive(SEXP i,
+                                            const struct vec_as_location_opts* opts) {
+  vctrs_eval_mask2(Rf_install("stop_location_negative_positive"),
                    syms_i, i,
+                   syms_arg, opts->arg,
                    vctrs_ns_env);
   never_reached("stop_location_negative_positive");
 }

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -13,7 +13,8 @@ static void stop_subscript_oob_name(SEXP i, SEXP names,
                                     const struct vec_as_location_opts* opts);
 static void stop_location_negative(SEXP i,
                                    const struct vec_as_location_opts* opts);
-static void stop_indicator_size(SEXP i, SEXP n);
+static void stop_indicator_size(SEXP i, SEXP n,
+                                const struct vec_as_location_opts* opts);
 static void stop_location_negative_missing(SEXP i);
 static void stop_location_negative_positive(SEXP i);
 static void stop_location_oob_non_consecutive(SEXP i, R_len_t size);
@@ -226,7 +227,7 @@ static SEXP lgl_as_location(SEXP subscript, R_len_t n,
   }
 
   SEXP n_obj = PROTECT(Rf_ScalarInteger(n));
-  stop_indicator_size(subscript, n_obj);
+  stop_indicator_size(subscript, n_obj, opts);
 
   never_reached("lgl_as_location");
 }
@@ -401,10 +402,12 @@ static void stop_location_negative(SEXP i,
   never_reached("stop_location_negative");
 }
 
-static void stop_indicator_size(SEXP i, SEXP n) {
-  vctrs_eval_mask2(Rf_install("stop_indicator_size"),
+static void stop_indicator_size(SEXP i, SEXP n,
+                                const struct vec_as_location_opts* opts) {
+  vctrs_eval_mask3(Rf_install("stop_indicator_size"),
                    syms_i, i,
                    syms_n, n,
+                   syms_arg, opts->arg,
                    vctrs_ns_env);
   never_reached("stop_indicator_size");
 }

--- a/src/subscript-loc.h
+++ b/src/subscript-loc.h
@@ -27,7 +27,15 @@ struct vec_as_location_opts {
   enum subscript_action action;
   enum num_as_location_loc_negative loc_negative;
   enum num_as_location_loc_oob loc_oob;
+  SEXP arg;
 };
+
+extern struct vec_as_location_opts vec_as_location_default_opts_obj;
+extern struct vec_as_location_opts vec_as_location_default_assign_opts_obj;
+
+static const struct vec_as_location_opts* const vec_as_location_default_opts = &vec_as_location_default_opts_obj;
+static const struct vec_as_location_opts* const vec_as_location_default_assign_opts = &vec_as_location_default_assign_opts_obj;
+
 
 SEXP vec_as_location(SEXP i, R_len_t n, SEXP names);
 SEXP vec_as_location_opts(SEXP i, R_len_t n, SEXP names,

--- a/src/subscript-loc.h
+++ b/src/subscript-loc.h
@@ -27,7 +27,7 @@ struct vec_as_location_opts {
   enum subscript_action action;
   enum num_as_location_loc_negative loc_negative;
   enum num_as_location_loc_oob loc_oob;
-  SEXP arg;
+  SEXP subscript_arg;
 };
 
 extern struct vec_as_location_opts vec_as_location_default_opts_obj;

--- a/src/utils.c
+++ b/src/utils.c
@@ -80,6 +80,16 @@ SEXP vctrs_eval_mask3(SEXP fn,
   SEXP args[4] = { x, y, z, NULL };
   return vctrs_eval_mask_n(fn, syms, args, env);
 }
+SEXP vctrs_eval_mask4(SEXP fn,
+                      SEXP x1_sym, SEXP x1,
+                      SEXP x2_sym, SEXP x2,
+                      SEXP x3_sym, SEXP x3,
+                      SEXP x4_sym, SEXP x4,
+                      SEXP env) {
+  SEXP syms[5] = { x1_sym, x2_sym, x3_sym, x4_sym, NULL };
+  SEXP args[5] = { x1, x2, x3, x4, NULL };
+  return vctrs_eval_mask_n(fn, syms, args, env);
+}
 
 /**
  * Dispatch in the global environment

--- a/src/utils.c
+++ b/src/utils.c
@@ -90,6 +90,17 @@ SEXP vctrs_eval_mask4(SEXP fn,
   SEXP args[5] = { x1, x2, x3, x4, NULL };
   return vctrs_eval_mask_n(fn, syms, args, env);
 }
+SEXP vctrs_eval_mask5(SEXP fn,
+                      SEXP x1_sym, SEXP x1,
+                      SEXP x2_sym, SEXP x2,
+                      SEXP x3_sym, SEXP x3,
+                      SEXP x4_sym, SEXP x4,
+                      SEXP x5_sym, SEXP x5,
+                      SEXP env) {
+  SEXP syms[6] = { x1_sym, x2_sym, x3_sym, x4_sym, x5_sym, NULL };
+  SEXP args[6] = { x1, x2, x3, x4, x5, NULL };
+  return vctrs_eval_mask_n(fn, syms, args, env);
+}
 
 /**
  * Dispatch in the global environment
@@ -1013,6 +1024,8 @@ SEXP chrs_assign = NULL;
 SEXP chrs_rename = NULL;
 SEXP chrs_remove = NULL;
 SEXP chrs_negate = NULL;
+SEXP chrs_location = NULL;
+SEXP chrs_name = NULL;
 
 SEXP syms_i = NULL;
 SEXP syms_n = NULL;
@@ -1037,6 +1050,7 @@ SEXP syms_ptype = NULL;
 SEXP syms_missing = NULL;
 SEXP syms_size = NULL;
 SEXP syms_subscript_action = NULL;
+SEXP syms_subscript_type = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -1131,6 +1145,12 @@ void vctrs_init_utils(SEXP ns) {
 
   chrs_negate = Rf_mkString("negate");
   R_PreserveObject(chrs_negate);
+
+  chrs_location = Rf_mkString("location");
+  R_PreserveObject(chrs_location);
+
+  chrs_name = Rf_mkString("name");
+  R_PreserveObject(chrs_name);
 
 
   classes_tibble = Rf_allocVector(STRSXP, 3);
@@ -1237,6 +1257,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_missing = R_MissingArg;
   syms_size = Rf_install("size");
   syms_subscript_action = Rf_install("subscript_action");
+  syms_subscript_type = Rf_install("subscript_type");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.c
+++ b/src/utils.c
@@ -470,6 +470,17 @@ SEXP colnames(SEXP x) {
                          syms_x, x);
 }
 
+// [[ include("utils.h") ]]
+SEXP arg_validate(SEXP arg, const char* arg_nm) {
+  if (arg == R_NilValue) {
+    return chrs_empty;
+  } else if (r_is_string(arg)) {
+    return arg;
+  } else {
+    Rf_errorcall(R_NilValue, "`%s` tag must be a string", arg_nm);
+  }
+}
+
 
 void* r_vec_deref(SEXP x) {
   switch (TYPEOF(x)) {
@@ -1026,6 +1037,7 @@ SEXP chrs_remove = NULL;
 SEXP chrs_negate = NULL;
 SEXP chrs_location = NULL;
 SEXP chrs_name = NULL;
+SEXP chrs_empty = NULL;
 
 SEXP syms_i = NULL;
 SEXP syms_n = NULL;
@@ -1151,6 +1163,9 @@ void vctrs_init_utils(SEXP ns) {
 
   chrs_name = Rf_mkString("name");
   R_PreserveObject(chrs_name);
+
+  chrs_empty = Rf_mkString("");
+  R_PreserveObject(chrs_empty);
 
 
   classes_tibble = Rf_allocVector(STRSXP, 3);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1050,6 +1050,7 @@ SEXP syms_arg = NULL;
 SEXP syms_x_arg = NULL;
 SEXP syms_y_arg = NULL;
 SEXP syms_to_arg = NULL;
+SEXP syms_subscript_arg = NULL;
 SEXP syms_out = NULL;
 SEXP syms_value = NULL;
 SEXP syms_quiet = NULL;
@@ -1260,6 +1261,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_x_arg = Rf_install("x_arg");
   syms_y_arg = Rf_install("y_arg");
   syms_to_arg = Rf_install("to_arg");
+  syms_subscript_arg = Rf_install("subscript_arg");
   syms_out = Rf_install("out");
   syms_value = Rf_install("value");
   syms_quiet = Rf_install("quiet");

--- a/src/utils.h
+++ b/src/utils.h
@@ -46,6 +46,13 @@ SEXP vctrs_eval_mask4(SEXP fn,
                       SEXP x3_sym, SEXP x3,
                       SEXP x4_sym, SEXP x4,
                       SEXP env);
+SEXP vctrs_eval_mask5(SEXP fn,
+                      SEXP x1_sym, SEXP x1,
+                      SEXP x2_sym, SEXP x2,
+                      SEXP x3_sym, SEXP x3,
+                      SEXP x4_sym, SEXP x4,
+                      SEXP x5_sym, SEXP x5,
+                      SEXP env);
 
 SEXP vctrs_dispatch_n(SEXP fn_sym, SEXP fn,
                       SEXP* syms, SEXP* args);
@@ -259,6 +266,8 @@ extern SEXP chrs_assign;
 extern SEXP chrs_rename;
 extern SEXP chrs_remove;
 extern SEXP chrs_negate;
+extern SEXP chrs_location;
+extern SEXP chrs_name;
 
 extern SEXP syms_i;
 extern SEXP syms_n;
@@ -283,6 +292,7 @@ extern SEXP syms_ptype;
 extern SEXP syms_missing;
 extern SEXP syms_size;
 extern SEXP syms_subscript_action;
+extern SEXP syms_subscript_type;
 
 #define syms_names R_NamesSymbol
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -40,6 +40,12 @@ SEXP vctrs_eval_mask3(SEXP fn,
                       SEXP y_sym, SEXP y,
                       SEXP z_sym, SEXP z,
                       SEXP env);
+SEXP vctrs_eval_mask4(SEXP fn,
+                      SEXP x1_sym, SEXP x1,
+                      SEXP x2_sym, SEXP x2,
+                      SEXP x3_sym, SEXP x3,
+                      SEXP x4_sym, SEXP x4,
+                      SEXP env);
 
 SEXP vctrs_dispatch_n(SEXP fn_sym, SEXP fn,
                       SEXP* syms, SEXP* args);

--- a/src/utils.h
+++ b/src/utils.h
@@ -282,6 +282,7 @@ extern SEXP syms_arg;
 extern SEXP syms_x_arg;
 extern SEXP syms_y_arg;
 extern SEXP syms_to_arg;
+extern SEXP syms_subscript_arg;
 extern SEXP syms_out;
 extern SEXP syms_value;
 extern SEXP syms_quiet;

--- a/src/utils.h
+++ b/src/utils.h
@@ -88,6 +88,7 @@ SEXP vec_unique_colnames(SEXP x, bool quiet);
 SEXP s3_find_method(const char* generic, SEXP x);
 
 extern struct vctrs_arg* args_empty;
+SEXP arg_validate(SEXP arg, const char* arg_nm);
 
 void never_reached(const char* fn) __attribute__((noreturn));
 
@@ -268,6 +269,7 @@ extern SEXP chrs_remove;
 extern SEXP chrs_negate;
 extern SEXP chrs_location;
 extern SEXP chrs_name;
+extern SEXP chrs_empty;
 
 extern SEXP syms_i;
 extern SEXP syms_n;

--- a/tests/testthat/error/test-slice-assign.txt
+++ b/tests/testthat/error/test-slice-assign.txt
@@ -11,12 +11,12 @@ logical subscripts must match size of indexed vector
 ====================================================
 
 > vec_assign(1:2, c(TRUE, FALSE, TRUE), 5)
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 i Logical subscripts must match the size of the indexed input.
 x The input has size 2 but the subscript has size 3.
 
 > vec_assign(mtcars, c(TRUE, FALSE), mtcars[1, ])
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 i Logical subscripts must match the size of the indexed input.
 x The input has size 32 but the subscript has size 2.
 

--- a/tests/testthat/error/test-slice-assign.txt
+++ b/tests/testthat/error/test-slice-assign.txt
@@ -11,12 +11,12 @@ logical subscripts must match size of indexed vector
 ====================================================
 
 > vec_assign(1:2, c(TRUE, FALSE, TRUE), 5)
-Error: Must subset elements with a proper subscript vector.
+Error: Must assign elements with a proper subscript vector.
 i Logical subscripts must match the size of the indexed input.
 x The input has size 2 but the subscript has size 3.
 
 > vec_assign(mtcars, c(TRUE, FALSE), mtcars[1, ])
-Error: Must subset elements with a proper subscript vector.
+Error: Must assign elements with a proper subscript vector.
 i Logical subscripts must match the size of the indexed input.
 x The input has size 32 but the subscript has size 2.
 
@@ -40,4 +40,18 @@ i There are only 26 elements.
 > vec_assign(set_names(letters), "foo", "bar")
 Error: Must assign existing elements.
 x Can't assign element with unknown name `foo`.
+
+
+must assign with proper negative locations
+==========================================
+
+> vec_assign(1:3, c(-1, 1), 1:2)
+Error: Must assign elements with a proper subscript vector.
+x Negative locations can't be mixed with positive locations.
+i The subscript has a positive value at location 2.
+
+> vec_assign(1:3, c(-1, NA), 1:2)
+Error: Must assign elements with a proper subscript vector.
+x Negative locations can't have missing values.
+i The subscript has a missing value at location 2.
 

--- a/tests/testthat/error/test-slice.txt
+++ b/tests/testthat/error/test-slice.txt
@@ -10,12 +10,12 @@ Negative subscripts are checked
 ===============================
 
 > vec_slice(1:3, -c(1L, NA))
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x Negative locations can't have missing values.
 i The subscript has a missing value at location 2.
 
 > vec_slice(1:3, c(-1L, 1L))
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x Negative locations can't be mixed with positive locations.
 i The subscript has a positive value at location 2.
 

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -278,22 +278,22 @@ can optionally extend beyond the end
 > num_as_location(c(1, 3), 1, oob = "extend")
 Error: Can't subset elements beyond the end with non-consecutive locations.
 i The input has size 1.
-x The location 3 is not consecutive to the end.
+x The subscript contains non-consecutive location 3.
 
 > num_as_location(c(1:5, 7), 3, oob = "extend")
 Error: Can't subset elements beyond the end with non-consecutive locations.
 i The input has size 3.
-x The locations 4 and 7 are not consecutive.
+x The subscript contains non-consecutive locations 4 and 7.
 
 > num_as_location(c(1:5, 7, 1), 3, oob = "extend")
 Error: Can't subset elements beyond the end with non-consecutive locations.
 i The input has size 3.
-x The locations 4 and 7 are not consecutive.
+x The subscript contains non-consecutive locations 4 and 7.
 
 > num_as_location(c(1:5, 7, 1, 10), 3, oob = "extend")
 Error: Can't subset elements beyond the end with non-consecutive locations.
 i The input has size 3.
-x The locations 4, 7, and 10 are not consecutive.
+x The subscript contains non-consecutive locations 4, 7, and 10.
 
 
 missing values are supported in error formatters
@@ -307,7 +307,7 @@ i There are only 1 element.
 > num_as_location(c(1, NA, 3), 1, oob = "extend")
 Error: Can't subset elements beyond the end with non-consecutive locations.
 i The input has size 1.
-x The location 3 is not consecutive to the end.
+x The subscript contains non-consecutive location 3.
 
 
 can customise subscript type errors
@@ -352,8 +352,7 @@ i The subscript `foo` has a positive value at location 2.
 > num_as_location(c(1, 4), 2, oob = "extend", arg = "foo")
 Error: Can't subset elements beyond the end with non-consecutive locations.
 i The input has size 2.
-x The subscript `foo` contains non-consecutive locations.
-x The location 4 is not consecutive to the end.
+x The subscript `foo` contains non-consecutive location 4.
 
 > # With tibble columns
 > with_tibble_cols(num_as_location(-1, 2, negative = "error"))
@@ -394,8 +393,7 @@ i The subscript `tbl[i]` has a positive value at location 2.
 > with_tibble_cols(num_as_location(c(1, 4), 2, oob = "extend"))
 Error: Can't rename columns beyond the end with non-consecutive locations.
 i The input has size 2.
-x The subscript `tbl[i]` contains non-consecutive locations.
-x The location 4 is not consecutive to the end.
+x The subscript `tbl[i]` contains non-consecutive location 4.
 
 
 can customise OOB errors

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -286,22 +286,22 @@ can optionally extend beyond the end
 ====================================
 
 > num_as_location(c(1, 3), 1, oob = "extend")
-Error: Can't index beyond the end with non-consecutive locations.
+Error: Can't subset elements beyond the end with non-consecutive locations.
 i The input has size 1.
 x The location 3 is not consecutive to the end.
 
 > num_as_location(c(1:5, 7), 3, oob = "extend")
-Error: Can't index beyond the end with non-consecutive locations.
+Error: Can't subset elements beyond the end with non-consecutive locations.
 i The input has size 3.
 x The locations 4 and 7 are not consecutive.
 
 > num_as_location(c(1:5, 7, 1), 3, oob = "extend")
-Error: Can't index beyond the end with non-consecutive locations.
+Error: Can't subset elements beyond the end with non-consecutive locations.
 i The input has size 3.
 x The locations 4 and 7 are not consecutive.
 
 > num_as_location(c(1:5, 7, 1, 10), 3, oob = "extend")
-Error: Can't index beyond the end with non-consecutive locations.
+Error: Can't subset elements beyond the end with non-consecutive locations.
 i The input has size 3.
 x The locations 4, 7, and 10 are not consecutive.
 
@@ -315,7 +315,7 @@ x Can't subset locations 2 and 3.
 i There are only 1 element.
 
 > num_as_location(c(1, NA, 3), 1, oob = "extend")
-Error: Can't index beyond the end with non-consecutive locations.
+Error: Can't subset elements beyond the end with non-consecutive locations.
 i The input has size 1.
 x The location 3 is not consecutive to the end.
 
@@ -364,6 +364,12 @@ Error: Must subset elements with a proper subscript vector.
 x Negative locations can't be mixed with positive locations.
 i The subscript `foo` has a positive value at location 2.
 
+> num_as_location(c(1, 4), 2, oob = "extend", arg = "foo")
+Error: Can't subset elements beyond the end with non-consecutive locations.
+i The input has size 2.
+x The subscript `foo` contains non-consecutive locations.
+x The location 4 is not consecutive to the end.
+
 > # With tibble columns
 > with_tibble_cols(num_as_location(-1, 2, negative = "error"))
 Error: Must rename columns with a proper subscript vector.
@@ -404,6 +410,12 @@ i The subscript `tbl[i]` has a missing value at location 2.
 Error: Must rename columns with a proper subscript vector.
 x Negative locations can't be mixed with positive locations.
 i The subscript `tbl[i]` has a positive value at location 2.
+
+> with_tibble_cols(num_as_location(c(1, 4), 2, oob = "extend"))
+Error: Can't rename columns beyond the end with non-consecutive locations.
+i The input has size 2.
+x The subscript `tbl[i]` contains non-consecutive locations.
+x The location 4 is not consecutive to the end.
 
 
 can customise OOB errors

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -354,6 +354,11 @@ Error: Must subset elements with a proper subscript vector.
 i Logical subscripts must match the size of the indexed input.
 x The input has size 3 but the subscript `foo` has size 2.
 
+> vec_as_location(c(-1, NA), 3, arg = "foo")
+Error: Must subset elements with a proper subscript vector.
+x Negative locations can't have missing values.
+i The subscript `foo` has a missing value at location 2.
+
 > # With tibble columns
 > with_tibble_cols(num_as_location(-1, 2, negative = "error"))
 Error: Must rename columns with a proper subscript vector.
@@ -384,6 +389,11 @@ i This subscript must be size 1.
 Error: Must rename columns with a proper subscript vector.
 i Logical subscripts must match the size of the indexed input.
 x The input has size 3 but the subscript `tbl[i]` has size 2.
+
+> with_tibble_cols(vec_as_location(c(-1, NA), 3))
+Error: Must rename columns with a proper subscript vector.
+x Negative locations can't have missing values.
+i The subscript `tbl[i]` has a missing value at location 2.
 
 
 can customise OOB errors

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -258,27 +258,27 @@ vec_as_location() and variants check for OOB elements
 
 > # Numeric subscripts
 > vec_as_location(10L, 2L)
-Error: Must subset existing elements.
+Error: Must subset existing elements in `i`.
 x Can't subset location 10.
 i There are only 2 elements.
 
 > vec_as_location(-10L, 2L)
-Error: Must negate existing elements.
+Error: Must negate existing elements in `i`.
 x Can't negate location 10.
 i There are only 2 elements.
 
 > vec_as_location2(10L, 2L)
-Error: Must subset existing elements.
+Error: Must subset existing elements in `i`.
 x Can't subset location 10.
 i There are only 2 elements.
 
 > # Character subscripts
 > vec_as_location("foo", 1L, names = "bar")
-Error: Must subset existing elements.
+Error: Must subset existing elements in `i`.
 x Can't subset element with unknown name `foo`.
 
 > vec_as_location2("foo", 1L, names = "bar")
-Error: Must subset existing elements.
+Error: Must subset existing elements in `i`.
 x Can't subset element with unknown name `foo`.
 
 
@@ -310,7 +310,7 @@ missing values are supported in error formatters
 ================================================
 
 > num_as_location(c(1, NA, 2, 3), 1)
-Error: Must subset existing elements.
+Error: Must subset existing elements in `i`.
 x Can't subset locations 2 and 3.
 i There are only 1 element.
 
@@ -354,6 +354,16 @@ can customise OOB errors
 
 > vec_slice(set_names(letters), "foo")
 Error: Must subset existing elements.
+x Can't subset element with unknown name `foo`.
+
+> # With custom `arg`
+> vec_as_location(30, length(letters), arg = "foo")
+Error: Must subset existing elements in `foo`.
+x Can't subset location 30.
+i There are only 26 elements.
+
+> vec_as_location("foo", NULL, letters, arg = "foo")
+Error: Must subset existing elements in `foo`.
 x Can't subset element with unknown name `foo`.
 
 > # With tibble columns

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -42,7 +42,7 @@ logical subscripts must match size of indexed vector
 > vec_as_location(c(TRUE, FALSE), 3)
 Error: Must subset elements with a proper subscript vector.
 i Logical subscripts must match the size of the indexed input.
-x The input has size 3 but the subscript `i` has size 2.
+x The input has size 3 but the subscript has size 2.
 
 
 character subscripts require named vectors
@@ -84,7 +84,7 @@ i The subscript must contain indicators, locations or names.
 
 > vec_as_location(2.5, 3L)
 Error: Must subset elements with a proper subscript vector.
-x Lossy cast from `i` <double> to <integer>.
+x Lossy cast from <double> to <integer>.
 
 > vec_as_location(list(), 10L)
 Error: Must subset elements with a proper subscript vector.
@@ -149,7 +149,7 @@ i The subscript must contain locations or names.
 
 > vec_as_location2(2.5, 3L)
 Error: Must extract element with a single subscript.
-x Lossy cast from `i` <double> to <integer>.
+x Lossy cast from <double> to <integer>.
 
 > # Idem with custom `arg`
 > vec_as_location2(foobar(), 10L, arg = "foo")
@@ -258,27 +258,27 @@ vec_as_location() and variants check for OOB elements
 
 > # Numeric subscripts
 > vec_as_location(10L, 2L)
-Error: Must subset existing elements in `i`.
+Error: Must subset existing elements.
 x Can't subset location 10.
 i There are only 2 elements.
 
 > vec_as_location(-10L, 2L)
-Error: Must negate existing elements in `i`.
+Error: Must negate existing elements.
 x Can't negate location 10.
 i There are only 2 elements.
 
 > vec_as_location2(10L, 2L)
-Error: Must subset existing elements in `i`.
+Error: Must subset existing elements.
 x Can't subset location 10.
 i There are only 2 elements.
 
 > # Character subscripts
 > vec_as_location("foo", 1L, names = "bar")
-Error: Must subset existing elements in `i`.
+Error: Must subset existing elements.
 x Can't subset element with unknown name `foo`.
 
 > vec_as_location2("foo", 1L, names = "bar")
-Error: Must subset existing elements in `i`.
+Error: Must subset existing elements.
 x Can't subset element with unknown name `foo`.
 
 
@@ -310,7 +310,7 @@ missing values are supported in error formatters
 ================================================
 
 > num_as_location(c(1, NA, 2, 3), 1)
-Error: Must subset existing elements in `i`.
+Error: Must subset existing elements.
 x Can't subset locations 2 and 3.
 i There are only 1 element.
 

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -56,7 +56,7 @@ vec_as_location() requires integer, character, or logical inputs
 
 > vec_as_location(mtcars, 10L)
 Error: Must subset elements with a proper subscript vector.
-x `i` has the wrong type `data.frame<
+x The subscript has the wrong type `data.frame<
   mpg : double
   cyl : double
   disp: double
@@ -69,17 +69,17 @@ x `i` has the wrong type `data.frame<
   gear: double
   carb: double
 >`.
-i The subscript must contain indicators, locations or names.
+i It must contain indicators, locations or names.
 
 > vec_as_location(env(), 10L)
 Error: Must subset elements with a proper subscript vector.
-x `i` has the wrong type `environment`.
-i The subscript must contain indicators, locations or names.
+x The subscript has the wrong type `environment`.
+i It must contain indicators, locations or names.
 
 > vec_as_location(foobar(), 10L)
 Error: Must subset elements with a proper subscript vector.
-x `i` has the wrong type `vctrs_foobar`.
-i The subscript must contain indicators, locations or names.
+x The subscript has the wrong type `vctrs_foobar`.
+i It must contain indicators, locations or names.
 
 > vec_as_location(2.5, 3L)
 Error: Must subset elements with a proper subscript vector.
@@ -87,24 +87,24 @@ x Lossy cast from <double> to <integer>.
 
 > vec_as_location(list(), 10L)
 Error: Must subset elements with a proper subscript vector.
-x `i` has the wrong type `list`.
-i The subscript must contain indicators, locations or names.
+x The subscript has the wrong type `list`.
+i It must contain indicators, locations or names.
 
 > vec_as_location(function() NULL, 10L)
 Error: Must subset elements with a proper subscript vector.
-x `i` has the wrong type `closure`.
-i The subscript must contain indicators, locations or names.
+x The subscript has the wrong type `closure`.
+i It must contain indicators, locations or names.
 
 > # Idem with custom `arg`
 > vec_as_location(env(), 10L, arg = "foo")
 Error: Must subset elements with a proper subscript vector.
-x `foo` has the wrong type `environment`.
-i The subscript must contain indicators, locations or names.
+x The subscript `foo` has the wrong type `environment`.
+i It must contain indicators, locations or names.
 
 > vec_as_location(foobar(), 10L, arg = "foo")
 Error: Must subset elements with a proper subscript vector.
-x `foo` has the wrong type `vctrs_foobar`.
-i The subscript must contain indicators, locations or names.
+x The subscript `foo` has the wrong type `vctrs_foobar`.
+i It must contain indicators, locations or names.
 
 > vec_as_location(2.5, 3L, arg = "foo")
 Error: Must subset elements with a proper subscript vector.
@@ -116,12 +116,12 @@ vec_as_location2() requires integer or character inputs
 
 > vec_as_location2(TRUE, 10L)
 Error: Must extract element with a single subscript.
-x `i` has the wrong type `logical`.
-i The subscript must contain locations or names.
+x The subscript has the wrong type `logical`.
+i It must contain locations or names.
 
 > vec_as_location2(mtcars, 10L)
 Error: Must extract element with a single subscript.
-x `i` has the wrong type `data.frame<
+x The subscript has the wrong type `data.frame<
   mpg : double
   cyl : double
   disp: double
@@ -134,17 +134,17 @@ x `i` has the wrong type `data.frame<
   gear: double
   carb: double
 >`.
-i The subscript must contain locations or names.
+i It must contain locations or names.
 
 > vec_as_location2(env(), 10L)
 Error: Must extract element with a single subscript.
-x `i` has the wrong type `environment`.
-i The subscript must contain locations or names.
+x The subscript has the wrong type `environment`.
+i It must contain locations or names.
 
 > vec_as_location2(foobar(), 10L)
 Error: Must extract element with a single subscript.
-x `i` has the wrong type `vctrs_foobar`.
-i The subscript must contain locations or names.
+x The subscript has the wrong type `vctrs_foobar`.
+i It must contain locations or names.
 
 > vec_as_location2(2.5, 3L)
 Error: Must extract element with a single subscript.
@@ -153,8 +153,8 @@ x Lossy cast from <double> to <integer>.
 > # Idem with custom `arg`
 > vec_as_location2(foobar(), 10L, arg = "foo")
 Error: Must extract element with a single subscript.
-x `foo` has the wrong type `vctrs_foobar`.
-i The subscript must contain locations or names.
+x The subscript `foo` has the wrong type `vctrs_foobar`.
+i It must contain locations or names.
 
 > vec_as_location2(2.5, 3L, arg = "foo")
 Error: Must extract element with a single subscript.
@@ -170,7 +170,7 @@ x The subscript has size 2 but must be size 1.
 
 > vec_as_location2(mtcars, 10L)
 Error: Must extract element with a single subscript.
-x `i` has the wrong type `data.frame<
+x The subscript has the wrong type `data.frame<
   mpg : double
   cyl : double
   disp: double
@@ -183,7 +183,7 @@ x `i` has the wrong type `data.frame<
   gear: double
   carb: double
 >`.
-i The subscript must contain locations or names.
+i It must contain locations or names.
 
 > # Idem with custom `arg`
 > vec_as_location2(1:2, 2L, arg = "foo")
@@ -192,7 +192,7 @@ x The subscript `foo` has size 2 but must be size 1.
 
 > vec_as_location2(mtcars, 10L, arg = "foo")
 Error: Must extract element with a single subscript.
-x `foo` has the wrong type `data.frame<
+x The subscript `foo` has the wrong type `data.frame<
   mpg : double
   cyl : double
   disp: double
@@ -205,7 +205,7 @@ x `foo` has the wrong type `data.frame<
   gear: double
   carb: double
 >`.
-i The subscript must contain locations or names.
+i It must contain locations or names.
 
 > vec_as_location2(1:2, 2L, arg = "foo")
 Error: Must extract element with a single subscript.

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -42,7 +42,7 @@ logical subscripts must match size of indexed vector
 > vec_as_location(c(TRUE, FALSE), 3)
 Error: Must subset elements with a proper subscript vector.
 i Logical subscripts must match the size of the indexed input.
-x The input has size 3 but the subscript has size 2.
+x The input has size 3 but the subscript `i` has size 2.
 
 
 character subscripts require named vectors
@@ -349,6 +349,11 @@ Error: Must extract element with a single subscript.
 x `foo` has the wrong size 2.
 i This subscript must be size 1.
 
+> vec_as_location(c(TRUE, FALSE), 3, arg = "foo")
+Error: Must subset elements with a proper subscript vector.
+i Logical subscripts must match the size of the indexed input.
+x The input has size 3 but the subscript `foo` has size 2.
+
 > # With tibble columns
 > with_tibble_cols(num_as_location(-1, 2, negative = "error"))
 Error: Must rename columns with a proper subscript vector.
@@ -374,6 +379,11 @@ i This subscript can't be missing.
 Error: Must rename column with a single subscript.
 x `tbl[i]` has the wrong size 2.
 i This subscript must be size 1.
+
+> with_tibble_cols(vec_as_location(c(TRUE, FALSE), 3))
+Error: Must rename columns with a proper subscript vector.
+i Logical subscripts must match the size of the indexed input.
+x The input has size 3 but the subscript `tbl[i]` has size 2.
 
 
 can customise OOB errors

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -359,6 +359,11 @@ Error: Must subset elements with a proper subscript vector.
 x Negative locations can't have missing values.
 i The subscript `foo` has a missing value at location 2.
 
+> vec_as_location(c(-1, 1), 3, arg = "foo")
+Error: Must subset elements with a proper subscript vector.
+x Negative locations can't be mixed with positive locations.
+i The subscript `foo` has a positive value at location 2.
+
 > # With tibble columns
 > with_tibble_cols(num_as_location(-1, 2, negative = "error"))
 Error: Must rename columns with a proper subscript vector.
@@ -394,6 +399,11 @@ x The input has size 3 but the subscript `tbl[i]` has size 2.
 Error: Must rename columns with a proper subscript vector.
 x Negative locations can't have missing values.
 i The subscript `tbl[i]` has a missing value at location 2.
+
+> with_tibble_cols(vec_as_location(c(-1, 1), 3))
+Error: Must rename columns with a proper subscript vector.
+x Negative locations can't be mixed with positive locations.
+i The subscript `tbl[i]` has a positive value at location 2.
 
 
 can customise OOB errors

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -3,12 +3,12 @@ vec_as_location() checks for mix of negative and missing locations
 ==================================================================
 
 > vec_as_location(-c(1L, NA), 30)
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x Negative locations can't have missing values.
 i The subscript has a missing value at location 2.
 
 > vec_as_location(-c(1L, rep(NA, 10)), 30)
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x Negative locations can't have missing values.
 i The subscript has 10 missing values at locations 2, 3, 4, 5, 6, ...
 
@@ -17,12 +17,12 @@ vec_as_location() checks for mix of negative and positive locations
 ===================================================================
 
 > vec_as_location(c(-1L, 1L), 30)
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x Negative locations can't be mixed with positive locations.
 i The subscript has a positive value at location 2.
 
 > vec_as_location(c(-1L, rep(1L, 10)), 30)
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x Negative locations can't be mixed with positive locations.
 i The subscript has 10 missing values at locations 2, 3, 4, 5, 6, ...
 
@@ -31,16 +31,16 @@ num_as_location() optionally forbids negative indices
 =====================================================
 
 > num_as_location(dbl(1, -1), 2L, negative = "error")
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `i` contains negative locations.
-i These subscripts must be positive integers.
+i The subscript must contain positive locations.
 
 
 logical subscripts must match size of indexed vector
 ====================================================
 
 > vec_as_location(c(TRUE, FALSE), 3)
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 i Logical subscripts must match the size of the indexed input.
 x The input has size 3 but the subscript has size 2.
 
@@ -56,7 +56,7 @@ vec_as_location() requires integer, character, or logical inputs
 ================================================================
 
 > vec_as_location(mtcars, 10L)
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `i` has the wrong type `data.frame<
   mpg : double
   cyl : double
@@ -73,42 +73,42 @@ x `i` has the wrong type `data.frame<
 i The subscript must contain indicators, locations or names.
 
 > vec_as_location(env(), 10L)
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `i` has the wrong type `environment`.
 i The subscript must contain indicators, locations or names.
 
 > vec_as_location(foobar(), 10L)
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `i` has the wrong type `vctrs_foobar`.
 i The subscript must contain indicators, locations or names.
 
 > vec_as_location(2.5, 3L)
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x Lossy cast from `i` <double> to <integer>.
 
 > vec_as_location(list(), 10L)
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `i` has the wrong type `list`.
 i The subscript must contain indicators, locations or names.
 
 > vec_as_location(function() NULL, 10L)
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `i` has the wrong type `closure`.
 i The subscript must contain indicators, locations or names.
 
 > # Idem with custom `arg`
 > vec_as_location(env(), 10L, arg = "foo")
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `foo` has the wrong type `environment`.
 i The subscript must contain indicators, locations or names.
 
 > vec_as_location(foobar(), 10L, arg = "foo")
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `foo` has the wrong type `vctrs_foobar`.
 i The subscript must contain indicators, locations or names.
 
 > vec_as_location(2.5, 3L, arg = "foo")
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x Lossy cast from `foo` <double> to <integer>.
 
 
@@ -116,12 +116,12 @@ vec_as_location2() requires integer or character inputs
 =======================================================
 
 > vec_as_location2(TRUE, 10L)
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `i` has the wrong type `logical`.
 i The subscript must contain locations or names.
 
 > vec_as_location2(mtcars, 10L)
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `i` has the wrong type `data.frame<
   mpg : double
   cyl : double
@@ -138,27 +138,27 @@ x `i` has the wrong type `data.frame<
 i The subscript must contain locations or names.
 
 > vec_as_location2(env(), 10L)
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `i` has the wrong type `environment`.
 i The subscript must contain locations or names.
 
 > vec_as_location2(foobar(), 10L)
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `i` has the wrong type `vctrs_foobar`.
 i The subscript must contain locations or names.
 
 > vec_as_location2(2.5, 3L)
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x Lossy cast from `i` <double> to <integer>.
 
 > # Idem with custom `arg`
 > vec_as_location2(foobar(), 10L, arg = "foo")
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `foo` has the wrong type `vctrs_foobar`.
 i The subscript must contain locations or names.
 
 > vec_as_location2(2.5, 3L, arg = "foo")
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x Lossy cast from `foo` <double> to <integer>.
 
 
@@ -166,12 +166,12 @@ vec_as_location2() requires length 1 inputs
 ===========================================
 
 > vec_as_location2(1:2, 2L)
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `i` has the wrong size 2.
 i This subscript must be size 1.
 
 > vec_as_location2(mtcars, 10L)
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `i` has the wrong type `data.frame<
   mpg : double
   cyl : double
@@ -189,12 +189,12 @@ i The subscript must contain locations or names.
 
 > # Idem with custom `arg`
 > vec_as_location2(1:2, 2L, arg = "foo")
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `foo` has the wrong size 2.
 i This subscript must be size 1.
 
 > vec_as_location2(mtcars, 10L, arg = "foo")
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `foo` has the wrong type `data.frame<
   mpg : double
   cyl : double
@@ -211,7 +211,7 @@ x `foo` has the wrong type `data.frame<
 i The subscript must contain locations or names.
 
 > vec_as_location2(1:2, 2L, arg = "foo")
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `foo` has the wrong size 2.
 i This subscript must be size 1.
 
@@ -220,35 +220,35 @@ vec_as_location2() requires positive integers
 =============================================
 
 > vec_as_location2(0, 2L)
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `i` can't be zero.
-i This subscript must be a positive integer.
+i The subscript must be a positive location.
 
 > vec_as_location2(-1, 2L)
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `i` (with value -1) has the wrong sign.
-i This subscript must be a positive integer.
+i The subscript must be a positive location.
 
 > # Idem with custom `arg`
 > vec_as_location2(0, 2L, arg = "foo")
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `foo` can't be zero.
-i This subscript must be a positive integer.
+i The subscript must be a positive location.
 
 > # vec_as_location2() fails with NA
 > vec_as_location2(na_int, 2L)
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `i` can't be `NA`.
 i This subscript can't be missing.
 
 > vec_as_location2(na_chr, 1L, names = "foo")
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `i` can't be `NA`.
 i This subscript can't be missing.
 
 > # Idem with custom `arg`
 > vec_as_location2(na_int, 2L, arg = "foo")
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `foo` can't be `NA`.
 i This subscript can't be missing.
 
@@ -318,6 +318,35 @@ i There are only 1 element.
 Error: Can't index beyond the end with non-consecutive locations.
 i The input has size 1.
 x The location 3 is not consecutive to the end.
+
+
+can customise subscript type errors
+===================================
+
+> with_tibble_cols(num_as_location(-1, 2, negative = "error"))
+Error: Must rename columns with a proper subscript vector.
+x `tbl[i]` contains negative locations.
+i The subscript must contain positive locations.
+
+> with_tibble_cols(num_as_location2(-1, 2, negative = "error"))
+Error: Must rename column with a single subscript.
+x `tbl[i]` (with value -1) has the wrong sign.
+i The subscript must be a positive location.
+
+> with_tibble_cols(vec_as_location2(0, 2))
+Error: Must rename column with a single subscript.
+x `tbl[i]` can't be zero.
+i The subscript must be a positive location.
+
+> with_tibble_cols(vec_as_location2(na_dbl, 2))
+Error: Must rename column with a single subscript.
+x `tbl[i]` can't be `NA`.
+i This subscript can't be missing.
+
+> with_tibble_cols(vec_as_location2(c(1, 2), 2))
+Error: Must rename column with a single subscript.
+x `tbl[i]` has the wrong size 2.
+i This subscript must be size 1.
 
 
 can customise OOB errors

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -323,6 +323,33 @@ x The location 3 is not consecutive to the end.
 can customise subscript type errors
 ===================================
 
+> # With custom `arg`
+> num_as_location(-1, 2, negative = "error", arg = "foo")
+Error: Must subset elements with a proper subscript vector.
+x `foo` contains negative locations.
+i The subscript must contain positive locations.
+
+> num_as_location2(-1, 2, negative = "error", arg = "foo")
+Error: Must extract element with a single subscript.
+x `foo` (with value -1) has the wrong sign.
+i The subscript must be a positive location.
+
+> vec_as_location2(0, 2, arg = "foo")
+Error: Must extract element with a single subscript.
+x `foo` can't be zero.
+i The subscript must be a positive location.
+
+> vec_as_location2(na_dbl, 2, arg = "foo")
+Error: Must extract element with a single subscript.
+x `foo` can't be `NA`.
+i This subscript can't be missing.
+
+> vec_as_location2(c(1, 2), 2, arg = "foo")
+Error: Must extract element with a single subscript.
+x `foo` has the wrong size 2.
+i This subscript must be size 1.
+
+> # With tibble columns
 > with_tibble_cols(num_as_location(-1, 2, negative = "error"))
 Error: Must rename columns with a proper subscript vector.
 x `tbl[i]` contains negative locations.

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -32,8 +32,7 @@ num_as_location() optionally forbids negative indices
 
 > num_as_location(dbl(1, -1), 2L, negative = "error")
 Error: Must subset elements with a proper subscript vector.
-x `i` contains negative locations.
-i The subscript must contain positive locations.
+x The subscript can't contain negative locations.
 
 
 logical subscripts must match size of indexed vector
@@ -167,8 +166,7 @@ vec_as_location2() requires length 1 inputs
 
 > vec_as_location2(1:2, 2L)
 Error: Must extract element with a single subscript.
-x `i` has the wrong size 2.
-i This subscript must be size 1.
+x The subscript has size 2 but must be size 1.
 
 > vec_as_location2(mtcars, 10L)
 Error: Must extract element with a single subscript.
@@ -190,8 +188,7 @@ i The subscript must contain locations or names.
 > # Idem with custom `arg`
 > vec_as_location2(1:2, 2L, arg = "foo")
 Error: Must extract element with a single subscript.
-x `foo` has the wrong size 2.
-i This subscript must be size 1.
+x The subscript `foo` has size 2 but must be size 1.
 
 > vec_as_location2(mtcars, 10L, arg = "foo")
 Error: Must extract element with a single subscript.
@@ -212,8 +209,7 @@ i The subscript must contain locations or names.
 
 > vec_as_location2(1:2, 2L, arg = "foo")
 Error: Must extract element with a single subscript.
-x `foo` has the wrong size 2.
-i This subscript must be size 1.
+x The subscript `foo` has size 2 but must be size 1.
 
 
 vec_as_location2() requires positive integers
@@ -221,36 +217,30 @@ vec_as_location2() requires positive integers
 
 > vec_as_location2(0, 2L)
 Error: Must extract element with a single subscript.
-x `i` can't be zero.
-i The subscript must be a positive location.
+x The subscript has value 0 but must be a positive location.
 
 > vec_as_location2(-1, 2L)
 Error: Must extract element with a single subscript.
-x `i` (with value -1) has the wrong sign.
-i The subscript must be a positive location.
+x The subscript has value -1 but must be a positive location.
 
 > # Idem with custom `arg`
 > vec_as_location2(0, 2L, arg = "foo")
 Error: Must extract element with a single subscript.
-x `foo` can't be zero.
-i The subscript must be a positive location.
+x The subscript `foo` has value 0 but must be a positive location.
 
 > # vec_as_location2() fails with NA
 > vec_as_location2(na_int, 2L)
 Error: Must extract element with a single subscript.
-x `i` can't be `NA`.
-i This subscript can't be missing.
+x The subscript can't be `NA`.
 
 > vec_as_location2(na_chr, 1L, names = "foo")
 Error: Must extract element with a single subscript.
-x `i` can't be `NA`.
-i This subscript can't be missing.
+x The subscript can't be `NA`.
 
 > # Idem with custom `arg`
 > vec_as_location2(na_int, 2L, arg = "foo")
 Error: Must extract element with a single subscript.
-x `foo` can't be `NA`.
-i This subscript can't be missing.
+x The subscript `foo` can't be `NA`.
 
 
 vec_as_location() and variants check for OOB elements
@@ -326,28 +316,23 @@ can customise subscript type errors
 > # With custom `arg`
 > num_as_location(-1, 2, negative = "error", arg = "foo")
 Error: Must subset elements with a proper subscript vector.
-x `foo` contains negative locations.
-i The subscript must contain positive locations.
+x The subscript `foo` can't contain negative locations.
 
 > num_as_location2(-1, 2, negative = "error", arg = "foo")
 Error: Must extract element with a single subscript.
-x `foo` (with value -1) has the wrong sign.
-i The subscript must be a positive location.
+x The subscript `foo` has value -1 but must be a positive location.
 
 > vec_as_location2(0, 2, arg = "foo")
 Error: Must extract element with a single subscript.
-x `foo` can't be zero.
-i The subscript must be a positive location.
+x The subscript `foo` has value 0 but must be a positive location.
 
 > vec_as_location2(na_dbl, 2, arg = "foo")
 Error: Must extract element with a single subscript.
-x `foo` can't be `NA`.
-i This subscript can't be missing.
+x The subscript `foo` can't be `NA`.
 
 > vec_as_location2(c(1, 2), 2, arg = "foo")
 Error: Must extract element with a single subscript.
-x `foo` has the wrong size 2.
-i This subscript must be size 1.
+x The subscript `foo` has size 2 but must be size 1.
 
 > vec_as_location(c(TRUE, FALSE), 3, arg = "foo")
 Error: Must subset elements with a proper subscript vector.
@@ -373,28 +358,23 @@ x The location 4 is not consecutive to the end.
 > # With tibble columns
 > with_tibble_cols(num_as_location(-1, 2, negative = "error"))
 Error: Must rename columns with a proper subscript vector.
-x `tbl[i]` contains negative locations.
-i The subscript must contain positive locations.
+x The subscript `tbl[i]` can't contain negative locations.
 
 > with_tibble_cols(num_as_location2(-1, 2, negative = "error"))
 Error: Must rename column with a single subscript.
-x `tbl[i]` (with value -1) has the wrong sign.
-i The subscript must be a positive location.
+x The subscript `tbl[i]` has value -1 but must be a positive location.
 
 > with_tibble_cols(vec_as_location2(0, 2))
 Error: Must rename column with a single subscript.
-x `tbl[i]` can't be zero.
-i The subscript must be a positive location.
+x The subscript `tbl[i]` has value 0 but must be a positive location.
 
 > with_tibble_cols(vec_as_location2(na_dbl, 2))
 Error: Must rename column with a single subscript.
-x `tbl[i]` can't be `NA`.
-i This subscript can't be missing.
+x The subscript `tbl[i]` can't be `NA`.
 
 > with_tibble_cols(vec_as_location2(c(1, 2), 2))
 Error: Must rename column with a single subscript.
-x `tbl[i]` has the wrong size 2.
-i This subscript must be size 1.
+x The subscript `tbl[i]` has size 2 but must be size 1.
 
 > with_tibble_cols(vec_as_location(c(TRUE, FALSE), 3))
 Error: Must rename columns with a proper subscript vector.

--- a/tests/testthat/error/test-subscript.txt
+++ b/tests/testthat/error/test-subscript.txt
@@ -3,32 +3,32 @@ vec_as_subscript() forbids subscript types
 ==========================================
 
 > vec_as_subscript(1L, indicator = "error", location = "error")
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `i` has the wrong type `integer`.
 i The subscript must contain names.
 
 > vec_as_subscript("foo", indicator = "error", name = "error")
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `i` has the wrong type `character`.
 i The subscript must contain locations.
 
 > vec_as_subscript(TRUE, indicator = "error")
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `i` has the wrong type `logical`.
 i The subscript must contain locations or names.
 
 > vec_as_subscript("foo", name = "error")
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `i` has the wrong type `character`.
 i The subscript must contain indicators or locations.
 
 > vec_as_subscript(NULL, location = "error")
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `i` has the wrong type `NULL`.
 i The subscript must contain indicators or names.
 
 > vec_as_subscript(quote(foo), name = "error")
-Error: Must subset with a proper subscript vector.
+Error: Must subset elements with a proper subscript vector.
 x `i` has the wrong type `symbol`.
 i The subscript must contain indicators or locations.
 
@@ -37,17 +37,26 @@ vec_as_subscript2() forbids subscript types
 ===========================================
 
 > vec_as_subscript2(1L, location = "error", indicator = "error")
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `i` has the wrong type `integer`.
 i The subscript must contain names.
 
 > vec_as_subscript2("foo", name = "error", indicator = "error")
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `i` has the wrong type `character`.
 i The subscript must contain locations.
 
 > vec_as_subscript2(TRUE, indicator = "error")
-Error: Must extract with a single subscript.
+Error: Must extract element with a single subscript.
 x `i` has the wrong type `logical`.
 i The subscript must contain locations or names.
+
+
+can customise subscript errors
+==============================
+
+> with_tibble_cols(vec_as_subscript(env()))
+Error: Must rename columns with a proper subscript vector.
+x `tbl[i]` has the wrong type `environment`.
+i The subscript must contain indicators, locations or names.
 

--- a/tests/testthat/error/test-subscript.txt
+++ b/tests/testthat/error/test-subscript.txt
@@ -4,33 +4,33 @@ vec_as_subscript() forbids subscript types
 
 > vec_as_subscript(1L, indicator = "error", location = "error")
 Error: Must subset elements with a proper subscript vector.
-x `i` has the wrong type `integer`.
-i The subscript must contain names.
+x The subscript has the wrong type `integer`.
+i It must contain names.
 
 > vec_as_subscript("foo", indicator = "error", name = "error")
 Error: Must subset elements with a proper subscript vector.
-x `i` has the wrong type `character`.
-i The subscript must contain locations.
+x The subscript has the wrong type `character`.
+i It must contain locations.
 
 > vec_as_subscript(TRUE, indicator = "error")
 Error: Must subset elements with a proper subscript vector.
-x `i` has the wrong type `logical`.
-i The subscript must contain locations or names.
+x The subscript has the wrong type `logical`.
+i It must contain locations or names.
 
 > vec_as_subscript("foo", name = "error")
 Error: Must subset elements with a proper subscript vector.
-x `i` has the wrong type `character`.
-i The subscript must contain indicators or locations.
+x The subscript has the wrong type `character`.
+i It must contain indicators or locations.
 
 > vec_as_subscript(NULL, location = "error")
 Error: Must subset elements with a proper subscript vector.
-x `i` has the wrong type `NULL`.
-i The subscript must contain indicators or names.
+x The subscript has the wrong type `NULL`.
+i It must contain indicators or names.
 
 > vec_as_subscript(quote(foo), name = "error")
 Error: Must subset elements with a proper subscript vector.
-x `i` has the wrong type `symbol`.
-i The subscript must contain indicators or locations.
+x The subscript has the wrong type `symbol`.
+i It must contain indicators or locations.
 
 
 vec_as_subscript2() forbids subscript types
@@ -38,18 +38,18 @@ vec_as_subscript2() forbids subscript types
 
 > vec_as_subscript2(1L, location = "error", indicator = "error")
 Error: Must extract element with a single subscript.
-x `i` has the wrong type `integer`.
-i The subscript must contain names.
+x The subscript has the wrong type `integer`.
+i It must contain names.
 
 > vec_as_subscript2("foo", name = "error", indicator = "error")
 Error: Must extract element with a single subscript.
-x `i` has the wrong type `character`.
-i The subscript must contain locations.
+x The subscript has the wrong type `character`.
+i It must contain locations.
 
 > vec_as_subscript2(TRUE, indicator = "error")
 Error: Must extract element with a single subscript.
-x `i` has the wrong type `logical`.
-i The subscript must contain locations or names.
+x The subscript has the wrong type `logical`.
+i It must contain locations or names.
 
 
 can customise subscript errors
@@ -57,6 +57,6 @@ can customise subscript errors
 
 > with_tibble_cols(vec_as_subscript(env()))
 Error: Must rename columns with a proper subscript vector.
-x `tbl[i]` has the wrong type `environment`.
-i The subscript must contain indicators, locations or names.
+x The subscript `tbl[i]` has the wrong type `environment`.
+i It must contain indicators, locations or names.
 

--- a/tests/testthat/helper-conditions.R
+++ b/tests/testthat/helper-conditions.R
@@ -1,13 +1,13 @@
 
 with_subscript_data <- function(expr,
-                                arg,
+                                subscript_arg,
                                 subscript_elt = NULL,
                                 subscript_action = NULL) {
   local_options(rlang_force_unhandled_error = TRUE)
   tryCatch(
     expr,
     vctrs_error_subscript = function(cnd) {
-      cnd$arg <- arg
+      cnd$subscript_arg <- subscript_arg
       cnd$subscript_elt <- subscript_elt
       cnd$subscript_action <- subscript_action
       cnd_signal(cnd)
@@ -18,7 +18,7 @@ with_subscript_data <- function(expr,
 with_tibble_cols <- function(expr) {
   with_subscript_data(
     expr,
-    arg = quote(tbl[i]),
+    subscript_arg = quote(tbl[i]),
     subscript_elt = "column",
     subscript_action = "rename"
   )
@@ -26,7 +26,7 @@ with_tibble_cols <- function(expr) {
 with_tibble_rows <- function(expr) {
   with_subscript_data(
     expr,
-    arg = quote(tbl[i]),
+    subscript_arg = quote(tbl[i]),
     subscript_elt = "row",
     subscript_action = "remove"
   )

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -364,6 +364,19 @@ test_that("must assign existing elements", {
   })
 })
 
+test_that("must assign with proper negative locations", {
+  verify_errors({
+    expect_error(
+      vec_assign(1:3, c(-1, 1), 1:2),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      vec_assign(1:3, c(-1, NA), 1:2),
+      class = "vctrs_error_subscript_type"
+    )
+  })
+})
+
 test_that("slice and assign have informative errors", {
   verify_output(test_path("error", "test-slice-assign.txt"), {
     "# `vec_assign()` requires recyclable value"
@@ -378,5 +391,9 @@ test_that("slice and assign have informative errors", {
     vec_assign(1:3, "foo", 10)
     vec_slice(letters, -100) <- "foo"
     vec_assign(set_names(letters), "foo", "bar")
+
+    "# must assign with proper negative locations"
+    vec_assign(1:3, c(-1, 1), 1:2)
+    vec_assign(1:3, c(-1, NA), 1:2)
   })
 })

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -255,6 +255,29 @@ test_that("missing values are supported in error formatters", {
 
 test_that("can customise subscript type errors", {
   verify_errors({
+    "With custom `arg`"
+    expect_error(
+      num_as_location(-1, 2, negative = "error", arg = "foo"),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      num_as_location2(-1, 2, negative = "error", arg = "foo"),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      vec_as_location2(0, 2, arg = "foo"),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      vec_as_location2(na_dbl, 2, arg = "foo"),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      vec_as_location2(c(1, 2), 2, arg = "foo"),
+      class = "vctrs_error_subscript_type"
+    )
+
+    "With tibble columns"
     expect_error(
       with_tibble_cols(num_as_location(-1, 2, negative = "error")),
       class = "vctrs_error_subscript_type"
@@ -406,6 +429,13 @@ test_that("conversion to locations has informative error messages", {
     num_as_location(c(1, NA, 3), 1, oob = "extend")
 
     "# can customise subscript type errors"
+    "With custom `arg`"
+    num_as_location(-1, 2, negative = "error", arg = "foo")
+    num_as_location2(-1, 2, negative = "error", arg = "foo")
+    vec_as_location2(0, 2, arg = "foo")
+    vec_as_location2(na_dbl, 2, arg = "foo")
+    vec_as_location2(c(1, 2), 2, arg = "foo")
+    "With tibble columns"
     with_tibble_cols(num_as_location(-1, 2, negative = "error"))
     with_tibble_cols(num_as_location2(-1, 2, negative = "error"))
     with_tibble_cols(vec_as_location2(0, 2))

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -285,6 +285,16 @@ test_that("can customise OOB errors", {
       class = "vctrs_error_subscript_oob"
     )
 
+    "With custom `arg`"
+    expect_error(
+      vec_as_location(30, length(letters), arg = "foo"),
+      class = "vctrs_error_subscript_oob"
+    )
+    expect_error(
+      vec_as_location("foo", NULL, letters, arg = "foo"),
+      class = "vctrs_error_subscript_oob"
+    )
+
     "With tibble columns"
     expect_error(
       with_tibble_cols(vec_slice(set_names(letters), "foo")),
@@ -404,6 +414,9 @@ test_that("conversion to locations has informative error messages", {
 
     "# can customise OOB errors"
     vec_slice(set_names(letters), "foo")
+    "With custom `arg`"
+    vec_as_location(30, length(letters), arg = "foo")
+    vec_as_location("foo", NULL, letters, arg = "foo")
     "With tibble columns"
     with_tibble_cols(vec_slice(set_names(letters), "foo"))
     with_tibble_cols(vec_slice(set_names(letters), 30))

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -276,6 +276,10 @@ test_that("can customise subscript type errors", {
       vec_as_location2(c(1, 2), 2, arg = "foo"),
       class = "vctrs_error_subscript_type"
     )
+    expect_error(
+      vec_as_location(c(TRUE, FALSE), 3, arg = "foo"),
+      class = "vctrs_error_subscript_size"
+    )
 
     "With tibble columns"
     expect_error(
@@ -297,6 +301,10 @@ test_that("can customise subscript type errors", {
     expect_error(
       with_tibble_cols(vec_as_location2(c(1, 2), 2)),
       class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      with_tibble_cols(vec_as_location(c(TRUE, FALSE), 3)),
+      class = "vctrs_error_subscript_size"
     )
   })
 })
@@ -435,12 +443,14 @@ test_that("conversion to locations has informative error messages", {
     vec_as_location2(0, 2, arg = "foo")
     vec_as_location2(na_dbl, 2, arg = "foo")
     vec_as_location2(c(1, 2), 2, arg = "foo")
+    vec_as_location(c(TRUE, FALSE), 3, arg = "foo")
     "With tibble columns"
     with_tibble_cols(num_as_location(-1, 2, negative = "error"))
     with_tibble_cols(num_as_location2(-1, 2, negative = "error"))
     with_tibble_cols(vec_as_location2(0, 2))
     with_tibble_cols(vec_as_location2(na_dbl, 2))
     with_tibble_cols(vec_as_location2(c(1, 2), 2))
+    with_tibble_cols(vec_as_location(c(TRUE, FALSE), 3))
 
     "# can customise OOB errors"
     vec_slice(set_names(letters), "foo")

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -253,6 +253,31 @@ test_that("missing values are supported in error formatters", {
   })
 })
 
+test_that("can customise subscript type errors", {
+  verify_errors({
+    expect_error(
+      with_tibble_cols(num_as_location(-1, 2, negative = "error")),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      with_tibble_cols(num_as_location2(-1, 2, negative = "error")),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      with_tibble_cols(vec_as_location2(0, 2)),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      with_tibble_cols(vec_as_location2(na_dbl, 2)),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      with_tibble_cols(vec_as_location2(c(1, 2), 2)),
+      class = "vctrs_error_subscript_type"
+    )
+  })
+})
+
 test_that("can customise OOB errors", {
   verify_errors({
     expect_error(
@@ -369,6 +394,13 @@ test_that("conversion to locations has informative error messages", {
     "# missing values are supported in error formatters"
     num_as_location(c(1, NA, 2, 3), 1)
     num_as_location(c(1, NA, 3), 1, oob = "extend")
+
+    "# can customise subscript type errors"
+    with_tibble_cols(num_as_location(-1, 2, negative = "error"))
+    with_tibble_cols(num_as_location2(-1, 2, negative = "error"))
+    with_tibble_cols(vec_as_location2(0, 2))
+    with_tibble_cols(vec_as_location2(na_dbl, 2))
+    with_tibble_cols(vec_as_location2(c(1, 2), 2))
 
     "# can customise OOB errors"
     vec_slice(set_names(letters), "foo")

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -288,6 +288,10 @@ test_that("can customise subscript type errors", {
       vec_as_location(c(-1, 1), 3, arg = "foo"),
       class = "vctrs_error_subscript_type"
     )
+    expect_error(
+      num_as_location(c(1, 4), 2, oob = "extend", arg = "foo"),
+      class = "vctrs_error_subscript_oob"
+    )
 
     "With tibble columns"
     expect_error(
@@ -321,6 +325,10 @@ test_that("can customise subscript type errors", {
     expect_error(
       with_tibble_cols(vec_as_location(c(-1, 1), 3)),
       class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      with_tibble_cols(num_as_location(c(1, 4), 2, oob = "extend")),
+      class = "vctrs_error_subscript_oob"
     )
   })
 })
@@ -462,6 +470,7 @@ test_that("conversion to locations has informative error messages", {
     vec_as_location(c(TRUE, FALSE), 3, arg = "foo")
     vec_as_location(c(-1, NA), 3, arg = "foo")
     vec_as_location(c(-1, 1), 3, arg = "foo")
+    num_as_location(c(1, 4), 2, oob = "extend", arg = "foo")
     "With tibble columns"
     with_tibble_cols(num_as_location(-1, 2, negative = "error"))
     with_tibble_cols(num_as_location2(-1, 2, negative = "error"))
@@ -471,6 +480,7 @@ test_that("conversion to locations has informative error messages", {
     with_tibble_cols(vec_as_location(c(TRUE, FALSE), 3))
     with_tibble_cols(vec_as_location(c(-1, NA), 3))
     with_tibble_cols(vec_as_location(c(-1, 1), 3))
+    with_tibble_cols(num_as_location(c(1, 4), 2, oob = "extend"))
 
     "# can customise OOB errors"
     vec_slice(set_names(letters), "foo")

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -284,6 +284,10 @@ test_that("can customise subscript type errors", {
       vec_as_location(c(-1, NA), 3, arg = "foo"),
       class = "vctrs_error_subscript_type"
     )
+    expect_error(
+      vec_as_location(c(-1, 1), 3, arg = "foo"),
+      class = "vctrs_error_subscript_type"
+    )
 
     "With tibble columns"
     expect_error(
@@ -312,6 +316,10 @@ test_that("can customise subscript type errors", {
     )
     expect_error(
       with_tibble_cols(vec_as_location(c(-1, NA), 3)),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      with_tibble_cols(vec_as_location(c(-1, 1), 3)),
       class = "vctrs_error_subscript_type"
     )
   })
@@ -453,6 +461,7 @@ test_that("conversion to locations has informative error messages", {
     vec_as_location2(c(1, 2), 2, arg = "foo")
     vec_as_location(c(TRUE, FALSE), 3, arg = "foo")
     vec_as_location(c(-1, NA), 3, arg = "foo")
+    vec_as_location(c(-1, 1), 3, arg = "foo")
     "With tibble columns"
     with_tibble_cols(num_as_location(-1, 2, negative = "error"))
     with_tibble_cols(num_as_location2(-1, 2, negative = "error"))
@@ -461,6 +470,7 @@ test_that("conversion to locations has informative error messages", {
     with_tibble_cols(vec_as_location2(c(1, 2), 2))
     with_tibble_cols(vec_as_location(c(TRUE, FALSE), 3))
     with_tibble_cols(vec_as_location(c(-1, NA), 3))
+    with_tibble_cols(vec_as_location(c(-1, 1), 3))
 
     "# can customise OOB errors"
     vec_slice(set_names(letters), "foo")

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -280,6 +280,10 @@ test_that("can customise subscript type errors", {
       vec_as_location(c(TRUE, FALSE), 3, arg = "foo"),
       class = "vctrs_error_subscript_size"
     )
+    expect_error(
+      vec_as_location(c(-1, NA), 3, arg = "foo"),
+      class = "vctrs_error_subscript_type"
+    )
 
     "With tibble columns"
     expect_error(
@@ -305,6 +309,10 @@ test_that("can customise subscript type errors", {
     expect_error(
       with_tibble_cols(vec_as_location(c(TRUE, FALSE), 3)),
       class = "vctrs_error_subscript_size"
+    )
+    expect_error(
+      with_tibble_cols(vec_as_location(c(-1, NA), 3)),
+      class = "vctrs_error_subscript_type"
     )
   })
 })
@@ -444,6 +452,7 @@ test_that("conversion to locations has informative error messages", {
     vec_as_location2(na_dbl, 2, arg = "foo")
     vec_as_location2(c(1, 2), 2, arg = "foo")
     vec_as_location(c(TRUE, FALSE), 3, arg = "foo")
+    vec_as_location(c(-1, NA), 3, arg = "foo")
     "With tibble columns"
     with_tibble_cols(num_as_location(-1, 2, negative = "error"))
     with_tibble_cols(num_as_location2(-1, 2, negative = "error"))
@@ -451,6 +460,7 @@ test_that("conversion to locations has informative error messages", {
     with_tibble_cols(vec_as_location2(na_dbl, 2))
     with_tibble_cols(vec_as_location2(c(1, 2), 2))
     with_tibble_cols(vec_as_location(c(TRUE, FALSE), 3))
+    with_tibble_cols(vec_as_location(c(-1, NA), 3))
 
     "# can customise OOB errors"
     vec_slice(set_names(letters), "foo")

--- a/tests/testthat/test-subscript.R
+++ b/tests/testthat/test-subscript.R
@@ -42,6 +42,15 @@ test_that("vec_as_subscript() handles symbols", {
   )
 })
 
+test_that("can customise subscript errors", {
+  verify_errors({
+    expect_error(
+      with_tibble_cols(vec_as_subscript(env())),
+      class = "vctrs_error_subscript_type"
+    )
+  })
+})
+
 test_that("subscript functions have informative error messages", {
   verify_output(test_path("error", "test-subscript.txt"), {
     "# vec_as_subscript() forbids subscript types"
@@ -56,5 +65,8 @@ test_that("subscript functions have informative error messages", {
     vec_as_subscript2(1L, location = "error", indicator = "error")
     vec_as_subscript2("foo", name = "error", indicator = "error")
     vec_as_subscript2(TRUE, indicator = "error")
+
+    "# can customise subscript errors"
+    with_tibble_cols(vec_as_subscript(env()))
   })
 })


### PR DESCRIPTION
Branched from #767 

* Use `subscript_arg` condition field instead of `arg`. This is more consistent and we might also want to provide arg info about subsetted input.

* More error messages now include `subscript_arg`.

* Removed default `arg = "i"` because it's most likely not relevant for the user. When the arg is not supplied, we refer to the subscript generically with "The subscript".

* Pass options struct more consistently across as-location routines. Add `subscript_arg` to option struct so it's properly forwarded.

* The errors for scalar locations are less redundant.