### PR TITLE
Datetime performance - `vec_ptype2()`

### DIFF
--- a/src/ptype2-dispatch.c
+++ b/src/ptype2-dispatch.c
@@ -21,6 +21,18 @@ SEXP vec_ptype2_dispatch(SEXP x, SEXP y,
   case vctrs_type2_s3_bare_ordered_bare_ordered:
     return ord_ptype2(x, y, x_arg, y_arg);
 
+  case vctrs_type2_s3_bare_date_bare_date:
+    return vctrs_shared_empty_date;
+
+  case vctrs_type2_s3_bare_date_bare_posixct:
+  case vctrs_type2_s3_bare_date_bare_posixlt:
+    return date_datetime_ptype2(x, y);
+
+  case vctrs_type2_s3_bare_posixct_bare_posixct:
+  case vctrs_type2_s3_bare_posixct_bare_posixlt:
+  case vctrs_type2_s3_bare_posixlt_bare_posixlt:
+    return datetime_datetime_ptype2(x, y);
+
   default:
     return vec_ptype2_dispatch_s3(x, y, x_arg, y_arg);
   }

--- a/src/type-date-time.c
+++ b/src/type-date-time.c
@@ -1,0 +1,86 @@
+#include "vctrs.h"
+#include "utils.h"
+
+static SEXP new_empty_datetime(SEXP tzone);
+static SEXP get_tzone(SEXP x);
+
+// [[ include("vctrs.h") ]]
+SEXP date_datetime_ptype2(SEXP x, SEXP y) {
+  SEXP x_class = PROTECT(Rf_getAttrib(x, R_ClassSymbol));
+  SEXP x_first_class = STRING_ELT(x_class, 0);
+
+  SEXP tzone = (x_first_class == strings_date) ? get_tzone(y) : get_tzone(x);
+  PROTECT(tzone);
+
+  SEXP out = new_empty_datetime(tzone);
+
+  UNPROTECT(2);
+  return out;
+}
+
+static SEXP tzone_union(SEXP x_tzone, SEXP y_tzone);
+
+// [[ include("vctrs.h") ]]
+SEXP datetime_datetime_ptype2(SEXP x, SEXP y) {
+  SEXP x_tzone = PROTECT(get_tzone(x));
+  SEXP y_tzone = PROTECT(get_tzone(y));
+
+  // Never allocates
+  SEXP tzone = tzone_union(x_tzone, y_tzone);
+
+  SEXP out = new_empty_datetime(tzone);
+
+  UNPROTECT(2);
+  return out;
+}
+
+
+static SEXP new_empty_datetime(SEXP tzone) {
+  SEXP out = PROTECT(Rf_allocVector(REALSXP, 0));
+
+  Rf_setAttrib(out, R_ClassSymbol, classes_posixct);
+  Rf_setAttrib(out, syms_tzone, tzone);
+
+  UNPROTECT(1);
+  return out;
+}
+
+static SEXP get_tzone(SEXP x) {
+  SEXP tzone = PROTECT(Rf_getAttrib(x, syms_tzone));
+
+  if (tzone == R_NilValue) {
+    UNPROTECT(1);
+    return chrs_empty;
+  }
+
+  R_len_t size = Rf_length(tzone);
+
+  if (size == 1) {
+    UNPROTECT(1);
+    return tzone;
+  }
+
+  if (size == 0) {
+    Rf_errorcall(R_NilValue, "Corrupt datetime with 0-length `tzone` attribute");
+  }
+
+  // If there are multiple, only take the first
+  SEXP out = PROTECT(Rf_allocVector(STRSXP, 1));
+  SET_STRING_ELT(out, 0, STRING_ELT(tzone, 0));
+
+  UNPROTECT(2);
+  return out;
+}
+
+// `get_tzone()` is guaranteed to return 1 element
+static inline bool tzone_is_local(SEXP tzone) {
+  return STRING_ELT(tzone, 0) == strings_empty;
+}
+
+static SEXP tzone_union(SEXP x_tzone, SEXP y_tzone) {
+  if (tzone_is_local(x_tzone)) {
+    return y_tzone;
+  } else {
+    return x_tzone;
+  }
+}

--- a/src/typeof2-s3.c
+++ b/src/typeof2-s3.c
@@ -17,6 +17,9 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_null_bare_factor;
     case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_null_bare_ordered;
+    case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_null_bare_date;
+    case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_null_bare_posixct;
+    case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_null_bare_posixlt;
     default:                       *left = 0; return vctrs_type2_s3_null_unknown;
     }
   }
@@ -24,6 +27,9 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_logical_bare_factor;
     case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_logical_bare_ordered;
+    case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_logical_bare_date;
+    case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_logical_bare_posixct;
+    case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_logical_bare_posixlt;
     default:                       *left = 0; return vctrs_type2_s3_logical_unknown;
     }
   }
@@ -31,6 +37,9 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_integer_bare_factor;
     case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_integer_bare_ordered;
+    case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_integer_bare_date;
+    case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_integer_bare_posixct;
+    case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_integer_bare_posixlt;
     default:                       *left = 0; return vctrs_type2_s3_integer_unknown;
     }
   }
@@ -38,6 +47,9 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_double_bare_factor;
     case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_double_bare_ordered;
+    case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_double_bare_date;
+    case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_double_bare_posixct;
+    case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_double_bare_posixlt;
     default:                       *left = 0; return vctrs_type2_s3_double_unknown;
     }
   }
@@ -45,6 +57,9 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_complex_bare_factor;
     case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_complex_bare_ordered;
+    case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_complex_bare_date;
+    case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_complex_bare_posixct;
+    case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_complex_bare_posixlt;
     default:                       *left = 0; return vctrs_type2_s3_complex_unknown;
     }
   }
@@ -52,6 +67,9 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_character_bare_factor;
     case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_character_bare_ordered;
