### PR TITLE
Add option to check missing values in subscript vectors

### DIFF
--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -24,7 +24,7 @@
 #'   not used. The default value of `NULL` will result in an error
 #'   if `i` is a character vector.
 #' @param missing Whether to throw an `"error"` when `i` is a missing
-#'   value, or `"ignore"` it (return it as is). By default, vector
+#'   value, or `"propagate"` it (return it as is). By default, vector
 #'   subscripts can contain missing values and scalar subscripts can't.
 #' @param arg The argument name to be displayed in error messages when
 #'   `vec_as_location()` and `vec_as_location2()` are used to check the
@@ -57,7 +57,7 @@ vec_as_location <- function(i,
                             n,
                             names = NULL,
                             ...,
-                            missing = c("ignore", "error"),
+                            missing = c("propagate", "error"),
                             arg = NULL) {
   if (!missing(...)) ellipsis::check_dots_empty()
 
@@ -84,7 +84,7 @@ vec_as_location <- function(i,
 num_as_location <- function(i,
                             n,
                             ...,
-                            missing = c("ignore", "error"),
+                            missing = c("propagate", "error"),
                             negative = c("invert", "error", "ignore"),
                             oob = c("error", "extend"),
                             arg = NULL) {
@@ -111,7 +111,7 @@ vec_as_location2 <- function(i,
                              n,
                              names = NULL,
                              ...,
-                             missing = c("error", "ignore"),
+                             missing = c("error", "propagate"),
                              arg = NULL) {
   if (!missing(...)) ellipsis::check_dots_empty()
   result_get(vec_as_location2_result(
@@ -131,7 +131,7 @@ num_as_location2 <- function(i,
                              n,
                              ...,
                              negative = c("error", "ignore"),
-                             missing = c("error", "ignore"),
+                             missing = c("error", "propagate"),
                              arg = NULL) {
   if (!missing(...)) ellipsis::check_dots_empty()
 
@@ -154,7 +154,7 @@ vec_as_location2_result <- function(i,
                                     missing,
                                     negative,
                                     arg) {
-  allow_missing <- arg_match(missing, c("error", "ignore")) == "ignore"
+  allow_missing <- arg_match(missing, c("error", "propagate")) == "propagate"
   allow_negative <- arg_match(negative, c("error", "ignore")) == "ignore"
 
   result <- vec_as_subscript2_result(

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -23,6 +23,9 @@
 #'   vector that `i` will be matched against to construct the index. Otherwise,
 #'   not used. The default value of `NULL` will result in an error
 #'   if `i` is a character vector.
+#' @param missing Whether to throw an `"error"` when `i` is a missing
+#'   value, or `"ignore"` it (return it as is). By default, vector
+#'   subscripts can contain missing values and scalar subscripts can't.
 #' @param arg The argument name to be displayed in error messages when
 #'   `vec_as_location()` and `vec_as_location2()` are used to check the
 #'   type of a function input.
@@ -54,6 +57,7 @@ vec_as_location <- function(i,
                             n,
                             names = NULL,
                             ...,
+                            missing = c("ignore", "error"),
                             arg = NULL) {
   if (!missing(...)) ellipsis::check_dots_empty()
 
@@ -65,6 +69,7 @@ vec_as_location <- function(i,
     names = names,
     loc_negative = "invert",
     loc_oob = "error",
+    missing = missing,
     arg = arg
   )
 }
@@ -79,6 +84,7 @@ vec_as_location <- function(i,
 num_as_location <- function(i,
                             n,
                             ...,
+                            missing = c("ignore", "error"),
                             negative = c("invert", "error", "ignore"),
                             oob = c("error", "extend"),
                             arg = NULL) {
@@ -94,13 +100,12 @@ num_as_location <- function(i,
     names = NULL,
     loc_negative = negative,
     loc_oob = oob,
+    missing = missing,
     arg = arg
   )
 }
 
 #' @rdname vec_as_location
-#' @param missing Whether to throw an `"error"` when `i` is a missing
-#'   value, or `"ignore"` it (return it as is).
 #' @export
 vec_as_location2 <- function(i,
                              n,
@@ -335,6 +340,30 @@ cnd_bullets_location_need_non_negative <- function(cnd, ...) {
   cnd$subscript_arg <- append_arg("The subscript", cnd$subscript_arg)
   format_error_bullets(c(
     x = glue::glue_data(cnd, "{subscript_arg} can't contain negative locations.")
+  ))
+}
+
+stop_subscript_missing <- function(i, ...) {
+  cnd_signal(new_error_subscript_type(
+    i = i,
+    body = cnd_bullets_subscript_missing,
+    ...
+  ))
+}
+cnd_bullets_subscript_missing <- function(cnd, ...) {
+  cnd$subscript_arg <- append_arg("The subscript", cnd$subscript_arg)
+
+  missing_loc <- which(is.na(cnd$i))
+  if (length(missing_loc) == 1) {
+    missing_line <- glue::glue("It has a missing value at location {missing_loc}")
+  } else {
+    missing_enum <- enumerate(missing_loc)
+    missing_line <- glue::glue("It has missing values at locations {missing_enum}")
+  }
+
+  format_error_bullets(c(
+    x = glue::glue_data(cnd, "{subscript_arg} can't contain missing values."),
+    x = missing_line
   ))
 }
 

--- a/R/vctrs-deprecated.R
+++ b/R/vctrs-deprecated.R
@@ -79,7 +79,7 @@ vec_as_index <- function(i, n, names = NULL) {
     names = names,
     loc_negative = "invert",
     loc_oob = "error",
-    missing = "ignore",
+    missing = "propagate",
     arg = NULL
   )
 }

--- a/R/vctrs-deprecated.R
+++ b/R/vctrs-deprecated.R
@@ -79,6 +79,7 @@ vec_as_index <- function(i, n, names = NULL) {
     names = names,
     loc_negative = "invert",
     loc_oob = "error",
+    missing = "ignore",
     arg = NULL
   )
 }

--- a/man/vec_as_location.Rd
+++ b/man/vec_as_location.Rd
@@ -7,12 +7,20 @@
 \alias{num_as_location2}
 \title{Create a vector of locations}
 \usage{
-vec_as_location(i, n, names = NULL, ..., arg = NULL)
+vec_as_location(
+  i,
+  n,
+  names = NULL,
+  ...,
+  missing = c("propagate", "error"),
+  arg = NULL
+)
 
 num_as_location(
   i,
   n,
   ...,
+  missing = c("propagate", "error"),
   negative = c("invert", "error", "ignore"),
   oob = c("error", "extend"),
   arg = NULL
@@ -23,7 +31,7 @@ vec_as_location2(
   n,
   names = NULL,
   ...,
-  missing = c("error", "ignore"),
+  missing = c("error", "propagate"),
   arg = NULL
 )
 
@@ -32,7 +40,7 @@ num_as_location2(
   n,
   ...,
   negative = c("error", "ignore"),
-  missing = c("error", "ignore"),
+  missing = c("error", "propagate"),
   arg = NULL
 )
 }
@@ -50,6 +58,10 @@ vector that \code{i} will be matched against to construct the index. Otherwise,
 not used. The default value of \code{NULL} will result in an error
 if \code{i} is a character vector.}
 
+\item{missing}{Whether to throw an \code{"error"} when \code{i} is a missing
+value, or \code{"propagate"} it (return it as is). By default, vector
+subscripts can contain missing values and scalar subscripts can't.}
+
 \item{arg}{The argument name to be displayed in error messages when
 \code{vec_as_location()} and \code{vec_as_location2()} are used to check the
 type of a function input.}
@@ -61,9 +73,6 @@ negative location value, or \code{"ignore"} it.}
 elements are out-of-bounds. If \code{"extend"}, out-of-bounds
 locations are allowed if they are consecutive after the end. This
 can be used to implement extendable vectors like \code{letters[1:30]}.}
-
-\item{missing}{Whether to throw an \code{"error"} when \code{i} is a missing
-value, or \code{"ignore"} it (return it as is).}
 }
 \value{
 \code{vec_as_location()} returns an integer vector that can be used

--- a/src/init.c
+++ b/src/init.c
@@ -44,7 +44,7 @@ extern SEXP vctrs_is_vector(SEXP);
 extern SEXP vctrs_type2(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_typeof2(SEXP, SEXP);
 extern SEXP vctrs_cast(SEXP, SEXP, SEXP, SEXP);
-extern SEXP vctrs_as_location(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_as_location(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_slice(SEXP, SEXP);
 extern SEXP vctrs_init(SEXP, SEXP);
 extern SEXP vctrs_chop(SEXP, SEXP);
@@ -145,7 +145,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_type2",                      (DL_FUNC) &vctrs_type2, 4},
   {"vctrs_typeof2",                    (DL_FUNC) &vctrs_typeof2, 2},
   {"vctrs_cast",                       (DL_FUNC) &vctrs_cast, 4},
-  {"vctrs_as_location",                (DL_FUNC) &vctrs_as_location, 6},
+  {"vctrs_as_location",                (DL_FUNC) &vctrs_as_location, 7},
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 2},
   {"vctrs_init",                       (DL_FUNC) &vctrs_init, 2},
   {"vctrs_chop",                       (DL_FUNC) &vctrs_chop, 2},

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -312,7 +312,7 @@ static enum subscript_missing parse_subscript_arg_missing(SEXP x) {
 
   const char* str = CHAR(STRING_ELT(x, 0));
 
-  if (!strcmp(str, "ignore")) return SUBSCRIPT_MISSING_PROPAGATE;
+  if (!strcmp(str, "propagate")) return SUBSCRIPT_MISSING_PROPAGATE;
   if (!strcmp(str, "error")) return SUBSCRIPT_MISSING_ERROR;
   stop_subscript_arg_missing();
 

--- a/src/subscript-loc.h
+++ b/src/subscript-loc.h
@@ -13,6 +13,10 @@ enum subscript_action {
   SUBSCRIPT_ACTION_REMOVE,
   SUBSCRIPT_ACTION_NEGATE
 };
+enum subscript_missing {
+  SUBSCRIPT_MISSING_PROPAGATE,
+  SUBSCRIPT_MISSING_ERROR
+};
 enum num_as_location_loc_negative {
   LOC_NEGATIVE_INVERT,
   LOC_NEGATIVE_ERROR,
@@ -27,6 +31,7 @@ struct vec_as_location_opts {
   enum subscript_action action;
   enum num_as_location_loc_negative loc_negative;
   enum num_as_location_loc_oob loc_oob;
+  enum subscript_missing missing;
   SEXP subscript_arg;
 };
 

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -443,3 +443,22 @@ Error: Must remove existing rows in `tbl[i]`.
 x Can't remove locations 27, 28, 29, and 30.
 i There are only 26 rows.
 
+
+can disallow missing values
+===========================
+
+> vec_as_location(c(1, NA), 2, missing = "error")
+Error: Must subset elements with a proper subscript vector.
+x The subscript can't contain missing values.
+x It has a missing value at location 2
+
+> vec_as_location(c(1, NA, 2, NA), 2, missing = "error", arg = "foo")
+Error: Must subset elements with a proper subscript vector.
+x The subscript can't contain missing values.
+x It has missing values at locations 2 and 4
+
+> with_tibble_cols(vec_as_location(c(1, NA, 2, NA), 2, missing = "error"))
+Error: Must rename columns with a proper subscript vector.
+x The subscript `tbl[i]` can't contain missing values.
+x It has missing values at locations 2 and 4
+

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -143,12 +143,12 @@ test_that("vec_as_location() preserves names if possible", {
 })
 
 test_that("vec_as_location2() optionally allows missing values", {
-  expect_identical(vec_as_location2(NA, 2L, missing = "ignore"), na_int)
+  expect_identical(vec_as_location2(NA, 2L, missing = "propagate"), na_int)
   expect_error(vec_as_location2(NA, 2L, missing = "error"), class = "vctrs_error_subscript_type")
 })
 
 test_that("num_as_location2() optionally allows missing and negative locations", {
-  expect_identical(num_as_location2(na_dbl, 2L, missing = "ignore"), na_int)
+  expect_identical(num_as_location2(na_dbl, 2L, missing = "propagate"), na_int)
   expect_identical(num_as_location2(-1, 2L, negative = "ignore"), -1L)
   expect_error(num_as_location2(-3, 2L, negative = "ignore"), class = "vctrs_error_subscript_oob")
   expect_error(num_as_location2(0, 2L, negative = "ignore"), class = "vctrs_error_subscript_type")

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -253,6 +253,23 @@ test_that("missing values are supported in error formatters", {
   })
 })
 
+test_that("can disallow missing values", {
+  verify_errors({
+    expect_error(
+      vec_as_location(c(1, NA), 2, missing = "error"),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      vec_as_location(c(1, NA, 2, NA), 2, missing = "error", arg = "foo"),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      with_tibble_cols(vec_as_location(c(1, NA, 2, NA), 2, missing = "error")),
+      class = "vctrs_error_subscript_type"
+    )
+  })
+})
+
 test_that("can customise subscript type errors", {
   verify_errors({
     "With custom `arg`"
@@ -495,5 +512,10 @@ test_that("conversion to locations has informative error messages", {
     with_tibble_rows(vec_slice(set_names(letters), c("foo", "bar")))
     with_tibble_rows(vec_slice(set_names(letters), 1:30))
     with_tibble_rows(vec_slice(set_names(letters), -(1:30)))
+
+    "# can disallow missing values"
+    vec_as_location(c(1, NA), 2, missing = "error")
+    vec_as_location(c(1, NA, 2, NA), 2, missing = "error", arg = "foo")
+    with_tibble_cols(vec_as_location(c(1, NA, 2, NA), 2, missing = "error"))
   })
 })


### PR DESCRIPTION
Branched from #768.

Will be useful for tibble, cc @krlmlr 

Also renames "ignore" option to "propagate", which seems clearer for missing values.