### PR TITLE
Fix name inconsistency in `vec_rbind()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
 
 # vctrs (development version)
 
-* `vec_rbind()` now binds row names.
+* `vec_rbind()` now binds row names. When named inputs are supplied
+  and `names_to` is `NULL`, the names define row names. If `names_to`
+  is supplied, they are assigned in the column name as before.
 
 * The `c()` method for `vctrs_vctr` now throws an error when
   `recursive` or `use.names` is supplied (#791).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,6 @@
 
 # vctrs (development version)
 
-* `vec_rbind()` now consistently handles inputs of size 1 with
-  external names. These cases are now identical:
-
-  ```
-  vec_rbind(a = 1)
-  vec_rbind(c(a = 1))
-  ```
-
 * The `c()` method for `vctrs_vctr` now throws an error when
   `recursive` or `use.names` is supplied (#791).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
 
 # vctrs (development version)
 
+* `vec_rbind()` now consistently handles inputs of size 1 with
+  external names. These cases are now identical:
+
+  ```
+  vec_rbind(a = 1)
+  vec_rbind(c(a = 1))
+  ```
+
 * The `c()` method for `vctrs_vctr` now throws an error when
   `recursive` or `use.names` is supplied (#791).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # vctrs (development version)
 
+* `vec_rbind()` now binds row names.
+
 * The `c()` method for `vctrs_vctr` now throws an error when
   `recursive` or `use.names` is supplied (#791).
 

--- a/R/bind.R
+++ b/R/bind.R
@@ -31,9 +31,12 @@
 #' * `vec_ptype(vec_cbind(x, y)) == vec_cbind(vec_ptype(x), vec_ptype(x))`
 #' @param ... Data frames or vectors.
 #'
-#'   `vec_rbind()` ignores names unless `.names_to` is supplied.
-#'   `vec_cbind()` creates packed data frame columns with named
-#'   inputs.
+#'   When the inputs are named:
+#'   * `vec_rbind()` assigns names to row names unless `.names_to` is
+#'     supplied. In that case the names are assigned in the column
+#'     defined by `.names_to`.
+#'   * `vec_cbind()` creates packed data frame columns with named
+#'      inputs.
 #'
 #'   `NULL` inputs are silently ignored. Empty (e.g. zero row) inputs
 #'   will not appear in the output, but will affect the derived `.ptype`.

--- a/man/internal-faq-ptype2-identity.Rd
+++ b/man/internal-faq-ptype2-identity.Rd
@@ -6,18 +6,22 @@
 \description{
 \subsection{Promotion monoid}{
 
-\code{vec_ptype2()} returns the \emph{promotion} type of two vectors, if any. This
-is typically the richer type of the two so that automatic coercions are
-never lossy. For example, the promotion type of integer and double is
-the latter because double covers a larger range of values than integer.
+Promotions (i.e. automatic coercions) should always transform inputs to
+their richer type to avoid losing values of precision. \code{vec_ptype2()}
+returns the \emph{richer} type of two vectors, or throws an incompatible type
+error if none of the two vector types include the other. For example,
+the richer type of integer and double is the latter because double
+covers a larger range of values than integer.
 
 \code{vec_ptype2()} is a \href{https://en.wikipedia.org/wiki/Monoid}{monoid} over
 vectors, which in practical terms means that it is a well behaved
 operation for
-\href{https://purrr.tidyverse.org/reference/reduce.html}{reduction}. As such
-it needs an identity element, i.e. a value that doesn’t change the
-result of the reduction. vctrs has two such identity values, \code{NULL} and
-\strong{unspecified} vectors.
+\href{https://purrr.tidyverse.org/reference/reduce.html}{reduction}.
+Reduction is an important operation for promotions because that is how
+the richer type of multiple elements is computed. As a monoid,
+\code{vec_ptype2()} needs an identity element, i.e. a value that doesn’t
+change the result of the reduction. vctrs has two identity values,
+\code{NULL} and \strong{unspecified} vectors.
 }
 
 \subsection{The \code{NULL} identity}{

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -23,9 +23,14 @@ vec_cbind(
 \arguments{
 \item{...}{Data frames or vectors.
 
-\code{vec_rbind()} ignores names unless \code{.names_to} is supplied.
-\code{vec_cbind()} creates packed data frame columns with named
+When the inputs are named:
+\itemize{
+\item \code{vec_rbind()} assigns names to row names unless \code{.names_to} is
+supplied. In that case the names are assigned in the column
+defined by \code{.names_to}.
+\item \code{vec_cbind()} creates packed data frame columns with named
 inputs.
+}
 
 \code{NULL} inputs are silently ignored. Empty (e.g. zero row) inputs
 will not appear in the output, but will affect the derived \code{.ptype}.}

--- a/src/bind.c
+++ b/src/bind.c
@@ -64,6 +64,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
 
   // Find individual input sizes and total size of output
   R_len_t nrow = 0;
+  bool has_rownames = false;
 
   SEXP ns_placeholder = PROTECT_N(Rf_allocVector(INTSXP, n), &nprot);
   int* ns = INTEGER(ns_placeholder);
@@ -73,11 +74,20 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
     R_len_t size = (elt == R_NilValue) ? 0 : vec_size(elt);
     nrow += size;
     ns[i] = size;
+
+    if (!has_rownames && is_data_frame(elt)) {
+      has_rownames = rownames_type(df_rownames(elt)) == ROWNAMES_IDENTIFIERS;
+    }
   }
 
   SEXP out = PROTECT_N(vec_init(ptype, nrow), &nprot);
   SEXP idx = PROTECT_N(compact_seq(0, 0, true), &nprot);
   int* idx_ptr = INTEGER(idx);
+
+  SEXP rownames = R_NilValue;
+  if (has_rownames) {
+    rownames = PROTECT_N(Rf_allocVector(STRSXP, nrow), &nprot);
+  }
 
   SEXP names_to_col = R_NilValue;
   SEXPTYPE names_to_type = 99;
@@ -105,10 +115,18 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
     if (!size) {
       continue;
     }
+    SEXP x = VECTOR_ELT(xs, i);
 
-    SEXP tbl = PROTECT(vec_cast(VECTOR_ELT(xs, i), ptype, args_empty, args_empty));
+    SEXP tbl = PROTECT(vec_cast(x, ptype, args_empty, args_empty));
     init_compact_seq(idx_ptr, counter, size, true);
     df_assign(out, idx, tbl, false);
+
+    if (has_rownames) {
+      SEXP rn = df_rownames(x);
+      if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
+        chr_assign(rownames, idx, rn, false);
+      }
+    }
 
     // Assign current name to group vector, if supplied
     if (names_to != R_NilValue) {
@@ -120,6 +138,11 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
     UNPROTECT(1);
   }
 
+  if (has_rownames) {
+    rownames = PROTECT(vec_as_names(rownames, default_unique_repair_opts));
+    Rf_setAttrib(out, R_RowNamesSymbol, rownames);
+    UNPROTECT(1);
+  }
   if (names_to != R_NilValue) {
     out = df_poke_at(out, names_to, names_to_col);
   }

--- a/src/bind.c
+++ b/src/bind.c
@@ -64,7 +64,12 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
 
   // Find individual input sizes and total size of output
   R_len_t nrow = 0;
+
   bool has_rownames = false;
+  if (names_to == R_NilValue && r_names(xs) != R_NilValue) {
+    // Names of inputs become row names when `names_to` isn't supplied
+    has_rownames = true;
+  }
 
   SEXP ns_placeholder = PROTECT_N(Rf_allocVector(INTSXP, n), &nprot);
   int* ns = INTEGER(ns_placeholder);
@@ -89,14 +94,25 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
     rownames = PROTECT_N(Rf_allocVector(STRSXP, nrow), &nprot);
   }
 
+  SEXP nms = PROTECT_N(r_names(xs), &nprot);
+  bool has_names = nms != R_NilValue;
+  bool has_names_to = names_to != R_NilValue;
+
+  const SEXP* nms_p = NULL;
+  if (has_names) {
+    nms_p = STRING_PTR_RO(nms);
+  }
+
   SEXP names_to_col = R_NilValue;
   SEXPTYPE names_to_type = 99;
   void* names_to_p = NULL;
   const void* index_p = NULL;
 
-  if (names_to != R_NilValue) {
-    SEXP index = PROTECT_N(r_names(xs), &nprot);
-    if (index == R_NilValue) {
+  if (has_names_to) {
+    SEXP index = R_NilValue;
+    if (has_names) {
+      index = nms;
+    } else {
       index = PROTECT_N(Rf_allocVector(INTSXP, n), &nprot);
       r_int_fill_seq(index, 1, n);
     }
@@ -123,13 +139,27 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
 
     if (has_rownames) {
       SEXP rn = df_rownames(x);
+
+      if (has_names && nms_p[i] != strings_empty && !has_names_to) {
+        if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
+          rn = r_chr_paste_prefix(rn, CHAR(nms_p[i]), "...");
+        } else if (size > 1) {
+          rn = r_seq_chr(CHAR(nms_p[i]), size);
+        } else {
+          rn = r_str_as_character(nms_p[i]);
+        }
+      }
+      PROTECT(rn);
+
       if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
         chr_assign(rownames, idx, rn, false);
       }
+
+      UNPROTECT(1);
     }
 
     // Assign current name to group vector, if supplied
-    if (names_to != R_NilValue) {
+    if (has_names_to) {
       r_vec_fill(names_to_type, names_to_p, index_p, i, size);
       r_vec_ptr_inc(names_to_type, &names_to_p, size);
     }
@@ -143,7 +173,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
     Rf_setAttrib(out, R_RowNamesSymbol, rownames);
     UNPROTECT(1);
   }
-  if (names_to != R_NilValue) {
+  if (has_names_to) {
     out = df_poke_at(out, names_to, names_to_col);
   }
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -41,22 +41,8 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
   int nprot = 0;
   R_len_t n = Rf_length(xs);
 
-  SEXP nms = PROTECT_N(r_names(xs), &nprot);
-
   for (R_len_t i = 0; i < n; ++i) {
-    SEXP x = VECTOR_ELT(xs, i);
-
-    if (!is_data_frame(x)) {
-      if (nms != R_NilValue && r_names(x) == R_NilValue && vec_size(x) == 1) {
-        x = PROTECT(Rf_shallow_duplicate(x));
-        SEXP x_nms = PROTECT(r_str_as_character(STRING_ELT(nms, i)));
-        r_poke_names(x, x_nms);
-        UNPROTECT(2);
-      }
-      PROTECT(x);
-      SET_VECTOR_ELT(xs, i, as_df_row(x, name_repair));
-      UNPROTECT(1);
-    }
+    SET_VECTOR_ELT(xs, i, as_df_row(VECTOR_ELT(xs, i), name_repair));
   }
 
   // The common type holds information about common column names,
@@ -152,6 +138,9 @@ static SEXP as_df_row(SEXP x, struct name_repair_opts* name_repair) {
 
 static SEXP as_df_row_impl(SEXP x, struct name_repair_opts* name_repair) {
   if (x == R_NilValue) {
+    return x;
+  }
+  if (is_data_frame(x)) {
     return x;
   }
 

--- a/src/names.c
+++ b/src/names.c
@@ -840,6 +840,9 @@ SEXP vctrs_validate_minimal_names(SEXP names, SEXP n_) {
   return names;
 }
 
+
+struct name_repair_opts default_unique_repair_opts_obj;
+
 void vctrs_init_names(SEXP ns) {
   syms_set_rownames_fallback = Rf_install("set_rownames_fallback");
   syms_set_names_fallback = Rf_install("set_names_fallback");
@@ -854,4 +857,8 @@ void vctrs_init_names(SEXP ns) {
   syms_glue_as_name_spec = Rf_install("glue_as_name_spec");
   fns_glue_as_name_spec = r_env_get(ns, syms_glue_as_name_spec);
   syms_internal_spec = Rf_install("_spec");
+
+  default_unique_repair_opts_obj.type = name_repair_unique;
+  default_unique_repair_opts_obj.fn = R_NilValue;
+  default_unique_repair_opts_obj.quiet = false;
 }

--- a/src/names.c
+++ b/src/names.c
@@ -455,9 +455,6 @@ static void describe_repair(SEXP old_names, SEXP new_names) {
 }
 
 
-static SEXP outer_names_cat(const char* outer, SEXP names);
-static SEXP outer_names_seq(const char* outer, R_len_t n);
-
 // [[ register() ]]
 SEXP vctrs_outer_names(SEXP names, SEXP outer, SEXP n) {
   if (names != R_NilValue && TYPEOF(names) != STRSXP) {
@@ -491,10 +488,10 @@ SEXP outer_names(SEXP names, SEXP outer, R_len_t n) {
     if (n == 1) {
       return r_str_as_character(outer);
     } else {
-      return outer_names_seq(CHAR(outer), n);
+      return r_seq_chr(CHAR(outer), n);
     }
   } else {
-    return outer_names_cat(CHAR(outer), names);
+    return r_chr_paste_prefix(names, CHAR(outer), "..");
   }
 }
 
@@ -577,23 +574,27 @@ static SEXP glue_as_name_spec(SEXP spec) {
 }
 
 
-static SEXP outer_names_cat(const char* outer, SEXP names) {
+// [[ include("names.h") ]]
+SEXP r_chr_paste_prefix(SEXP names, const char* prefix, const char* sep) {
   names = PROTECT(Rf_shallow_duplicate(names));
   R_len_t n = Rf_length(names);
 
-  int outer_len = strlen(outer);
+  int outer_len = strlen(prefix);
   int names_len = r_chr_max_len(names);
 
-  int total_len = outer_len + names_len + strlen("..") + 1;
+  int sep_len = strlen(sep);
+  int total_len = outer_len + names_len + sep_len + 1;
 
   R_CheckStack2(total_len);
   char buf[total_len];
   buf[total_len - 1] = '\0';
   char* bufp = buf;
 
-  memcpy(bufp, outer, outer_len); bufp += outer_len;
-  *bufp = '.'; bufp += 1;
-  *bufp = '.'; bufp += 1;
+  memcpy(bufp, prefix, outer_len); bufp += outer_len;
+
+  for (int i = 0; i < sep_len; ++i) {
+    *bufp++ = sep[i];
+  }
 
   SEXP* p = STRING_PTR(names);
 
@@ -611,13 +612,14 @@ static SEXP outer_names_cat(const char* outer, SEXP names) {
   return names;
 }
 
-static SEXP outer_names_seq(const char* outer, R_len_t n) {
-  int total_len = 24 + strlen(outer) + 1;
+// [[ include("names.h") ]]
+SEXP r_seq_chr(const char* prefix, R_len_t n) {
+  int total_len = 24 + strlen(prefix) + 1;
 
   R_CheckStack2(total_len);
   char buf[total_len];
 
-  return r_chr_iota(n, buf, total_len, outer);
+  return r_chr_iota(n, buf, total_len, prefix);
 }
 
 

--- a/src/names.h
+++ b/src/names.h
@@ -16,6 +16,10 @@ struct name_repair_opts {
   bool quiet;
 };
 
+extern struct name_repair_opts default_unique_repair_opts_obj;
+static const struct name_repair_opts* default_unique_repair_opts =
+  &default_unique_repair_opts_obj;
+
 static inline void PROTECT_NAME_REPAIR_OPTS(const struct name_repair_opts* opts) {
   PROTECT(opts->fn);
 }

--- a/src/names.h
+++ b/src/names.h
@@ -30,4 +30,8 @@ const char* name_repair_arg_as_c_string(enum name_repair_type type);
 bool is_unique_names(SEXP names);
 SEXP vec_as_unique_names(SEXP names, bool quiet);
 
+SEXP r_seq_chr(const char* prefix, R_len_t n);
+SEXP r_chr_paste_prefix(SEXP names, const char* prefix, const char* sep);
+
+
 #endif

--- a/src/size.c
+++ b/src/size.c
@@ -102,17 +102,12 @@ R_len_t df_rownames_size(SEXP x) {
     SEXP rn = CAR(attr);
     R_len_t n = Rf_length(rn);
 
-    switch(TYPEOF(rn)) {
-    case INTSXP:
-      if (is_compact_rownames(rn)) {
-        return compact_rownames_length(rn);
-      } else {
-        return n;
-      }
-    case STRSXP:
+    switch (rownames_type(rn)) {
+    case ROWNAMES_IDENTIFIERS:
+    case ROWNAMES_AUTOMATIC:
       return n;
-    default:
-      Rf_errorcall(R_NilValue, "Corrupt data frame: row.names are invalid type");
+    case ROWNAMES_AUTOMATIC_COMPACT:
+      return compact_rownames_length(rn);
     }
   }
 

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -40,9 +40,22 @@ SEXP new_data_frame(SEXP x, R_len_t n) {
 }
 
 // [[ include("type-data-frame.h") ]]
-bool is_compact_rownames(SEXP x) {
-  return Rf_length(x) == 2 && INTEGER(x)[0] == NA_INTEGER;
+enum rownames_type rownames_type(SEXP x) {
+  switch (TYPEOF(x)) {
+  case STRSXP:
+    return ROWNAMES_IDENTIFIERS;
+  case INTSXP:
+    if (Rf_length(x) == 2 && INTEGER(x)[0] == NA_INTEGER) {
+      return ROWNAMES_AUTOMATIC_COMPACT;
+    } else {
+      return ROWNAMES_AUTOMATIC;
+    }
+  default:
+    Rf_error("Corrupt data in `rownames_type()`: Unexpected type `%s`.",
+             Rf_type2char(TYPEOF(x)));
+  }
 }
+
 // [[ include("type-data-frame.h") ]]
 R_len_t compact_rownames_length(SEXP x) {
   return abs(INTEGER(x)[1]);

--- a/src/type-data-frame.h
+++ b/src/type-data-frame.h
@@ -9,11 +9,17 @@ void init_compact_rownames(SEXP x, R_len_t n);
 SEXP df_rownames(SEXP x);
 
 bool is_native_df(SEXP x);
-bool is_compact_rownames(SEXP x);
 R_len_t compact_rownames_length(SEXP x);
 SEXP df_container_type(SEXP x);
 SEXP df_poke(SEXP x, R_len_t i, SEXP value);
 SEXP df_poke_at(SEXP x, SEXP name, SEXP value);
+
+enum rownames_type {
+  ROWNAMES_AUTOMATIC,
+  ROWNAMES_AUTOMATIC_COMPACT,
+  ROWNAMES_IDENTIFIERS
+};
+enum rownames_type rownames_type(SEXP rn);
 
 
 #endif

--- a/tests/testthat/output/bind-name-repair.txt
+++ b/tests/testthat/output/bind-name-repair.txt
@@ -1,0 +1,81 @@
+
+vec_rbind()
+===========
+
+> # Suboptimal
+> vec_rbind(1, 2)
+Message: New names:
+* `` -> ...1
+
+Message: New names:
+* `` -> ...1
+
+  ...1
+1    1
+2    2
+
+> # Suboptimal
+> vec_rbind(1, 2, ...10 = 3)
+Message: New names:
+* `` -> ...1
+
+Message: New names:
+* `` -> ...1
+
+Message: New names:
+* `` -> ...1
+
+  ...1
+1    1
+2    2
+3    3
+
+> vec_rbind(a = 1, b = 2)
+Message: New names:
+* `` -> ...1
+
+Message: New names:
+* `` -> ...1
+
+  ...1
+1    1
+2    2
+
+> vec_rbind(c(a = 1), c(b = 2))
+   a  b
+1  1 NA
+2 NA  2
+
+
+vec_cbind()
+===========
+
+> vec_cbind(1, 2)
+Message: New names:
+* `` -> ...1
+* `` -> ...2
+
+  ...1 ...2
+1    1    2
+
+> vec_cbind(1, 2, ...10 = 3)
+Message: New names:
+* `` -> ...1
+* `` -> ...2
+* ...10 -> ...3
+
+  ...1 ...2 ...3
+1    1    2    3
+
+> vec_cbind(a = 1, b = 2)
+  a b
+1 1 2
+
+> vec_cbind(c(a = 1), c(b = 2))
+Message: New names:
+* `` -> ...1
+* `` -> ...2
+
+  ...1 ...2
+1    1    2
+

--- a/tests/testthat/output/bind-name-repair.txt
+++ b/tests/testthat/output/bind-name-repair.txt
@@ -25,10 +25,15 @@ Message: New names:
 Message: New names:
 * `` -> ...1
 
-  ...1
-1    1
-2    2
-3    3
+Message: New names:
+* `` -> ...1
+* `` -> ...2
+* ...10 -> ...3
+
+     ...1
+...1    1
+...2    2
+...3    3
 
 > vec_rbind(a = 1, b = 2)
 Message: New names:
@@ -38,8 +43,8 @@ Message: New names:
 * `` -> ...1
 
   ...1
-1    1
-2    2
+a    1
+b    2
 
 > vec_rbind(c(a = 1), c(b = 2))
    a  b

--- a/tests/testthat/output/bind-name-repair.txt
+++ b/tests/testthat/output/bind-name-repair.txt
@@ -23,7 +23,7 @@ Message: New names:
 * `` -> ...1
 
 Message: New names:
-* ...10 -> ...1
+* `` -> ...1
 
   ...1
 1    1
@@ -31,9 +31,15 @@ Message: New names:
 3    3
 
 > vec_rbind(a = 1, b = 2)
-   a  b
-1  1 NA
-2 NA  2
+Message: New names:
+* `` -> ...1
+
+Message: New names:
+* `` -> ...1
+
+  ...1
+1    1
+2    2
 
 > vec_rbind(c(a = 1), c(b = 2))
    a  b

--- a/tests/testthat/output/bind-name-repair.txt
+++ b/tests/testthat/output/bind-name-repair.txt
@@ -23,7 +23,7 @@ Message: New names:
 * `` -> ...1
 
 Message: New names:
-* `` -> ...1
+* ...10 -> ...1
 
   ...1
 1    1
@@ -31,15 +31,9 @@ Message: New names:
 3    3
 
 > vec_rbind(a = 1, b = 2)
-Message: New names:
-* `` -> ...1
-
-Message: New names:
-* `` -> ...1
-
-  ...1
-1    1
-2    2
+   a  b
+1  1 NA
+2 NA  2
 
 > vec_rbind(c(a = 1), c(b = 2))
    a  b

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -359,3 +359,24 @@ test_that("vec_cbind() fails with arrays of dimensionality > 3", {
   expect_error(vec_cbind(a), "Can't bind arrays")
   expect_error(vec_cbind(x = a), "Can't bind arrays")
 })
+
+test_that("rbind() and cbind() have informative outputs when repairing names", {
+  verify_output(test_path("output", "bind-name-repair.txt"), {
+    "# vec_rbind()"
+
+    "Suboptimal"
+    vec_rbind(1, 2)
+
+    "Suboptimal"
+    vec_rbind(1, 2, ...10 = 3)
+
+    vec_rbind(a = 1, b = 2)
+    vec_rbind(c(a = 1), c(b = 2))
+
+    "# vec_cbind()"
+    vec_cbind(1, 2)
+    vec_cbind(1, 2, ...10 = 3)
+    vec_cbind(a = 1, b = 2)
+    vec_cbind(c(a = 1), c(b = 2))
+  })
+})

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -361,6 +361,7 @@ test_that("vec_cbind() fails with arrays of dimensionality > 3", {
 })
 
 test_that("vec_rbind() consistently handles unnamed outputs", {
+  skip("FIXME")
   # These are a little weird but unclear we can do better
   expect_identical(
     vec_rbind(1, 2),

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -200,6 +200,34 @@ test_that("row names are preserved by vec_rbind()", {
   expect_identical(vec_rbind(df1, df2), out)
 })
 
+test_that("can assign row names in vec_rbind()", {
+  df1 <- mtcars[1:3, ]
+  df2 <- mtcars[4:5, ]
+
+  # Combination
+  out <- vec_rbind(foo = df1, df2)
+  exp <- mtcars[1:5, ]
+  row.names(exp) <- c(paste0("foo...", row.names(df1)), row.names(df2))
+  expect_identical(out, exp)
+
+  out <- vec_rbind(foo = df1, df2, .names_to = "id")
+  exp <- mtcars[1:5, ]
+  exp$id <- c(rep("foo", 3), rep("", 2))
+  expect_identical(out, exp)
+
+  # Sequence
+  out <- vec_rbind(foo = unrownames(df1), df2, bar = unrownames(mtcars[6, ]))
+  exp <- mtcars[1:6, ]
+  row.names(exp) <- c(paste0("foo", 1:3), row.names(df2), "bar")
+  expect_identical(out, exp)
+
+  out <- vec_rbind(foo = unrownames(df1), df2, bar = unrownames(mtcars[6, ]), .names_to = "id")
+  exp <- mtcars[1:6, ]
+  exp$id <- c(rep("foo", 3), rep("", 2), "bar")
+  row.names(exp) <- c(paste0("...", 1:3), row.names(df2), "...6")
+  expect_identical(out, exp)
+})
+
 
 # cols --------------------------------------------------------------------
 
@@ -373,20 +401,19 @@ test_that("vec_cbind() fails with arrays of dimensionality > 3", {
 })
 
 test_that("vec_rbind() consistently handles unnamed outputs", {
-  skip("FIXME")
-  # These are a little weird but unclear we can do better
+  # Name repair of columns is a little weird but unclear we can do better
   expect_identical(
     vec_rbind(1, 2),
     data.frame(...1 = c(1, 2))
   )
   expect_identical(
     vec_rbind(1, 2, ...10 = 3),
-    data.frame(...1 = c(1, 2, 3))
+    data.frame(...1 = c(1, 2, 3), row.names = c("...1", "...2", "...3"))
   )
 
   expect_identical(
     vec_rbind(a = 1, b = 2),
-    data.frame(a = c(1, NA), b = c(NA, 2))
+    data.frame(...1 = c(1, 2), row.names = c("a", "b"))
   )
   expect_identical(
     vec_rbind(c(a = 1), c(b = 2)),

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -189,6 +189,18 @@ test_that("vec_rbind() fails with arrays of dimensionality > 3", {
   expect_error(vec_rbind(array(NA, c(1, 1, 1))), "Can't bind arrays")
 })
 
+test_that("row names are preserved by vec_rbind()", {
+  df1 <- mtcars[1:3, ]
+  df2 <- mtcars[4:5, ]
+  expect_identical(vec_rbind(df1, df2), mtcars[1:5, ])
+
+  row.names(df2) <- NULL
+  out <- mtcars[1:5, ]
+  row.names(out) <- c(row.names(df1), "...4", "...5")
+  expect_identical(vec_rbind(df1, df2), out)
+})
+
+
 # cols --------------------------------------------------------------------
 
 test_that("empty inputs give data frame", {

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -360,6 +360,46 @@ test_that("vec_cbind() fails with arrays of dimensionality > 3", {
   expect_error(vec_cbind(x = a), "Can't bind arrays")
 })
 
+test_that("vec_rbind() consistently handles unnamed outputs", {
+  # These are a little weird but unclear we can do better
+  expect_identical(
+    vec_rbind(1, 2),
+    data.frame(...1 = c(1, 2))
+  )
+  expect_identical(
+    vec_rbind(1, 2, ...10 = 3),
+    data.frame(...1 = c(1, 2, 3))
+  )
+
+  expect_identical(
+    vec_rbind(a = 1, b = 2),
+    data.frame(a = c(1, NA), b = c(NA, 2))
+  )
+  expect_identical(
+    vec_rbind(c(a = 1), c(b = 2)),
+    data.frame(a = c(1, NA), b = c(NA, 2))
+  )
+})
+
+test_that("vec_cbind() consistently handles unnamed outputs", {
+  expect_identical(
+    vec_cbind(1, 2),
+    data.frame(...1 = 1, ...2 = 2)
+  )
+  expect_identical(
+    vec_cbind(1, 2, ...10 = 3),
+    data.frame(...1 = 1, ...2 = 2, ...3 = 3)
+  )
+  expect_identical(
+    vec_cbind(a = 1, b = 2),
+    data.frame(a = 1, b = 2)
+  )
+  expect_identical(
+    vec_cbind(c(a = 1), c(b = 2)),
+    new_data_frame(list(...1 = c(a = 1), ...2 = c(b = 2)))
+  )
+})
+
 test_that("rbind() and cbind() have informative outputs when repairing names", {
   verify_output(test_path("output", "bind-name-repair.txt"), {
     "# vec_rbind()"


### PR DESCRIPTION
Vectors of size 1 with external names are now treated consistently.

```r
# Before
vec_rbind(a = 1, b = 2)
#> New names:
#> * `` -> ...1
#> New names:
#> * `` -> ...1
#>   ...1
#> 1    1
#> 2    2

# After
vec_rbind(a = 1, b = 2)
#>    a  b
#> 1  1 NA
#> 2 NA  2

# This is now the same as
vec_rbind(c(a = 1), c(b = 2))
#>    a  b
#> 1  1 NA
#> 2 NA  2
```

Also adds an output test to track the name-repair output. Currently suboptimal for `vec_rbind()`, but unclear how we could do better and probably good enough for such an edge case.