+    case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_character_bare_date;
+    case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_character_bare_posixct;
+    case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_character_bare_posixlt;
     default:                       *left = 0; return vctrs_type2_s3_character_unknown;
     }
   }
@@ -59,6 +77,9 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_raw_bare_factor;
     case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_raw_bare_ordered;
+    case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_raw_bare_date;
+    case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_raw_bare_posixct;
+    case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_raw_bare_posixlt;
     default:                       *left = 0; return vctrs_type2_s3_raw_unknown;
     }
   }
@@ -66,6 +87,9 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_list_bare_factor;
     case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_list_bare_ordered;
+    case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_list_bare_date;
+    case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_list_bare_posixct;
+    case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_list_bare_posixlt;
     default:                       *left = 0; return vctrs_type2_s3_list_unknown;
     }
   }
@@ -73,6 +97,9 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_dataframe_bare_factor;
     case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_dataframe_bare_ordered;
+    case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_dataframe_bare_date;
+    case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_dataframe_bare_posixct;
+    case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_dataframe_bare_posixlt;
     default:                       *left = 0; return vctrs_type2_s3_dataframe_unknown;
     }
   }
@@ -80,6 +107,9 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_scalar_bare_factor;
     case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_scalar_bare_ordered;
+    case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_scalar_bare_date;
+    case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_scalar_bare_posixct;
+    case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_scalar_bare_posixlt;
     default:                       *left = 0; return vctrs_type2_s3_scalar_unknown;
     }
   }
@@ -112,6 +142,9 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
       switch (class_type(y)) {
       case vctrs_class_bare_factor:  *left = -1; return vctrs_type2_s3_bare_factor_bare_factor;
       case vctrs_class_bare_ordered: *left =  0; return vctrs_type2_s3_bare_factor_bare_ordered;
+      case vctrs_class_bare_date:    *left =  0; return vctrs_type2_s3_bare_factor_bare_date;
+      case vctrs_class_bare_posixct: *left =  0; return vctrs_type2_s3_bare_factor_bare_posixct;
+      case vctrs_class_bare_posixlt: *left =  0; return vctrs_type2_s3_bare_factor_bare_posixlt;
       default:                       *left =  0; return vctrs_type2_s3_bare_factor_unknown;
       }
     }}
@@ -132,7 +165,79 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
       switch (class_type(y)) {
       case vctrs_class_bare_factor:  *left =  1; return vctrs_type2_s3_bare_factor_bare_ordered;
       case vctrs_class_bare_ordered: *left = -1; return vctrs_type2_s3_bare_ordered_bare_ordered;
+      case vctrs_class_bare_date:    *left =  0; return vctrs_type2_s3_bare_ordered_bare_date;
+      case vctrs_class_bare_posixct: *left =  0; return vctrs_type2_s3_bare_ordered_bare_posixct;
+      case vctrs_class_bare_posixlt: *left =  0; return vctrs_type2_s3_bare_ordered_bare_posixlt;
       default:                       *left =  0; return vctrs_type2_s3_bare_ordered_unknown;
+      }
+    }}
+  }
+  case vctrs_class_bare_date: {
+    switch (type_y) {
+    case vctrs_type_null:            *left =  1; return vctrs_type2_s3_null_bare_date;
+    case vctrs_type_logical:         *left =  1; return vctrs_type2_s3_logical_bare_date;
+    case vctrs_type_integer:         *left =  1; return vctrs_type2_s3_integer_bare_date;
+    case vctrs_type_double:          *left =  1; return vctrs_type2_s3_double_bare_date;
+    case vctrs_type_complex:         *left =  1; return vctrs_type2_s3_complex_bare_date;
+    case vctrs_type_character:       *left =  1; return vctrs_type2_s3_character_bare_date;
+    case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_date;
+    case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_date;
+    case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_date;
+    case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_date;
+    case vctrs_type_s3: {
+      switch (class_type(y)) {
+      case vctrs_class_bare_factor:  *left =  1; return vctrs_type2_s3_bare_factor_bare_date;
+      case vctrs_class_bare_ordered: *left =  1; return vctrs_type2_s3_bare_ordered_bare_date;
+      case vctrs_class_bare_date:    *left = -1; return vctrs_type2_s3_bare_date_bare_date;
+      case vctrs_class_bare_posixct: *left =  0; return vctrs_type2_s3_bare_date_bare_posixct;
+      case vctrs_class_bare_posixlt: *left =  0; return vctrs_type2_s3_bare_date_bare_posixlt;
+      default:                       *left =  0; return vctrs_type2_s3_bare_date_unknown;
+      }
+    }}
+  }
+  case vctrs_class_bare_posixct: {
+    switch (type_y) {
+    case vctrs_type_null:            *left =  1; return vctrs_type2_s3_null_bare_posixct;
+    case vctrs_type_logical:         *left =  1; return vctrs_type2_s3_logical_bare_posixct;
+    case vctrs_type_integer:         *left =  1; return vctrs_type2_s3_integer_bare_posixct;
+    case vctrs_type_double:          *left =  1; return vctrs_type2_s3_double_bare_posixct;
+    case vctrs_type_complex:         *left =  1; return vctrs_type2_s3_complex_bare_posixct;
+    case vctrs_type_character:       *left =  1; return vctrs_type2_s3_character_bare_posixct;
+    case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_posixct;
+    case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_posixct;
+    case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_posixct;
+    case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_posixct;
+    case vctrs_type_s3: {
+      switch (class_type(y)) {
+      case vctrs_class_bare_factor:  *left =  1; return vctrs_type2_s3_bare_factor_bare_posixct;
+      case vctrs_class_bare_ordered: *left =  1; return vctrs_type2_s3_bare_ordered_bare_posixct;
+      case vctrs_class_bare_date:    *left =  1; return vctrs_type2_s3_bare_date_bare_posixct;
+      case vctrs_class_bare_posixct: *left = -1; return vctrs_type2_s3_bare_posixct_bare_posixct;
+      case vctrs_class_bare_posixlt: *left =  0; return vctrs_type2_s3_bare_posixct_bare_posixlt;
+      default:                       *left =  0; return vctrs_type2_s3_bare_posixct_unknown;
+      }
+    }}
+  }
+  case vctrs_class_bare_posixlt: {
+    switch (type_y) {
+    case vctrs_type_null:            *left =  1; return vctrs_type2_s3_null_bare_posixlt;
+    case vctrs_type_logical:         *left =  1; return vctrs_type2_s3_logical_bare_posixlt;
+    case vctrs_type_integer:         *left =  1; return vctrs_type2_s3_integer_bare_posixlt;
+    case vctrs_type_double:          *left =  1; return vctrs_type2_s3_double_bare_posixlt;
+    case vctrs_type_complex:         *left =  1; return vctrs_type2_s3_complex_bare_posixlt;
+    case vctrs_type_character:       *left =  1; return vctrs_type2_s3_character_bare_posixlt;
+    case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_posixlt;
+    case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_posixlt;
+    case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_posixlt;
+    case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_posixlt;
+    case vctrs_type_s3: {
+      switch (class_type(y)) {
+      case vctrs_class_bare_factor:  *left =  1; return vctrs_type2_s3_bare_factor_bare_posixlt;
+      case vctrs_class_bare_ordered: *left =  1; return vctrs_type2_s3_bare_ordered_bare_posixlt;
+      case vctrs_class_bare_date:    *left =  1; return vctrs_type2_s3_bare_date_bare_posixlt;
+      case vctrs_class_bare_posixct: *left =  1; return vctrs_type2_s3_bare_posixct_bare_posixlt;
+      case vctrs_class_bare_posixlt: *left = -1; return vctrs_type2_s3_bare_posixlt_bare_posixlt;
+      default:                       *left =  0; return vctrs_type2_s3_bare_posixlt_unknown;
       }
     }}
   }
