### PR TITLE
Fix custom name repair

### DIFF
--- a/R/names.R
+++ b/R/names.R
@@ -159,7 +159,7 @@ vec_as_names <- function(names,
 
   if (is_function(repair)) {
     names <- as_minimal_names(names)
-    new_names <- validate_minimal(repair(names), n = length(names))
+    new_names <- validate_minimal_names(repair(names), n = length(names))
 
     if (!quiet) {
       describe_repair(names, new_names)
@@ -179,26 +179,11 @@ vec_as_names <- function(names,
 validate_name_repair_arg <- function(repair) {
   .Call(vctrs_validate_name_repair_arg, repair)
 }
-validate_minimal <- function(names, n = NULL) {
-  if (is.null(names)) {
-    abort("Names repair functions can't return `NULL`.")
-  }
-  if (!is_character(names)) {
-    abort("Names repair functions must return a character vector.")
-  }
-  if (!is_null(n) && length(names) != n) {
-    abort(sprintf(
-      "Repaired names have length %d instead of length %d.",
-      length(names), n
-    ))
-  }
-  if (anyNA(names)) {
-    abort("Names repair functions can't return `NA` values.")
-  }
-  names
+validate_minimal_names <- function(names, n = NULL) {
+  .Call(vctrs_validate_minimal_names, names, n)
 }
 validate_unique <- function(names, n = NULL) {
-  validate_minimal(names, n)
+  validate_minimal_names(names, n)
 
   empty_names <- which(names == "")
   if (has_length(empty_names)) {
@@ -237,7 +222,7 @@ vec_names2 <- function(x,
 
   if (is_function(repair)) {
     names <- minimal_names(x)
-    new_names <- validate_minimal(repair(names), n = length(names))
+    new_names <- validate_minimal_names(repair(names), n = length(names))
 
     if (!quiet) {
       describe_repair(names, new_names)

--- a/R/names.R
+++ b/R/names.R
@@ -155,7 +155,7 @@ vec_as_names <- function(names,
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
-  repair <- validate_repair(repair)
+  repair <- validate_name_repair_arg(repair)
 
   if (is_function(repair)) {
     names <- as_minimal_names(names)
@@ -176,16 +176,8 @@ vec_as_names <- function(names,
   )
 }
 
-validate_repair <- function(repair = c("minimal", "unique", "universal", "check_unique")) {
-  if (is_formula(repair, scoped = TRUE, lhs = FALSE)) {
-    repair <- as_function(repair)
-  }
-
-  if (is_function(repair)) {
-    repair
-  } else {
-    arg_match(repair)
-  }
+validate_name_repair_arg <- function(repair) {
+  .Call(vctrs_validate_name_repair_arg, repair)
 }
 validate_minimal <- function(names, n = NULL) {
   if (is.null(names)) {
@@ -241,7 +233,7 @@ vec_names2 <- function(x,
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
-  repair <- validate_repair(repair)
+  repair <- validate_name_repair_arg(repair)
 
   if (is_function(repair)) {
     names <- minimal_names(x)

--- a/R/names.R
+++ b/R/names.R
@@ -155,25 +155,7 @@ vec_as_names <- function(names,
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
-  repair <- validate_name_repair_arg(repair)
-
-  if (is_function(repair)) {
-    names <- as_minimal_names(names)
-    new_names <- validate_minimal_names(repair(names), n = length(names))
-
-    if (!quiet) {
-      describe_repair(names, new_names)
-    }
-
-    return(new_names)
-  }
-
-  switch(repair,
-    minimal = as_minimal_names(names),
-    unique = as_unique_names(names, quiet = quiet),
-    universal = as_universal_names(as_minimal_names(names), quiet = quiet),
-    check_unique = validate_unique(names)
-  )
+  .Call(vctrs_as_names, names, repair, quiet)
 }
 
 validate_name_repair_arg <- function(repair) {

--- a/src/bind.c
+++ b/src/bind.c
@@ -389,7 +389,7 @@ static SEXP vec_as_df_col(SEXP x, SEXP outer) {
 }
 
 struct name_repair_opts validate_bind_name_repair(SEXP name_repair, bool allow_minimal) {
-  struct name_repair_opts opts = validate_name_repair(name_repair, false);
+  struct name_repair_opts opts = new_name_repair_opts(name_repair, false);
 
   switch (opts.type) {
   case name_repair_unique: break;

--- a/src/bind.c
+++ b/src/bind.c
@@ -392,10 +392,13 @@ struct name_repair_opts validate_bind_name_repair(SEXP name_repair, bool allow_m
   struct name_repair_opts opts = new_name_repair_opts(name_repair, false);
 
   switch (opts.type) {
-  case name_repair_unique: break;
-  case name_repair_universal: break;
-  case name_repair_check_unique: break;
-  case name_repair_minimal: if (allow_minimal) break;
+  case name_repair_custom:
+  case name_repair_unique:
+  case name_repair_universal:
+  case name_repair_check_unique:
+    break;
+  case name_repair_minimal:
+    if (allow_minimal) break; // else fallthrough
   default:
     if (allow_minimal) {
       Rf_errorcall(R_NilValue,

--- a/src/c.c
+++ b/src/c.c
@@ -19,7 +19,7 @@ SEXP vctrs_c(SEXP call, SEXP op, SEXP args, SEXP env) {
   SEXP name_spec = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
   SEXP name_repair = PROTECT(Rf_eval(CAR(args), env));
 
-  struct name_repair_opts name_repair_opts = validate_name_repair(name_repair);
+  struct name_repair_opts name_repair_opts = validate_name_repair(name_repair, false);
   PROTECT_NAME_REPAIR_OPTS(&name_repair_opts);
 
   SEXP out = vec_c(xs, ptype, name_spec, &name_repair_opts);
@@ -126,7 +126,7 @@ SEXP vec_c(SEXP xs,
   out = PROTECT(vec_restore(out, ptype, R_NilValue));
 
   if (has_names) {
-    out_names = PROTECT(vec_as_names(out_names, name_repair, false));
+    out_names = PROTECT(vec_as_names(out_names, name_repair));
     out = vec_set_names(out, out_names);
     REPROTECT(out, out_pi);
     UNPROTECT(1);

--- a/src/c.c
+++ b/src/c.c
@@ -19,10 +19,12 @@ SEXP vctrs_c(SEXP call, SEXP op, SEXP args, SEXP env) {
   SEXP name_spec = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
   SEXP name_repair = PROTECT(Rf_eval(CAR(args), env));
 
-  enum name_repair_arg repair_arg = validate_name_repair(name_repair);
-  SEXP out = vec_c(xs, ptype, name_spec, repair_arg);
+  struct name_repair_opts name_repair_opts = validate_name_repair(name_repair);
+  PROTECT_NAME_REPAIR_OPTS(&name_repair_opts);
 
-  UNPROTECT(4);
+  SEXP out = vec_c(xs, ptype, name_spec, &name_repair_opts);
+
+  UNPROTECT(5);
   return out;
 }
 
@@ -34,7 +36,7 @@ static void stop_vec_c_fallback(SEXP xs, SEXP name_spec, SEXP ptype);
 SEXP vec_c(SEXP xs,
            SEXP ptype,
            SEXP name_spec,
-           enum name_repair_arg name_repair) {
+           const struct name_repair_opts* name_repair) {
   R_len_t n = Rf_length(xs);
 
   if (needs_vec_c_fallback(xs)) {

--- a/src/c.c
+++ b/src/c.c
@@ -19,7 +19,7 @@ SEXP vctrs_c(SEXP call, SEXP op, SEXP args, SEXP env) {
   SEXP name_spec = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
   SEXP name_repair = PROTECT(Rf_eval(CAR(args), env));
 
-  struct name_repair_opts name_repair_opts = validate_name_repair(name_repair, false);
+  struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair, false);
   PROTECT_NAME_REPAIR_OPTS(&name_repair_opts);
 
   SEXP out = vec_c(xs, ptype, name_spec, &name_repair_opts);

--- a/src/init.c
+++ b/src/init.c
@@ -83,6 +83,7 @@ extern SEXP vctrs_apply_name_spec(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_proxy_recursive(SEXP, SEXP);
 extern SEXP vctrs_maybe_translate_encoding(SEXP);
 extern SEXP vctrs_maybe_translate_encoding2(SEXP, SEXP);
+extern SEXP vctrs_validate_name_repair_arg(SEXP);
 
 // Very experimental
 // Available in the API header
@@ -185,6 +186,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_maybe_translate_encoding",   (DL_FUNC) &vctrs_maybe_translate_encoding, 1},
   {"vctrs_maybe_translate_encoding2",  (DL_FUNC) &vctrs_maybe_translate_encoding2, 2},
   {"vctrs_rle",                        (DL_FUNC) &altrep_rle_Make, 1},
+  {"vctrs_validate_name_repair_arg",   (DL_FUNC) &vctrs_validate_name_repair_arg, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -84,6 +84,7 @@ extern SEXP vctrs_proxy_recursive(SEXP, SEXP);
 extern SEXP vctrs_maybe_translate_encoding(SEXP);
 extern SEXP vctrs_maybe_translate_encoding2(SEXP, SEXP);
 extern SEXP vctrs_validate_name_repair_arg(SEXP);
+extern SEXP vctrs_validate_minimal_names(SEXP, SEXP);
 
 // Very experimental
 // Available in the API header
@@ -187,6 +188,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_maybe_translate_encoding2",  (DL_FUNC) &vctrs_maybe_translate_encoding2, 2},
   {"vctrs_rle",                        (DL_FUNC) &altrep_rle_Make, 1},
   {"vctrs_validate_name_repair_arg",   (DL_FUNC) &vctrs_validate_name_repair_arg, 1},
+  {"vctrs_validate_minimal_names",     (DL_FUNC) &vctrs_validate_minimal_names, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -85,6 +85,7 @@ extern SEXP vctrs_maybe_translate_encoding(SEXP);
 extern SEXP vctrs_maybe_translate_encoding2(SEXP, SEXP);
 extern SEXP vctrs_validate_name_repair_arg(SEXP);
 extern SEXP vctrs_validate_minimal_names(SEXP, SEXP);
+extern SEXP vctrs_as_names(SEXP, SEXP, SEXP);
 
 // Very experimental
 // Available in the API header
@@ -189,6 +190,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_rle",                        (DL_FUNC) &altrep_rle_Make, 1},
   {"vctrs_validate_name_repair_arg",   (DL_FUNC) &vctrs_validate_name_repair_arg, 1},
   {"vctrs_validate_minimal_names",     (DL_FUNC) &vctrs_validate_minimal_names, 2},
+  {"vctrs_as_names",                   (DL_FUNC) &vctrs_as_names, 3},
   {NULL, NULL, 0}
 };
 

--- a/src/names.c
+++ b/src/names.c
@@ -770,6 +770,39 @@ const char* name_repair_arg_as_c_string(enum name_repair_type type) {
   never_reached("name_repair_arg_as_c_string");
 }
 
+static void vec_validate_minimal_names(SEXP names, R_len_t n) {
+  if (names == R_NilValue) {
+    Rf_errorcall(R_NilValue, "Names repair functions can't return `NULL`.");
+  }
+
+  if (TYPEOF(names) != STRSXP) {
+    Rf_errorcall(R_NilValue, "Names repair functions must return a character vector.");
+  }
+
+  if (n >= 0 && Rf_length(names) != n) {
+    Rf_errorcall(R_NilValue,
+                 "Repaired names have length %d instead of length %d.",
+                 Rf_length(names),
+                 n);
+  }
+
+  if (r_chr_has_string(names, NA_STRING)) {
+    Rf_errorcall(R_NilValue, "Names repair functions can't return `NA` values.");
+  }
+}
+SEXP vctrs_validate_minimal_names(SEXP names, SEXP n_) {
+  R_len_t n = -1;
+
+  if (TYPEOF(n_) == INTSXP) {
+    if (Rf_length(n_) != 1) {
+      Rf_error("Internal error (minimal names validation): `n` must be a single number.");
+    }
+    n = INTEGER(n_)[0];
+  }
+
+  vec_validate_minimal_names(names, n);
+  return names;
+}
 
 void vctrs_init_names(SEXP ns) {
   syms_set_rownames_fallback = Rf_install("set_rownames_fallback");

--- a/src/names.c
+++ b/src/names.c
@@ -22,13 +22,13 @@ SEXP vec_as_universal_names(SEXP names, bool quiet);
 SEXP vec_validate_unique_names(SEXP names);
 
 
-// [[ include("vctrs.h") ]]
-SEXP vec_as_names(SEXP names, const struct name_repair_opts* opts, bool quiet) {
+// [[ include("names.h") ]]
+SEXP vec_as_names(SEXP names, const struct name_repair_opts* opts) {
   switch (opts->type) {
   case name_repair_none: return names;
   case name_repair_minimal: return vctrs_as_minimal_names(names);
-  case name_repair_unique: return vec_as_unique_names(names, quiet);
-  case name_repair_universal: return vec_as_universal_names(names, quiet);
+  case name_repair_unique: return vec_as_unique_names(names, opts->quiet);
+  case name_repair_universal: return vec_as_universal_names(names, opts->quiet);
   case name_repair_check_unique: return vec_validate_unique_names(names);
   case name_repair_custom:
     Rf_error("TODO: unimplemented");
@@ -694,7 +694,7 @@ SEXP vec_set_names(SEXP x, SEXP names) {
 }
 
 SEXP vctrs_validate_name_repair_arg(SEXP arg) {
-  struct name_repair_opts opts = validate_name_repair(arg);
+  struct name_repair_opts opts = validate_name_repair(arg, true);
   if (opts.type == name_repair_custom) {
     return opts.fn;
   } else if (Rf_length(arg) != 1) {
@@ -708,10 +708,11 @@ void stop_name_repair() {
   Rf_errorcall(R_NilValue, "`.name_repair` must be a string or a function. See `?vctrs::vec_as_names`.");
 }
 
-struct name_repair_opts validate_name_repair(SEXP name_repair) {
+struct name_repair_opts validate_name_repair(SEXP name_repair, bool quiet) {
   struct name_repair_opts opts = {
     .type = 0,
-    .fn = R_NilValue
+    .fn = R_NilValue,
+    .quiet = quiet
   };
 
   switch (TYPEOF(name_repair)) {

--- a/src/names.c
+++ b/src/names.c
@@ -694,7 +694,7 @@ SEXP vec_set_names(SEXP x, SEXP names) {
 }
 
 SEXP vctrs_validate_name_repair_arg(SEXP arg) {
-  struct name_repair_opts opts = validate_name_repair(arg, true);
+  struct name_repair_opts opts = new_name_repair_opts(arg, true);
   if (opts.type == name_repair_custom) {
     return opts.fn;
   } else if (Rf_length(arg) != 1) {
@@ -708,7 +708,7 @@ void stop_name_repair() {
   Rf_errorcall(R_NilValue, "`.name_repair` must be a string or a function. See `?vctrs::vec_as_names`.");
 }
 
-struct name_repair_opts validate_name_repair(SEXP name_repair, bool quiet) {
+struct name_repair_opts new_name_repair_opts(SEXP name_repair, bool quiet) {
   struct name_repair_opts opts = {
     .type = 0,
     .fn = R_NilValue,
@@ -754,7 +754,7 @@ struct name_repair_opts validate_name_repair(SEXP name_repair, bool quiet) {
     stop_name_repair();
   }
 
-  never_reached("validate_name_repair");
+  never_reached("new_name_repair_opts");
 }
 
 // [[ include("vctrs.h") ]]

--- a/src/names.h
+++ b/src/names.h
@@ -1,17 +1,27 @@
 #ifndef VCTRS_NAMES_H
 #define VCTRS_NAMES_H
 
-enum name_repair_arg {
-  name_repair_none,
+enum name_repair_type {
+  name_repair_none = 0,
   name_repair_minimal,
   name_repair_unique,
   name_repair_universal,
-  name_repair_check_unique
+  name_repair_check_unique,
+  name_repair_custom = 99
 };
 
-const char* name_repair_arg_as_c_string(enum name_repair_arg arg);
-enum name_repair_arg validate_name_repair(SEXP arg);
-SEXP vec_as_names(SEXP names, enum name_repair_arg type, bool quiet);
+struct name_repair_opts {
+  enum name_repair_type type;
+  SEXP fn;
+};
+
+static inline void PROTECT_NAME_REPAIR_OPTS(const struct name_repair_opts* opts) {
+  PROTECT(opts->fn);
+}
+
+SEXP vec_as_names(SEXP names, const struct name_repair_opts* opts, bool quiet);
+struct name_repair_opts validate_name_repair(SEXP name_repair);
+const char* name_repair_arg_as_c_string(enum name_repair_type type);
 bool is_unique_names(SEXP names);
 SEXP vec_as_unique_names(SEXP names, bool quiet);
 

--- a/src/names.h
+++ b/src/names.h
@@ -21,7 +21,7 @@ static inline void PROTECT_NAME_REPAIR_OPTS(const struct name_repair_opts* opts)
 }
 
 SEXP vec_as_names(SEXP names, const struct name_repair_opts* opts);
-struct name_repair_opts validate_name_repair(SEXP name_repair, bool quiet);
+struct name_repair_opts new_name_repair_opts(SEXP name_repair, bool quiet);
 const char* name_repair_arg_as_c_string(enum name_repair_type type);
 bool is_unique_names(SEXP names);
 SEXP vec_as_unique_names(SEXP names, bool quiet);

--- a/src/names.h
+++ b/src/names.h
@@ -13,14 +13,15 @@ enum name_repair_type {
 struct name_repair_opts {
   enum name_repair_type type;
   SEXP fn;
+  bool quiet;
 };
 
 static inline void PROTECT_NAME_REPAIR_OPTS(const struct name_repair_opts* opts) {
   PROTECT(opts->fn);
 }
 
-SEXP vec_as_names(SEXP names, const struct name_repair_opts* opts, bool quiet);
-struct name_repair_opts validate_name_repair(SEXP name_repair);
+SEXP vec_as_names(SEXP names, const struct name_repair_opts* opts);
+struct name_repair_opts validate_name_repair(SEXP name_repair, bool quiet);
 const char* name_repair_arg_as_c_string(enum name_repair_type type);
 bool is_unique_names(SEXP names);
 SEXP vec_as_unique_names(SEXP names, bool quiet);

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -60,13 +60,18 @@ static SEXP levels_union(SEXP x, SEXP y) {
   SET_VECTOR_ELT(args, 0, x);
   SET_VECTOR_ELT(args, 1, y);
 
+  const struct name_repair_opts name_repair_opts = {
+    .type = name_repair_none,
+    .fn = R_NilValue
+  };
+
   // Combine with known ptype
   // No name repair because this is just combining factor levels
   SEXP xy = PROTECT(vec_c(
     args,
     vctrs_shared_empty_chr,
     R_NilValue,
-    name_repair_none
+    &name_repair_opts
   ));
 
   SEXP out = vec_unique(xy);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1117,6 +1117,7 @@ SEXP syms_missing = NULL;
 SEXP syms_size = NULL;
 SEXP syms_subscript_action = NULL;
 SEXP syms_subscript_type = NULL;
+SEXP syms_repair = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -1343,6 +1344,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_size = Rf_install("size");
   syms_subscript_action = Rf_install("subscript_action");
   syms_subscript_type = Rf_install("subscript_type");
+  syms_repair = Rf_install("repair");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.c
+++ b/src/utils.c
@@ -818,19 +818,16 @@ SEXP r_new_environment(SEXP parent, R_len_t size) {
 static SEXP new_function_call = NULL;
 static SEXP new_function__formals_node = NULL;
 static SEXP new_function__body_node = NULL;
-static SEXP new_function__env_node = NULL;
 
 SEXP r_new_function(SEXP formals, SEXP body, SEXP env) {
   SETCAR(new_function__formals_node, formals);
   SETCAR(new_function__body_node, body);
-  SETCAR(new_function__env_node, env);
 
-  SEXP fn = Rf_eval(new_function_call, R_BaseEnv);
+  SEXP fn = Rf_eval(new_function_call, env);
 
   // Free for gc
   SETCAR(new_function__formals_node, R_NilValue);
   SETCAR(new_function__body_node, R_NilValue);
-  SETCAR(new_function__env_node, R_NilValue);
 
   return fn;
 }
@@ -1357,12 +1354,11 @@ void vctrs_init_utils(SEXP ns) {
   new_env__parent_node = CDDR(new_env_call);
   new_env__size_node = CDR(new_env__parent_node);
 
-  new_function_call = r_parse_eval("as.call(list(`function`, NULL, NULL, NULL))", R_BaseEnv);
+  new_function_call = r_parse_eval("as.call(list(`function`, NULL, NULL))", R_BaseEnv);
   R_PreserveObject(new_function_call);
 
   new_function__formals_node = CDR(new_function_call);
   new_function__body_node = CDR(new_function__formals_node);
-  new_function__env_node = CDR(new_function__body_node);
 
   const char* formals_code = "pairlist2(... = , .x = quote(..1), .y = quote(..2), . = quote(..1))";
   rlang_formula_formals = r_parse_eval(formals_code, ns);

--- a/src/utils.h
+++ b/src/utils.h
@@ -319,6 +319,7 @@ extern SEXP syms_missing;
 extern SEXP syms_size;
 extern SEXP syms_subscript_action;
 extern SEXP syms_subscript_type;
+extern SEXP syms_repair;
 
 #define syms_names R_NamesSymbol
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -283,7 +283,7 @@ SEXP vec_match(SEXP needles, SEXP haystack);
 SEXP vec_c(SEXP xs,
            SEXP ptype,
            SEXP name_spec,
-           enum name_repair_arg name_repair);
+           const struct name_repair_opts* name_repair);
 
 SEXP vec_type2(SEXP x,
                SEXP y,

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -170,6 +170,8 @@ test_that("can repair names in `vec_rbind()` (#229)", {
 
   expect_named(vec_rbind(list(`_` = 1)), "_")
   expect_named(vec_rbind(list(`_` = 1), .name_repair = "universal"), c("._"))
+
+  expect_named(vec_rbind(list(a = 1, a = 2), .name_repair = ~ toupper(.)), c("A", "A"))
 })
 
 test_that("can construct an id column", {
@@ -269,6 +271,7 @@ test_that("can repair names in `vec_cbind()` (#227)", {
   expect_named(vec_cbind(`_` = 1, .name_repair = "universal"), "._")
 
   expect_named(vec_cbind(a = 1, a = 2, .name_repair = "minimal"), c("a", "a"))
+  expect_named(vec_cbind(a = 1, a = 2, .name_repair = toupper), c("A", "A"))
 })
 
 test_that("can supply `.names_to` to `vec_rbind()` (#229)", {

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -104,6 +104,8 @@ test_that("vec_c() repairs names", {
   expect_error(vec_c(a = 1, a = 2, `_` = 3, .name_repair = "check_unique"), class = "vctrs_error_names_must_be_unique")
 
   expect_named(vec_c(a = 1, a = 2, `_` = 3, .name_repair = "universal"), c("a...1", "a...2", "._"))
+
+  expect_named(vec_c(a = 1, a = 2, .name_repair = ~ toupper(.)), c("A", "A"))
 })
 
 test_that("vec_c() doesn't use outer names for data frames (#524)", {

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -113,10 +113,10 @@ test_that("vec_as_names() repairs names before invoking repair function", {
   expect_identical(vec_as_names(chr(NA, NA), repair = identity), c("", ""))
 })
 
-test_that("validate_minimal() checks names", {
-  expect_error(validate_minimal(1), "must return a character vector")
-  expect_error(validate_minimal(NULL), "can't return `NULL`")
-  expect_error(validate_minimal(chr(NA)), "can't return `NA` values")
+test_that("validate_minimal_names() checks names", {
+  expect_error(validate_minimal_names(1), "must return a character vector")
+  expect_error(validate_minimal_names(NULL), "can't return `NULL`")
+  expect_error(validate_minimal_names(chr(NA)), "can't return `NA` values")
 })
 
 test_that("validate_unique() checks unique names", {

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -1,13 +1,5 @@
 context("test-names")
 
-
-# API -----------------------------------------------------------------
-
-test_that("Consistent values for repair argument", {
-  expect_identical(formals(validate_repair)$repair, formals(vec_as_names)$repair)
-  expect_identical(formals(validate_repair)$repair, formals(vec_names2)$repair)
-})
-
 # vec_names() ---------------------------------------------------------
 
 test_that("vec_names() retrieves names", {
@@ -109,7 +101,11 @@ test_that("vec_as_names() keeps the names of a named vector", {
 })
 
 test_that("vec_as_names() accepts and checks repair function", {
-  expect_identical(vec_as_names(c("", ""), repair = ~ rep_along(.x, "foo")), c("foo", "foo"))
+  f <- local({
+    local_obj <- "foo"
+    ~ rep_along(.x, local_obj)
+  })
+  expect_identical(vec_as_names(c("", ""), repair = f), c("foo", "foo"))
   expect_error(vec_as_names(c("", ""), repair = function(nms) "foo"), "length 1 instead of length 2")
 })
 
@@ -129,6 +125,17 @@ test_that("validate_unique() checks unique names", {
   expect_error(validate_unique(chr("a", "a")), class = "vctrs_error_names_must_be_unique")
   expect_error(validate_unique(chr("..1")), class = "vctrs_error_names_cannot_be_dot_dot")
   expect_error(validate_unique(chr("...")), class = "vctrs_error_names_cannot_be_dot_dot")
+})
+
+test_that("vec_as_names_validate() validates repair arguments", {
+  expect_identical(
+    validate_name_repair_arg(c("unique", "check_unique")),
+    "unique"
+  )
+  expect_identical(
+    validate_name_repair_arg(~ toupper(.))(letters),
+    LETTERS
+  )
 })
 
 


### PR DESCRIPTION
Closes #804
Closes tidyverse/tidyr#876

Implements `vec_as_names()` natively to merge the R and C code paths.