### PR TITLE
More `vec_cast()` inheritance

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -169,8 +169,10 @@ vec_coercible_cast <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 #' @export
 vec_default_cast <- function(x, to, x_arg = "x", to_arg = "to") {
   if (is_unspecified(x)) {
-    vec_init(to, length(x))
-  } else {
-    stop_incompatible_cast(x, to, x_arg = x_arg, to_arg = to_arg)
+    return(vec_init(to, length(x)))
   }
+  if (is_same_type(x, to)) {
+    return(x)
+  }
+  stop_incompatible_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -323,7 +323,10 @@ vec_ptype2.list.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 #' @rdname vec_cast
 #' @export vec_cast.logical
 #' @method vec_cast logical
-vec_cast.logical <- function(x, to, ...) {
+vec_cast.logical <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  if (is.object(to)) {
+    return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
+  }
   UseMethod("vec_cast.logical")
 }
 #' @export
@@ -385,7 +388,10 @@ vec_cast.logical.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 #' @rdname vec_cast
 #' @export vec_cast.integer
 #' @method vec_cast integer
-vec_cast.integer <- function(x, to, ...) {
+vec_cast.integer <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  if (is.object(to)) {
+    return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
+  }
   UseMethod("vec_cast.integer")
 }
 #' @export
@@ -438,7 +444,10 @@ vec_cast.integer.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 #' @rdname vec_cast
 #' @export vec_cast.double
 #' @method vec_cast double
-vec_cast.double <- function(x, to, ...) {
+vec_cast.double <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  if (is.object(to)) {
+    return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
+  }
   UseMethod("vec_cast.double")
 }
 #' @export
@@ -491,7 +500,10 @@ vec_cast.double.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 #' @rdname vec_cast
 #' @export vec_cast.complex
 #' @method vec_cast complex
-vec_cast.complex <- function(x, to, ...) {
+vec_cast.complex <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  if (is.object(to)) {
+    return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
+  }
   UseMethod("vec_cast.complex")
 }
 #' @export
@@ -535,7 +547,10 @@ vec_cast.complex.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 #' @rdname vec_cast
 #' @export vec_cast.raw
 #' @method vec_cast raw
-vec_cast.raw <- function(x, to, ...) {
+vec_cast.raw <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  if (is.object(to)) {
+    return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
+  }
   UseMethod("vec_cast.raw")
 }
 #' @export
@@ -564,7 +579,10 @@ vec_cast.raw.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 #' @rdname vec_cast
 #' @export vec_cast.character
 #' @method vec_cast character
-vec_cast.character <- function(x, to, ...) {
+vec_cast.character <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  if (is.object(to)) {
+    return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
+  }
   UseMethod("vec_cast.character")
 }
 #' @export
@@ -617,7 +635,10 @@ vec_cast.character.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 #' @export vec_cast.list
 #' @method vec_cast list
 #' @export
-vec_cast.list <- function(x, to, ...) {
+vec_cast.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  if (is.object(to)) {
+    return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
+  }
   UseMethod("vec_cast.list")
 }
 #' @export

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -19,19 +19,19 @@ vec_cast_common(..., .to = NULL)
 
 vec_restore(x, to, ..., n = NULL)
 
-\method{vec_cast}{logical}(x, to, ...)
+\method{vec_cast}{logical}(x, to, ..., x_arg = "x", to_arg = "to")
 
-\method{vec_cast}{integer}(x, to, ...)
+\method{vec_cast}{integer}(x, to, ..., x_arg = "x", to_arg = "to")
 
-\method{vec_cast}{double}(x, to, ...)
+\method{vec_cast}{double}(x, to, ..., x_arg = "x", to_arg = "to")
 
-\method{vec_cast}{complex}(x, to, ...)
+\method{vec_cast}{complex}(x, to, ..., x_arg = "x", to_arg = "to")
 
-\method{vec_cast}{raw}(x, to, ...)
+\method{vec_cast}{raw}(x, to, ..., x_arg = "x", to_arg = "to")
 
-\method{vec_cast}{character}(x, to, ...)
+\method{vec_cast}{character}(x, to, ..., x_arg = "x", to_arg = "to")
 
-\method{vec_cast}{list}(x, to, ...)
+\method{vec_cast}{list}(x, to, ..., x_arg = "x", to_arg = "to")
 }
 \arguments{
 \item{x}{Vectors to cast.}

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -21,6 +21,10 @@ test_that("cast base methods are not inherited", {
   }
 })
 
+test_that("default cast allows objects with the same type", {
+  x <- structure(1, class = c("foo", "double"))
+  expect_equal(vec_cast(x, x), x)
+})
 
 # shape_match -------------------------------------------------------------
 

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -15,9 +15,9 @@ test_that("cast base methods are not inherited", {
   # FIXME: Should also disallow data frame and list methods
   ptypes <- vec_remove(base_empty_types, c("null", "dataframe", "list"))
   for (ptype in ptypes) {
-    x <- new_vctr(ptype, class = "foobar", inherit_base_type = TRUE)
-    expect_is(vec_cast(ptype, x), "foobar")
-    expect_error(vec_cast(x, !!ptype), class = "vctrs_error_incompatible_cast")
+    x <- structure(ptype, class = c("foobar", typeof(ptype)))
+    expect_error(vec_cast(ptype, x), class = "vctrs_error_incompatible_cast")
+    expect_error(vec_cast(x, ptype), class = "vctrs_error_incompatible_cast")
   }
 })
 


### PR DESCRIPTION
Closes #776 with the usage of `is_same_type()` in `vec_default_cast()`

Addresses https://github.com/r-lib/vctrs/issues/753#issuecomment-576969414 by adding `is.object(to)` checks in the first level of casting dispatch.

@lionel- you specifically tested that something else was supposed to happen, i.e.

```r
expect_is(vec_cast(ptype, x), "foobar")
```

should this not have been an error? You can cast from, for example, `<double>` to `<foobar>` without writing a method for it? I found this super confusing when writing an S4 `bdays` class that "contained" an integer, and then was automatically able to do:

```r
> vec_cast(1, bdays(2, schedule()))
[1] 1
```

(That is the same problem as https://github.com/r-lib/vctrs/issues/753#issuecomment-576969414)

Also, part of the confusion came from the fact that a `vctrs_vctr` was being used in the tests, which has its own `vec_cast.vctrs_vctr.default()` method. I've changed the test to use a non-vctrs_vctr object