@@ -152,6 +257,9 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
       switch (class_type(y)) {
       case vctrs_class_bare_factor:  *left =  1; return vctrs_type2_s3_bare_factor_unknown;
       case vctrs_class_bare_ordered: *left =  1; return vctrs_type2_s3_bare_ordered_unknown;
+      case vctrs_class_bare_date:    *left =  1; return vctrs_type2_s3_bare_date_unknown;
+      case vctrs_class_bare_posixct: *left =  1; return vctrs_type2_s3_bare_posixct_unknown;
+      case vctrs_class_bare_posixlt: *left =  1; return vctrs_type2_s3_bare_posixlt_unknown;
       default:                       *left = -1; return vctrs_type2_s3_unknown_unknown;
       }
     }}
@@ -169,50 +277,98 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   switch (type) {
   case vctrs_type2_s3_null_bare_factor:            return "vctrs_type2_s3_null_bare_factor";
   case vctrs_type2_s3_null_bare_ordered:           return "vctrs_type2_s3_null_bare_ordered";
+  case vctrs_type2_s3_null_bare_date:              return "vctrs_type2_s3_null_bare_date";
+  case vctrs_type2_s3_null_bare_posixct:           return "vctrs_type2_s3_null_bare_posixct";
+  case vctrs_type2_s3_null_bare_posixlt:           return "vctrs_type2_s3_null_bare_posixlt";
   case vctrs_type2_s3_null_unknown:                return "vctrs_type2_s3_null_unknown";
 
   case vctrs_type2_s3_logical_bare_factor:         return "vctrs_type2_s3_logical_bare_factor";
   case vctrs_type2_s3_logical_bare_ordered:        return "vctrs_type2_s3_logical_bare_ordered";
+  case vctrs_type2_s3_logical_bare_date:           return "vctrs_type2_s3_logical_bare_date";
+  case vctrs_type2_s3_logical_bare_posixct:        return "vctrs_type2_s3_logical_bare_posixct";
+  case vctrs_type2_s3_logical_bare_posixlt:        return "vctrs_type2_s3_logical_bare_posixlt";
   case vctrs_type2_s3_logical_unknown:             return "vctrs_type2_s3_logical_unknown";
 
   case vctrs_type2_s3_integer_bare_factor:         return "vctrs_type2_s3_integer_bare_factor";
   case vctrs_type2_s3_integer_bare_ordered:        return "vctrs_type2_s3_integer_bare_ordered";
+  case vctrs_type2_s3_integer_bare_date:           return "vctrs_type2_s3_integer_bare_date";
+  case vctrs_type2_s3_integer_bare_posixct:        return "vctrs_type2_s3_integer_bare_posixct";
+  case vctrs_type2_s3_integer_bare_posixlt:        return "vctrs_type2_s3_integer_bare_posixlt";
   case vctrs_type2_s3_integer_unknown:             return "vctrs_type2_s3_integer_unknown";
 
   case vctrs_type2_s3_double_bare_factor:          return "vctrs_type2_s3_double_bare_factor";
   case vctrs_type2_s3_double_bare_ordered:         return "vctrs_type2_s3_double_bare_ordered";
+  case vctrs_type2_s3_double_bare_date:            return "vctrs_type2_s3_double_bare_date";
+  case vctrs_type2_s3_double_bare_posixct:         return "vctrs_type2_s3_double_bare_posixct";
+  case vctrs_type2_s3_double_bare_posixlt:         return "vctrs_type2_s3_double_bare_posixlt";
   case vctrs_type2_s3_double_unknown:              return "vctrs_type2_s3_double_unknown";
 
   case vctrs_type2_s3_complex_bare_factor:         return "vctrs_type2_s3_complex_bare_factor";
   case vctrs_type2_s3_complex_bare_ordered:        return "vctrs_type2_s3_complex_bare_ordered";
+  case vctrs_type2_s3_complex_bare_date:           return "vctrs_type2_s3_complex_bare_date";
+  case vctrs_type2_s3_complex_bare_posixct:        return "vctrs_type2_s3_complex_bare_posixct";
+  case vctrs_type2_s3_complex_bare_posixlt:        return "vctrs_type2_s3_complex_bare_posixlt";
   case vctrs_type2_s3_complex_unknown:             return "vctrs_type2_s3_complex_unknown";
 
   case vctrs_type2_s3_character_bare_factor:       return "vctrs_type2_s3_character_bare_factor";
   case vctrs_type2_s3_character_bare_ordered:      return "vctrs_type2_s3_character_bare_ordered";
+  case vctrs_type2_s3_character_bare_date:         return "vctrs_type2_s3_character_bare_date";
+  case vctrs_type2_s3_character_bare_posixct:      return "vctrs_type2_s3_character_bare_posixct";
+  case vctrs_type2_s3_character_bare_posixlt:      return "vctrs_type2_s3_character_bare_posixlt";
   case vctrs_type2_s3_character_unknown:           return "vctrs_type2_s3_character_unknown";
 
   case vctrs_type2_s3_raw_bare_factor:             return "vctrs_type2_s3_raw_bare_factor";
   case vctrs_type2_s3_raw_bare_ordered:            return "vctrs_type2_s3_raw_bare_ordered";
+  case vctrs_type2_s3_raw_bare_date:               return "vctrs_type2_s3_raw_bare_date";
+  case vctrs_type2_s3_raw_bare_posixct:            return "vctrs_type2_s3_raw_bare_posixct";
+  case vctrs_type2_s3_raw_bare_posixlt:            return "vctrs_type2_s3_raw_bare_posixlt";
   case vctrs_type2_s3_raw_unknown:                 return "vctrs_type2_s3_raw_unknown";
 
   case vctrs_type2_s3_list_bare_factor:            return "vctrs_type2_s3_list_bare_factor";
   case vctrs_type2_s3_list_bare_ordered:           return "vctrs_type2_s3_list_bare_ordered";
+  case vctrs_type2_s3_list_bare_date:              return "vctrs_type2_s3_list_bare_date";
+  case vctrs_type2_s3_list_bare_posixct:           return "vctrs_type2_s3_list_bare_posixct";
+  case vctrs_type2_s3_list_bare_posixlt:           return "vctrs_type2_s3_list_bare_posixlt";
   case vctrs_type2_s3_list_unknown:                return "vctrs_type2_s3_list_unknown";
 
   case vctrs_type2_s3_dataframe_bare_factor:       return "vctrs_type2_s3_dataframe_bare_factor";
   case vctrs_type2_s3_dataframe_bare_ordered:      return "vctrs_type2_s3_dataframe_bare_ordered";
+  case vctrs_type2_s3_dataframe_bare_date:         return "vctrs_type2_s3_dataframe_bare_date";
+  case vctrs_type2_s3_dataframe_bare_posixct:      return "vctrs_type2_s3_dataframe_bare_posixct";
+  case vctrs_type2_s3_dataframe_bare_posixlt:      return "vctrs_type2_s3_dataframe_bare_posixlt";
   case vctrs_type2_s3_dataframe_unknown:           return "vctrs_type2_s3_dataframe_unknown";
 
   case vctrs_type2_s3_scalar_bare_factor:          return "vctrs_type2_s3_scalar_bare_factor";
   case vctrs_type2_s3_scalar_bare_ordered:         return "vctrs_type2_s3_scalar_bare_ordered";
+  case vctrs_type2_s3_scalar_bare_date:            return "vctrs_type2_s3_scalar_bare_date";
+  case vctrs_type2_s3_scalar_bare_posixct:         return "vctrs_type2_s3_scalar_bare_posixct";
+  case vctrs_type2_s3_scalar_bare_posixlt:         return "vctrs_type2_s3_scalar_bare_posixlt";
   case vctrs_type2_s3_scalar_unknown:              return "vctrs_type2_s3_scalar_unknown";
 
   case vctrs_type2_s3_bare_factor_bare_factor:     return "vctrs_type2_s3_bare_factor_bare_factor";
   case vctrs_type2_s3_bare_factor_bare_ordered:    return "vctrs_type2_s3_bare_factor_bare_ordered";
+  case vctrs_type2_s3_bare_factor_bare_date:       return "vctrs_type2_s3_bare_factor_bare_date";
+  case vctrs_type2_s3_bare_factor_bare_posixct:    return "vctrs_type2_s3_bare_factor_bare_posixct";
+  case vctrs_type2_s3_bare_factor_bare_posixlt:    return "vctrs_type2_s3_bare_factor_bare_posixlt";
   case vctrs_type2_s3_bare_factor_unknown:         return "vctrs_type2_s3_bare_factor_unknown";
 
   case vctrs_type2_s3_bare_ordered_bare_ordered:   return "vctrs_type2_s3_bare_ordered_bare_ordered";
+  case vctrs_type2_s3_bare_ordered_bare_date:      return "vctrs_type2_s3_bare_ordered_bare_date";
+  case vctrs_type2_s3_bare_ordered_bare_posixct:   return "vctrs_type2_s3_bare_ordered_bare_posixct";
+  case vctrs_type2_s3_bare_ordered_bare_posixlt:   return "vctrs_type2_s3_bare_ordered_bare_posixlt";
   case vctrs_type2_s3_bare_ordered_unknown:        return "vctrs_type2_s3_bare_ordered_unknown";
+
+  case vctrs_type2_s3_bare_date_bare_date:         return "vctrs_type2_s3_bare_date_bare_date";
+  case vctrs_type2_s3_bare_date_bare_posixct:      return "vctrs_type2_s3_bare_date_bare_posixct";
+  case vctrs_type2_s3_bare_date_bare_posixlt:      return "vctrs_type2_s3_bare_date_bare_posixlt";
+  case vctrs_type2_s3_bare_date_unknown:           return "vctrs_type2_s3_bare_date_unknown";
+
+  case vctrs_type2_s3_bare_posixct_bare_posixct:   return "vctrs_type2_s3_bare_posixct_bare_posixct";
+  case vctrs_type2_s3_bare_posixct_bare_posixlt:   return "vctrs_type2_s3_bare_posixct_bare_posixlt";
+  case vctrs_type2_s3_bare_posixct_unknown:        return "vctrs_type2_s3_bare_posixct_unknown";
+
+  case vctrs_type2_s3_bare_posixlt_bare_posixlt:   return "vctrs_type2_s3_bare_posixlt_bare_posixlt";
+  case vctrs_type2_s3_bare_posixlt_unknown:        return "vctrs_type2_s3_bare_posixlt_unknown";
 
   case vctrs_type2_s3_unknown_unknown:             return "vctrs_type2_s3_unknown_unknown";
   }

