### PR TITLE
Allow `""` as a valid name for `<vctrs_vctr>` objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* If `NA_character_` is specified as a name for `vctrs_vctr` objects, it is
+  now automatically repaired to `""` (#780).
+
 * `""` is now an allowed name for `vctrs_vctr` objects (#780).
 
 * `list_of()` is now much faster when many values are provided.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `""` is now an allowed name for `vctrs_vctr` objects (#780).
+
 * `list_of()` is now much faster when many values are provided.
 
 * `vec_as_location()` evaluates `arg` only in case of error, for performance

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -100,17 +100,17 @@ new_vctr <- function(.data,
 validate_names <- function(.data) {
   nms <- names(.data)
 
-  if (!names_all_or_nothing(nms)) {
-    stop("If any elements of `.data` are named, all must be named", call. = FALSE)
+  if (any_na_names(nms)) {
+    abort("The names of `.data` must not be `NA`.")
   }
 
   nms
 }
-names_all_or_nothing <- function(names) {
+any_na_names <- function(names) {
   if (is.null(names)) {
-    TRUE
+    FALSE
   } else {
-    all(names != "" & !is.na(names))
+    any(is.na(names))
   }
 }
 
@@ -269,8 +269,8 @@ diff.vctrs_vctr <- function(x, lag = 1L, differences = 1L, ...) {
   if (length(value) != 0 && length(value) != length(x)) {
     abort("`names()` must be the same length as x.")
   }
-  if (!names_all_or_nothing(value)) {
-    abort("If any elements are named, all elements must be named.")
+  if (any_na_names(value)) {
+    abort("Names must not be `NA`.")
   }
   NextMethod()
 }

--- a/tests/testthat/test-type-list-of.R
+++ b/tests/testthat/test-type-list-of.R
@@ -63,6 +63,15 @@ test_that("constructor requires size 0 ptype", {
   expect_error(new_list_of(ptype = 1), "must have size 0")
 })
 
+test_that("can combine a mix of named and unnamed list-ofs (#784)", {
+  a <- new_list_of(list(x = 1L), ptype = integer())
+  b <- new_list_of(list(2L), ptype = integer())
+
+  expect <- new_list_of(list(x = 1L, 2L), ptype = integer())
+
+  expect_identical(vec_c(a, b), expect)
+})
+
 # Subsetting --------------------------------------------------------------
 
 test_that("[ preserves type", {

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -283,17 +283,30 @@ test_that("na.fail() works", {
 # names -------------------------------------------------------------------
 
 test_that("all elements must be named if any are named", {
-  expect_error(new_vctr(setNames(1:2, c("a", NA))), "named")
-  expect_error(new_vctr(setNames(1:2, c("a", ""))), "named")
+  expect_error(new_vctr(setNames(1:2, c("a", NA))), "must not be `NA`")
+})
+
+test_that("the empty string is an allowed name", {
+  expect_named(new_vctr(set_names(1, "")), "")
+  expect_named(new_vctr(set_names(1:2, c("", "x"))), c("", "x"))
 })
 
 test_that("can not provide invalid names", {
   x <- new_vctr(c(a = 1, b = 2))
   expect_error(names(x) <- "x", "length")
-  expect_error(names(x) <- c("x", NA), "named")
-  expect_error(names(x) <- c("x", ""), "named")
+  expect_error(names(x) <- c("x", NA), "must not be `NA`")
   expect_error(names(x) <- c("x", "y", "z"), "length")
   expect_error(names(x) <- NULL, NA)
+})
+
+test_that("can set names to the empty string", {
+  x <- new_vctr(c(a = 1, b = 2))
+
+  names(x) <- c("", "")
+  expect_named(x, c("", ""))
+
+  names(x) <- c("", "x")
+  expect_named(x, c("", "x"))
 })
 
 test_that("can use [ and [[ with names", {

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -286,7 +286,7 @@ test_that("all elements must be named if any are named", {
   expect_error(new_vctr(setNames(1:2, c("a", NA))), "must not be `NA`")
 })
 
-test_that("the empty string is an allowed name", {
+test_that("the empty string is an allowed name (#784)", {
   expect_named(new_vctr(set_names(1, "")), "")
   expect_named(new_vctr(set_names(1:2, c("", "x"))), c("", "x"))
 })
@@ -299,7 +299,7 @@ test_that("can not provide invalid names", {
   expect_error(names(x) <- NULL, NA)
 })
 
-test_that("can set names to the empty string", {
+test_that("can set names to the empty string (#784)", {
   x <- new_vctr(c(a = 1, b = 2))
 
   names(x) <- c("", "")

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -282,8 +282,9 @@ test_that("na.fail() works", {
 
 # names -------------------------------------------------------------------
 
-test_that("all elements must be named if any are named", {
-  expect_error(new_vctr(setNames(1:2, c("a", NA))), "must not be `NA`")
+test_that("`NA_character_` names are repaired to the empty string (#784)", {
+  expect_named(new_vctr(set_names(1, NA_character_)), "")
+  expect_named(new_vctr(set_names(1:2, c("a", NA))), c("a", ""))
 })
 
 test_that("the empty string is an allowed name (#784)", {
@@ -294,7 +295,6 @@ test_that("the empty string is an allowed name (#784)", {
 test_that("can not provide invalid names", {
   x <- new_vctr(c(a = 1, b = 2))
   expect_error(names(x) <- "x", "length")
-  expect_error(names(x) <- c("x", NA), "must not be `NA`")
   expect_error(names(x) <- c("x", "y", "z"), "length")
   expect_error(names(x) <- NULL, NA)
 })
@@ -307,6 +307,16 @@ test_that("can set names to the empty string (#784)", {
 
   names(x) <- c("", "x")
   expect_named(x, c("", "x"))
+})
+
+test_that("setting names to `NA_character_` repairs to the empty string (#784)", {
+  x <- new_vctr(1:2)
+
+  names(x) <- c(NA_character_, NA_character_)
+  expect_named(x, c("", ""))
+
+  names(x) <- c("x", NA_character_)
+  expect_named(x, c("x", ""))
 })
 
 test_that("can use [ and [[ with names", {


### PR DESCRIPTION
Closes #780 
Closes #1268
Closes https://github.com/tidyverse/haven/issues/526 (need to manually close that)
https://github.com/tidyverse/tidyr/issues/1212 requires this

Related to #1108, in that it fixes the issue originally brought up there, but I think there is still more work to do in terms of the order attributes are restored.

---

This PR adjusts the restriction that neither `NA_character_` nor `""` were allowed as names for `vctrs_vctr` objects. We now:
- Allow `""` names
- Repair `NA_character_` names by converting them to `""` silently

---

It turns out that `""` arises as a valid name in many scenarios, and disallowing it as a valid name has caused many issues.

- `""` is used as the name in `vec_slice(x, NA_integer_)` when `x` is a named vector
- Combining a named vector with an unnamed vector will force `""` as a name (see the hidden list-of comment below)

And `NA_character_` names seem to appear in practice (i.e. #1268 and https://github.com/tidyverse/haven/issues/526), so providing something that deals with them in a reasonable way is also useful.