### PR TITLE
Factor performance - `vec_cast()`

### DIFF
--- a/R/type-factor.R
+++ b/R/type-factor.R
@@ -122,10 +122,17 @@ vec_cast.factor <- function(x, to, ...) {
 #' @method vec_cast.factor factor
 vec_cast.factor.factor <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (length(levels(to)) == 0L) {
-    factor(as.character(x), levels = unique(x), ordered = is.ordered(to))
+    levels <- levels(x)
+    if (is.null(levels)) {
+      exclude <- NA
+      levels <- unique(x)
+    } else {
+      exclude <- NULL
+    }
+    factor(as.character(x), levels = levels, ordered = is.ordered(to), exclude = exclude)
   } else {
     lossy <- !(x %in% levels(to) | is.na(x))
-    out <- factor(x, levels = levels(to), ordered = is.ordered(to))
+    out <- factor(x, levels = levels(to), ordered = is.ordered(to), exclude = NULL)
     maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
   }
 }

--- a/src/cast-dispatch.c
+++ b/src/cast-dispatch.c
@@ -1,0 +1,90 @@
+#include "vctrs.h"
+#include "utils.h"
+
+static SEXP vec_cast_dispatch2(SEXP x,
+                               SEXP to,
+                               enum vctrs_type x_type,
+                               bool* lossy,
+                               struct vctrs_arg* x_arg,
+                               struct vctrs_arg* to_arg);
+
+// [[ include("vctrs.h") ]]
+SEXP vec_cast_dispatch(SEXP x,
+                       SEXP to,
+                       enum vctrs_type x_type,
+                       enum vctrs_type to_type,
+                       bool* lossy,
+                       struct vctrs_arg* x_arg,
+                       struct vctrs_arg* to_arg) {
+  switch (to_type) {
+  case vctrs_type_character:
+    switch (class_type(x)) {
+    case vctrs_class_bare_factor:
+      return fct_as_character(x, x_arg);
+
+    case vctrs_class_bare_ordered:
+      return ord_as_character(x, x_arg);
+
+    default:
+      break;
+    }
+
+  case vctrs_type_s3:
+    return vec_cast_dispatch2(x, to, x_type, lossy, x_arg, to_arg);
+
+  default:
+    break;
+  }
+
+  return R_NilValue;
+}
+
+
+static SEXP vec_cast_dispatch2(SEXP x, SEXP to,
+                               enum vctrs_type x_type,
+                               bool* lossy,
+                               struct vctrs_arg* x_arg,
+                               struct vctrs_arg* to_arg) {
+  switch (class_type(to)) {
+  case vctrs_class_bare_factor:
+    switch (x_type) {
+    case vctrs_type_character:
+      return chr_as_factor(x, to, lossy, to_arg);
+
+    case vctrs_type_s3:
+      switch (class_type(x)) {
+      case vctrs_class_bare_factor:
+        return fct_as_factor(x, to, lossy, x_arg, to_arg);
+
+      default:
+        break;
+      }
+
+    default:
+      break;
+    }
+
+  case vctrs_class_bare_ordered:
+    switch (x_type) {
+    case vctrs_type_character:
+      return chr_as_ordered(x, to, lossy, to_arg);
+
+    case vctrs_type_s3:
+      switch (class_type(x)) {
+      case vctrs_class_bare_ordered:
+        return ord_as_ordered(x, to, lossy, x_arg, to_arg);
+
+      default:
+        break;
+      }
+
+    default:
+      break;
+    }
+
+  default:
+    break;
+  }
+
+  return R_NilValue;
+}

