### PR TITLE
Declare C API functions with `extern`

### DIFF
--- a/inst/include/vctrs.h
+++ b/inst/include/vctrs.h
@@ -5,13 +5,13 @@
 #include <R_ext/Rdynload.h>
 #include <stdbool.h>
 
-SEXP (*vec_proxy)(SEXP);
-SEXP (*vec_restore)(SEXP, SEXP, SEXP);
-SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool);
-SEXP (*vec_slice_impl)(SEXP, SEXP);
-SEXP (*vec_names)(SEXP);
-SEXP (*vec_set_names)(SEXP, SEXP);
-SEXP (*vec_chop)(SEXP, SEXP);
+extern SEXP (*vec_proxy)(SEXP);
+extern SEXP (*vec_restore)(SEXP, SEXP, SEXP);
+extern SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool);
+extern SEXP (*vec_slice_impl)(SEXP, SEXP);
+extern SEXP (*vec_names)(SEXP);
+extern SEXP (*vec_set_names)(SEXP, SEXP);
+extern SEXP (*vec_chop)(SEXP, SEXP);
 
 void vctrs_init_api();
 


### PR DESCRIPTION
On GCC10, {slider} seems to fail because of the "multiple definition" warning we've seen elsewhere.
https://www.stats.ox.ac.uk/pub/bdr/gcc10/slider.log

Same warning as:
topepo/Cubist#26

I've fixed my imports of the non-exported vctrs C api here:
https://github.com/DavisVaughan/slider/commit/8054cc95acde15a0a11ce4712388d236b1bc3629

But we need to fix the exported vctrs C api as well, which is what this commit does.

_It would be great if we could do a small vctrs release with just this, so CRAN doesn't get mad about slider. This PR is on top of current master, which doesn't seem like the right way to do the patch release. So I'm declaring this as a draft PR and tagging @lionel- since hopefully he knows how to merge this in the right way._

You can reproduce the problem by being in the slider RStudio project and running 

```r
withr::with_makevars(
  c("CFLAGS" = "-fno-common"), 
  {
    pkgbuild::clean_dll()
    devtools::load_all()
  }
)
```

Declaring these as `extern` makes the warnings go away.