### PR TITLE
Only fall back to `c()` if a method is implemented

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,9 @@
   `recursive` or `use.names` is supplied (#791).
 
 * `vec_c()` now falls back to `base::c()` if the vector doesn't
-  implement `vec_ptype2()`. This should improve the compatibility of
-  vctrs-based functions with foreign classes (#801).
+  implement `vec_ptype2()` but implements `c()`. This should improve
+  the compatibility of vctrs-based functions with foreign classes
+  (#801).
 
 
 # vctrs 0.2.2

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -83,7 +83,7 @@ SEXP vctrs_proxy_recursive(SEXP x, SEXP kind_) {
 }
 
 SEXP vec_proxy_method(SEXP x) {
-  return s3_find_method("vec_proxy", x);
+  return s3_find_method("vec_proxy", x, vctrs_method_table);
 }
 
 // This should be faster than normal dispatch but also means that

--- a/src/utils.c
+++ b/src/utils.c
@@ -9,6 +9,7 @@ SEXP (*rlang_unbox)(SEXP) = NULL;
 SEXP (*rlang_env_dots_values)(SEXP) = NULL;
 SEXP (*rlang_env_dots_list)(SEXP) = NULL;
 SEXP vctrs_method_table = NULL;
+SEXP base_method_table = NULL;
 
 SEXP strings_tbl = NULL;
 SEXP strings_tbl_df = NULL;
@@ -1130,6 +1131,8 @@ struct vctrs_arg* args_empty = NULL;
 void vctrs_init_utils(SEXP ns) {
   vctrs_ns_env = ns;
   vctrs_method_table = r_env_get(ns, Rf_install(".__S3MethodsTable__."));
+
+  base_method_table = r_env_get(R_BaseNamespace, Rf_install(".__S3MethodsTable__."));
 
   vctrs_shared_empty_str = Rf_mkString("");
   R_PreserveObject(vctrs_shared_empty_str);

--- a/src/utils.c
+++ b/src/utils.c
@@ -283,7 +283,7 @@ static SEXP s3_method_sym(const char* generic, const char* class) {
 }
 
 // First check in global env, then in method table
-static SEXP s3_get_method(const char* generic, const char* class) {
+static SEXP s3_get_method(const char* generic, const char* class, SEXP table) {
   SEXP sym = s3_method_sym(generic, class);
 
   SEXP method = r_env_get(R_GlobalEnv, sym);
@@ -291,7 +291,7 @@ static SEXP s3_get_method(const char* generic, const char* class) {
     return method;
   }
 
-  method = r_env_get(vctrs_method_table, sym);
+  method = r_env_get(table, sym);
   if (r_is_function(method)) {
     return method;
   }
@@ -299,7 +299,7 @@ static SEXP s3_get_method(const char* generic, const char* class) {
   return R_NilValue;
 }
 
-SEXP s3_find_method(const char* generic, SEXP x) {
+SEXP s3_find_method(const char* generic, SEXP x, SEXP table) {
   if (!OBJECT(x)) {
     return R_NilValue;
   }
@@ -309,7 +309,7 @@ SEXP s3_find_method(const char* generic, SEXP x) {
   int n_class = Rf_length(class);
 
   for (int i = 0; i < n_class; ++i, ++class_ptr) {
-    SEXP method = s3_get_method(generic, CHAR(*class_ptr));
+    SEXP method = s3_get_method(generic, CHAR(*class_ptr), table);
     if (method != R_NilValue) {
       UNPROTECT(1);
       return method;
@@ -323,7 +323,8 @@ SEXP s3_find_method(const char* generic, SEXP x) {
 // [[ include("utils.h") ]]
 bool vec_implements_ptype2(SEXP x) {
   if (vec_typeof(x) == vctrs_type_s3) {
-    return s3_find_method("vec_ptype2", x) != R_NilValue;
+    SEXP met = s3_find_method("vec_ptype2", x, vctrs_method_table);
+    return met != R_NilValue;
   } else {
     return true;
   }

--- a/src/utils.h
+++ b/src/utils.h
@@ -86,7 +86,7 @@ SEXP vec_unique_colnames(SEXP x, bool quiet);
 
 // Returns S3 method for `generic` suitable for the class of `x`. The
 // inheritance hierarchy is explored except for the default method.
-SEXP s3_find_method(const char* generic, SEXP x);
+SEXP s3_find_method(const char* generic, SEXP x, SEXP table);
 bool vec_implements_ptype2(SEXP x);
 
 bool list_is_s3_homogeneous(SEXP xs);
@@ -326,6 +326,9 @@ extern SEXP syms_repair;
 extern SEXP fns_bracket;
 extern SEXP fns_quote;
 extern SEXP fns_names;
+
+
+extern SEXP vctrs_method_table;
 
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -329,6 +329,7 @@ extern SEXP fns_names;
 
 
 extern SEXP vctrs_method_table;
+extern SEXP base_method_table;
 
 
 #endif

--- a/tests/testthat/error/test-c.txt
+++ b/tests/testthat/error/test-c.txt
@@ -1,15 +1,20 @@
 
-vec_c() fallback doesn't support `name_spec`
-============================================
+vec_c() falls back to c() for foreign classes
+=============================================
 
-> vec_c(foobar(1), foobar(2), .name_spec = "{outer}_{inner}")
-Error: Can't use a name specification with non-vctrs types.
+> vec_c(foobar(1), foobar(2))
+Error: Can't find vctrs or base methods for concatenation.
 vctrs methods must be implemented for class `vctrs_foobar`.
 See <https://vctrs.r-lib.org/articles/s3-vector.html>.
 
 
 vec_c() fallback doesn't support `name_spec` or `ptype`
 =======================================================
+
+> vec_c(foobar(1), foobar(2), .name_spec = "{outer}_{inner}")
+Error: Can't use a name specification with non-vctrs types.
+vctrs methods must be implemented for class `vctrs_foobar`.
+See <https://vctrs.r-lib.org/articles/s3-vector.html>.
 
 > vec_c(foobar(1), foobar(2), .ptype = "")
 Error: Can't specify a prototype with non-vctrs types.


### PR DESCRIPTION
This restricts the `c()` fallback. The class must implement `c()` for the fallback to apply, this way we avoid improper concatenation behaviour such as `c(factor("foo"), factor("bar"))`.

The first commit parameterises the S3 method getters with method table so we can inspect base implementations.