--- a/src/cast.c
+++ b/src/cast.c
@@ -267,9 +267,16 @@ static SEXP df_as_dataframe(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vct
 }
 
 static SEXP vec_cast_switch(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg) {
-  switch (vec_typeof(to)) {
+  enum vctrs_type to_type = vec_typeof(to);
+  enum vctrs_type x_type = vec_typeof(x);
+
+  if (to_type == vctrs_type_s3 || x_type == vctrs_type_s3) {
+    return vec_cast_dispatch(x, to, x_type, to_type, lossy, x_arg, to_arg);
+  }
+
+  switch (to_type) {
   case vctrs_type_logical:
-    switch (vec_typeof(x)) {
+    switch (x_type) {
     case vctrs_type_logical:
       return x;
     case vctrs_type_integer:
@@ -284,7 +291,7 @@ static SEXP vec_cast_switch(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_ar
     break;
 
   case vctrs_type_integer:
-    switch (vec_typeof(x)) {
+    switch (x_type) {
     case vctrs_type_logical:
       return lgl_as_integer(x, lossy);
     case vctrs_type_integer:
@@ -300,7 +307,7 @@ static SEXP vec_cast_switch(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_ar
     break;
 
   case vctrs_type_double:
-    switch (vec_typeof(x)) {
+    switch (x_type) {
     case vctrs_type_logical:
       return lgl_as_double(x, lossy);
     case vctrs_type_integer:
@@ -316,7 +323,7 @@ static SEXP vec_cast_switch(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_ar
     break;
 
   case vctrs_type_character:
-    switch (vec_typeof(x)) {
+    switch (x_type) {
     case vctrs_type_logical:
     case vctrs_type_integer:
     case vctrs_type_double:
@@ -329,7 +336,7 @@ static SEXP vec_cast_switch(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_ar
     break;
 
   case vctrs_type_dataframe:
-    switch (vec_typeof(x)) {
+    switch (x_type) {
     case vctrs_type_dataframe:
       return df_as_dataframe(x, to, x_arg, to_arg);
     default:

--- a/src/cast.c
+++ b/src/cast.c
@@ -189,10 +189,6 @@ static SEXP int_as_double(SEXP x, bool* lossy) {
   return out;
 }
 
-
-// From dictionary.c
-SEXP vctrs_match(SEXP needles, SEXP haystack);
-
 // Defined below
 static SEXP df_as_dataframe(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 
@@ -223,7 +219,7 @@ static SEXP df_as_dataframe(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vct
     Rf_error("Internal error in `df_as_dataframe()`: Data frame must have names.");
   }
 
-  SEXP to_dups_pos = PROTECT(vctrs_match(to_names, x_names));
+  SEXP to_dups_pos = PROTECT(vec_match(to_names, x_names));
   int* to_dups_pos_data = INTEGER(to_dups_pos);
 
   R_len_t to_len = Rf_length(to_dups_pos);

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -236,7 +236,7 @@ SEXP vctrs_id(SEXP x) {
 }
 
 // [[ register() ]]
-SEXP vctrs_match(SEXP needles, SEXP haystack) {
+SEXP vec_match(SEXP needles, SEXP haystack) {
   int nprot = 0;
   int _;
   SEXP type = PROTECT_N(vec_type2(needles, haystack, &args_needles, &args_haystack, &_), &nprot);

--- a/src/equal.c
+++ b/src/equal.c
@@ -617,8 +617,8 @@ int equal_na(SEXP x, R_len_t i) {
   }                                                       \
   while (0)
 
-// [[ register() ]]
-SEXP vctrs_equal_na(SEXP x) {
+// [[ register(); include("vctrs.h") ]]
+SEXP vec_equal_na(SEXP x) {
   R_len_t n = vec_size(x);
   SEXP out = PROTECT(Rf_allocVector(LGLSXP, n));
   int32_t* p = LOGICAL(out);
@@ -635,8 +635,8 @@ SEXP vctrs_equal_na(SEXP x) {
   case vctrs_type_character: EQUAL_NA(SEXP, STRING_PTR_RO, chr_equal_na_scalar); break;
   case vctrs_type_list:      EQUAL_NA_BARRIER(list_equal_na_scalar); break;
   case vctrs_type_dataframe: EQUAL_NA_BARRIER(df_equal_na_scalar); break;
-  case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't detect `NA` values in scalars with `vctrs_equal_na()`.");
-  default:                   Rf_error("Unimplemented type in `vctrs_equal_na()`.");
+  case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't detect `NA` values in scalars with `vec_equal_na()`.");
+  default:                   Rf_error("Unimplemented type in `vec_equal_na()`.");
   }
 
   UNPROTECT(2);

--- a/src/equal.c
+++ b/src/equal.c
@@ -617,8 +617,8 @@ int equal_na(SEXP x, R_len_t i) {
   }                                                       \
   while (0)
 
-// [[ register(); include("vctrs.h") ]]
-SEXP vec_equal_na(SEXP x) {
+// [[ register() ]]
+SEXP vctrs_equal_na(SEXP x) {
   R_len_t n = vec_size(x);
   SEXP out = PROTECT(Rf_allocVector(LGLSXP, n));
   int32_t* p = LOGICAL(out);
@@ -635,8 +635,8 @@ SEXP vec_equal_na(SEXP x) {
   case vctrs_type_character: EQUAL_NA(SEXP, STRING_PTR_RO, chr_equal_na_scalar); break;
   case vctrs_type_list:      EQUAL_NA_BARRIER(list_equal_na_scalar); break;
   case vctrs_type_dataframe: EQUAL_NA_BARRIER(df_equal_na_scalar); break;
-  case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't detect `NA` values in scalars with `vec_equal_na()`.");
-  default:                   Rf_error("Unimplemented type in `vec_equal_na()`.");
+  case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't detect `NA` values in scalars with `vctrs_equal_na()`.");
+  default:                   Rf_error("Unimplemented type in `vctrs_equal_na()`.");
   }
 
   UNPROTECT(2);

--- a/src/init.c
+++ b/src/init.c
@@ -30,7 +30,7 @@ extern SEXP vctrs_group_id(SEXP);
 extern SEXP vctrs_group_rle(SEXP);
 extern SEXP vec_group_loc(SEXP);
 extern SEXP vctrs_equal(SEXP, SEXP, SEXP);
-extern SEXP vec_equal_na(SEXP);
+extern SEXP vctrs_equal_na(SEXP);
 extern SEXP vctrs_compare(SEXP, SEXP, SEXP);
 extern SEXP vec_match(SEXP, SEXP);
 extern SEXP vctrs_duplicated_any(SEXP);
@@ -135,7 +135,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_dim_n",                      (DL_FUNC) &vctrs_dim_n, 1},
   {"vctrs_is_unspecified",             (DL_FUNC) &vctrs_is_unspecified, 1},
   {"vctrs_equal",                      (DL_FUNC) &vctrs_equal, 3},
-  {"vctrs_equal_na",                   (DL_FUNC) &vec_equal_na, 1},
+  {"vctrs_equal_na",                   (DL_FUNC) &vctrs_equal_na, 1},
   {"vctrs_compare",                    (DL_FUNC) &vctrs_compare, 3},
   {"vctrs_match",                      (DL_FUNC) &vec_match, 2},
   {"vctrs_typeof",                     (DL_FUNC) &vctrs_typeof, 2},

--- a/src/init.c
+++ b/src/init.c
@@ -30,7 +30,7 @@ extern SEXP vctrs_group_id(SEXP);
 extern SEXP vctrs_group_rle(SEXP);
 extern SEXP vec_group_loc(SEXP);
 extern SEXP vctrs_equal(SEXP, SEXP, SEXP);
-extern SEXP vctrs_equal_na(SEXP);
+extern SEXP vec_equal_na(SEXP);
 extern SEXP vctrs_compare(SEXP, SEXP, SEXP);
 extern SEXP vec_match(SEXP, SEXP);
 extern SEXP vctrs_duplicated_any(SEXP);
@@ -135,7 +135,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_dim_n",                      (DL_FUNC) &vctrs_dim_n, 1},
   {"vctrs_is_unspecified",             (DL_FUNC) &vctrs_is_unspecified, 1},
   {"vctrs_equal",                      (DL_FUNC) &vctrs_equal, 3},
-  {"vctrs_equal_na",                   (DL_FUNC) &vctrs_equal_na, 1},
+  {"vctrs_equal_na",                   (DL_FUNC) &vec_equal_na, 1},
   {"vctrs_compare",                    (DL_FUNC) &vctrs_compare, 3},
   {"vctrs_match",                      (DL_FUNC) &vec_match, 2},
   {"vctrs_typeof",                     (DL_FUNC) &vctrs_typeof, 2},

--- a/src/init.c
+++ b/src/init.c
@@ -32,7 +32,7 @@ extern SEXP vec_group_loc(SEXP);
 extern SEXP vctrs_equal(SEXP, SEXP, SEXP);
 extern SEXP vctrs_equal_na(SEXP);
 extern SEXP vctrs_compare(SEXP, SEXP, SEXP);
-extern SEXP vctrs_match(SEXP, SEXP);
+extern SEXP vec_match(SEXP, SEXP);
 extern SEXP vctrs_duplicated_any(SEXP);
 extern SEXP vctrs_size(SEXP);
 extern SEXP vec_dim(SEXP);
@@ -137,7 +137,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_equal",                      (DL_FUNC) &vctrs_equal, 3},
   {"vctrs_equal_na",                   (DL_FUNC) &vctrs_equal_na, 1},
   {"vctrs_compare",                    (DL_FUNC) &vctrs_compare, 3},
-  {"vctrs_match",                      (DL_FUNC) &vctrs_match, 2},
+  {"vctrs_match",                      (DL_FUNC) &vec_match, 2},
   {"vctrs_typeof",                     (DL_FUNC) &vctrs_typeof, 2},
   {"vctrs_init_library",               (DL_FUNC) &vctrs_init_library, 1},
   {"vctrs_is_vector",                  (DL_FUNC) &vctrs_is_vector, 1},

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -295,6 +295,23 @@ static SEXP fct_as_factor_impl(SEXP x, SEXP x_levels, SEXP to_levels, bool* loss
     }
   }
 
+  // No recoding required if contiguous subset.
+  // Duplicate, strip non-factor attributes, and re-initialize with new levels.
+  // Using `r_maybe_duplicate()` avoids an immediate copy using ALTREP wrappers.
+  if (is_contiguous_subset) {
+    SEXP out = PROTECT(r_maybe_duplicate(x));
+    SET_ATTRIB(out, R_NilValue);
+
+    if (ordered) {
+      init_ordered(out, to_levels);
+    } else {
+      init_factor(out, to_levels);
+    }
+
+    UNPROTECT(1);
+    return out;
+  }
+
   const int* p_x = INTEGER_RO(x);
 
   SEXP out = PROTECT(Rf_allocVector(INTSXP, x_size));
@@ -304,13 +321,6 @@ static SEXP fct_as_factor_impl(SEXP x, SEXP x_levels, SEXP to_levels, bool* loss
     init_ordered(out, to_levels);
   } else {
     init_factor(out, to_levels);
-  }
-
-  // No recode required
-  if (is_contiguous_subset) {
-    memcpy(p_out, p_x, x_size * sizeof(int));
-    UNPROTECT(1);
-    return out;
   }
 
   SEXP recode = PROTECT(vec_match(x_levels, to_levels));

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -155,17 +155,11 @@ static SEXP chr_as_factor_impl(SEXP x, SEXP levels, bool* lossy, bool ordered) {
 
   // Detect lossy no-matches, but allow `NA` values from `x`
   for (R_len_t i = 0; i < size; ++i) {
-    if (p_out[i] != NA_INTEGER) {
-      continue;
+    if (p_out[i] == NA_INTEGER && p_x[i] != NA_STRING) {
+      *lossy = true;
+      UNPROTECT(1);
+      return R_NilValue;
     }
-
-    if (p_x[i] == NA_STRING) {
-      continue;
-    }
-
-    *lossy = true;
-    UNPROTECT(1);
-    return R_NilValue;
   }
 
   if (ordered) {

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -74,3 +74,289 @@ static SEXP levels_union(SEXP x, SEXP y) {
   UNPROTECT(2);
   return out;
 }
+
+// -----------------------------------------------------------------------------
+
+static void new_factor(SEXP x, SEXP levels);
+static void new_ordered(SEXP x, SEXP levels);
+
+
+// [[ include("vctrs.h") ]]
+SEXP fct_as_character(SEXP x, struct vctrs_arg* x_arg) {
+  SEXP levels = Rf_getAttrib(x, R_LevelsSymbol);
+
+  if (TYPEOF(levels) != STRSXP) {
+    stop_corrupt_factor_levels(x, x_arg);
+  }
+
+  return Rf_asCharacterFactor(x);
+}
+
+// [[ include("vctrs.h") ]]
+SEXP ord_as_character(SEXP x, struct vctrs_arg* x_arg) {
+  return fct_as_character(x, x_arg);
+}
+
+
+static SEXP chr_as_factor_from_self(SEXP x, bool ordered);
+static SEXP chr_as_factor_impl(SEXP x, SEXP levels, bool* lossy, bool ordered);
+
+// [[ include("vctrs.h") ]]
+SEXP chr_as_factor(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* to_arg) {
+  SEXP levels = Rf_getAttrib(to, R_LevelsSymbol);
+
+  if (TYPEOF(levels) != STRSXP) {
+    stop_corrupt_factor_levels(to, to_arg);
+  }
+
+  // When `to` has no levels, it is treated as a template and the
+  // levels come from `x`
+  if (vec_size(levels) == 0) {
+    return chr_as_factor_from_self(x, false);
+  }
+
+  return chr_as_factor_impl(x, levels, lossy, false);
+}
+
+// [[ include("vctrs.h") ]]
+SEXP chr_as_ordered(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* to_arg) {
+  SEXP levels = Rf_getAttrib(to, R_LevelsSymbol);
+
+  if (TYPEOF(levels) != STRSXP) {
+    stop_corrupt_ordered_levels(to, to_arg);
+  }
+
+  // When `to` has no levels, it is treated as a template and the
+  // levels come from `x`
+  if (vec_size(levels) == 0) {
+    return chr_as_factor_from_self(x, true);
+  }
+
+  return chr_as_factor_impl(x, levels, lossy, true);
+}
+
+static SEXP chr_as_factor_impl(SEXP x, SEXP levels, bool* lossy, bool ordered) {
+  SEXP out = PROTECT(vec_match(x, levels));
+  const int* p_out = INTEGER(out);
+
+  R_len_t size = vec_size(x);
+  const SEXP* p_x = STRING_PTR_RO(x);
+
+  // Detect lossy no-matches, but allow `NA` values from `x`
+  for (R_len_t i = 0; i < size; ++i) {
+    if (p_out[i] != NA_INTEGER) {
+      continue;
+    }
+
+    if (p_x[i] == NA_STRING) {
+      continue;
+    }
+
+    *lossy = true;
+    UNPROTECT(1);
+    return R_NilValue;
+  }
+
+  if (ordered) {
+    new_ordered(out, levels);
+  } else {
+    new_factor(out, levels);
+  }
+
+  UNPROTECT(1);
+  return out;
+}
+
+static SEXP remove_na_levels(SEXP levels);
+
+// Factor levels are added in order of appearance
+// `NA` values in `x` are not considered factor levels
+static SEXP chr_as_factor_from_self(SEXP x, bool ordered) {
+  SEXP levels = PROTECT(vec_unique(x));
+  levels = PROTECT(remove_na_levels(levels));
+
+  // `NA` values in `x` correctly become `NA` values in the result
+  SEXP out = PROTECT(vec_match(x, levels));
+
+  if (ordered) {
+    new_ordered(out, levels);
+  } else {
+    new_factor(out, levels);
+  }
+
+  UNPROTECT(3);
+  return out;
+}
+
+static SEXP remove_na_levels(SEXP levels) {
+  int n_prot = 0;
+
+  R_len_t size = vec_size(levels);
+  const SEXP* p_levels = STRING_PTR_RO(levels);
+
+  bool any_na = false;
+  SEXP is_not_na = PROTECT_N(Rf_allocVector(LGLSXP, size), &n_prot);
+  int* p_is_not_na = LOGICAL(is_not_na);
+
+  for (R_len_t i = 0; i < size; ++i) {
+    if (p_levels[i] == NA_STRING) {
+      any_na = true;
+      p_is_not_na[i] = 0;
+    } else {
+      p_is_not_na[i] = 1;
+    }
+  }
+
+  // Remove `NA` levels if required
+  if (any_na) {
+    levels = PROTECT_N(vec_slice(levels, is_not_na), &n_prot);
+  }
+
+  UNPROTECT(n_prot);
+  return levels;
+}
+
+
+static SEXP fct_as_factor_impl(SEXP x, SEXP x_levels, SEXP to_levels, bool* lossy, bool ordered);
+
+// [[ include("vctrs.h") ]]
+SEXP fct_as_factor(SEXP x,
+                   SEXP to,
+                   bool* lossy,
+                   struct vctrs_arg* x_arg,
+                   struct vctrs_arg* to_arg) {
+
+  SEXP x_levels = Rf_getAttrib(x, R_LevelsSymbol);
+  SEXP to_levels = Rf_getAttrib(to, R_LevelsSymbol);
+
+  if (TYPEOF(x_levels) != STRSXP) {
+    stop_corrupt_factor_levels(x, x_arg);
+  }
+
+  if (TYPEOF(to_levels) != STRSXP) {
+    stop_corrupt_factor_levels(to, to_arg);
+  }
+
+  return fct_as_factor_impl(x, x_levels, to_levels, lossy, false);
+}
+
+// [[ include("vctrs.h") ]]
+SEXP ord_as_ordered(SEXP x,
+                    SEXP to,
+                    bool* lossy,
+                    struct vctrs_arg* x_arg,
+                    struct vctrs_arg* to_arg) {
+
+  SEXP x_levels = Rf_getAttrib(x, R_LevelsSymbol);
+  SEXP to_levels = Rf_getAttrib(to, R_LevelsSymbol);
+
+  if (TYPEOF(x_levels) != STRSXP) {
+    stop_corrupt_ordered_levels(x, x_arg);
+  }
+
+  if (TYPEOF(to_levels) != STRSXP) {
+    stop_corrupt_ordered_levels(to, to_arg);
+  }
+
+  return fct_as_factor_impl(x, x_levels, to_levels, lossy, true);
+}
+
+static SEXP fct_as_factor_impl(SEXP x, SEXP x_levels, SEXP to_levels, bool* lossy, bool ordered) {
+  // Early exit if levels are identical
+  if (x_levels == to_levels) {
+    return x;
+  }
+
+  R_len_t x_levels_size = vec_size(x_levels);
+  R_len_t to_levels_size = vec_size(to_levels);
+
+  // Early exit if `to` has no levels. In this case it is being used as
+  // a template
+  if (to_levels_size == 0) {
+    return x;
+  }
+
+  // Always lossy if there are more levels in `x` than in `to`
+  if (x_levels_size > to_levels_size) {
+    *lossy = true;
+    return R_NilValue;
+  }
+
+  R_len_t x_size = vec_size(x);
+
+  const SEXP* p_x_levels = STRING_PTR_RO(x_levels);
+  const SEXP* p_to_levels = STRING_PTR_RO(to_levels);
+
+  bool is_contiguous_subset = true;
+
+  for (R_len_t i = 0; i < x_levels_size; ++i) {
+    if (p_x_levels[i] != p_to_levels[i]) {
+      is_contiguous_subset = false;
+      break;
+    }
+  }
+
+  const int* p_x = INTEGER_RO(x);
+
+  SEXP out = PROTECT(Rf_allocVector(INTSXP, x_size));
+  int* p_out = INTEGER(out);
+
+  if (ordered) {
+    new_ordered(out, to_levels);
+  } else {
+    new_factor(out, to_levels);
+  }
+
+  // No recode required
+  if (is_contiguous_subset) {
+    memcpy(p_out, p_x, x_size * sizeof(int));
+    UNPROTECT(1);
+    return out;
+  }
+
+  SEXP recode = PROTECT(vec_match(x_levels, to_levels));
+  const int* p_recode = INTEGER_RO(recode);
+
+  // Detect if there are any levels in `x` that aren't in `to`
+  for (R_len_t i = 0; i < x_levels_size; ++i) {
+    if (p_recode[i] == NA_INTEGER) {
+      *lossy = true;
+      UNPROTECT(2);
+      return R_NilValue;
+    }
+  }
+
+  // Recode `x` int values into `to` level ordering
+  for (R_len_t i = 0; i < x_size; ++i) {
+    const int elt = p_x[i];
+
+    if (elt == NA_INTEGER) {
+      p_out[i] = NA_INTEGER;
+      continue;
+    }
+
+    p_out[i] = p_recode[elt - 1];
+  }
+
+  UNPROTECT(2);
+  return out;
+}
+
+
+static void new_factor(SEXP x, SEXP levels) {
+  if (TYPEOF(x) != INTSXP) {
+    Rf_errorcall(R_NilValue, "Internal error: Only integers can be made into factors");
+  }
+
+  Rf_setAttrib(x, R_LevelsSymbol, levels);
+  Rf_setAttrib(x, R_ClassSymbol, classes_factor);
+}
+
+static void new_ordered(SEXP x, SEXP levels) {
+  if (TYPEOF(x) != INTSXP) {
+    Rf_errorcall(R_NilValue, "Internal error: Only integers can be made into ordered factors");
+  }
+
+  Rf_setAttrib(x, R_LevelsSymbol, levels);
+  Rf_setAttrib(x, R_ClassSymbol, classes_ordered);
+}

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -83,12 +83,13 @@ static void new_ordered(SEXP x, SEXP levels);
 
 // [[ include("vctrs.h") ]]
 SEXP fct_as_character(SEXP x, struct vctrs_arg* x_arg) {
-  SEXP levels = Rf_getAttrib(x, R_LevelsSymbol);
+  SEXP levels = PROTECT(Rf_getAttrib(x, R_LevelsSymbol));
 
   if (TYPEOF(levels) != STRSXP) {
     stop_corrupt_factor_levels(x, x_arg);
   }
 
+  UNPROTECT(1);
   return Rf_asCharacterFactor(x);
 }
 
@@ -103,36 +104,46 @@ static SEXP chr_as_factor_impl(SEXP x, SEXP levels, bool* lossy, bool ordered);
 
 // [[ include("vctrs.h") ]]
 SEXP chr_as_factor(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* to_arg) {
-  SEXP levels = Rf_getAttrib(to, R_LevelsSymbol);
+  SEXP levels = PROTECT(Rf_getAttrib(to, R_LevelsSymbol));
 
   if (TYPEOF(levels) != STRSXP) {
     stop_corrupt_factor_levels(to, to_arg);
   }
 
+  SEXP out;
+
   // When `to` has no levels, it is treated as a template and the
   // levels come from `x`
   if (vec_size(levels) == 0) {
-    return chr_as_factor_from_self(x, false);
+    out = chr_as_factor_from_self(x, false);
+  } else {
+    out = chr_as_factor_impl(x, levels, lossy, false);
   }
 
-  return chr_as_factor_impl(x, levels, lossy, false);
+  UNPROTECT(1);
+  return out;
 }
 
 // [[ include("vctrs.h") ]]
 SEXP chr_as_ordered(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* to_arg) {
-  SEXP levels = Rf_getAttrib(to, R_LevelsSymbol);
+  SEXP levels = PROTECT(Rf_getAttrib(to, R_LevelsSymbol));
 
   if (TYPEOF(levels) != STRSXP) {
     stop_corrupt_ordered_levels(to, to_arg);
   }
 
+  SEXP out;
+
   // When `to` has no levels, it is treated as a template and the
   // levels come from `x`
   if (vec_size(levels) == 0) {
-    return chr_as_factor_from_self(x, true);
+    out = chr_as_factor_from_self(x, true);
+  } else {
+    out = chr_as_factor_impl(x, levels, lossy, true);
   }
 
-  return chr_as_factor_impl(x, levels, lossy, true);
+  UNPROTECT(1);
+  return out;
 }
 
 static SEXP chr_as_factor_impl(SEXP x, SEXP levels, bool* lossy, bool ordered) {
@@ -224,8 +235,8 @@ SEXP fct_as_factor(SEXP x,
                    struct vctrs_arg* x_arg,
                    struct vctrs_arg* to_arg) {
 
-  SEXP x_levels = Rf_getAttrib(x, R_LevelsSymbol);
-  SEXP to_levels = Rf_getAttrib(to, R_LevelsSymbol);
+  SEXP x_levels = PROTECT(Rf_getAttrib(x, R_LevelsSymbol));
+  SEXP to_levels = PROTECT(Rf_getAttrib(to, R_LevelsSymbol));
 
   if (TYPEOF(x_levels) != STRSXP) {
     stop_corrupt_factor_levels(x, x_arg);
@@ -235,7 +246,10 @@ SEXP fct_as_factor(SEXP x,
     stop_corrupt_factor_levels(to, to_arg);
   }
 
-  return fct_as_factor_impl(x, x_levels, to_levels, lossy, false);
+  SEXP out = fct_as_factor_impl(x, x_levels, to_levels, lossy, false);
+
+  UNPROTECT(2);
+  return out;
 }
 
 // [[ include("vctrs.h") ]]
@@ -245,8 +259,8 @@ SEXP ord_as_ordered(SEXP x,
                     struct vctrs_arg* x_arg,
                     struct vctrs_arg* to_arg) {
 
-  SEXP x_levels = Rf_getAttrib(x, R_LevelsSymbol);
-  SEXP to_levels = Rf_getAttrib(to, R_LevelsSymbol);
+  SEXP x_levels = PROTECT(Rf_getAttrib(x, R_LevelsSymbol));
+  SEXP to_levels = PROTECT(Rf_getAttrib(to, R_LevelsSymbol));
 
   if (TYPEOF(x_levels) != STRSXP) {
     stop_corrupt_ordered_levels(x, x_arg);
@@ -256,7 +270,10 @@ SEXP ord_as_ordered(SEXP x,
     stop_corrupt_ordered_levels(to, to_arg);
   }
 
-  return fct_as_factor_impl(x, x_levels, to_levels, lossy, true);
+  SEXP out = fct_as_factor_impl(x, x_levels, to_levels, lossy, true);
+
+  UNPROTECT(2);
+  return out;
 }
 
 static SEXP fct_as_factor_impl(SEXP x, SEXP x_levels, SEXP to_levels, bool* lossy, bool ordered) {

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -189,31 +189,29 @@ static SEXP chr_as_factor_from_self(SEXP x, bool ordered) {
 }
 
 static SEXP remove_na_levels(SEXP levels) {
-  int n_prot = 0;
-
   R_len_t size = vec_size(levels);
   const SEXP* p_levels = STRING_PTR_RO(levels);
 
+  // There would only ever be 1 `NA` level
+  int na_loc;
   bool any_na = false;
-  SEXP is_not_na = PROTECT_N(Rf_allocVector(LGLSXP, size), &n_prot);
-  int* p_is_not_na = LOGICAL(is_not_na);
 
   for (R_len_t i = 0; i < size; ++i) {
-    if (p_levels[i] == NA_STRING) {
-      any_na = true;
-      p_is_not_na[i] = 0;
-    } else {
-      p_is_not_na[i] = 1;
+    if (p_levels[i] != NA_STRING) {
+      continue;
     }
+
+    any_na = true;
+    na_loc = (i + 1) * -1;
+    break;
   }
 
-  // Remove `NA` levels if required
+  // Remove `NA` level if required
   if (any_na) {
-    levels = PROTECT_N(vec_slice(levels, is_not_na), &n_prot);
+    return vec_slice(levels, r_int(na_loc));
+  } else {
+    return levels;
   }
-
-  UNPROTECT(n_prot);
-  return levels;
 }
 
 

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -174,8 +174,8 @@ static SEXP chr_as_factor_impl(SEXP x, SEXP levels, bool* lossy, bool ordered) {
 
 static SEXP remove_na_levels(SEXP levels);
 
-// Factor levels are added in order of appearance
-// `NA` values in `x` are not considered factor levels
+// Factor levels are added in order of appearance.
+// `NA` values in `x` are not considered factor levels.
 static SEXP chr_as_factor_from_self(SEXP x, bool ordered) {
   SEXP levels = PROTECT(vec_unique(x));
   levels = PROTECT(remove_na_levels(levels));

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -197,26 +197,16 @@ static SEXP remove_na_levels(SEXP levels) {
   R_len_t size = vec_size(levels);
   const SEXP* p_levels = STRING_PTR_RO(levels);
 
-  // There would only ever be 1 `NA` level
-  int na_loc;
-  bool any_na = false;
-
+  // There might only ever be 1 `NA` level.
+  // Remove it if it exists.
   for (R_len_t i = 0; i < size; ++i) {
-    if (p_levels[i] != NA_STRING) {
-      continue;
+    if (p_levels[i] == NA_STRING) {
+      int na_loc = (i + 1) * -1;
+      return vec_slice(levels, r_int(na_loc));
     }
-
-    any_na = true;
-    na_loc = (i + 1) * -1;
-    break;
   }
 
-  // Remove `NA` level if required
-  if (any_na) {
-    return vec_slice(levels, r_int(na_loc));
-  } else {
-    return levels;
-  }
+  return levels;
 }
 
 

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -77,8 +77,8 @@ static SEXP levels_union(SEXP x, SEXP y) {
 
 // -----------------------------------------------------------------------------
 
-static void new_factor(SEXP x, SEXP levels);
-static void new_ordered(SEXP x, SEXP levels);
+static void init_factor(SEXP x, SEXP levels);
+static void init_ordered(SEXP x, SEXP levels);
 
 
 // [[ include("vctrs.h") ]]
@@ -163,9 +163,9 @@ static SEXP chr_as_factor_impl(SEXP x, SEXP levels, bool* lossy, bool ordered) {
   }
 
   if (ordered) {
-    new_ordered(out, levels);
+    init_ordered(out, levels);
   } else {
-    new_factor(out, levels);
+    init_factor(out, levels);
   }
 
   UNPROTECT(1);
@@ -184,9 +184,9 @@ static SEXP chr_as_factor_from_self(SEXP x, bool ordered) {
   SEXP out = PROTECT(vec_match(x, levels));
 
   if (ordered) {
-    new_ordered(out, levels);
+    init_ordered(out, levels);
   } else {
-    new_factor(out, levels);
+    init_factor(out, levels);
   }
 
   UNPROTECT(3);
@@ -301,9 +301,9 @@ static SEXP fct_as_factor_impl(SEXP x, SEXP x_levels, SEXP to_levels, bool* loss
   int* p_out = INTEGER(out);
 
   if (ordered) {
-    new_ordered(out, to_levels);
+    init_ordered(out, to_levels);
   } else {
-    new_factor(out, to_levels);
+    init_factor(out, to_levels);
   }
 
   // No recode required
@@ -342,7 +342,7 @@ static SEXP fct_as_factor_impl(SEXP x, SEXP x_levels, SEXP to_levels, bool* loss
 }
 
 
-static void new_factor(SEXP x, SEXP levels) {
+static void init_factor(SEXP x, SEXP levels) {
   if (TYPEOF(x) != INTSXP) {
     Rf_errorcall(R_NilValue, "Internal error: Only integers can be made into factors");
   }
@@ -351,7 +351,7 @@ static void new_factor(SEXP x, SEXP levels) {
   Rf_setAttrib(x, R_ClassSymbol, classes_factor);
 }
 
-static void new_ordered(SEXP x, SEXP levels) {
+static void init_ordered(SEXP x, SEXP levels) {
   if (TYPEOF(x) != INTSXP) {
     Rf_errorcall(R_NilValue, "Internal error: Only integers can be made into ordered factors");
   }

--- a/src/type2.c
+++ b/src/type2.c
@@ -76,16 +76,12 @@ SEXP vec_type2(SEXP x, SEXP y,
   }
 }
 
-
-// From dictionary.c
-SEXP vctrs_match(SEXP needles, SEXP haystack);
-
 SEXP df_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) {
   SEXP x_names = PROTECT(r_names(x));
   SEXP y_names = PROTECT(r_names(y));
 
-  SEXP x_dups_pos = PROTECT(vctrs_match(x_names, y_names));
-  SEXP y_dups_pos = PROTECT(vctrs_match(y_names, x_names));
+  SEXP x_dups_pos = PROTECT(vec_match(x_names, y_names));
+  SEXP y_dups_pos = PROTECT(vec_match(y_names, x_names));
 
   int* x_dups_pos_data = INTEGER(x_dups_pos);
   int* y_dups_pos_data = INTEGER(y_dups_pos);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -278,6 +278,7 @@ SEXP vec_recycle(SEXP x, R_len_t size, struct vctrs_arg* x_arg);
 SEXP vec_recycle_common(SEXP xs, R_len_t size);
 SEXP vec_names(SEXP x);
 SEXP vec_group_loc(SEXP x);
+SEXP vec_match(SEXP needles, SEXP haystack);
 
 SEXP vec_c(SEXP xs,
            SEXP ptype,

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -279,6 +279,7 @@ SEXP vec_recycle_common(SEXP xs, R_len_t size);
 SEXP vec_names(SEXP x);
 SEXP vec_group_loc(SEXP x);
 SEXP vec_match(SEXP needles, SEXP haystack);
+SEXP vec_equal_na(SEXP x);
 
 SEXP vec_c(SEXP xs,
            SEXP ptype,

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -279,7 +279,6 @@ SEXP vec_recycle_common(SEXP xs, R_len_t size);
 SEXP vec_names(SEXP x);
 SEXP vec_group_loc(SEXP x);
 SEXP vec_match(SEXP needles, SEXP haystack);
-SEXP vec_equal_na(SEXP x);
 
 SEXP vec_c(SEXP xs,
            SEXP ptype,

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -304,6 +304,14 @@ SEXP vec_ptype2_dispatch_s3(SEXP x,
                             struct vctrs_arg* x_arg,
                             struct vctrs_arg* y_arg);
 
+SEXP vec_cast_dispatch(SEXP x,
+                       SEXP to,
+                       enum vctrs_type x_type,
+                       enum vctrs_type to_type,
+                       bool* lossy,
+                       struct vctrs_arg* x_arg,
+                       struct vctrs_arg* to_arg);
+
 bool is_data_frame(SEXP x);
 bool is_record(SEXP x);
 
@@ -414,6 +422,15 @@ enum vctrs_dbl_class dbl_classify(double x);
 
 SEXP fct_ptype2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
 SEXP ord_ptype2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
+
+SEXP fct_as_character(SEXP x, struct vctrs_arg* x_arg);
+SEXP ord_as_character(SEXP x, struct vctrs_arg* x_arg);
+
+SEXP chr_as_factor(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* to_arg);
+SEXP fct_as_factor(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
+
+SEXP chr_as_ordered(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* to_arg);
+SEXP ord_as_ordered(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 
 // Character translation ----------------------------------------
 

--- a/tests/testthat/test-type-factor.R
+++ b/tests/testthat/test-type-factor.R
@@ -144,6 +144,12 @@ test_that("NA are not considered lossy in factor cast (#109)", {
   expect_warning(vec_cast(f, f[1]), NA)
 })
 
+test_that("Casting to a factor with explicit NA levels retains them", {
+  f <- factor(c("x", NA), exclude = NULL)
+  expect_identical(vec_cast(f, f), f)
+  expect_identical(vec_cast(f, factor()), f)
+})
+
 # Arithmetic and factor ---------------------------------------------------
 
 test_that("factors don't support math or arthimetic", {


### PR DESCRIPTION
This PR adds internal `vec_cast()` dispatch for factors/ordered factors.

It does so in a way that is similar to `vec_ptype2()`, using the extension prototype idea @lionel- and I used there. I've added a `vec_cast_dispatch()` path in `vec_cast_switch()`, which allows us to hand off to specific C level casting routines for factors. The routines themselves live in `type-factor.c`.

I've maintained all the behavior from before, including the "template" idea of doing `vec_cast(factor("x"), factor())`.

A number of performance improvements were made, the largest being the easy case where `x` and `to` are both factors with the same levels, in which case there is nothing to do.

```r
library(vctrs)

vec_cast.factor.factor <- vctrs:::vec_cast.factor.factor
vec_cast.factor.character <- vctrs:::vec_cast.factor.character

a <- factor(rep("a", 1e5))
```

Casting to a factor with the same levels is now very fast

```r
bench::mark(
  vec_cast(a, a),
  vec_cast.factor.factor(a, a)
)
#> # A tibble: 2 x 6
#>   expression                        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast(a, a)                  897ns   1.21µs   790069.        0B     79.0
#> 2 vec_cast.factor.factor(a, a)   2.98ms   3.84ms      242.    4.61MB     24.2
```

Same with casting to a template

```r
template <- factor()

bench::mark(
  vec_cast(a, template),
  vec_cast.factor.factor(a, template)
)
#> # A tibble: 2 x 6
#>   expression                               min median `itr/sec` mem_alloc
#>   <bch:expr>                          <bch:tm> <bch:>     <dbl> <bch:byt>
#> 1 vec_cast(a, template)                  951ns 1.21µs   761576.        0B
#> 2 vec_cast.factor.factor(a, template)   1.16ms 1.54ms      637.    1.91MB
#> # … with 1 more variable: `gc/sec` <dbl>
```

The factor to factor conversion tries to be somewhat smart when the levels are different, and the levels of `x` are a subset of the levels of `to`. If the levels of `x` are a contiguous subset of the levels of `to` then we can just construct a new factor immediately without "recoding" the underlying integer values.

```r
# no recoding required because levels of `a` are a contiguous subset of `ab`
# i.e. c("a") is a subset of c("a", "b") and is in the same order
ab <- factor(c(rep("a", 1e5/2), rep("b", 1e5/2)), levels = c("a", "b"))

bench::mark(
  vec_cast(a, ab),
  vec_cast.factor.factor(a, ab),
  factor(a, levels = levels(ab))
)
#> # A tibble: 3 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast(a, ab)                 31.03µs  57.17µs    14451.  390.67KB    122. 
#> 2 vec_cast.factor.factor(a, ab)    2.87ms   3.55ms      284.    4.58MB     29.4
#> 3 factor(a, levels = levels(ab))   1.36ms   1.48ms      672.    1.91MB     34.6
```

Here is a small comparison of recoding vs not recoding

```r
# recoding required because levels of `a` are NOT a contiguous subset of `ba`
# i.e. c("a") is a subset of c("b", "a") but is NOT in order
ba <- factor(c(rep("b", 1e5/2), rep("a", 1e5/2)), levels = c("b", "a"))

bench::mark(
  vec_cast(a, ab),
  vec_cast(a, ba),
  check = FALSE,
  iterations = 5000
)
#> # A tibble: 2 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast(a, ab)   30.2µs   55.5µs    15426.     391KB    118. 
#> 2 vec_cast(a, ba)   53.7µs   81.2µs    12208.     391KB     86.1
```

Here is an example of what is probably the worst case scenario. Every value is a different level. Faster than the original implementation still.

```r
# probably the slowest it would ever be
many_levels <- factor(paste0("a", 1:1e5), levels = paste0("a", 1:1e5))
many_levels_rev <- factor(rev(paste0("a", 1:1e5)), levels = rev(paste0("a", 1:1e5)))

bench::mark(
  vec_cast(many_levels, many_levels_rev),
  vec_cast.factor.factor(many_levels, many_levels_rev),
  factor(many_levels, levels = levels(many_levels_rev)),
  iterations = 50
)
#> # A tibble: 3 x 6
#>   expression                                               min median `itr/sec`
#>   <bch:expr>                                            <bch:> <bch:>     <dbl>
#> 1 vec_cast(many_levels, many_levels_rev)                10.6ms 12.2ms      80.7
#> 2 vec_cast.factor.factor(many_levels, many_levels_rev)  18.1ms 19.4ms      51.0
#> 3 factor(many_levels, levels = levels(many_levels_rev)) 12.4ms   13ms      76.3
#> # … with 2 more variables: mem_alloc <bch:byt>, `gc/sec` <dbl>
```

I've also added character -> factor C routines. The one where `to` is a template takes the longest because we have to take the unique values of `x` to get the levels, run through them and remove the `NA` level if it exists, and then match that against `x`.

```r
chr <- paste0("a", 1:3e5)
fct <- factor(chr, levels = chr)

bench::mark(
  vec_cast(chr, fct),
  vec_cast.factor.character(chr, fct),
  iterations = 50
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                             min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                          <bch:> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast(chr, fct)                  36.9ms 39.6ms      23.8    5.43MB     5.71
#> 2 vec_cast.factor.character(chr, fct) 74.2ms   85ms      11.3   34.89MB    14.7

bench::mark(
  vec_cast(chr, template),
  vec_cast.factor.character(chr, template),
  iterations = 50
)
#> # A tibble: 2 x 6
#>   expression                                  min median `itr/sec` mem_alloc
#>   <bch:expr>                               <bch:> <bch:>     <dbl> <bch:byt>
#> 1 vec_cast(chr, template)                  56.5ms 60.4ms      16.6      16MB
#> 2 vec_cast.factor.character(chr, template) 66.7ms 66.7ms      15.0    30.3MB
#> # … with 1 more variable: `gc/sec` <dbl>
```