--- a/src/utils-dispatch.c
+++ b/src/utils-dispatch.c
@@ -45,7 +45,8 @@ bool is_record(SEXP x) {
   enum vctrs_class_type type = class_type(x);
   return
     type == vctrs_class_rcrd ||
-    type == vctrs_class_posixlt;
+    type == vctrs_class_posixlt ||
+    type == vctrs_class_bare_posixlt;
 }
 
 
@@ -75,14 +76,27 @@ static enum vctrs_class_type class_type_impl(SEXP class) {
       return vctrs_class_bare_data_frame;
     } else if (p0 == strings_factor) {
       return vctrs_class_bare_factor;
+    } else if (p0 == strings_date) {
+      return vctrs_class_bare_date;
     }
 
     break;
   }
   case 2: {
-    if (p[0] == strings_ordered &&
-        p[1] == strings_factor) {
+    SEXP p0 = p[0];
+    SEXP p1 = p[1];
+
+    if (p0 == strings_ordered &&
+        p1 == strings_factor) {
       return vctrs_class_bare_ordered;
+    }
+
+    if (p1 == strings_posixt) {
+      if (p0 == strings_posixct) {
+        return vctrs_class_bare_posixct;
+      } else if (p0 == strings_posixlt) {
+        return vctrs_class_bare_posixlt;
+      }
     }
 
     break;
@@ -121,6 +135,9 @@ static const char* class_type_as_str(enum vctrs_class_type type) {
   case vctrs_class_bare_factor: return "bare_factor";
   case vctrs_class_bare_ordered: return "bare_ordered";
   case vctrs_class_rcrd: return "rcrd";
+  case vctrs_class_bare_date: return "bare_date";
+  case vctrs_class_bare_posixct: return "bare_posixct";
+  case vctrs_class_bare_posixlt: return "bare_posixlt";
   case vctrs_class_posixlt: return "posixlt";
   case vctrs_class_unknown: return "unknown";
   case vctrs_class_none: return "none";

--- a/src/utils.c
+++ b/src/utils.c
@@ -15,8 +15,10 @@ SEXP strings_tbl = NULL;
 SEXP strings_tbl_df = NULL;
 SEXP strings_data_frame = NULL;
 SEXP strings_vctrs_rcrd = NULL;
-SEXP strings_posixt = NULL;
+SEXP strings_date = NULL;
+SEXP strings_posixct = NULL;
 SEXP strings_posixlt = NULL;
+SEXP strings_posixt = NULL;
 SEXP strings_factor = NULL;
 SEXP strings_ordered = NULL;
 SEXP strings_vctrs_vctr = NULL;
@@ -1184,7 +1186,7 @@ void vctrs_init_utils(SEXP ns) {
 
   // Holds the CHARSXP objects because unlike symbols they can be
   // garbage collected
-  strings = Rf_allocVector(STRSXP, 18);
+  strings = Rf_allocVector(STRSXP, 20);
   R_PreserveObject(strings);
 
   strings_dots = Rf_mkChar("...");
@@ -1196,50 +1198,56 @@ void vctrs_init_utils(SEXP ns) {
   strings_vctrs_rcrd = Rf_mkChar("vctrs_rcrd");
   SET_STRING_ELT(strings, 2, strings_vctrs_rcrd);
 
+  strings_date = Rf_mkChar("Date");
+  SET_STRING_ELT(strings, 3, strings_date);
+
+  strings_posixct = Rf_mkChar("POSIXct");
+  SET_STRING_ELT(strings, 4, strings_posixct);
+
   strings_posixlt = Rf_mkChar("POSIXlt");
-  SET_STRING_ELT(strings, 3, strings_posixlt);
+  SET_STRING_ELT(strings, 5, strings_posixlt);
 
   strings_posixt = Rf_mkChar("POSIXt");
-  SET_STRING_ELT(strings, 4, strings_posixlt);
+  SET_STRING_ELT(strings, 6, strings_posixlt);
 
   strings_vctrs_vctr = Rf_mkChar("vctrs_vctr");
-  SET_STRING_ELT(strings, 5, strings_vctrs_vctr);
+  SET_STRING_ELT(strings, 7, strings_vctrs_vctr);
 
   strings_none = Rf_mkChar("none");
-  SET_STRING_ELT(strings, 6, strings_none);
+  SET_STRING_ELT(strings, 8, strings_none);
 
   strings_minimal = Rf_mkChar("minimal");
-  SET_STRING_ELT(strings, 7, strings_minimal);
+  SET_STRING_ELT(strings, 9, strings_minimal);
 
   strings_unique = Rf_mkChar("unique");
-  SET_STRING_ELT(strings, 8, strings_unique);
+  SET_STRING_ELT(strings, 10, strings_unique);
 
   strings_universal = Rf_mkChar("universal");
-  SET_STRING_ELT(strings, 9, strings_universal);
+  SET_STRING_ELT(strings, 11, strings_universal);
 
   strings_check_unique = Rf_mkChar("check_unique");
-  SET_STRING_ELT(strings, 10, strings_check_unique);
+  SET_STRING_ELT(strings, 12, strings_check_unique);
 
   strings_key = Rf_mkChar("key");
-  SET_STRING_ELT(strings, 11, strings_key);
+  SET_STRING_ELT(strings, 13, strings_key);
 
   strings_loc = Rf_mkChar("loc");
-  SET_STRING_ELT(strings, 12, strings_loc);
+  SET_STRING_ELT(strings, 14, strings_loc);
 
   strings_val = Rf_mkChar("val");
-  SET_STRING_ELT(strings, 13, strings_val);
+  SET_STRING_ELT(strings, 15, strings_val);
 
   strings_group = Rf_mkChar("group");
-  SET_STRING_ELT(strings, 14, strings_group);
+  SET_STRING_ELT(strings, 16, strings_group);
 
   strings_length = Rf_mkChar("length");
-  SET_STRING_ELT(strings, 15, strings_length);
+  SET_STRING_ELT(strings, 17, strings_length);
 
   strings_factor = Rf_mkChar("factor");
-  SET_STRING_ELT(strings, 16, strings_factor);
+  SET_STRING_ELT(strings, 18, strings_factor);
 
   strings_ordered = Rf_mkChar("ordered");
-  SET_STRING_ELT(strings, 17, strings_ordered);
+  SET_STRING_ELT(strings, 19, strings_ordered);
 
 
   classes_data_frame = Rf_allocVector(STRSXP, 1);

--- a/src/utils.c
+++ b/src/utils.c
@@ -28,6 +28,8 @@ SEXP strings_list = NULL;
 SEXP classes_data_frame = NULL;
 SEXP classes_factor = NULL;
 SEXP classes_ordered = NULL;
+SEXP classes_date = NULL;
+SEXP classes_posixct = NULL;
 SEXP classes_tibble = NULL;
 SEXP classes_list_of = NULL;
 SEXP classes_vctrs_group_rle = NULL;
@@ -1109,6 +1111,7 @@ SEXP vctrs_shared_empty_cpl = NULL;
 SEXP vctrs_shared_empty_chr = NULL;
 SEXP vctrs_shared_empty_raw = NULL;
 SEXP vctrs_shared_empty_list = NULL;
+SEXP vctrs_shared_empty_date = NULL;
 SEXP vctrs_shared_true = NULL;
 SEXP vctrs_shared_false = NULL;
 Rcomplex vctrs_shared_na_cpl;
@@ -1166,6 +1169,7 @@ SEXP syms_size = NULL;
 SEXP syms_subscript_action = NULL;
 SEXP syms_subscript_type = NULL;
 SEXP syms_repair = NULL;
+SEXP syms_tzone = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -1265,6 +1269,15 @@ void vctrs_init_utils(SEXP ns) {
   SET_STRING_ELT(classes_ordered, 0, strings_ordered);
   SET_STRING_ELT(classes_ordered, 1, strings_factor);
 
+  classes_date = Rf_allocVector(STRSXP, 1);
+  R_PreserveObject(classes_date);
+  SET_STRING_ELT(classes_date, 0, strings_date);
+
+  classes_posixct = Rf_allocVector(STRSXP, 2);
+  R_PreserveObject(classes_posixct);
+  SET_STRING_ELT(classes_posixct, 0, strings_posixct);
+  SET_STRING_ELT(classes_posixct, 1, strings_posixt);
+
 
   chrs_subset = Rf_mkString("subset");
   R_PreserveObject(chrs_subset);
@@ -1351,6 +1364,11 @@ void vctrs_init_utils(SEXP ns) {
   R_PreserveObject(vctrs_shared_empty_list);
   MARK_NOT_MUTABLE(vctrs_shared_empty_list);
 
+  vctrs_shared_empty_date = Rf_allocVector(REALSXP, 0);
+  R_PreserveObject(vctrs_shared_empty_date);
+  Rf_setAttrib(vctrs_shared_empty_date, R_ClassSymbol, classes_date);
+  MARK_NOT_MUTABLE(vctrs_shared_empty_date);
+
   vctrs_shared_true = Rf_allocVector(LGLSXP, 1);
   R_PreserveObject(vctrs_shared_true);
   MARK_NOT_MUTABLE(vctrs_shared_true);
@@ -1401,6 +1419,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_subscript_action = Rf_install("subscript_action");
   syms_subscript_type = Rf_install("subscript_type");
   syms_repair = Rf_install("repair");
+  syms_tzone = Rf_install("tzone");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.h
+++ b/src/utils.h
@@ -272,6 +272,8 @@ extern SEXP strings_tbl;
 extern SEXP strings_tbl_df;
 extern SEXP strings_data_frame;
 extern SEXP strings_vctrs_rcrd;
+extern SEXP strings_date;
+extern SEXP strings_posixct;
 extern SEXP strings_posixlt;
 extern SEXP strings_posixt;
 extern SEXP strings_factor;

--- a/src/utils.h
+++ b/src/utils.h
@@ -265,6 +265,8 @@ extern SEXP vctrs_shared_zero_int;
 extern SEXP classes_data_frame;
 extern SEXP classes_factor;
 extern SEXP classes_ordered;
+extern SEXP classes_date;
+extern SEXP classes_posixct;
 extern SEXP classes_tibble;
 extern SEXP classes_list_of;
 extern SEXP classes_vctrs_group_rle;
@@ -329,6 +331,7 @@ extern SEXP syms_size;
 extern SEXP syms_subscript_action;
 extern SEXP syms_subscript_type;
 extern SEXP syms_repair;
+extern SEXP syms_tzone;
 
 #define syms_names R_NamesSymbol
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -19,6 +19,9 @@ enum vctrs_class_type {
   vctrs_class_bare_factor,
   vctrs_class_bare_ordered,
   vctrs_class_rcrd,
+  vctrs_class_bare_date,
+  vctrs_class_bare_posixct,
+  vctrs_class_bare_posixlt,
   vctrs_class_posixlt,
   vctrs_class_unknown,
   vctrs_class_none

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -172,50 +172,98 @@ enum vctrs_type2 {
 enum vctrs_type2_s3 {
   vctrs_type2_s3_null_bare_factor,
   vctrs_type2_s3_null_bare_ordered,
+  vctrs_type2_s3_null_bare_date,
+  vctrs_type2_s3_null_bare_posixct,
+  vctrs_type2_s3_null_bare_posixlt,
   vctrs_type2_s3_null_unknown,
 
   vctrs_type2_s3_logical_bare_factor,
   vctrs_type2_s3_logical_bare_ordered,
+  vctrs_type2_s3_logical_bare_date,
+  vctrs_type2_s3_logical_bare_posixct,
+  vctrs_type2_s3_logical_bare_posixlt,
   vctrs_type2_s3_logical_unknown,
 
   vctrs_type2_s3_integer_bare_factor,
   vctrs_type2_s3_integer_bare_ordered,
+  vctrs_type2_s3_integer_bare_date,
+  vctrs_type2_s3_integer_bare_posixct,
+  vctrs_type2_s3_integer_bare_posixlt,
   vctrs_type2_s3_integer_unknown,
 
   vctrs_type2_s3_double_bare_factor,
   vctrs_type2_s3_double_bare_ordered,
+  vctrs_type2_s3_double_bare_date,
+  vctrs_type2_s3_double_bare_posixct,
+  vctrs_type2_s3_double_bare_posixlt,
   vctrs_type2_s3_double_unknown,
 
   vctrs_type2_s3_complex_bare_factor,
   vctrs_type2_s3_complex_bare_ordered,
+  vctrs_type2_s3_complex_bare_date,
+  vctrs_type2_s3_complex_bare_posixct,
+  vctrs_type2_s3_complex_bare_posixlt,
   vctrs_type2_s3_complex_unknown,
 
   vctrs_type2_s3_character_bare_factor,
   vctrs_type2_s3_character_bare_ordered,
+  vctrs_type2_s3_character_bare_date,
+  vctrs_type2_s3_character_bare_posixct,
+  vctrs_type2_s3_character_bare_posixlt,
   vctrs_type2_s3_character_unknown,
 
   vctrs_type2_s3_raw_bare_factor,
   vctrs_type2_s3_raw_bare_ordered,
+  vctrs_type2_s3_raw_bare_date,
+  vctrs_type2_s3_raw_bare_posixct,
+  vctrs_type2_s3_raw_bare_posixlt,
   vctrs_type2_s3_raw_unknown,
 
   vctrs_type2_s3_list_bare_factor,
   vctrs_type2_s3_list_bare_ordered,
+  vctrs_type2_s3_list_bare_date,
+  vctrs_type2_s3_list_bare_posixct,
+  vctrs_type2_s3_list_bare_posixlt,
   vctrs_type2_s3_list_unknown,
 
   vctrs_type2_s3_dataframe_bare_factor,
   vctrs_type2_s3_dataframe_bare_ordered,
+  vctrs_type2_s3_dataframe_bare_date,
+  vctrs_type2_s3_dataframe_bare_posixct,
+  vctrs_type2_s3_dataframe_bare_posixlt,
   vctrs_type2_s3_dataframe_unknown,
 
   vctrs_type2_s3_scalar_bare_factor,
   vctrs_type2_s3_scalar_bare_ordered,
+  vctrs_type2_s3_scalar_bare_date,
+  vctrs_type2_s3_scalar_bare_posixct,
+  vctrs_type2_s3_scalar_bare_posixlt,
   vctrs_type2_s3_scalar_unknown,
 
   vctrs_type2_s3_bare_factor_bare_factor,
   vctrs_type2_s3_bare_factor_bare_ordered,
+  vctrs_type2_s3_bare_factor_bare_date,
+  vctrs_type2_s3_bare_factor_bare_posixct,
+  vctrs_type2_s3_bare_factor_bare_posixlt,
   vctrs_type2_s3_bare_factor_unknown,
 
   vctrs_type2_s3_bare_ordered_bare_ordered,
+  vctrs_type2_s3_bare_ordered_bare_date,
+  vctrs_type2_s3_bare_ordered_bare_posixct,
+  vctrs_type2_s3_bare_ordered_bare_posixlt,
   vctrs_type2_s3_bare_ordered_unknown,
+
+  vctrs_type2_s3_bare_date_bare_date,
+  vctrs_type2_s3_bare_date_bare_posixct,
+  vctrs_type2_s3_bare_date_bare_posixlt,
+  vctrs_type2_s3_bare_date_unknown,
+
+  vctrs_type2_s3_bare_posixct_bare_posixct,
+  vctrs_type2_s3_bare_posixct_bare_posixlt,
+  vctrs_type2_s3_bare_posixct_unknown,
+
+  vctrs_type2_s3_bare_posixlt_bare_posixlt,
+  vctrs_type2_s3_bare_posixlt_unknown,
 
   vctrs_type2_s3_unknown_unknown
 };

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -278,6 +278,7 @@ extern SEXP vctrs_shared_empty_cpl;
 extern SEXP vctrs_shared_empty_chr;
 extern SEXP vctrs_shared_empty_raw;
 extern SEXP vctrs_shared_empty_list;
+extern SEXP vctrs_shared_empty_date;
 extern SEXP vctrs_shared_empty_uns;
 
 extern SEXP vctrs_shared_true;
@@ -478,6 +479,11 @@ SEXP fct_as_factor(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_arg, struct
 
 SEXP chr_as_ordered(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* to_arg);
 SEXP ord_as_ordered(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
+
+// Datetime methods ---------------------------------------------
+
+SEXP date_datetime_ptype2(SEXP x, SEXP y);
+SEXP datetime_datetime_ptype2(SEXP x, SEXP y);
 
 // Character translation ----------------------------------------
 

--- a/tests/testthat/helper-types.R
+++ b/tests/testthat/helper-types.R
@@ -13,7 +13,10 @@ base_empty_types <- list(
 
 base_s3_empty_types <- list(
   bare_factor = new_factor(),
-  bare_ordered = new_ordered()
+  bare_ordered = new_ordered(),
+  bare_date = new_date(),
+  bare_posixct = new_datetime(tzone = "UTC"),
+  bare_posixlt = as.POSIXlt(new_datetime(tzone = "UTC"))
 )
 
 proxied_empty_types <- list(

--- a/tests/testthat/test-type-date-time.R
+++ b/tests/testthat/test-type-date-time.R
@@ -93,6 +93,15 @@ test_that("POSIXlt always steered towards POSIXct", {
   expect_equal(vec_ptype2(dtl, dtl), dtc[0])
 })
 
+test_that("vec_ptype2() on a POSIXlt with multiple time zones returns the first", {
+  rlang::with_options(TZ = "America/New_York", {
+    x <- as.POSIXlt(new_datetime(tzone = ""))
+  })
+
+  expect_identical(attr(x, "tzone"), c("", "EST", "EDT"))
+  expect_identical(attr(vec_ptype2(x, new_date()), "tzone"), "")
+})
+
 test_that("vec_ptype2(<Date>, NA) is symmetric (#687)", {
   date <- new_date()
   expect_identical(

--- a/tests/testthat/test-type-date-time.R
+++ b/tests/testthat/test-type-date-time.R
@@ -94,12 +94,10 @@ test_that("POSIXlt always steered towards POSIXct", {
 })
 
 test_that("vec_ptype2() on a POSIXlt with multiple time zones returns the first", {
-  rlang::with_options(TZ = "America/New_York", {
-    x <- as.POSIXlt(new_datetime(tzone = ""))
-  })
+  x <- as.POSIXlt(new_datetime(), tz = "Pacific/Auckland")
 
-  expect_identical(attr(x, "tzone"), c("", "EST", "EDT"))
-  expect_identical(attr(vec_ptype2(x, new_date()), "tzone"), "")
+  expect_identical(attr(x, "tzone"), c("Pacific/Auckland", "NZST", "NZDT"))
+  expect_identical(attr(vec_ptype2(x, new_date()), "tzone"), "Pacific/Auckland")
 })
 
 test_that("vec_ptype2(<Date>, NA) is symmetric (#687)", {

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -136,9 +136,15 @@ test_that("class_type() detects classes", {
   expect_identical(class_type(subclass(new_factor())), "unknown")
   expect_identical(class_type(subclass(new_ordered())), "unknown")
 
-  expect_identical(class_type(as.POSIXlt(Sys.Date())), "posixlt")
+
+  expect_identical(class_type(new_date()), "bare_date")
+  expect_identical(class_type(new_datetime()), "bare_posixct")
+  expect_identical(class_type(as.POSIXlt(new_date())), "bare_posixlt")
+  expect_identical(class_type(subclass(new_date())), "unknown")
+  expect_identical(class_type(subclass(new_datetime())), "unknown")
+  expect_identical(class_type(subclass(as.POSIXlt(new_date()))), "posixlt")
+
   expect_identical(class_type(new_rcrd(list(a = 1))), "rcrd")
-  expect_identical(class_type(subclass(as.POSIXlt(Sys.Date()))), "posixlt")
   expect_identical(class_type(subclass(new_rcrd(list(a = 1)))), "rcrd")
 
   expect_identical(class_type(NA), "none")


### PR DESCRIPTION
This PR adds native C level `vec_ptype2()` dispatch for `Date`, `POSIXct` and `POSIXlt` classes

This was fairly straightforward now that we have the dispatch infrastructure in place. I've separated `vctrs_class_bare_posixct` from `vctrs_class_bare_posixlt` because I'm fairly certain it will be useful to have the distinction when we go to implement the cast methods. For the ptype2 methods it doesn't matter as much.

We get nice performance improvements all around.

``` r
library(vctrs)

date <- new_date()
datetime <- new_datetime(tzone = "UTC")
```

Two dates, nothing to do

```r
# before
bench::mark(vec_ptype2(date, date))
#> # A tibble: 1 x 6
#>   expression                  min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>             <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(date, date)   15.2µs   17.7µs    54523.    6.66KB     81.9

# after
bench::mark(vec_ptype2(date, date))
#> # A tibble: 1 x 6
#>   expression                  min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>             <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(date, date)    842ns   1.23µs   793154.        0B     159.
```

Two datetimes, takes the "union" of the tzones

```r
# before
bench::mark(vec_ptype2(datetime, datetime))
#> # A tibble: 1 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(datetime, datetime)   19.3µs   22.5µs    40507.    25.1KB     20.3

# after
bench::mark(vec_ptype2(datetime, datetime))
#> # A tibble: 1 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(datetime, datetime)   1.23µs   1.41µs   516363.        0B        0
```

Date and datetime, uses tzone of the datetime

```r
# before
bench::mark(vec_ptype2(datetime, date))
#> # A tibble: 1 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(datetime, date)   16.5µs   18.4µs    51397.    4.38KB     25.7

# after
bench::mark(vec_ptype2(datetime, date))
#> # A tibble: 1 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(datetime, date)   1.23µs   1.45µs   676618.        0B        0
```