### PR TITLE
Add native handling of `unspecified()`

### DIFF
--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -86,11 +86,11 @@ vec_ptype2.list <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 #' @method vec_ptype2.logical logical
 #' @export
 vec_ptype2.logical.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
-  # Special case `vec_ptype2(NA, NA)` to ensure that
-  # `unspecified()` is returned
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else if (is_unspecified(x) && is_unspecified(y)) {
+    # Special case `vec_ptype2(NA, NA)` to ensure that
+    # `unspecified()` is returned
     unspecified()
   } else {
     shape_match(logical(), x, y)

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -86,8 +86,12 @@ vec_ptype2.list <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 #' @method vec_ptype2.logical logical
 #' @export
 vec_ptype2.logical.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  # Special case `vec_ptype2(NA, NA)` to ensure that
+  # `unspecified()` is returned
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
+  } else if (is_unspecified(x) && is_unspecified(y)) {
+    unspecified()
   } else {
     shape_match(logical(), x, y)
   }

--- a/man/internal-faq-ptype2-identity.Rd
+++ b/man/internal-faq-ptype2-identity.Rd
@@ -77,7 +77,7 @@ vctrs has an internal vector type of class \code{vctrs_unspecified}. Users
 normally don’t see such vectors in the wild, but they do come up when
 taking the common type of an unspecified vector with another identity
 value:\if{html}{\out{<div class="r">}}\preformatted{vec_ptype2(NA, NA)
-#> logical(0)
+#> <unspecified> [0]
 vec_ptype2(NA, NULL)
 #> <unspecified> [0]
 vec_ptype2(NULL, NA)

--- a/src/cast-dispatch.c
+++ b/src/cast-dispatch.c
@@ -8,8 +8,6 @@ static SEXP vec_cast_dispatch2(SEXP x,
                                struct vctrs_arg* x_arg,
                                struct vctrs_arg* to_arg);
 
-static SEXP vec_cast_dispatch_unspecified_s3(SEXP x, SEXP to);
-
 // [[ include("vctrs.h") ]]
 SEXP vec_cast_dispatch(SEXP x,
                        SEXP to,
@@ -18,10 +16,6 @@ SEXP vec_cast_dispatch(SEXP x,
                        bool* lossy,
                        struct vctrs_arg* x_arg,
                        struct vctrs_arg* to_arg) {
-  if (x_type == vctrs_type_unspecified) {
-    return vec_cast_dispatch_unspecified_s3(x, to);
-  }
-
   switch (to_type) {
   case vctrs_type_character:
     switch (class_type(x)) {
@@ -93,30 +87,4 @@ static SEXP vec_cast_dispatch2(SEXP x, SEXP to,
   }
 
   return R_NilValue;
-}
-
-// For known bare classes, we can immediately call `vec_init()`.
-// Otherwise, we have to allow R level dispatch.
-static SEXP vec_cast_dispatch_unspecified_s3(SEXP x, SEXP to) {
-  switch(class_type(to)) {
-  case vctrs_class_bare_data_frame:
-  case vctrs_class_bare_tibble:
-  case vctrs_class_bare_factor:
-  case vctrs_class_bare_ordered:
-  case vctrs_class_bare_date:
-  case vctrs_class_bare_posixct:
-  case vctrs_class_bare_posixlt:
-    return vec_init(to, vec_size(x));
-
-  case vctrs_class_rcrd:
-  case vctrs_class_data_frame:
-  case vctrs_class_posixlt:
-  case vctrs_class_unknown:
-    return R_NilValue;
-
-  case vctrs_class_none:
-    Rf_errorcall(R_NilValue, "Internal error: The non-unspecified object should be S3");
-  }
-
-  never_reached("vec_cast_dispatch_unspecified_s3");
 }

--- a/src/cast-dispatch.c
+++ b/src/cast-dispatch.c
@@ -117,4 +117,6 @@ static SEXP vec_cast_dispatch_unspecified_s3(SEXP x, SEXP to) {
   case vctrs_class_none:
     Rf_errorcall(R_NilValue, "Internal error: The non-unspecified object should be S3");
   }
+
+  never_reached("vec_cast_dispatch_unspecified_s3");
 }

--- a/src/cast-dispatch.c
+++ b/src/cast-dispatch.c
@@ -8,6 +8,8 @@ static SEXP vec_cast_dispatch2(SEXP x,
                                struct vctrs_arg* x_arg,
                                struct vctrs_arg* to_arg);
 
+static SEXP vec_cast_dispatch_unspecified_s3(SEXP x, SEXP to);
+
 // [[ include("vctrs.h") ]]
 SEXP vec_cast_dispatch(SEXP x,
                        SEXP to,
@@ -16,6 +18,10 @@ SEXP vec_cast_dispatch(SEXP x,
                        bool* lossy,
                        struct vctrs_arg* x_arg,
                        struct vctrs_arg* to_arg) {
+  if (x_type == vctrs_type_unspecified) {
+    return vec_cast_dispatch_unspecified_s3(x, to);
+  }
+
   switch (to_type) {
   case vctrs_type_character:
     switch (class_type(x)) {
@@ -87,4 +93,28 @@ static SEXP vec_cast_dispatch2(SEXP x, SEXP to,
   }
 
   return R_NilValue;
+}
+
+// For known bare classes, we can immediately call `vec_init()`.
+// Otherwise, we have to allow R level dispatch.
+static SEXP vec_cast_dispatch_unspecified_s3(SEXP x, SEXP to) {
+  switch(class_type(to)) {
+  case vctrs_class_bare_data_frame:
+  case vctrs_class_bare_tibble:
+  case vctrs_class_bare_factor:
+  case vctrs_class_bare_ordered:
+  case vctrs_class_bare_date:
+  case vctrs_class_bare_posixct:
+  case vctrs_class_bare_posixlt:
+    return vec_init(to, vec_size(x));
+
+  case vctrs_class_rcrd:
+  case vctrs_class_data_frame:
+  case vctrs_class_posixlt:
+  case vctrs_class_unknown:
+    return R_NilValue;
+
+  case vctrs_class_none:
+    Rf_errorcall(R_NilValue, "Internal error: The non-unspecified object should be S3");
+  }
 }

--- a/src/cast.c
+++ b/src/cast.c
@@ -380,6 +380,8 @@ static SEXP vec_cast_dispatch_unspecified(SEXP x, SEXP to, enum vctrs_type to_ty
   case vctrs_type_null:
     Rf_errorcall(R_NilValue, "Internal error: NULL inputs should have been handled earlier.");
   }
+
+  never_reached("vec_cast_dispatch_unspecified");
 }
 
 // [[ register() ]]

--- a/src/cast.c
+++ b/src/cast.c
@@ -267,16 +267,21 @@ static SEXP df_as_dataframe(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vct
   return out;
 }
 
+static SEXP vec_cast_dispatch_unspecified(SEXP x,
+                                          SEXP to,
+                                          struct vctrs_arg* to_arg,
+                                          enum vctrs_type to_type);
+
 static SEXP vec_cast_switch(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg) {
   enum vctrs_type to_type = vec_typeof(to);
   enum vctrs_type x_type = vec_typeof(x);
 
-  if (x_type == vctrs_type_unspecified) {
-    return vec_init(to, vec_size(x));
-  }
-
   if (to_type == vctrs_type_s3 || x_type == vctrs_type_s3) {
     return vec_cast_dispatch(x, to, x_type, to_type, lossy, x_arg, to_arg);
+  }
+
+  if (x_type == vctrs_type_unspecified) {
+    return vec_cast_dispatch_unspecified(x, to, to_arg, to_type);
   }
 
   switch (to_type) {
@@ -353,6 +358,34 @@ static SEXP vec_cast_switch(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_ar
   }
 
   return R_NilValue;
+}
+
+static SEXP vec_cast_dispatch_unspecified(SEXP x,
+                                          SEXP to,
+                                          struct vctrs_arg* to_arg,
+                                          enum vctrs_type to_type) {
+  switch(to_type) {
+  case vctrs_type_logical:
+  case vctrs_type_integer:
+  case vctrs_type_double:
+  case vctrs_type_character:
+  case vctrs_type_complex:
+  case vctrs_type_raw:
+  case vctrs_type_list:
+  case vctrs_type_dataframe:
+  case vctrs_type_unspecified:
+    return vec_init(to, vec_size(x));
+
+  // Allow R level error handling to take over
+  case vctrs_type_scalar:
+    return R_NilValue;
+
+  case vctrs_type_s3:
+    Rf_errorcall(R_NilValue, "Internal error: s3 inputs should have been handled earlier.");
+
+  case vctrs_type_null:
+    Rf_errorcall(R_NilValue, "Internal error: NULL inputs should have been handled earlier.");
+  }
 }
 
 // [[ register() ]]

--- a/src/cast.c
+++ b/src/cast.c
@@ -267,10 +267,7 @@ static SEXP df_as_dataframe(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vct
   return out;
 }
 
-static SEXP vec_cast_dispatch_unspecified(SEXP x,
-                                          SEXP to,
-                                          struct vctrs_arg* to_arg,
-                                          enum vctrs_type to_type);
+static SEXP vec_cast_dispatch_unspecified(SEXP x, SEXP to, enum vctrs_type to_type);
 
 static SEXP vec_cast_switch(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg) {
   enum vctrs_type to_type = vec_typeof(to);
@@ -281,7 +278,7 @@ static SEXP vec_cast_switch(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_ar
   }
 
   if (x_type == vctrs_type_unspecified) {
-    return vec_cast_dispatch_unspecified(x, to, to_arg, to_type);
+    return vec_cast_dispatch_unspecified(x, to, to_type);
   }
 
   switch (to_type) {
@@ -360,10 +357,7 @@ static SEXP vec_cast_switch(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_ar
   return R_NilValue;
 }
 
-static SEXP vec_cast_dispatch_unspecified(SEXP x,
-                                          SEXP to,
-                                          struct vctrs_arg* to_arg,
-                                          enum vctrs_type to_type) {
+static SEXP vec_cast_dispatch_unspecified(SEXP x, SEXP to, enum vctrs_type to_type) {
   switch(to_type) {
   case vctrs_type_logical:
   case vctrs_type_integer:

--- a/src/cast.c
+++ b/src/cast.c
@@ -271,6 +271,13 @@ static SEXP vec_cast_switch(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_ar
   enum vctrs_type x_type = vec_typeof(x);
   enum vctrs_type to_type = vec_typeof(to);
 
+  if (x_type == vctrs_type_scalar) {
+    stop_scalar_type(x, x_arg);
+  }
+  if (to_type == vctrs_type_scalar) {
+    stop_scalar_type(to, to_arg);
+  }
+
   if (x_type == vctrs_type_unspecified) {
     return vec_init(to, vec_size(x));
   }

--- a/src/cast.c
+++ b/src/cast.c
@@ -271,6 +271,10 @@ static SEXP vec_cast_switch(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_ar
   enum vctrs_type to_type = vec_typeof(to);
   enum vctrs_type x_type = vec_typeof(x);
 
+  if (x_type == vctrs_type_unspecified) {
+    return vec_init(to, vec_size(x));
+  }
+
   if (to_type == vctrs_type_s3 || x_type == vctrs_type_s3) {
     return vec_cast_dispatch(x, to, x_type, to_type, lossy, x_arg, to_arg);
   }

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -66,6 +66,31 @@ void stop_recycle_incompatible_size(R_len_t x_size, R_len_t size,
   Rf_error("Internal error: `stop_recycle_incompatible_size()` should have jumped earlier");
 }
 
+void stop_incompatible_type(SEXP x,
+                            SEXP y,
+                            struct vctrs_arg* x_arg,
+                            struct vctrs_arg* y_arg) {
+  SEXP syms[5] = {
+    syms_x,
+    syms_y,
+    r_sym("x_arg"),
+    r_sym("y_arg"),
+    NULL
+  };
+  SEXP args[5] = {
+    PROTECT(r_protect(x)),
+    PROTECT(r_protect(y)),
+    PROTECT(vctrs_arg(x_arg)),
+    PROTECT(vctrs_arg(y_arg)),
+    NULL
+  };
+
+  SEXP call = PROTECT(r_call(r_sym("stop_incompatible_type"), syms, args));
+  Rf_eval(call, vctrs_ns_env);
+
+  Rf_error("Internal error: `stop_incompatible_type()` should have jumped earlier");
+}
+
 void stop_corrupt_factor_levels(SEXP x, struct vctrs_arg* arg) {
   SEXP call = PROTECT(Rf_lang3(Rf_install("stop_corrupt_factor_levels"),
                                PROTECT(r_protect(x)),

--- a/src/ptype2-dispatch.c
+++ b/src/ptype2-dispatch.c
@@ -79,6 +79,8 @@ static SEXP vec_ptype2_dispatch_unspecified_s3(SEXP x,
   case vctrs_class_none:
     Rf_errorcall(R_NilValue, "Internal error: The non-unspecified object should be S3");
   }
+
+  never_reached("vec_ptype2_dispatch_unspecified_s3");
 }
 
 // Initialised at load time

--- a/src/ptype2-dispatch.c
+++ b/src/ptype2-dispatch.c
@@ -1,6 +1,12 @@
 #include "vctrs.h"
 #include "utils.h"
 
+static SEXP vec_ptype2_dispatch_unspecified_s3(SEXP x,
+                                               SEXP y,
+                                               struct vctrs_arg* x_arg,
+                                               struct vctrs_arg* y_arg,
+                                               bool left_unspecified);
+
 // [[ include("vctrs.h") ]]
 SEXP vec_ptype2_dispatch(SEXP x, SEXP y,
                          enum vctrs_type x_type,
@@ -8,6 +14,13 @@ SEXP vec_ptype2_dispatch(SEXP x, SEXP y,
                          struct vctrs_arg* x_arg,
                          struct vctrs_arg* y_arg,
                          int* left) {
+  if (x_type == vctrs_type_unspecified) {
+    return vec_ptype2_dispatch_unspecified_s3(x, y, x_arg, y_arg, true);
+  }
+  if (y_type == vctrs_type_unspecified) {
+    return vec_ptype2_dispatch_unspecified_s3(x, y, x_arg, y_arg, false);
+  }
+
   enum vctrs_type2_s3 type2_s3 = vec_typeof2_s3_impl(x, y, x_type, y_type, left);
 
   switch (type2_s3) {
@@ -35,6 +48,36 @@ SEXP vec_ptype2_dispatch(SEXP x, SEXP y,
 
   default:
     return vec_ptype2_dispatch_s3(x, y, x_arg, y_arg);
+  }
+}
+
+// Be explicit about allowing known bare classes to directly call `vec_type()`.
+// Unknown classes must go through R level dispatch.
+static SEXP vec_ptype2_dispatch_unspecified_s3(SEXP x,
+                                               SEXP y,
+                                               struct vctrs_arg* x_arg,
+                                               struct vctrs_arg* y_arg,
+                                               bool left_unspecified) {
+  enum vctrs_class_type type = left_unspecified ? class_type(y) : class_type(x);
+
+  switch(type) {
+  case vctrs_class_bare_data_frame:
+  case vctrs_class_bare_tibble:
+  case vctrs_class_bare_factor:
+  case vctrs_class_bare_ordered:
+  case vctrs_class_bare_date:
+  case vctrs_class_bare_posixct:
+  case vctrs_class_bare_posixlt:
+    return left_unspecified ? vec_type(y) : vec_type(x);
+
+  case vctrs_class_rcrd:
+  case vctrs_class_data_frame:
+  case vctrs_class_posixlt:
+  case vctrs_class_unknown:
+    return vec_ptype2_dispatch_s3(x, y, x_arg, y_arg);
+
+  case vctrs_class_none:
+    Rf_errorcall(R_NilValue, "Internal error: The non-unspecified object should be S3");
   }
 }
 

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -77,9 +77,10 @@ SEXP vec_assign_impl(SEXP proxy, SEXP index, SEXP value, bool clone) {
   case vctrs_type_raw:         return raw_assign(proxy, index, value, clone);
   case vctrs_type_list:        return list_assign(proxy, index, value, clone);
   case vctrs_type_dataframe:   return df_assign(proxy, index, value, clone);
-  case vctrs_type_s3:
+  case vctrs_type_null:
   case vctrs_type_unspecified:
-  case vctrs_type_null:        Rf_error("Internal error in `vec_assign_impl()`: Unexpected type %s.",
+  case vctrs_type_s3:
+                               Rf_error("Internal error in `vec_assign_impl()`: Unexpected type %s.",
                                         vec_type_as_str(vec_typeof(proxy)));
   case vctrs_type_scalar:      stop_scalar_type(proxy, args_empty);
   }

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -69,18 +69,19 @@ SEXP vec_assign(SEXP x, SEXP index, SEXP value) {
  */
 SEXP vec_assign_impl(SEXP proxy, SEXP index, SEXP value, bool clone) {
   switch (vec_proxy_typeof(proxy)) {
-  case vctrs_type_logical:   return lgl_assign(proxy, index, value, clone);
-  case vctrs_type_integer:   return int_assign(proxy, index, value, clone);
-  case vctrs_type_double:    return dbl_assign(proxy, index, value, clone);
-  case vctrs_type_complex:   return cpl_assign(proxy, index, value, clone);
-  case vctrs_type_character: return chr_assign(proxy, index, value, clone);
-  case vctrs_type_raw:       return raw_assign(proxy, index, value, clone);
-  case vctrs_type_list:      return list_assign(proxy, index, value, clone);
-  case vctrs_type_dataframe: return df_assign(proxy, index, value, clone);
+  case vctrs_type_logical:     return lgl_assign(proxy, index, value, clone);
+  case vctrs_type_integer:     return int_assign(proxy, index, value, clone);
+  case vctrs_type_double:      return dbl_assign(proxy, index, value, clone);
+  case vctrs_type_complex:     return cpl_assign(proxy, index, value, clone);
+  case vctrs_type_character:   return chr_assign(proxy, index, value, clone);
+  case vctrs_type_raw:         return raw_assign(proxy, index, value, clone);
+  case vctrs_type_list:        return list_assign(proxy, index, value, clone);
+  case vctrs_type_dataframe:   return df_assign(proxy, index, value, clone);
   case vctrs_type_s3:
-  case vctrs_type_null:      Rf_error("Internal error in `vec_assign_impl()`: Unexpected type %s.",
-                                      vec_type_as_str(vec_typeof(proxy)));
-  case vctrs_type_scalar:    stop_scalar_type(proxy, args_empty);
+  case vctrs_type_unspecified:
+  case vctrs_type_null:        Rf_error("Internal error in `vec_assign_impl()`: Unexpected type %s.",
+                                        vec_type_as_str(vec_typeof(proxy)));
+  case vctrs_type_scalar:      stop_scalar_type(proxy, args_empty);
   }
   never_reached("vec_assign_impl");
 }

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -119,8 +119,8 @@ static bool class_is_null(SEXP x) {
 
 // [[ include("vctrs.h") ]]
 enum vctrs_type vec_typeof(SEXP x) {
-  // Check for unspecified objects created with `unspecified()`, which
-  // are objects, meaning they don't go through `vec_base_typeof()`
+  // Important to place this check before `vec_base_typeof()`, which
+  // allows vectors of `NA` to pass through as `vctrs_type_logical`
   if (vec_is_unspecified(x)) {
     return vctrs_type_unspecified;
   }

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -161,6 +161,7 @@ void vctrs_stop_unsupported_type(enum vctrs_type type, const char* fn) {
 const char* vec_type_as_str(enum vctrs_type type) {
   switch (type) {
   case vctrs_type_null:         return "null";
+  case vctrs_type_unspecified:  return "unspecified";
   case vctrs_type_logical:      return "logical";
   case vctrs_type_integer:      return "integer";
   case vctrs_type_double:       return "double";
@@ -170,7 +171,6 @@ const char* vec_type_as_str(enum vctrs_type type) {
   case vctrs_type_list:         return "list";
   case vctrs_type_dataframe:    return "dataframe";
   case vctrs_type_s3:           return "s3";
-  case vctrs_type_unspecified:  return "unspecified";
   case vctrs_type_scalar:       return "scalar";
   }
   never_reached("vec_type_as_str");

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -119,6 +119,12 @@ static bool class_is_null(SEXP x) {
 
 // [[ include("vctrs.h") ]]
 enum vctrs_type vec_typeof(SEXP x) {
+  // Check for unspecified objects created with `unspecified()`, which
+  // are objects, meaning they don't go through `vec_base_typeof()`
+  if (vec_is_unspecified(x)) {
+    return vctrs_type_unspecified;
+  }
+
   if (!OBJECT(x) || class_is_null(x)) {
     return vec_base_typeof(x, false);
   }
@@ -154,17 +160,18 @@ void vctrs_stop_unsupported_type(enum vctrs_type type, const char* fn) {
 
 const char* vec_type_as_str(enum vctrs_type type) {
   switch (type) {
-  case vctrs_type_null:      return "null";
-  case vctrs_type_logical:   return "logical";
-  case vctrs_type_integer:   return "integer";
-  case vctrs_type_double:    return "double";
-  case vctrs_type_complex:   return "complex";
-  case vctrs_type_character: return "character";
-  case vctrs_type_raw:       return "raw";
-  case vctrs_type_list:      return "list";
-  case vctrs_type_dataframe: return "dataframe";
-  case vctrs_type_s3:        return "s3";
-  case vctrs_type_scalar:    return "scalar";
+  case vctrs_type_null:         return "null";
+  case vctrs_type_logical:      return "logical";
+  case vctrs_type_integer:      return "integer";
+  case vctrs_type_double:       return "double";
+  case vctrs_type_complex:      return "complex";
+  case vctrs_type_character:    return "character";
+  case vctrs_type_raw:          return "raw";
+  case vctrs_type_list:         return "list";
+  case vctrs_type_dataframe:    return "dataframe";
+  case vctrs_type_s3:           return "s3";
+  case vctrs_type_unspecified:  return "unspecified";
+  case vctrs_type_scalar:       return "scalar";
   }
   never_reached("vec_type_as_str");
 }

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -119,7 +119,7 @@ static bool class_is_null(SEXP x) {
 
 // [[ include("vctrs.h") ]]
 enum vctrs_type vec_typeof(SEXP x) {
-  // Important to place this check before `vec_base_typeof()`, which
+  // Check for unspecified vectors before `vec_base_typeof()` which
   // allows vectors of `NA` to pass through as `vctrs_type_logical`
   if (vec_is_unspecified(x)) {
     return vctrs_type_unspecified;

--- a/src/type.c
+++ b/src/type.c
@@ -15,6 +15,7 @@ SEXP vec_type(SEXP x) {
   switch (vec_typeof(x)) {
   case vctrs_type_scalar:      return x;
   case vctrs_type_null:        return R_NilValue;
+  case vctrs_type_unspecified: return vctrs_shared_empty_uns;
   case vctrs_type_logical:     return vec_type_slice(x, vctrs_shared_empty_lgl);
   case vctrs_type_integer:     return vec_type_slice(x, vctrs_shared_empty_int);
   case vctrs_type_double:      return vec_type_slice(x, vctrs_shared_empty_dbl);
@@ -24,7 +25,6 @@ SEXP vec_type(SEXP x) {
   case vctrs_type_list:        return vec_type_slice(x, vctrs_shared_empty_list);
   case vctrs_type_dataframe:   return df_map(x, &vec_type);
   case vctrs_type_s3:          return s3_type(x);
-  case vctrs_type_unspecified: return vctrs_shared_empty_uns;
   }
   never_reached("vec_type_impl");
 }

--- a/src/type.c
+++ b/src/type.c
@@ -8,23 +8,23 @@ static SEXP fns_vec_type_finalise_dispatch = NULL;
 
 
 static SEXP vec_type_slice(SEXP x, SEXP empty);
-static SEXP lgl_type(SEXP x);
 static SEXP s3_type(SEXP x);
 
 // [[ include("vctrs.h"); register() ]]
 SEXP vec_type(SEXP x) {
   switch (vec_typeof(x)) {
-  case vctrs_type_scalar:    return x;
-  case vctrs_type_null:      return R_NilValue;
-  case vctrs_type_logical:   return lgl_type(x);
-  case vctrs_type_integer:   return vec_type_slice(x, vctrs_shared_empty_int);
-  case vctrs_type_double:    return vec_type_slice(x, vctrs_shared_empty_dbl);
-  case vctrs_type_complex:   return vec_type_slice(x, vctrs_shared_empty_cpl);
-  case vctrs_type_character: return vec_type_slice(x, vctrs_shared_empty_chr);
-  case vctrs_type_raw:       return vec_type_slice(x, vctrs_shared_empty_raw);
-  case vctrs_type_list:      return vec_type_slice(x, vctrs_shared_empty_list);
-  case vctrs_type_dataframe: return df_map(x, &vec_type);
-  case vctrs_type_s3:        return s3_type(x);
+  case vctrs_type_scalar:      return x;
+  case vctrs_type_null:        return R_NilValue;
+  case vctrs_type_logical:     return vec_type_slice(x, vctrs_shared_empty_lgl);
+  case vctrs_type_integer:     return vec_type_slice(x, vctrs_shared_empty_int);
+  case vctrs_type_double:      return vec_type_slice(x, vctrs_shared_empty_dbl);
+  case vctrs_type_complex:     return vec_type_slice(x, vctrs_shared_empty_cpl);
+  case vctrs_type_character:   return vec_type_slice(x, vctrs_shared_empty_chr);
+  case vctrs_type_raw:         return vec_type_slice(x, vctrs_shared_empty_raw);
+  case vctrs_type_list:        return vec_type_slice(x, vctrs_shared_empty_list);
+  case vctrs_type_dataframe:   return df_map(x, &vec_type);
+  case vctrs_type_s3:          return s3_type(x);
+  case vctrs_type_unspecified: return vctrs_shared_empty_uns;
   }
   never_reached("vec_type_impl");
 }
@@ -35,13 +35,6 @@ static SEXP vec_type_slice(SEXP x, SEXP empty) {
   } else {
     // Slicing preserves attributes
     return vec_slice(x, R_NilValue);
-  }
-}
-static SEXP lgl_type(SEXP x) {
-  if (vec_is_unspecified(x)) {
-    return vctrs_shared_empty_uns;
-  } else {
-    return vec_type_slice(x, vctrs_shared_empty_lgl);
   }
 }
 static SEXP s3_type(SEXP x) {

--- a/src/type2.c
+++ b/src/type2.c
@@ -38,6 +38,13 @@ SEXP vec_type2(SEXP x, SEXP y,
     stop_scalar_type(y, y_arg);
   }
 
+  if (type_x == vctrs_type_unspecified) {
+    return vec_type(y);
+  }
+  if (type_y == vctrs_type_unspecified) {
+    return vec_type(x);
+  }
+
   if (type_x == vctrs_type_s3 || type_y == vctrs_type_s3) {
     return vec_ptype2_dispatch(x, y, type_x, type_y, x_arg, y_arg, left);
   }

--- a/src/type2.c
+++ b/src/type2.c
@@ -105,7 +105,6 @@ static SEXP vec_ptype2_dispatch_unspecified(SEXP x,
                                             enum vctrs_type type,
                                             bool left_unspecified) {
   switch(type) {
-  case vctrs_type_null:
   case vctrs_type_logical:
   case vctrs_type_integer:
   case vctrs_type_double:
@@ -120,6 +119,10 @@ static SEXP vec_ptype2_dispatch_unspecified(SEXP x,
 
   case vctrs_type_list:
     return vec_ptype2_dispatch_unspecified_list(x, y, x_arg, y_arg, left_unspecified);
+
+  case vctrs_type_null: {
+    Rf_errorcall(R_NilValue, "Internal error: NULL inputs should have been handled earlier.");
+  }
 
   case vctrs_type_s3: {
     Rf_errorcall(R_NilValue, "Internal error: s3 inputs should have been handled earlier.");

--- a/src/type2.c
+++ b/src/type2.c
@@ -131,6 +131,8 @@ static SEXP vec_ptype2_dispatch_unspecified(SEXP x,
   case vctrs_type_scalar:
     Rf_errorcall(R_NilValue, "Internal error: scalar inputs should have been handled earlier.");
   }
+
+  never_reached("vec_ptype2_dispatch_unspecified");
 }
 
 // TODO - Revisit if this behavior is appropriate. For now,

--- a/src/typeof2-s3.c
+++ b/src/typeof2-s3.c
@@ -107,6 +107,9 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_unspecified_bare_factor;
     case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_unspecified_bare_ordered;
+    case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_unspecified_bare_date;
+    case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_unspecified_bare_posixct;
+    case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_unspecified_bare_posixlt;
     default:                       *left = 0; return vctrs_type2_s3_unspecified_unknown;
     }
   }
@@ -192,6 +195,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
     case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_date;
     case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_date;
     case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_date;
+    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_date;
     case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_date;
     case vctrs_type_s3: {
       switch (class_type(y)) {
@@ -215,6 +219,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
     case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_posixct;
     case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_posixct;
     case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_posixct;
+    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_posixct;
     case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_posixct;
     case vctrs_type_s3: {
       switch (class_type(y)) {
@@ -238,6 +243,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
     case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_posixlt;
     case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_posixlt;
     case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_posixlt;
+    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_posixlt;
     case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_posixlt;
     case vctrs_type_s3: {
       switch (class_type(y)) {
@@ -350,6 +356,9 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
 
   case vctrs_type2_s3_unspecified_bare_factor:     return "vctrs_type2_s3_unspecified_bare_factor";
   case vctrs_type2_s3_unspecified_bare_ordered:    return "vctrs_type2_s3_unspecified_bare_ordered";
+  case vctrs_type2_s3_unspecified_bare_date:       return "vctrs_type2_s3_unspecified_bare_date";
+  case vctrs_type2_s3_unspecified_bare_posixct:    return "vctrs_type2_s3_unspecified_bare_posixct";
+  case vctrs_type2_s3_unspecified_bare_posixlt:    return "vctrs_type2_s3_unspecified_bare_posixlt";
   case vctrs_type2_s3_unspecified_unknown:         return "vctrs_type2_s3_unspecified_unknown";
 
   case vctrs_type2_s3_scalar_bare_factor:          return "vctrs_type2_s3_scalar_bare_factor";

--- a/src/typeof2-s3.c
+++ b/src/typeof2-s3.c
@@ -103,6 +103,13 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     default:                       *left = 0; return vctrs_type2_s3_dataframe_unknown;
     }
   }
+  case vctrs_type_unspecified: {
+    switch (class_type(y)) {
+    case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_unspecified_bare_factor;
+    case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_unspecified_bare_ordered;
+    default:                       *left = 0; return vctrs_type2_s3_unspecified_unknown;
+    }
+  }
   case vctrs_type_scalar: {
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_scalar_bare_factor;
@@ -137,6 +144,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
     case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_factor;
     case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_factor;
     case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_factor;
+    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_factor;
     case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_factor;
     case vctrs_type_s3: {
       switch (class_type(y)) {
@@ -160,6 +168,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
     case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_ordered;
     case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_ordered;
     case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_ordered;
+    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_ordered;
     case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_ordered;
     case vctrs_type_s3: {
       switch (class_type(y)) {
@@ -252,6 +261,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
     case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_unknown;
     case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_unknown;
     case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_unknown;
+    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_unknown;
     case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_unknown;
     case vctrs_type_s3: {
       switch (class_type(y)) {
@@ -337,6 +347,10 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_dataframe_bare_posixct:      return "vctrs_type2_s3_dataframe_bare_posixct";
   case vctrs_type2_s3_dataframe_bare_posixlt:      return "vctrs_type2_s3_dataframe_bare_posixlt";
   case vctrs_type2_s3_dataframe_unknown:           return "vctrs_type2_s3_dataframe_unknown";
+
+  case vctrs_type2_s3_unspecified_bare_factor:     return "vctrs_type2_s3_unspecified_bare_factor";
+  case vctrs_type2_s3_unspecified_bare_ordered:    return "vctrs_type2_s3_unspecified_bare_ordered";
+  case vctrs_type2_s3_unspecified_unknown:         return "vctrs_type2_s3_unspecified_unknown";
 
   case vctrs_type2_s3_scalar_bare_factor:          return "vctrs_type2_s3_scalar_bare_factor";
   case vctrs_type2_s3_scalar_bare_ordered:         return "vctrs_type2_s3_scalar_bare_ordered";

--- a/src/typeof2-s3.c
+++ b/src/typeof2-s3.c
@@ -23,6 +23,16 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     default:                       *left = 0; return vctrs_type2_s3_null_unknown;
     }
   }
+  case vctrs_type_unspecified: {
+    switch (class_type(y)) {
+    case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_unspecified_bare_factor;
+    case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_unspecified_bare_ordered;
+    case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_unspecified_bare_date;
+    case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_unspecified_bare_posixct;
+    case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_unspecified_bare_posixlt;
+    default:                       *left = 0; return vctrs_type2_s3_unspecified_unknown;
+    }
+  }
   case vctrs_type_logical: {
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_logical_bare_factor;
@@ -103,16 +113,6 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     default:                       *left = 0; return vctrs_type2_s3_dataframe_unknown;
     }
   }
-  case vctrs_type_unspecified: {
-    switch (class_type(y)) {
-    case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_unspecified_bare_factor;
-    case vctrs_class_bare_ordered: *left = 0; return vctrs_type2_s3_unspecified_bare_ordered;
-    case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_unspecified_bare_date;
-    case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_unspecified_bare_posixct;
-    case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_unspecified_bare_posixlt;
-    default:                       *left = 0; return vctrs_type2_s3_unspecified_unknown;
-    }
-  }
   case vctrs_type_scalar: {
     switch (class_type(y)) {
     case vctrs_class_bare_factor:  *left = 0; return vctrs_type2_s3_scalar_bare_factor;
@@ -139,6 +139,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
   case vctrs_class_bare_factor: {
     switch (type_y) {
     case vctrs_type_null:            *left =  1; return vctrs_type2_s3_null_bare_factor;
+    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_factor;
     case vctrs_type_logical:         *left =  1; return vctrs_type2_s3_logical_bare_factor;
     case vctrs_type_integer:         *left =  1; return vctrs_type2_s3_integer_bare_factor;
     case vctrs_type_double:          *left =  1; return vctrs_type2_s3_double_bare_factor;
@@ -147,7 +148,6 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
     case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_factor;
     case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_factor;
     case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_factor;
-    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_factor;
     case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_factor;
     case vctrs_type_s3: {
       switch (class_type(y)) {
@@ -163,6 +163,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
   case vctrs_class_bare_ordered: {
     switch (type_y) {
     case vctrs_type_null:            *left =  1; return vctrs_type2_s3_null_bare_ordered;
+    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_ordered;
     case vctrs_type_logical:         *left =  1; return vctrs_type2_s3_logical_bare_ordered;
     case vctrs_type_integer:         *left =  1; return vctrs_type2_s3_integer_bare_ordered;
     case vctrs_type_double:          *left =  1; return vctrs_type2_s3_double_bare_ordered;
@@ -171,7 +172,6 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
     case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_ordered;
     case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_ordered;
     case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_ordered;
-    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_ordered;
     case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_ordered;
     case vctrs_type_s3: {
       switch (class_type(y)) {
@@ -187,6 +187,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
   case vctrs_class_bare_date: {
     switch (type_y) {
     case vctrs_type_null:            *left =  1; return vctrs_type2_s3_null_bare_date;
+    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_date;
     case vctrs_type_logical:         *left =  1; return vctrs_type2_s3_logical_bare_date;
     case vctrs_type_integer:         *left =  1; return vctrs_type2_s3_integer_bare_date;
     case vctrs_type_double:          *left =  1; return vctrs_type2_s3_double_bare_date;
@@ -195,7 +196,6 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
     case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_date;
     case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_date;
     case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_date;
-    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_date;
     case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_date;
     case vctrs_type_s3: {
       switch (class_type(y)) {
@@ -211,6 +211,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
   case vctrs_class_bare_posixct: {
     switch (type_y) {
     case vctrs_type_null:            *left =  1; return vctrs_type2_s3_null_bare_posixct;
+    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_posixct;
     case vctrs_type_logical:         *left =  1; return vctrs_type2_s3_logical_bare_posixct;
     case vctrs_type_integer:         *left =  1; return vctrs_type2_s3_integer_bare_posixct;
     case vctrs_type_double:          *left =  1; return vctrs_type2_s3_double_bare_posixct;
@@ -219,7 +220,6 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
     case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_posixct;
     case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_posixct;
     case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_posixct;
-    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_posixct;
     case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_posixct;
     case vctrs_type_s3: {
       switch (class_type(y)) {
@@ -235,6 +235,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
   case vctrs_class_bare_posixlt: {
     switch (type_y) {
     case vctrs_type_null:            *left =  1; return vctrs_type2_s3_null_bare_posixlt;
+    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_posixlt;
     case vctrs_type_logical:         *left =  1; return vctrs_type2_s3_logical_bare_posixlt;
     case vctrs_type_integer:         *left =  1; return vctrs_type2_s3_integer_bare_posixlt;
     case vctrs_type_double:          *left =  1; return vctrs_type2_s3_double_bare_posixlt;
@@ -243,7 +244,6 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
     case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_posixlt;
     case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_posixlt;
     case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_posixlt;
-    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_posixlt;
     case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_posixlt;
     case vctrs_type_s3: {
       switch (class_type(y)) {
@@ -259,6 +259,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
   default: {
     switch (type_y) {
     case vctrs_type_null:            *left =  1; return vctrs_type2_s3_null_unknown;
+    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_unknown;
     case vctrs_type_logical:         *left =  1; return vctrs_type2_s3_logical_unknown;
     case vctrs_type_integer:         *left =  1; return vctrs_type2_s3_integer_unknown;
     case vctrs_type_double:          *left =  1; return vctrs_type2_s3_double_unknown;
@@ -267,7 +268,6 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
     case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_unknown;
     case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_unknown;
     case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_unknown;
-    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_unknown;
     case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_unknown;
     case vctrs_type_s3: {
       switch (class_type(y)) {
@@ -297,6 +297,13 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_null_bare_posixct:           return "vctrs_type2_s3_null_bare_posixct";
   case vctrs_type2_s3_null_bare_posixlt:           return "vctrs_type2_s3_null_bare_posixlt";
   case vctrs_type2_s3_null_unknown:                return "vctrs_type2_s3_null_unknown";
+
+  case vctrs_type2_s3_unspecified_bare_factor:     return "vctrs_type2_s3_unspecified_bare_factor";
+  case vctrs_type2_s3_unspecified_bare_ordered:    return "vctrs_type2_s3_unspecified_bare_ordered";
+  case vctrs_type2_s3_unspecified_bare_date:       return "vctrs_type2_s3_unspecified_bare_date";
+  case vctrs_type2_s3_unspecified_bare_posixct:    return "vctrs_type2_s3_unspecified_bare_posixct";
+  case vctrs_type2_s3_unspecified_bare_posixlt:    return "vctrs_type2_s3_unspecified_bare_posixlt";
+  case vctrs_type2_s3_unspecified_unknown:         return "vctrs_type2_s3_unspecified_unknown";
 
   case vctrs_type2_s3_logical_bare_factor:         return "vctrs_type2_s3_logical_bare_factor";
   case vctrs_type2_s3_logical_bare_ordered:        return "vctrs_type2_s3_logical_bare_ordered";
@@ -353,13 +360,6 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_dataframe_bare_posixct:      return "vctrs_type2_s3_dataframe_bare_posixct";
   case vctrs_type2_s3_dataframe_bare_posixlt:      return "vctrs_type2_s3_dataframe_bare_posixlt";
   case vctrs_type2_s3_dataframe_unknown:           return "vctrs_type2_s3_dataframe_unknown";
-
-  case vctrs_type2_s3_unspecified_bare_factor:     return "vctrs_type2_s3_unspecified_bare_factor";
-  case vctrs_type2_s3_unspecified_bare_ordered:    return "vctrs_type2_s3_unspecified_bare_ordered";
-  case vctrs_type2_s3_unspecified_bare_date:       return "vctrs_type2_s3_unspecified_bare_date";
-  case vctrs_type2_s3_unspecified_bare_posixct:    return "vctrs_type2_s3_unspecified_bare_posixct";
-  case vctrs_type2_s3_unspecified_bare_posixlt:    return "vctrs_type2_s3_unspecified_bare_posixlt";
-  case vctrs_type2_s3_unspecified_unknown:         return "vctrs_type2_s3_unspecified_unknown";
 
   case vctrs_type2_s3_scalar_bare_factor:          return "vctrs_type2_s3_scalar_bare_factor";
   case vctrs_type2_s3_scalar_bare_ordered:         return "vctrs_type2_s3_scalar_bare_ordered";

--- a/src/typeof2.c
+++ b/src/typeof2.c
@@ -26,6 +26,7 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
   case vctrs_type_null: {
     switch (type_y) {
     case vctrs_type_null:        *left = -1; return vctrs_type2_null_null;
+    case vctrs_type_unspecified: *left =  0; return vctrs_type2_null_unspecified;
     case vctrs_type_logical:     *left =  0; return vctrs_type2_null_logical;
     case vctrs_type_integer:     *left =  0; return vctrs_type2_null_integer;
     case vctrs_type_double:      *left =  0; return vctrs_type2_null_double;
@@ -35,13 +36,29 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
     case vctrs_type_list:        *left =  0; return vctrs_type2_null_list;
     case vctrs_type_dataframe:   *left =  0; return vctrs_type2_null_dataframe;
     case vctrs_type_s3:          *left =  0; return vctrs_type2_null_s3;
-    case vctrs_type_unspecified: *left =  0; return vctrs_type2_null_unspecified;
     case vctrs_type_scalar:      *left =  0; return vctrs_type2_null_scalar;
+    }
+  }
+  case vctrs_type_unspecified: {
+    switch (type_y) {
+    case vctrs_type_null:        *left =  1; return vctrs_type2_null_unspecified;
+    case vctrs_type_unspecified: *left = -1; return vctrs_type2_unspecified_unspecified;
+    case vctrs_type_logical:     *left =  0; return vctrs_type2_unspecified_logical;
+    case vctrs_type_integer:     *left =  0; return vctrs_type2_unspecified_integer;
+    case vctrs_type_double:      *left =  0; return vctrs_type2_unspecified_double;
+    case vctrs_type_complex:     *left =  0; return vctrs_type2_unspecified_complex;
+    case vctrs_type_character:   *left =  0; return vctrs_type2_unspecified_character;
+    case vctrs_type_raw:         *left =  0; return vctrs_type2_unspecified_raw;
+    case vctrs_type_list:        *left =  0; return vctrs_type2_unspecified_list;
+    case vctrs_type_dataframe:   *left =  0; return vctrs_type2_unspecified_dataframe;
+    case vctrs_type_s3:          *left =  0; return vctrs_type2_unspecified_s3;
+    case vctrs_type_scalar:      *left =  0; return vctrs_type2_unspecified_scalar;
     }
   }
   case vctrs_type_logical: {
     switch (type_y) {
     case vctrs_type_null:        *left =  1; return vctrs_type2_null_logical;
+    case vctrs_type_unspecified: *left =  1; return vctrs_type2_unspecified_logical;
     case vctrs_type_logical:     *left = -1; return vctrs_type2_logical_logical;
     case vctrs_type_integer:     *left =  0; return vctrs_type2_logical_integer;
     case vctrs_type_double:      *left =  0; return vctrs_type2_logical_double;
@@ -51,13 +68,13 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
     case vctrs_type_list:        *left =  0; return vctrs_type2_logical_list;
     case vctrs_type_dataframe:   *left =  0; return vctrs_type2_logical_dataframe;
     case vctrs_type_s3:          *left =  0; return vctrs_type2_logical_s3;
-    case vctrs_type_unspecified: *left =  0; return vctrs_type2_logical_unspecified;
     case vctrs_type_scalar:      *left =  0; return vctrs_type2_logical_scalar;
     }
   }
   case vctrs_type_integer: {
     switch (type_y) {
     case vctrs_type_null:        *left =  1; return vctrs_type2_null_integer;
+    case vctrs_type_unspecified: *left =  1; return vctrs_type2_unspecified_integer;
     case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_integer;
     case vctrs_type_integer:     *left = -1; return vctrs_type2_integer_integer;
     case vctrs_type_double:      *left =  0; return vctrs_type2_integer_double;
@@ -67,13 +84,13 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
     case vctrs_type_list:        *left =  0; return vctrs_type2_integer_list;
     case vctrs_type_dataframe:   *left =  0; return vctrs_type2_integer_dataframe;
     case vctrs_type_s3:          *left =  0; return vctrs_type2_integer_s3;
-    case vctrs_type_unspecified: *left =  0; return vctrs_type2_integer_unspecified;
     case vctrs_type_scalar:      *left =  0; return vctrs_type2_integer_scalar;
     }
   }
   case vctrs_type_double: {
     switch (type_y) {
     case vctrs_type_null:        *left =  1; return vctrs_type2_null_double;
+    case vctrs_type_unspecified: *left =  1; return vctrs_type2_unspecified_double;
     case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_double;
     case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_double;
     case vctrs_type_double:      *left = -1; return vctrs_type2_double_double;
@@ -83,13 +100,13 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
     case vctrs_type_list:        *left =  0; return vctrs_type2_double_list;
     case vctrs_type_dataframe:   *left =  0; return vctrs_type2_double_dataframe;
     case vctrs_type_s3:          *left =  0; return vctrs_type2_double_s3;
-    case vctrs_type_unspecified: *left =  0; return vctrs_type2_double_unspecified;
     case vctrs_type_scalar:      *left =  0; return vctrs_type2_double_scalar;
     }
   }
   case vctrs_type_complex: {
     switch (type_y) {
     case vctrs_type_null:        *left =  1; return vctrs_type2_null_complex;
+    case vctrs_type_unspecified: *left =  1; return vctrs_type2_unspecified_complex;
     case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_complex;
     case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_complex;
     case vctrs_type_double:      *left =  1; return vctrs_type2_double_complex;
@@ -99,13 +116,13 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
     case vctrs_type_list:        *left =  0; return vctrs_type2_complex_list;
     case vctrs_type_dataframe:   *left =  0; return vctrs_type2_complex_dataframe;
     case vctrs_type_s3:          *left =  0; return vctrs_type2_complex_s3;
-    case vctrs_type_unspecified: *left =  0; return vctrs_type2_complex_unspecified;
     case vctrs_type_scalar:      *left =  0; return vctrs_type2_complex_scalar;
     }
   }
   case vctrs_type_character: {
     switch (type_y) {
     case vctrs_type_null:        *left =  1; return vctrs_type2_null_character;
+    case vctrs_type_unspecified: *left =  1; return vctrs_type2_unspecified_character;
     case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_character;
     case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_character;
     case vctrs_type_double:      *left =  1; return vctrs_type2_double_character;
@@ -115,13 +132,13 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
     case vctrs_type_list:        *left =  0; return vctrs_type2_character_list;
     case vctrs_type_dataframe:   *left =  0; return vctrs_type2_character_dataframe;
     case vctrs_type_s3:          *left =  0; return vctrs_type2_character_s3;
-    case vctrs_type_unspecified: *left =  0; return vctrs_type2_character_unspecified;
     case vctrs_type_scalar:      *left =  0; return vctrs_type2_character_scalar;
     }
   }
   case vctrs_type_raw: {
     switch (type_y) {
     case vctrs_type_null:        *left =  1; return vctrs_type2_null_raw;
+    case vctrs_type_unspecified: *left =  1; return vctrs_type2_unspecified_raw;
     case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_raw;
     case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_raw;
     case vctrs_type_double:      *left =  1; return vctrs_type2_double_raw;
@@ -131,13 +148,13 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
     case vctrs_type_list:        *left =  0; return vctrs_type2_raw_list;
     case vctrs_type_dataframe:   *left =  0; return vctrs_type2_raw_dataframe;
     case vctrs_type_s3:          *left =  0; return vctrs_type2_raw_s3;
-    case vctrs_type_unspecified: *left =  0; return vctrs_type2_raw_unspecified;
     case vctrs_type_scalar:      *left =  0; return vctrs_type2_raw_scalar;
     }
   }
   case vctrs_type_list: {
     switch (type_y) {
     case vctrs_type_null:        *left =  1; return vctrs_type2_null_list;
+    case vctrs_type_unspecified: *left =  1; return vctrs_type2_unspecified_list;
     case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_list;
     case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_list;
     case vctrs_type_double:      *left =  1; return vctrs_type2_double_list;
@@ -147,13 +164,13 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
     case vctrs_type_list:        *left = -1; return vctrs_type2_list_list;
     case vctrs_type_dataframe:   *left =  0; return vctrs_type2_list_dataframe;
     case vctrs_type_s3:          *left =  0; return vctrs_type2_list_s3;
-    case vctrs_type_unspecified: *left =  0; return vctrs_type2_list_unspecified;
     case vctrs_type_scalar:      *left =  0; return vctrs_type2_list_scalar;
     }
   }
   case vctrs_type_dataframe: {
     switch (type_y) {
     case vctrs_type_null:        *left =  1; return vctrs_type2_null_dataframe;
+    case vctrs_type_unspecified: *left =  1; return vctrs_type2_unspecified_dataframe;
     case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_dataframe;
     case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_dataframe;
     case vctrs_type_double:      *left =  1; return vctrs_type2_double_dataframe;
@@ -163,13 +180,13 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
     case vctrs_type_list:        *left =  1; return vctrs_type2_list_dataframe;
     case vctrs_type_dataframe:   *left = -1; return vctrs_type2_dataframe_dataframe;
     case vctrs_type_s3:          *left =  0; return vctrs_type2_dataframe_s3;
-    case vctrs_type_unspecified: *left =  0; return vctrs_type2_dataframe_unspecified;
     case vctrs_type_scalar:      *left =  0; return vctrs_type2_dataframe_scalar;
     }
   }
   case vctrs_type_s3: {
     switch (type_y) {
     case vctrs_type_null:        *left =  1; return vctrs_type2_null_s3;
+    case vctrs_type_unspecified: *left =  1; return vctrs_type2_unspecified_s3;
     case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_s3;
     case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_s3;
     case vctrs_type_double:      *left =  1; return vctrs_type2_double_s3;
@@ -179,29 +196,13 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
     case vctrs_type_list:        *left =  1; return vctrs_type2_list_s3;
     case vctrs_type_dataframe:   *left =  1; return vctrs_type2_dataframe_s3;
     case vctrs_type_s3:          *left = -1; return vctrs_type2_s3_s3;
-    case vctrs_type_unspecified: *left =  0; return vctrs_type2_s3_unspecified;
     case vctrs_type_scalar:      *left =  0; return vctrs_type2_s3_scalar;
-    }
-  }
-  case vctrs_type_unspecified: {
-    switch (type_y) {
-    case vctrs_type_null:        *left =  1; return vctrs_type2_null_unspecified;
-    case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_unspecified;
-    case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_unspecified;
-    case vctrs_type_double:      *left =  1; return vctrs_type2_double_unspecified;
-    case vctrs_type_complex:     *left =  1; return vctrs_type2_complex_unspecified;
-    case vctrs_type_character:   *left =  1; return vctrs_type2_character_unspecified;
-    case vctrs_type_raw:         *left =  1; return vctrs_type2_raw_unspecified;
-    case vctrs_type_list:        *left =  1; return vctrs_type2_list_unspecified;
-    case vctrs_type_dataframe:   *left =  1; return vctrs_type2_dataframe_unspecified;
-    case vctrs_type_s3:          *left =  1; return vctrs_type2_s3_unspecified;
-    case vctrs_type_unspecified: *left = -1; return vctrs_type2_unspecified_unspecified;
-    case vctrs_type_scalar:      *left =  0; return vctrs_type2_unspecified_scalar;
     }
   }
   case vctrs_type_scalar: {
     switch (type_y) {
     case vctrs_type_null:        *left =  1; return vctrs_type2_null_scalar;
+    case vctrs_type_unspecified: *left =  1; return vctrs_type2_unspecified_scalar;
     case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_scalar;
     case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_scalar;
     case vctrs_type_double:      *left =  1; return vctrs_type2_double_scalar;
@@ -211,7 +212,6 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
     case vctrs_type_list:        *left =  1; return vctrs_type2_list_scalar;
     case vctrs_type_dataframe:   *left =  1; return vctrs_type2_dataframe_scalar;
     case vctrs_type_s3:          *left =  1; return vctrs_type2_s3_scalar;
-    case vctrs_type_unspecified: *left =  1; return vctrs_type2_unspecified_scalar;
     case vctrs_type_scalar:      *left = -1; return vctrs_type2_scalar_scalar;
     }
   }}
@@ -240,6 +240,18 @@ const char* vctrs_type2_as_str(enum vctrs_type2 type) {
   case vctrs_type2_null_unspecified:        return "vctrs_type2_null_unspecified";
   case vctrs_type2_null_scalar:             return "vctrs_type2_null_scalar";
 
+  case vctrs_type2_unspecified_logical:     return "vctrs_type2_unspecified_logical";
+  case vctrs_type2_unspecified_integer:     return "vctrs_type2_unspecified_integer";
+  case vctrs_type2_unspecified_double:      return "vctrs_type2_unspecified_double";
+  case vctrs_type2_unspecified_complex:     return "vctrs_type2_unspecified_complex";
+  case vctrs_type2_unspecified_character:   return "vctrs_type2_unspecified_character";
+  case vctrs_type2_unspecified_raw:         return "vctrs_type2_unspecified_raw";
+  case vctrs_type2_unspecified_list:        return "vctrs_type2_unspecified_list";
+  case vctrs_type2_unspecified_dataframe:   return "vctrs_type2_unspecified_dataframe";
+  case vctrs_type2_unspecified_s3:          return "vctrs_type2_unspecified_s3";
+  case vctrs_type2_unspecified_unspecified: return "vctrs_type2_unspecified_unspecified";
+  case vctrs_type2_unspecified_scalar:      return "vctrs_type2_unspecified_scalar";
+
   case vctrs_type2_logical_logical:         return "vctrs_type2_logical_logical";
   case vctrs_type2_logical_integer:         return "vctrs_type2_logical_integer";
   case vctrs_type2_logical_double:          return "vctrs_type2_logical_double";
@@ -249,7 +261,6 @@ const char* vctrs_type2_as_str(enum vctrs_type2 type) {
   case vctrs_type2_logical_list:            return "vctrs_type2_logical_list";
   case vctrs_type2_logical_dataframe:       return "vctrs_type2_logical_dataframe";
   case vctrs_type2_logical_s3:              return "vctrs_type2_logical_s3";
-  case vctrs_type2_logical_unspecified:     return "vctrs_type2_logical_unspecified";
   case vctrs_type2_logical_scalar:          return "vctrs_type2_logical_scalar";
 
   case vctrs_type2_integer_integer:         return "vctrs_type2_integer_integer";
@@ -260,7 +271,6 @@ const char* vctrs_type2_as_str(enum vctrs_type2 type) {
   case vctrs_type2_integer_list:            return "vctrs_type2_integer_list";
   case vctrs_type2_integer_dataframe:       return "vctrs_type2_integer_dataframe";
   case vctrs_type2_integer_s3:              return "vctrs_type2_integer_s3";
-  case vctrs_type2_integer_unspecified:     return "vctrs_type2_integer_unspecified";
   case vctrs_type2_integer_scalar:          return "vctrs_type2_integer_scalar";
 
   case vctrs_type2_double_double:           return "vctrs_type2_double_double";
@@ -270,7 +280,6 @@ const char* vctrs_type2_as_str(enum vctrs_type2 type) {
   case vctrs_type2_double_list:             return "vctrs_type2_double_list";
   case vctrs_type2_double_dataframe:        return "vctrs_type2_double_dataframe";
   case vctrs_type2_double_s3:               return "vctrs_type2_double_s3";
-  case vctrs_type2_double_unspecified:      return "vctrs_type2_double_unspecified";
   case vctrs_type2_double_scalar:           return "vctrs_type2_double_scalar";
 
   case vctrs_type2_complex_complex:         return "vctrs_type2_complex_complex";
@@ -279,7 +288,6 @@ const char* vctrs_type2_as_str(enum vctrs_type2 type) {
   case vctrs_type2_complex_list:            return "vctrs_type2_complex_list";
   case vctrs_type2_complex_dataframe:       return "vctrs_type2_complex_dataframe";
   case vctrs_type2_complex_s3:              return "vctrs_type2_complex_s3";
-  case vctrs_type2_complex_unspecified:     return "vctrs_type2_complex_unspecified";
   case vctrs_type2_complex_scalar:          return "vctrs_type2_complex_scalar";
 
   case vctrs_type2_character_character:     return "vctrs_type2_character_character";
@@ -287,33 +295,25 @@ const char* vctrs_type2_as_str(enum vctrs_type2 type) {
   case vctrs_type2_character_list:          return "vctrs_type2_character_list";
   case vctrs_type2_character_dataframe:     return "vctrs_type2_character_dataframe";
   case vctrs_type2_character_s3:            return "vctrs_type2_character_s3";
-  case vctrs_type2_character_unspecified:   return "vctrs_type2_character_unspecified";
   case vctrs_type2_character_scalar:        return "vctrs_type2_character_scalar";
 
   case vctrs_type2_raw_raw:                 return "vctrs_type2_raw_raw";
   case vctrs_type2_raw_list:                return "vctrs_type2_raw_list";
   case vctrs_type2_raw_dataframe:           return "vctrs_type2_raw_dataframe";
   case vctrs_type2_raw_s3:                  return "vctrs_type2_raw_s3";
-  case vctrs_type2_raw_unspecified:         return "vctrs_type2_raw_unspecified";
   case vctrs_type2_raw_scalar:              return "vctrs_type2_raw_scalar";
 
   case vctrs_type2_list_list:               return "vctrs_type2_list_list";
   case vctrs_type2_list_dataframe:          return "vctrs_type2_list_dataframe";
   case vctrs_type2_list_s3:                 return "vctrs_type2_list_s3";
-  case vctrs_type2_list_unspecified:        return "vctrs_type2_list_unspecified";
   case vctrs_type2_list_scalar:             return "vctrs_type2_list_scalar";
 
   case vctrs_type2_dataframe_dataframe:     return "vctrs_type2_dataframe_dataframe";
   case vctrs_type2_dataframe_s3:            return "vctrs_type2_dataframe_s3";
-  case vctrs_type2_dataframe_unspecified:   return "vctrs_type2_dataframe_unspecified";
   case vctrs_type2_dataframe_scalar:        return "vctrs_type2_dataframe_scalar";
 
   case vctrs_type2_s3_s3:                   return "vctrs_type2_s3_s3";
-  case vctrs_type2_s3_unspecified:          return "vctrs_type2_s3_unspecified";
   case vctrs_type2_s3_scalar:               return "vctrs_type2_s3_scalar";
-
-  case vctrs_type2_unspecified_unspecified: return "vctrs_type2_unspecified_unspecified";
-  case vctrs_type2_unspecified_scalar:      return "vctrs_type2_unspecified_scalar";
 
   case vctrs_type2_scalar_scalar:           return "vctrs_type2_scalar_scalar";
   }

--- a/src/typeof2.c
+++ b/src/typeof2.c
@@ -25,167 +25,194 @@ enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x,
   switch (type_x) {
   case vctrs_type_null: {
     switch (type_y) {
-    case vctrs_type_null:      *left = -1; return vctrs_type2_null_null;
-    case vctrs_type_logical:   *left =  0; return vctrs_type2_null_logical;
-    case vctrs_type_integer:   *left =  0; return vctrs_type2_null_integer;
-    case vctrs_type_double:    *left =  0; return vctrs_type2_null_double;
-    case vctrs_type_complex:   *left =  0; return vctrs_type2_null_complex;
-    case vctrs_type_character: *left =  0; return vctrs_type2_null_character;
-    case vctrs_type_raw:       *left =  0; return vctrs_type2_null_raw;
-    case vctrs_type_list:      *left =  0; return vctrs_type2_null_list;
-    case vctrs_type_dataframe: *left =  0; return vctrs_type2_null_dataframe;
-    case vctrs_type_s3:        *left =  0; return vctrs_type2_null_s3;
-    case vctrs_type_scalar:    *left =  0; return vctrs_type2_null_scalar;
+    case vctrs_type_null:        *left = -1; return vctrs_type2_null_null;
+    case vctrs_type_logical:     *left =  0; return vctrs_type2_null_logical;
+    case vctrs_type_integer:     *left =  0; return vctrs_type2_null_integer;
+    case vctrs_type_double:      *left =  0; return vctrs_type2_null_double;
+    case vctrs_type_complex:     *left =  0; return vctrs_type2_null_complex;
+    case vctrs_type_character:   *left =  0; return vctrs_type2_null_character;
+    case vctrs_type_raw:         *left =  0; return vctrs_type2_null_raw;
+    case vctrs_type_list:        *left =  0; return vctrs_type2_null_list;
+    case vctrs_type_dataframe:   *left =  0; return vctrs_type2_null_dataframe;
+    case vctrs_type_s3:          *left =  0; return vctrs_type2_null_s3;
+    case vctrs_type_unspecified: *left =  0; return vctrs_type2_null_unspecified;
+    case vctrs_type_scalar:      *left =  0; return vctrs_type2_null_scalar;
     }
   }
   case vctrs_type_logical: {
     switch (type_y) {
-    case vctrs_type_null:      *left =  1; return vctrs_type2_null_logical;
-    case vctrs_type_logical:   *left = -1; return vctrs_type2_logical_logical;
-    case vctrs_type_integer:   *left =  0; return vctrs_type2_logical_integer;
-    case vctrs_type_double:    *left =  0; return vctrs_type2_logical_double;
-    case vctrs_type_complex:   *left =  0; return vctrs_type2_logical_complex;
-    case vctrs_type_character: *left =  0; return vctrs_type2_logical_character;
-    case vctrs_type_raw:       *left =  0; return vctrs_type2_logical_raw;
-    case vctrs_type_list:      *left =  0; return vctrs_type2_logical_list;
-    case vctrs_type_dataframe: *left =  0; return vctrs_type2_logical_dataframe;
-    case vctrs_type_s3:        *left =  0; return vctrs_type2_logical_s3;
-    case vctrs_type_scalar:    *left =  0; return vctrs_type2_logical_scalar;
+    case vctrs_type_null:        *left =  1; return vctrs_type2_null_logical;
+    case vctrs_type_logical:     *left = -1; return vctrs_type2_logical_logical;
+    case vctrs_type_integer:     *left =  0; return vctrs_type2_logical_integer;
+    case vctrs_type_double:      *left =  0; return vctrs_type2_logical_double;
+    case vctrs_type_complex:     *left =  0; return vctrs_type2_logical_complex;
+    case vctrs_type_character:   *left =  0; return vctrs_type2_logical_character;
+    case vctrs_type_raw:         *left =  0; return vctrs_type2_logical_raw;
+    case vctrs_type_list:        *left =  0; return vctrs_type2_logical_list;
+    case vctrs_type_dataframe:   *left =  0; return vctrs_type2_logical_dataframe;
+    case vctrs_type_s3:          *left =  0; return vctrs_type2_logical_s3;
+    case vctrs_type_unspecified: *left =  0; return vctrs_type2_logical_unspecified;
+    case vctrs_type_scalar:      *left =  0; return vctrs_type2_logical_scalar;
     }
   }
   case vctrs_type_integer: {
     switch (type_y) {
-    case vctrs_type_null:      *left =  1; return vctrs_type2_null_integer;
-    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_integer;
-    case vctrs_type_integer:   *left = -1; return vctrs_type2_integer_integer;
-    case vctrs_type_double:    *left =  0; return vctrs_type2_integer_double;
-    case vctrs_type_complex:   *left =  0; return vctrs_type2_integer_complex;
-    case vctrs_type_character: *left =  0; return vctrs_type2_integer_character;
-    case vctrs_type_raw:       *left =  0; return vctrs_type2_integer_raw;
-    case vctrs_type_list:      *left =  0; return vctrs_type2_integer_list;
-    case vctrs_type_dataframe: *left =  0; return vctrs_type2_integer_dataframe;
-    case vctrs_type_s3:        *left =  0; return vctrs_type2_integer_s3;
-    case vctrs_type_scalar:    *left =  0; return vctrs_type2_integer_scalar;
+    case vctrs_type_null:        *left =  1; return vctrs_type2_null_integer;
+    case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_integer;
+    case vctrs_type_integer:     *left = -1; return vctrs_type2_integer_integer;
+    case vctrs_type_double:      *left =  0; return vctrs_type2_integer_double;
+    case vctrs_type_complex:     *left =  0; return vctrs_type2_integer_complex;
+    case vctrs_type_character:   *left =  0; return vctrs_type2_integer_character;
+    case vctrs_type_raw:         *left =  0; return vctrs_type2_integer_raw;
+    case vctrs_type_list:        *left =  0; return vctrs_type2_integer_list;
+    case vctrs_type_dataframe:   *left =  0; return vctrs_type2_integer_dataframe;
+    case vctrs_type_s3:          *left =  0; return vctrs_type2_integer_s3;
+    case vctrs_type_unspecified: *left =  0; return vctrs_type2_integer_unspecified;
+    case vctrs_type_scalar:      *left =  0; return vctrs_type2_integer_scalar;
     }
   }
   case vctrs_type_double: {
     switch (type_y) {
-    case vctrs_type_null:      *left =  1; return vctrs_type2_null_double;
-    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_double;
-    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_double;
-    case vctrs_type_double:    *left = -1; return vctrs_type2_double_double;
-    case vctrs_type_complex:   *left =  0; return vctrs_type2_double_complex;
-    case vctrs_type_character: *left =  0; return vctrs_type2_double_character;
-    case vctrs_type_raw:       *left =  0; return vctrs_type2_double_raw;
-    case vctrs_type_list:      *left =  0; return vctrs_type2_double_list;
-    case vctrs_type_dataframe: *left =  0; return vctrs_type2_double_dataframe;
-    case vctrs_type_s3:        *left =  0; return vctrs_type2_double_s3;
-    case vctrs_type_scalar:    *left =  0; return vctrs_type2_double_scalar;
+    case vctrs_type_null:        *left =  1; return vctrs_type2_null_double;
+    case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_double;
+    case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_double;
+    case vctrs_type_double:      *left = -1; return vctrs_type2_double_double;
+    case vctrs_type_complex:     *left =  0; return vctrs_type2_double_complex;
+    case vctrs_type_character:   *left =  0; return vctrs_type2_double_character;
+    case vctrs_type_raw:         *left =  0; return vctrs_type2_double_raw;
+    case vctrs_type_list:        *left =  0; return vctrs_type2_double_list;
+    case vctrs_type_dataframe:   *left =  0; return vctrs_type2_double_dataframe;
+    case vctrs_type_s3:          *left =  0; return vctrs_type2_double_s3;
+    case vctrs_type_unspecified: *left =  0; return vctrs_type2_double_unspecified;
+    case vctrs_type_scalar:      *left =  0; return vctrs_type2_double_scalar;
     }
   }
   case vctrs_type_complex: {
     switch (type_y) {
-    case vctrs_type_null:      *left =  1; return vctrs_type2_null_complex;
-    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_complex;
-    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_complex;
-    case vctrs_type_double:    *left =  1; return vctrs_type2_double_complex;
-    case vctrs_type_complex:   *left = -1; return vctrs_type2_complex_complex;
-    case vctrs_type_character: *left =  0; return vctrs_type2_complex_character;
-    case vctrs_type_raw:       *left =  0; return vctrs_type2_complex_raw;
-    case vctrs_type_list:      *left =  0; return vctrs_type2_complex_list;
-    case vctrs_type_dataframe: *left =  0; return vctrs_type2_complex_dataframe;
-    case vctrs_type_s3:        *left =  0; return vctrs_type2_complex_s3;
-    case vctrs_type_scalar:    *left =  0; return vctrs_type2_complex_scalar;
+    case vctrs_type_null:        *left =  1; return vctrs_type2_null_complex;
+    case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_complex;
+    case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_complex;
+    case vctrs_type_double:      *left =  1; return vctrs_type2_double_complex;
+    case vctrs_type_complex:     *left = -1; return vctrs_type2_complex_complex;
+    case vctrs_type_character:   *left =  0; return vctrs_type2_complex_character;
+    case vctrs_type_raw:         *left =  0; return vctrs_type2_complex_raw;
+    case vctrs_type_list:        *left =  0; return vctrs_type2_complex_list;
+    case vctrs_type_dataframe:   *left =  0; return vctrs_type2_complex_dataframe;
+    case vctrs_type_s3:          *left =  0; return vctrs_type2_complex_s3;
+    case vctrs_type_unspecified: *left =  0; return vctrs_type2_complex_unspecified;
+    case vctrs_type_scalar:      *left =  0; return vctrs_type2_complex_scalar;
     }
   }
   case vctrs_type_character: {
     switch (type_y) {
-    case vctrs_type_null:      *left =  1; return vctrs_type2_null_character;
-    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_character;
-    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_character;
-    case vctrs_type_double:    *left =  1; return vctrs_type2_double_character;
-    case vctrs_type_complex:   *left =  1; return vctrs_type2_complex_character;
-    case vctrs_type_character: *left = -1; return vctrs_type2_character_character;
-    case vctrs_type_raw:       *left =  0; return vctrs_type2_character_raw;
-    case vctrs_type_list:      *left =  0; return vctrs_type2_character_list;
-    case vctrs_type_dataframe: *left =  0; return vctrs_type2_character_dataframe;
-    case vctrs_type_s3:        *left =  0; return vctrs_type2_character_s3;
-    case vctrs_type_scalar:    *left =  0; return vctrs_type2_character_scalar;
+    case vctrs_type_null:        *left =  1; return vctrs_type2_null_character;
+    case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_character;
+    case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_character;
+    case vctrs_type_double:      *left =  1; return vctrs_type2_double_character;
+    case vctrs_type_complex:     *left =  1; return vctrs_type2_complex_character;
+    case vctrs_type_character:   *left = -1; return vctrs_type2_character_character;
+    case vctrs_type_raw:         *left =  0; return vctrs_type2_character_raw;
+    case vctrs_type_list:        *left =  0; return vctrs_type2_character_list;
+    case vctrs_type_dataframe:   *left =  0; return vctrs_type2_character_dataframe;
+    case vctrs_type_s3:          *left =  0; return vctrs_type2_character_s3;
+    case vctrs_type_unspecified: *left =  0; return vctrs_type2_character_unspecified;
+    case vctrs_type_scalar:      *left =  0; return vctrs_type2_character_scalar;
     }
   }
   case vctrs_type_raw: {
     switch (type_y) {
-    case vctrs_type_null:      *left =  1; return vctrs_type2_null_raw;
-    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_raw;
-    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_raw;
-    case vctrs_type_double:    *left =  1; return vctrs_type2_double_raw;
-    case vctrs_type_complex:   *left =  1; return vctrs_type2_complex_raw;
-    case vctrs_type_character: *left =  1; return vctrs_type2_character_raw;
-    case vctrs_type_raw:       *left = -1; return vctrs_type2_raw_raw;
-    case vctrs_type_list:      *left =  0; return vctrs_type2_raw_list;
-    case vctrs_type_dataframe: *left =  0; return vctrs_type2_raw_dataframe;
-    case vctrs_type_s3:        *left =  0; return vctrs_type2_raw_s3;
-    case vctrs_type_scalar:    *left =  0; return vctrs_type2_raw_scalar;
+    case vctrs_type_null:        *left =  1; return vctrs_type2_null_raw;
+    case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_raw;
+    case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_raw;
+    case vctrs_type_double:      *left =  1; return vctrs_type2_double_raw;
+    case vctrs_type_complex:     *left =  1; return vctrs_type2_complex_raw;
+    case vctrs_type_character:   *left =  1; return vctrs_type2_character_raw;
+    case vctrs_type_raw:         *left = -1; return vctrs_type2_raw_raw;
+    case vctrs_type_list:        *left =  0; return vctrs_type2_raw_list;
+    case vctrs_type_dataframe:   *left =  0; return vctrs_type2_raw_dataframe;
+    case vctrs_type_s3:          *left =  0; return vctrs_type2_raw_s3;
+    case vctrs_type_unspecified: *left =  0; return vctrs_type2_raw_unspecified;
+    case vctrs_type_scalar:      *left =  0; return vctrs_type2_raw_scalar;
     }
   }
   case vctrs_type_list: {
     switch (type_y) {
-    case vctrs_type_null:      *left =  1; return vctrs_type2_null_list;
-    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_list;
-    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_list;
-    case vctrs_type_double:    *left =  1; return vctrs_type2_double_list;
-    case vctrs_type_complex:   *left =  1; return vctrs_type2_complex_list;
-    case vctrs_type_character: *left =  1; return vctrs_type2_character_list;
-    case vctrs_type_raw:       *left =  1; return vctrs_type2_raw_list;
-    case vctrs_type_list:      *left = -1; return vctrs_type2_list_list;
-    case vctrs_type_dataframe: *left =  0; return vctrs_type2_list_dataframe;
-    case vctrs_type_s3:        *left =  0; return vctrs_type2_list_s3;
-    case vctrs_type_scalar:    *left =  0; return vctrs_type2_list_scalar;
+    case vctrs_type_null:        *left =  1; return vctrs_type2_null_list;
+    case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_list;
+    case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_list;
+    case vctrs_type_double:      *left =  1; return vctrs_type2_double_list;
+    case vctrs_type_complex:     *left =  1; return vctrs_type2_complex_list;
+    case vctrs_type_character:   *left =  1; return vctrs_type2_character_list;
+    case vctrs_type_raw:         *left =  1; return vctrs_type2_raw_list;
+    case vctrs_type_list:        *left = -1; return vctrs_type2_list_list;
+    case vctrs_type_dataframe:   *left =  0; return vctrs_type2_list_dataframe;
+    case vctrs_type_s3:          *left =  0; return vctrs_type2_list_s3;
+    case vctrs_type_unspecified: *left =  0; return vctrs_type2_list_unspecified;
+    case vctrs_type_scalar:      *left =  0; return vctrs_type2_list_scalar;
     }
   }
   case vctrs_type_dataframe: {
     switch (type_y) {
-    case vctrs_type_null:      *left =  1; return vctrs_type2_null_dataframe;
-    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_dataframe;
-    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_dataframe;
-    case vctrs_type_double:    *left =  1; return vctrs_type2_double_dataframe;
-    case vctrs_type_complex:   *left =  1; return vctrs_type2_complex_dataframe;
-    case vctrs_type_character: *left =  1; return vctrs_type2_character_dataframe;
-    case vctrs_type_raw:       *left =  1; return vctrs_type2_raw_dataframe;
-    case vctrs_type_list:      *left =  1; return vctrs_type2_list_dataframe;
-    case vctrs_type_dataframe: *left = -1; return vctrs_type2_dataframe_dataframe;
-    case vctrs_type_s3:        *left =  0; return vctrs_type2_dataframe_s3;
-    case vctrs_type_scalar:    *left =  0; return vctrs_type2_dataframe_scalar;
+    case vctrs_type_null:        *left =  1; return vctrs_type2_null_dataframe;
+    case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_dataframe;
+    case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_dataframe;
+    case vctrs_type_double:      *left =  1; return vctrs_type2_double_dataframe;
+    case vctrs_type_complex:     *left =  1; return vctrs_type2_complex_dataframe;
+    case vctrs_type_character:   *left =  1; return vctrs_type2_character_dataframe;
+    case vctrs_type_raw:         *left =  1; return vctrs_type2_raw_dataframe;
+    case vctrs_type_list:        *left =  1; return vctrs_type2_list_dataframe;
+    case vctrs_type_dataframe:   *left = -1; return vctrs_type2_dataframe_dataframe;
+    case vctrs_type_s3:          *left =  0; return vctrs_type2_dataframe_s3;
+    case vctrs_type_unspecified: *left =  0; return vctrs_type2_dataframe_unspecified;
+    case vctrs_type_scalar:      *left =  0; return vctrs_type2_dataframe_scalar;
     }
   }
   case vctrs_type_s3: {
     switch (type_y) {
-    case vctrs_type_null:      *left =  1; return vctrs_type2_null_s3;
-    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_s3;
-    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_s3;
-    case vctrs_type_double:    *left =  1; return vctrs_type2_double_s3;
-    case vctrs_type_complex:   *left =  1; return vctrs_type2_complex_s3;
-    case vctrs_type_character: *left =  1; return vctrs_type2_character_s3;
-    case vctrs_type_raw:       *left =  1; return vctrs_type2_raw_s3;
-    case vctrs_type_list:      *left =  1; return vctrs_type2_list_s3;
-    case vctrs_type_dataframe: *left =  1; return vctrs_type2_dataframe_s3;
-    case vctrs_type_s3:        *left = -1; return vctrs_type2_s3_s3;
-    case vctrs_type_scalar:    *left =  0; return vctrs_type2_s3_scalar;
+    case vctrs_type_null:        *left =  1; return vctrs_type2_null_s3;
+    case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_s3;
+    case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_s3;
+    case vctrs_type_double:      *left =  1; return vctrs_type2_double_s3;
+    case vctrs_type_complex:     *left =  1; return vctrs_type2_complex_s3;
+    case vctrs_type_character:   *left =  1; return vctrs_type2_character_s3;
+    case vctrs_type_raw:         *left =  1; return vctrs_type2_raw_s3;
+    case vctrs_type_list:        *left =  1; return vctrs_type2_list_s3;
+    case vctrs_type_dataframe:   *left =  1; return vctrs_type2_dataframe_s3;
+    case vctrs_type_s3:          *left = -1; return vctrs_type2_s3_s3;
+    case vctrs_type_unspecified: *left =  0; return vctrs_type2_s3_unspecified;
+    case vctrs_type_scalar:      *left =  0; return vctrs_type2_s3_scalar;
+    }
+  }
+  case vctrs_type_unspecified: {
+    switch (type_y) {
+    case vctrs_type_null:        *left =  1; return vctrs_type2_null_unspecified;
+    case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_unspecified;
+    case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_unspecified;
+    case vctrs_type_double:      *left =  1; return vctrs_type2_double_unspecified;
+    case vctrs_type_complex:     *left =  1; return vctrs_type2_complex_unspecified;
+    case vctrs_type_character:   *left =  1; return vctrs_type2_character_unspecified;
+    case vctrs_type_raw:         *left =  1; return vctrs_type2_raw_unspecified;
+    case vctrs_type_list:        *left =  1; return vctrs_type2_list_unspecified;
+    case vctrs_type_dataframe:   *left =  1; return vctrs_type2_dataframe_unspecified;
+    case vctrs_type_s3:          *left =  1; return vctrs_type2_s3_unspecified;
+    case vctrs_type_unspecified: *left = -1; return vctrs_type2_unspecified_unspecified;
+    case vctrs_type_scalar:      *left =  0; return vctrs_type2_unspecified_scalar;
     }
   }
   case vctrs_type_scalar: {
     switch (type_y) {
-    case vctrs_type_null:      *left =  1; return vctrs_type2_null_scalar;
-    case vctrs_type_logical:   *left =  1; return vctrs_type2_logical_scalar;
-    case vctrs_type_integer:   *left =  1; return vctrs_type2_integer_scalar;
-    case vctrs_type_double:    *left =  1; return vctrs_type2_double_scalar;
-    case vctrs_type_complex:   *left =  1; return vctrs_type2_complex_scalar;
-    case vctrs_type_character: *left =  1; return vctrs_type2_character_scalar;
-    case vctrs_type_raw:       *left =  1; return vctrs_type2_raw_scalar;
-    case vctrs_type_list:      *left =  1; return vctrs_type2_list_scalar;
-    case vctrs_type_dataframe: *left =  1; return vctrs_type2_dataframe_scalar;
-    case vctrs_type_s3:        *left =  1; return vctrs_type2_s3_scalar;
-    case vctrs_type_scalar:    *left = -1; return vctrs_type2_scalar_scalar;
+    case vctrs_type_null:        *left =  1; return vctrs_type2_null_scalar;
+    case vctrs_type_logical:     *left =  1; return vctrs_type2_logical_scalar;
+    case vctrs_type_integer:     *left =  1; return vctrs_type2_integer_scalar;
+    case vctrs_type_double:      *left =  1; return vctrs_type2_double_scalar;
+    case vctrs_type_complex:     *left =  1; return vctrs_type2_complex_scalar;
+    case vctrs_type_character:   *left =  1; return vctrs_type2_character_scalar;
+    case vctrs_type_raw:         *left =  1; return vctrs_type2_raw_scalar;
+    case vctrs_type_list:        *left =  1; return vctrs_type2_list_scalar;
+    case vctrs_type_dataframe:   *left =  1; return vctrs_type2_dataframe_scalar;
+    case vctrs_type_s3:          *left =  1; return vctrs_type2_s3_scalar;
+    case vctrs_type_unspecified: *left =  1; return vctrs_type2_unspecified_scalar;
+    case vctrs_type_scalar:      *left = -1; return vctrs_type2_scalar_scalar;
     }
   }}
 
@@ -200,82 +227,95 @@ enum vctrs_type2 vec_typeof2(SEXP x, SEXP y) {
 
 const char* vctrs_type2_as_str(enum vctrs_type2 type) {
   switch (type) {
-  case vctrs_type2_null_null:           return "vctrs_type2_null_null";
-  case vctrs_type2_null_logical:        return "vctrs_type2_null_logical";
-  case vctrs_type2_null_integer:        return "vctrs_type2_null_integer";
-  case vctrs_type2_null_double:         return "vctrs_type2_null_double";
-  case vctrs_type2_null_complex:        return "vctrs_type2_null_complex";
-  case vctrs_type2_null_character:      return "vctrs_type2_null_character";
-  case vctrs_type2_null_raw:            return "vctrs_type2_null_raw";
-  case vctrs_type2_null_list:           return "vctrs_type2_null_list";
-  case vctrs_type2_null_dataframe:      return "vctrs_type2_null_dataframe";
-  case vctrs_type2_null_s3:             return "vctrs_type2_null_s3";
-  case vctrs_type2_null_scalar:         return "vctrs_type2_null_scalar";
+  case vctrs_type2_null_null:               return "vctrs_type2_null_null";
+  case vctrs_type2_null_logical:            return "vctrs_type2_null_logical";
+  case vctrs_type2_null_integer:            return "vctrs_type2_null_integer";
+  case vctrs_type2_null_double:             return "vctrs_type2_null_double";
+  case vctrs_type2_null_complex:            return "vctrs_type2_null_complex";
+  case vctrs_type2_null_character:          return "vctrs_type2_null_character";
+  case vctrs_type2_null_raw:                return "vctrs_type2_null_raw";
+  case vctrs_type2_null_list:               return "vctrs_type2_null_list";
+  case vctrs_type2_null_dataframe:          return "vctrs_type2_null_dataframe";
+  case vctrs_type2_null_s3:                 return "vctrs_type2_null_s3";
+  case vctrs_type2_null_unspecified:        return "vctrs_type2_null_unspecified";
+  case vctrs_type2_null_scalar:             return "vctrs_type2_null_scalar";
 
-  case vctrs_type2_logical_logical:     return "vctrs_type2_logical_logical";
-  case vctrs_type2_logical_integer:     return "vctrs_type2_logical_integer";
-  case vctrs_type2_logical_double:      return "vctrs_type2_logical_double";
-  case vctrs_type2_logical_complex:     return "vctrs_type2_logical_complex";
-  case vctrs_type2_logical_character:   return "vctrs_type2_logical_character";
-  case vctrs_type2_logical_raw:         return "vctrs_type2_logical_raw";
-  case vctrs_type2_logical_list:        return "vctrs_type2_logical_list";
-  case vctrs_type2_logical_dataframe:   return "vctrs_type2_logical_dataframe";
-  case vctrs_type2_logical_s3:          return "vctrs_type2_logical_s3";
-  case vctrs_type2_logical_scalar:      return "vctrs_type2_logical_scalar";
+  case vctrs_type2_logical_logical:         return "vctrs_type2_logical_logical";
+  case vctrs_type2_logical_integer:         return "vctrs_type2_logical_integer";
+  case vctrs_type2_logical_double:          return "vctrs_type2_logical_double";
+  case vctrs_type2_logical_complex:         return "vctrs_type2_logical_complex";
+  case vctrs_type2_logical_character:       return "vctrs_type2_logical_character";
+  case vctrs_type2_logical_raw:             return "vctrs_type2_logical_raw";
+  case vctrs_type2_logical_list:            return "vctrs_type2_logical_list";
+  case vctrs_type2_logical_dataframe:       return "vctrs_type2_logical_dataframe";
+  case vctrs_type2_logical_s3:              return "vctrs_type2_logical_s3";
+  case vctrs_type2_logical_unspecified:     return "vctrs_type2_logical_unspecified";
+  case vctrs_type2_logical_scalar:          return "vctrs_type2_logical_scalar";
 
-  case vctrs_type2_integer_integer:     return "vctrs_type2_integer_integer";
-  case vctrs_type2_integer_double:      return "vctrs_type2_integer_double";
-  case vctrs_type2_integer_complex:     return "vctrs_type2_integer_complex";
-  case vctrs_type2_integer_character:   return "vctrs_type2_integer_character";
-  case vctrs_type2_integer_raw:         return "vctrs_type2_integer_raw";
-  case vctrs_type2_integer_list:        return "vctrs_type2_integer_list";
-  case vctrs_type2_integer_dataframe:   return "vctrs_type2_integer_dataframe";
-  case vctrs_type2_integer_s3:          return "vctrs_type2_integer_s3";
-  case vctrs_type2_integer_scalar:      return "vctrs_type2_integer_scalar";
+  case vctrs_type2_integer_integer:         return "vctrs_type2_integer_integer";
+  case vctrs_type2_integer_double:          return "vctrs_type2_integer_double";
+  case vctrs_type2_integer_complex:         return "vctrs_type2_integer_complex";
+  case vctrs_type2_integer_character:       return "vctrs_type2_integer_character";
+  case vctrs_type2_integer_raw:             return "vctrs_type2_integer_raw";
+  case vctrs_type2_integer_list:            return "vctrs_type2_integer_list";
+  case vctrs_type2_integer_dataframe:       return "vctrs_type2_integer_dataframe";
+  case vctrs_type2_integer_s3:              return "vctrs_type2_integer_s3";
+  case vctrs_type2_integer_unspecified:     return "vctrs_type2_integer_unspecified";
+  case vctrs_type2_integer_scalar:          return "vctrs_type2_integer_scalar";
 
-  case vctrs_type2_double_double:       return "vctrs_type2_double_double";
-  case vctrs_type2_double_complex:      return "vctrs_type2_double_complex";
-  case vctrs_type2_double_character:    return "vctrs_type2_double_character";
-  case vctrs_type2_double_raw:          return "vctrs_type2_double_raw";
-  case vctrs_type2_double_list:         return "vctrs_type2_double_list";
-  case vctrs_type2_double_dataframe:    return "vctrs_type2_double_dataframe";
-  case vctrs_type2_double_s3:           return "vctrs_type2_double_s3";
-  case vctrs_type2_double_scalar:       return "vctrs_type2_double_scalar";
+  case vctrs_type2_double_double:           return "vctrs_type2_double_double";
+  case vctrs_type2_double_complex:          return "vctrs_type2_double_complex";
+  case vctrs_type2_double_character:        return "vctrs_type2_double_character";
+  case vctrs_type2_double_raw:              return "vctrs_type2_double_raw";
+  case vctrs_type2_double_list:             return "vctrs_type2_double_list";
+  case vctrs_type2_double_dataframe:        return "vctrs_type2_double_dataframe";
+  case vctrs_type2_double_s3:               return "vctrs_type2_double_s3";
+  case vctrs_type2_double_unspecified:      return "vctrs_type2_double_unspecified";
+  case vctrs_type2_double_scalar:           return "vctrs_type2_double_scalar";
 
-  case vctrs_type2_complex_complex:     return "vctrs_type2_complex_complex";
-  case vctrs_type2_complex_character:   return "vctrs_type2_complex_character";
-  case vctrs_type2_complex_raw:         return "vctrs_type2_complex_raw";
-  case vctrs_type2_complex_list:        return "vctrs_type2_complex_list";
-  case vctrs_type2_complex_dataframe:   return "vctrs_type2_complex_dataframe";
-  case vctrs_type2_complex_s3:          return "vctrs_type2_complex_s3";
-  case vctrs_type2_complex_scalar:      return "vctrs_type2_complex_scalar";
+  case vctrs_type2_complex_complex:         return "vctrs_type2_complex_complex";
+  case vctrs_type2_complex_character:       return "vctrs_type2_complex_character";
+  case vctrs_type2_complex_raw:             return "vctrs_type2_complex_raw";
+  case vctrs_type2_complex_list:            return "vctrs_type2_complex_list";
+  case vctrs_type2_complex_dataframe:       return "vctrs_type2_complex_dataframe";
+  case vctrs_type2_complex_s3:              return "vctrs_type2_complex_s3";
+  case vctrs_type2_complex_unspecified:     return "vctrs_type2_complex_unspecified";
+  case vctrs_type2_complex_scalar:          return "vctrs_type2_complex_scalar";
 
-  case vctrs_type2_character_character: return "vctrs_type2_character_character";
-  case vctrs_type2_character_raw:       return "vctrs_type2_character_raw";
-  case vctrs_type2_character_list:      return "vctrs_type2_character_list";
-  case vctrs_type2_character_dataframe: return "vctrs_type2_character_dataframe";
-  case vctrs_type2_character_s3:        return "vctrs_type2_character_s3";
-  case vctrs_type2_character_scalar:    return "vctrs_type2_character_scalar";
+  case vctrs_type2_character_character:     return "vctrs_type2_character_character";
+  case vctrs_type2_character_raw:           return "vctrs_type2_character_raw";
+  case vctrs_type2_character_list:          return "vctrs_type2_character_list";
+  case vctrs_type2_character_dataframe:     return "vctrs_type2_character_dataframe";
+  case vctrs_type2_character_s3:            return "vctrs_type2_character_s3";
+  case vctrs_type2_character_unspecified:   return "vctrs_type2_character_unspecified";
+  case vctrs_type2_character_scalar:        return "vctrs_type2_character_scalar";
 
-  case vctrs_type2_raw_raw:             return "vctrs_type2_raw_raw";
-  case vctrs_type2_raw_list:            return "vctrs_type2_raw_list";
-  case vctrs_type2_raw_dataframe:       return "vctrs_type2_raw_dataframe";
-  case vctrs_type2_raw_s3:              return "vctrs_type2_raw_s3";
-  case vctrs_type2_raw_scalar:          return "vctrs_type2_raw_scalar";
+  case vctrs_type2_raw_raw:                 return "vctrs_type2_raw_raw";
+  case vctrs_type2_raw_list:                return "vctrs_type2_raw_list";
+  case vctrs_type2_raw_dataframe:           return "vctrs_type2_raw_dataframe";
+  case vctrs_type2_raw_s3:                  return "vctrs_type2_raw_s3";
+  case vctrs_type2_raw_unspecified:         return "vctrs_type2_raw_unspecified";
+  case vctrs_type2_raw_scalar:              return "vctrs_type2_raw_scalar";
 
-  case vctrs_type2_list_list:           return "vctrs_type2_list_list";
-  case vctrs_type2_list_dataframe:      return "vctrs_type2_list_dataframe";
-  case vctrs_type2_list_s3:             return "vctrs_type2_list_s3";
-  case vctrs_type2_list_scalar:         return "vctrs_type2_list_scalar";
+  case vctrs_type2_list_list:               return "vctrs_type2_list_list";
+  case vctrs_type2_list_dataframe:          return "vctrs_type2_list_dataframe";
+  case vctrs_type2_list_s3:                 return "vctrs_type2_list_s3";
+  case vctrs_type2_list_unspecified:        return "vctrs_type2_list_unspecified";
+  case vctrs_type2_list_scalar:             return "vctrs_type2_list_scalar";
 
-  case vctrs_type2_dataframe_dataframe: return "vctrs_type2_dataframe_dataframe";
-  case vctrs_type2_dataframe_s3:        return "vctrs_type2_dataframe_s3";
-  case vctrs_type2_dataframe_scalar:    return "vctrs_type2_dataframe_scalar";
+  case vctrs_type2_dataframe_dataframe:     return "vctrs_type2_dataframe_dataframe";
+  case vctrs_type2_dataframe_s3:            return "vctrs_type2_dataframe_s3";
+  case vctrs_type2_dataframe_unspecified:   return "vctrs_type2_dataframe_unspecified";
+  case vctrs_type2_dataframe_scalar:        return "vctrs_type2_dataframe_scalar";
 
-  case vctrs_type2_s3_s3:               return "vctrs_type2_s3_s3";
-  case vctrs_type2_s3_scalar:           return "vctrs_type2_s3_scalar";
+  case vctrs_type2_s3_s3:                   return "vctrs_type2_s3_s3";
+  case vctrs_type2_s3_unspecified:          return "vctrs_type2_s3_unspecified";
+  case vctrs_type2_s3_scalar:               return "vctrs_type2_s3_scalar";
 
-  case vctrs_type2_scalar_scalar:       return "vctrs_type2_scalar_scalar";
+  case vctrs_type2_unspecified_unspecified: return "vctrs_type2_unspecified_unspecified";
+  case vctrs_type2_unspecified_scalar:      return "vctrs_type2_unspecified_scalar";
+
+  case vctrs_type2_scalar_scalar:           return "vctrs_type2_scalar_scalar";
   }
 
   never_reached("vctrs_type2_as_str");

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -24,6 +24,7 @@ enum vctrs_type {
   vctrs_type_list,
   vctrs_type_dataframe,
   vctrs_type_scalar,
+  vctrs_type_unspecified,
   vctrs_type_s3 = 255
 };
 
@@ -101,6 +102,7 @@ enum vctrs_type2 {
   vctrs_type2_null_list,
   vctrs_type2_null_dataframe,
   vctrs_type2_null_s3,
+  vctrs_type2_null_unspecified,
   vctrs_type2_null_scalar,
 
   vctrs_type2_logical_logical,
@@ -112,6 +114,7 @@ enum vctrs_type2 {
   vctrs_type2_logical_list,
   vctrs_type2_logical_dataframe,
   vctrs_type2_logical_s3,
+  vctrs_type2_logical_unspecified,
   vctrs_type2_logical_scalar,
 
   vctrs_type2_integer_integer,
@@ -122,6 +125,7 @@ enum vctrs_type2 {
   vctrs_type2_integer_list,
   vctrs_type2_integer_dataframe,
   vctrs_type2_integer_s3,
+  vctrs_type2_integer_unspecified,
   vctrs_type2_integer_scalar,
 
   vctrs_type2_double_double,
@@ -131,6 +135,7 @@ enum vctrs_type2 {
   vctrs_type2_double_list,
   vctrs_type2_double_dataframe,
   vctrs_type2_double_s3,
+  vctrs_type2_double_unspecified,
   vctrs_type2_double_scalar,
 
   vctrs_type2_complex_complex,
@@ -139,6 +144,7 @@ enum vctrs_type2 {
   vctrs_type2_complex_list,
   vctrs_type2_complex_dataframe,
   vctrs_type2_complex_s3,
+  vctrs_type2_complex_unspecified,
   vctrs_type2_complex_scalar,
 
   vctrs_type2_character_character,
@@ -146,25 +152,33 @@ enum vctrs_type2 {
   vctrs_type2_character_list,
   vctrs_type2_character_dataframe,
   vctrs_type2_character_s3,
+  vctrs_type2_character_unspecified,
   vctrs_type2_character_scalar,
 
   vctrs_type2_raw_raw,
   vctrs_type2_raw_list,
   vctrs_type2_raw_dataframe,
   vctrs_type2_raw_s3,
+  vctrs_type2_raw_unspecified,
   vctrs_type2_raw_scalar,
 
   vctrs_type2_list_list,
   vctrs_type2_list_dataframe,
   vctrs_type2_list_s3,
+  vctrs_type2_list_unspecified,
   vctrs_type2_list_scalar,
 
   vctrs_type2_dataframe_dataframe,
   vctrs_type2_dataframe_s3,
+  vctrs_type2_dataframe_unspecified,
   vctrs_type2_dataframe_scalar,
 
   vctrs_type2_s3_s3,
+  vctrs_type2_s3_unspecified,
   vctrs_type2_s3_scalar,
+
+  vctrs_type2_unspecified_unspecified,
+  vctrs_type2_unspecified_scalar,
 
   vctrs_type2_scalar_scalar
 };
@@ -232,6 +246,10 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_dataframe_bare_posixct,
   vctrs_type2_s3_dataframe_bare_posixlt,
   vctrs_type2_s3_dataframe_unknown,
+
+  vctrs_type2_s3_unspecified_bare_factor,
+  vctrs_type2_s3_unspecified_bare_ordered,
+  vctrs_type2_s3_unspecified_unknown,
 
   vctrs_type2_s3_scalar_bare_factor,
   vctrs_type2_s3_scalar_bare_ordered,

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -15,6 +15,7 @@ typedef R_xlen_t r_ssize_t;
 
 enum vctrs_type {
   vctrs_type_null = 0,
+  vctrs_type_unspecified,
   vctrs_type_logical,
   vctrs_type_integer,
   vctrs_type_double,
@@ -24,7 +25,6 @@ enum vctrs_type {
   vctrs_type_list,
   vctrs_type_dataframe,
   vctrs_type_scalar,
-  vctrs_type_unspecified,
   vctrs_type_s3 = 255
 };
 
@@ -93,6 +93,7 @@ bool vec_is_partial(SEXP x);
 // in `vec_typeof2()`
 enum vctrs_type2 {
   vctrs_type2_null_null,
+  vctrs_type2_null_unspecified,
   vctrs_type2_null_logical,
   vctrs_type2_null_integer,
   vctrs_type2_null_double,
@@ -102,8 +103,19 @@ enum vctrs_type2 {
   vctrs_type2_null_list,
   vctrs_type2_null_dataframe,
   vctrs_type2_null_s3,
-  vctrs_type2_null_unspecified,
   vctrs_type2_null_scalar,
+
+  vctrs_type2_unspecified_unspecified,
+  vctrs_type2_unspecified_logical,
+  vctrs_type2_unspecified_integer,
+  vctrs_type2_unspecified_double,
+  vctrs_type2_unspecified_complex,
+  vctrs_type2_unspecified_character,
+  vctrs_type2_unspecified_raw,
+  vctrs_type2_unspecified_list,
+  vctrs_type2_unspecified_dataframe,
+  vctrs_type2_unspecified_s3,
+  vctrs_type2_unspecified_scalar,
 
   vctrs_type2_logical_logical,
   vctrs_type2_logical_integer,
@@ -114,7 +126,6 @@ enum vctrs_type2 {
   vctrs_type2_logical_list,
   vctrs_type2_logical_dataframe,
   vctrs_type2_logical_s3,
-  vctrs_type2_logical_unspecified,
   vctrs_type2_logical_scalar,
 
   vctrs_type2_integer_integer,
@@ -125,7 +136,6 @@ enum vctrs_type2 {
   vctrs_type2_integer_list,
   vctrs_type2_integer_dataframe,
   vctrs_type2_integer_s3,
-  vctrs_type2_integer_unspecified,
   vctrs_type2_integer_scalar,
 
   vctrs_type2_double_double,
@@ -135,7 +145,6 @@ enum vctrs_type2 {
   vctrs_type2_double_list,
   vctrs_type2_double_dataframe,
   vctrs_type2_double_s3,
-  vctrs_type2_double_unspecified,
   vctrs_type2_double_scalar,
 
   vctrs_type2_complex_complex,
@@ -144,7 +153,6 @@ enum vctrs_type2 {
   vctrs_type2_complex_list,
   vctrs_type2_complex_dataframe,
   vctrs_type2_complex_s3,
-  vctrs_type2_complex_unspecified,
   vctrs_type2_complex_scalar,
 
   vctrs_type2_character_character,
@@ -152,33 +160,25 @@ enum vctrs_type2 {
   vctrs_type2_character_list,
   vctrs_type2_character_dataframe,
   vctrs_type2_character_s3,
-  vctrs_type2_character_unspecified,
   vctrs_type2_character_scalar,
 
   vctrs_type2_raw_raw,
   vctrs_type2_raw_list,
   vctrs_type2_raw_dataframe,
   vctrs_type2_raw_s3,
-  vctrs_type2_raw_unspecified,
   vctrs_type2_raw_scalar,
 
   vctrs_type2_list_list,
   vctrs_type2_list_dataframe,
   vctrs_type2_list_s3,
-  vctrs_type2_list_unspecified,
   vctrs_type2_list_scalar,
 
   vctrs_type2_dataframe_dataframe,
   vctrs_type2_dataframe_s3,
-  vctrs_type2_dataframe_unspecified,
   vctrs_type2_dataframe_scalar,
 
   vctrs_type2_s3_s3,
-  vctrs_type2_s3_unspecified,
   vctrs_type2_s3_scalar,
-
-  vctrs_type2_unspecified_unspecified,
-  vctrs_type2_unspecified_scalar,
 
   vctrs_type2_scalar_scalar
 };
@@ -190,6 +190,13 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_null_bare_posixct,
   vctrs_type2_s3_null_bare_posixlt,
   vctrs_type2_s3_null_unknown,
+
+  vctrs_type2_s3_unspecified_bare_factor,
+  vctrs_type2_s3_unspecified_bare_ordered,
+  vctrs_type2_s3_unspecified_bare_date,
+  vctrs_type2_s3_unspecified_bare_posixct,
+  vctrs_type2_s3_unspecified_bare_posixlt,
+  vctrs_type2_s3_unspecified_unknown,
 
   vctrs_type2_s3_logical_bare_factor,
   vctrs_type2_s3_logical_bare_ordered,
@@ -246,13 +253,6 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_dataframe_bare_posixct,
   vctrs_type2_s3_dataframe_bare_posixlt,
   vctrs_type2_s3_dataframe_unknown,
-
-  vctrs_type2_s3_unspecified_bare_factor,
-  vctrs_type2_s3_unspecified_bare_ordered,
-  vctrs_type2_s3_unspecified_bare_date,
-  vctrs_type2_s3_unspecified_bare_posixct,
-  vctrs_type2_s3_unspecified_bare_posixlt,
-  vctrs_type2_s3_unspecified_unknown,
 
   vctrs_type2_s3_scalar_bare_factor,
   vctrs_type2_s3_scalar_bare_ordered,

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -249,6 +249,9 @@ enum vctrs_type2_s3 {
 
   vctrs_type2_s3_unspecified_bare_factor,
   vctrs_type2_s3_unspecified_bare_ordered,
+  vctrs_type2_s3_unspecified_bare_date,
+  vctrs_type2_s3_unspecified_bare_posixct,
+  vctrs_type2_s3_unspecified_bare_posixlt,
   vctrs_type2_s3_unspecified_unknown,
 
   vctrs_type2_s3_scalar_bare_factor,

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -564,6 +564,11 @@ void stop_incompatible_size(SEXP x, SEXP y,
 void stop_recycle_incompatible_size(R_len_t x_size, R_len_t size,
                                     struct vctrs_arg* x_arg)
   __attribute__((noreturn));
+void stop_incompatible_type(SEXP x,
+                            SEXP y,
+                            struct vctrs_arg* x_arg,
+                            struct vctrs_arg* y_arg)
+  __attribute__((noreturn));
 void stop_corrupt_factor_levels(SEXP x, struct vctrs_arg* arg) __attribute__((noreturn));
 void stop_corrupt_ordered_levels(SEXP x, struct vctrs_arg* arg) __attribute__((noreturn));
 

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -8,6 +8,17 @@ test_that("new classes are uncoercible by default", {
   expect_error(vec_cast(x, 1), class = "vctrs_error_incompatible_cast")
 })
 
+# TODO - Uncomment the NULL tests after #814 is fixed
+test_that("casting requires vectors", {
+  #expect_error(vec_cast(NULL, quote(name)), class = "vctrs_error_scalar_type")
+  expect_error(vec_cast(NA, quote(name)), class = "vctrs_error_scalar_type")
+  expect_error(vec_cast(list(), quote(name)), class = "vctrs_error_scalar_type")
+  #expect_error(vec_cast(quote(name), NULL), class = "vctrs_error_scalar_type")
+  expect_error(vec_cast(quote(name), NA), class = "vctrs_error_scalar_type")
+  expect_error(vec_cast(quote(name), list()), class = "vctrs_error_scalar_type")
+  expect_error(vec_cast(quote(name), quote(name)), class = "vctrs_error_scalar_type")
+})
+
 test_that("dimensionality matches output" ,{
   x1 <- matrix(TRUE, nrow = 1, ncol = 1)
   x2 <- matrix(1, nrow = 0, ncol = 2)

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -209,6 +209,12 @@ test_that("equality is known to fail when comparing bytes to other encodings", {
   }
 })
 
+test_that("can compare unspecified", {
+  expect_equal(vec_compare(NA, NA), NA_integer_)
+  expect_equal(vec_compare(NA, NA, na_equal = TRUE), 0)
+  expect_equal(vec_compare(c(NA, NA), unspecified(2)), c(NA_integer_, NA_integer_))
+})
+
 # order/sort --------------------------------------------------------------
 
 test_that("can request NAs sorted first", {

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -339,6 +339,16 @@ test_that("NA do not propagate from function bodies or formals", {
   expect_false(vec_equal(list(fn), list(other)))
 })
 
+test_that("can check equality of unspecified objects", {
+  expect_equal(vec_equal(NA, NA), NA)
+  expect_true(vec_equal(NA, NA, na_equal = TRUE))
+
+  expect_equal(vec_equal(unspecified(1), unspecified(1)), NA)
+  expect_true(vec_equal(unspecified(1), unspecified(1), na_equal = TRUE))
+
+  expect_equal(vec_equal(NA, unspecified(1)), NA)
+  expect_true(vec_equal(NA, unspecified(1), na_equal = TRUE))
+})
 
 # proxy -------------------------------------------------------------------
 

--- a/tests/testthat/test-size.R
+++ b/tests/testthat/test-size.R
@@ -49,6 +49,12 @@ test_that("`NULL` has size zero", {
   expect_identical(vec_size(NULL), 0L)
 })
 
+test_that("can take the size of unspecified objects", {
+  expect_size(NA, 1)
+  expect_size(c(NA, NA), 2)
+  expect_size(unspecified(2), 2)
+})
+
 # vec_size_common ---------------------------------------------------------
 
 test_that("vec_size_common with no input is 0L unless `.absent` is provided", {

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -93,9 +93,13 @@ test_that("atomics can't be assigned in lists", {
 # TODO - Revisit this behavior, as it seems inconsistent from our emerging
 # treatment of `NA` as `list(NULL)` and makes internal handling more
 # complicated
-test_that("unspecified() can be assigned in lists, but NA unspecified cannot", {
+test_that("NA vector of unspecified cannot be assigned into lists", {
   x <- list(1, 2)
   expect_error(vec_slice(x, 1) <- NA, class = "vctrs_error_incompatible_type")
+})
+
+test_that("monitoring test - unspecified() can be assigned in lists", {
+  x <- list(1, 2)
   expect_error(vec_slice(x, 1) <- unspecified(1), NA)
   expect_equal(x, list(NULL, 2))
 })

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -294,6 +294,18 @@ test_that("slice-assign falls back to `[<-` when proxy is not implemented", {
   expect_identical(obj, c("dispatched", "dispatched", "baz"))
 })
 
+test_that("vec_assign() cannot assign unspecified values into foreign vector types", {
+  obj <- foobar(c("foo", "bar", "baz"))
+
+  # These are correctly incompatible cast errors, not type errors.
+  # There is a common type, it is `vec_ptype(obj)`, but you can't cast
+  # an unspecified vector to foreign types without implementing a method for it.
+  # (Just calling `vec_init(to, vec_size(x))` for all classes wouldn't work,
+  # since classes like integer64 might not support `NA_integer_` subsetting)
+  expect_error(vec_assign(obj, 1, NA), class = "vctrs_error_incompatible_cast")
+  expect_error(vec_assign(obj, 1, unspecified(1)), class = "vctrs_error_incompatible_cast")
+})
+
 test_that("slice-assign can assign unspecified values into foreign vector types", {
   obj <- foobar(c("foo", "bar", "baz"))
   expect_identical(vec_assign(obj, 1:2, NA), foobar(c(NA, NA, "baz")))

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -306,12 +306,6 @@ test_that("vec_assign() cannot assign unspecified values into foreign vector typ
   expect_error(vec_assign(obj, 1, unspecified(1)), class = "vctrs_error_incompatible_cast")
 })
 
-test_that("slice-assign can assign unspecified values into foreign vector types", {
-  obj <- foobar(c("foo", "bar", "baz"))
-  expect_identical(vec_assign(obj, 1:2, NA), foobar(c(NA, NA, "baz")))
-  expect_identical(vec_assign(obj, 1:2, unspecified(1)), foobar(c(NA, NA, "baz")))
-})
-
 test_that("slice-assign restores value before falling back to `[<-` (#443)", {
   called <- FALSE
 

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -83,11 +83,25 @@ test_that("can assign lists", {
 
 test_that("atomics can't be assigned in lists", {
   x <- list(NULL)
-  expect_error(vec_slice(x, 1) <- NA, class = "vctrs_error_incompatible_type")
-  expect_error(vec_assign(x, 1, NA), class = "vctrs_error_incompatible_type")
+  expect_error(vec_slice(x, 1) <- 1, class = "vctrs_error_incompatible_type")
+  expect_error(vec_assign(x, 1, 2), class = "vctrs_error_incompatible_type")
 
   expect_error(vec_slice(x, 1) <- "foo", class = "vctrs_error_incompatible_type")
   expect_error(vec_assign(x, 1, "foo"), class = "vctrs_error_incompatible_type")
+})
+
+test_that("unspecified can be assigned in lists", {
+  x <- list(1, 2)
+  expect_error(vec_slice(x, 1) <- NA, NA)
+  expect_equal(x, list(NULL, 2))
+
+  x <- list(1, 2)
+  expect_error(vec_slice(x, 1:2) <- NA, NA)
+  expect_equal(x, list(NULL, NULL))
+
+  x <- list(1, 2)
+  expect_error(vec_slice(x, 1) <- unspecified(1), NA)
+  expect_equal(x, list(NULL, 2))
 })
 
 test_that("can assign and slice-assign data frames", {

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -294,16 +294,12 @@ test_that("slice-assign falls back to `[<-` when proxy is not implemented", {
   expect_identical(obj, c("dispatched", "dispatched", "baz"))
 })
 
-test_that("vec_assign() cannot assign unspecified values into foreign vector types", {
+test_that("vec_assign() can always assign unspecified values into foreign vector types", {
   obj <- foobar(c("foo", "bar", "baz"))
+  expect <- foobar(c(NA, "bar", "baz"))
 
-  # These are correctly incompatible cast errors, not type errors.
-  # There is a common type, it is `vec_ptype(obj)`, but you can't cast
-  # an unspecified vector to foreign types without implementing a method for it.
-  # (Just calling `vec_init(to, vec_size(x))` for all classes wouldn't work,
-  # since classes like integer64 might not support `NA_integer_` subsetting)
-  expect_error(vec_assign(obj, 1, NA), class = "vctrs_error_incompatible_cast")
-  expect_error(vec_assign(obj, 1, unspecified(1)), class = "vctrs_error_incompatible_cast")
+  expect_identical(vec_assign(obj, 1, NA), expect)
+  expect_identical(vec_assign(obj, 1, unspecified(1)), expect)
 })
 
 test_that("slice-assign restores value before falling back to `[<-` (#443)", {

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -90,16 +90,12 @@ test_that("atomics can't be assigned in lists", {
   expect_error(vec_assign(x, 1, "foo"), class = "vctrs_error_incompatible_type")
 })
 
-test_that("unspecified can be assigned in lists", {
+# TODO - Revisit this behavior, as it seems inconsistent from our emerging
+# treatment of `NA` as `list(NULL)` and makes internal handling more
+# complicated
+test_that("unspecified() can be assigned in lists, but NA unspecified cannot", {
   x <- list(1, 2)
-  expect_error(vec_slice(x, 1) <- NA, NA)
-  expect_equal(x, list(NULL, 2))
-
-  x <- list(1, 2)
-  expect_error(vec_slice(x, 1:2) <- NA, NA)
-  expect_equal(x, list(NULL, NULL))
-
-  x <- list(1, 2)
+  expect_error(vec_slice(x, 1) <- NA, class = "vctrs_error_incompatible_type")
   expect_error(vec_slice(x, 1) <- unspecified(1), NA)
   expect_equal(x, list(NULL, 2))
 })

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -274,7 +274,7 @@ test_that("can use names to vec_slice<-() a named object", {
 
 test_that("slice-assign falls back to `[<-` when proxy is not implemented", {
   obj <- foobar(c("foo", "bar", "baz"))
-  expect_error(vec_slice(obj, 1:2) <- NA, class = "vctrs_error_incompatible_cast")
+  expect_error(vec_slice(obj, 1:2) <- TRUE, class = "vctrs_error_incompatible_type")
 
   vec_slice(obj, 1:2) <- foobar("quux")
 
@@ -294,8 +294,14 @@ test_that("slice-assign falls back to `[<-` when proxy is not implemented", {
   )
 
   obj <- foobar(c("foo", "bar", "baz"))
-  vec_slice(obj, 1:2) <- NA
+  vec_slice(obj, 1:2) <- TRUE
   expect_identical(obj, c("dispatched", "dispatched", "baz"))
+})
+
+test_that("slice-assign can assign unspecified values into foreign vector types", {
+  obj <- foobar(c("foo", "bar", "baz"))
+  expect_identical(vec_assign(obj, 1:2, NA), foobar(c(NA, NA, "baz")))
+  expect_identical(vec_assign(obj, 1:2, unspecified(1)), foobar(c(NA, NA, "baz")))
 })
 
 test_that("slice-assign restores value before falling back to `[<-` (#443)", {

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -391,6 +391,15 @@ test_that("vec_slice() asserts vectorness (#301)", {
   expect_error(vec_slice(NULL, 1), class = "vctrs_error_scalar_type")
 })
 
+test_that("slicing an unspecified logical vector returns a logical vector", {
+  expect_identical(vec_slice(NA, integer()), logical())
+  expect_identical(vec_slice(NA, c(1, 1)), c(NA, NA))
+})
+
+test_that("slicing an unspecified() object returns an unspecified()", {
+  expect_identical(vec_slice(unspecified(1), integer()), unspecified())
+  expect_identical(vec_slice(unspecified(1), c(1, 1)), unspecified(2))
+})
 
 # vec_init ----------------------------------------------------------------
 

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -112,6 +112,12 @@ test_that("dimensionality matches output" ,{
   expect_error(vec_cast(x, logical()), class = "vctrs_error_incompatible_cast")
 })
 
+test_that("the common type of two `NA` vectors is unspecified", {
+  expect_equal(vec_ptype2(NA, NA), unspecified())
+
+  # Ensure the R level dispatch is consistent
+  expect_equal(vec_default_ptype2(NA, NA), unspecified())
+})
 
 # Integer
 

--- a/tests/testthat/test-type-unspecified.R
+++ b/tests/testthat/test-type-unspecified.R
@@ -87,8 +87,8 @@ test_that("tibble::type_sum() knows about unspecified", {
 })
 
 test_that("casting to a scalar type errors", {
-  expect_error(vec_cast(NA, quote(x)), "Not a vector")
-  expect_error(vec_cast(unspecified(1), quote(x)), "Not a vector")
+  expect_error(vec_cast(NA, quote(x)), class = "vctrs_error_scalar_type")
+  expect_error(vec_cast(unspecified(1), quote(x)), class = "vctrs_error_scalar_type")
 })
 
 test_that("can cast to unspecified from unspecified", {

--- a/tests/testthat/test-type-unspecified.R
+++ b/tests/testthat/test-type-unspecified.R
@@ -91,12 +91,12 @@ test_that("casting to a scalar type errors", {
   expect_error(vec_cast(unspecified(1), quote(x)), class = "vctrs_error_scalar_type")
 })
 
-test_that("can cast to unspecified from unspecified", {
+test_that("monitoring test - can cast to unspecified from unspecified", {
   expect_identical(vec_cast(NA, unspecified()), unspecified(1))
   expect_identical(vec_cast(unspecified(1), unspecified()), unspecified(1))
 })
 
-test_that("casting unspecified input to NA unspecified results in NA vector", {
+test_that("monitoring test - casting unspecified input to NA unspecified results in NA vector", {
   expect_identical(vec_cast(unspecified(1), NA), NA)
   expect_identical(vec_cast(NA, NA), NA)
 })

--- a/tests/testthat/test-type-unspecified.R
+++ b/tests/testthat/test-type-unspecified.R
@@ -23,6 +23,14 @@ test_that("unknown type is idempotent", {
   expect_equal(types, rhs)
 })
 
+test_that("common type of unspecified and NULL is unspecified", {
+  expect_identical(vec_ptype2(unspecified(), NULL), unspecified())
+  expect_identical(vec_ptype2(NULL, unspecified()), unspecified())
+
+  expect_identical(vec_ptype2(NA, NULL), unspecified())
+  expect_identical(vec_ptype2(NULL, NA), unspecified())
+})
+
 test_that("subsetting works", {
   expect_identical(unspecified(4)[2:3], unspecified(2))
 })

--- a/tests/testthat/test-type-unspecified.R
+++ b/tests/testthat/test-type-unspecified.R
@@ -77,3 +77,19 @@ test_that("unspecified() validates input", {
 test_that("tibble::type_sum() knows about unspecified", {
   expect_identical(tibble::type_sum(unspecified(3)), "???")
 })
+
+test_that("casting to a scalar type errors", {
+  expect_error(vec_cast(NA, quote(x)), "Not a vector")
+  expect_error(vec_cast(unspecified(1), quote(x)), "Not a vector")
+})
+
+test_that("can cast to unspecified from unspecified", {
+  expect_identical(vec_cast(NA, unspecified()), unspecified(1))
+  expect_identical(vec_cast(unspecified(1), unspecified()), unspecified(1))
+})
+
+test_that("casting unspecified input to NA unspecified results in NA vector", {
+  expect_identical(vec_cast(unspecified(1), NA), NA)
+  expect_identical(vec_cast(NA, NA), NA)
+})
+

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -86,6 +86,11 @@ test_that("vec_ptype2() requires vectors", {
   expect_error(vec_ptype2(quote(name), quote(name)), class = "vctrs_error_scalar_type")
 })
 
+test_that("vec_ptype2() with unspecified requires vectors", {
+  expect_error(vec_ptype2(unspecified(), quote(name)), class = "vctrs_error_scalar_type")
+  expect_error(vec_ptype2(quote(name), unspecified()), class = "vctrs_error_scalar_type")
+})
+
 test_that("vec_ptype2() forwards argument tag", {
   expect_error(vec_ptype2(quote(name), list(), x_arg = "foo"), "`foo`", class = "vctrs_error_scalar_type")
   expect_error(vec_ptype2(list(), quote(name), y_arg = "foo"), "`foo`", class = "vctrs_error_scalar_type")


### PR DESCRIPTION
This PR adds native handling of `unspecified()`, which is one of the things slowing down https://github.com/tidyverse/dplyr/issues/4561.

This PR is the result of much conversation with @lionel- about what unspecified should be doing, especially in relation to `vec_ptype2()` and `vec_ptype_common()`.

This PR adds 5 major things:

1. `vec_typeof()` can now return `vctrs_type_unspecified`. This is helpful for controlling ptype2 and cast methods. `vec_base_typeof()` will never return this, meaning that `vec_proxy_typeof()` will continue to return `vctrs_type_logical` for unspecified vectors. This is nice because this is what `vec_compare()` and `vec_equal()` end up using, so no additional special handling is required for this new internal type.

2. The cast dispatch works by catching if `x` is unspecified, and having special behavior if so. Most of the time it just calls `vec_init(to, vec_size(x))`. If `y` happens to be s3, then a dispatch routine specific to `x` being unspecified and `y` being s3 is run to allow us to handle any "known" s3 classes more efficiently.

3. The ptype2 dispatch works similarly to the cast dispatch, except it checks if either `x` or `y` is unspecified. There is special handling for `vec_ptype2(NA, list())` here, which _currently_ should return an error, although @lionel- and I are unsure of this.

4. `vec_typeof2()` and `vec_typeof2_s3()` know about `vctrs_type_unspecified`. Even though the enum values aren't really used in the ptype2 and cast dispatch, I think it makes sense to flesh these out.

5. After talking with @lionel-, I've changed `vec_ptype2(NA, NA)` so that it returns `unspecified()`. `vec_ptype_common()` will finalise this, so it will still return `logical()`. This fixes iterative `vec_ptype2()` calls like `vec_ptype2(vec_ptype2(NA, NA), "")`, which previously errored.

Below are some benchmarks. Improvements are pretty good, but I'd like to see more improvements in the `vec_ptype2(<unspecified>, <bare-factor>)` cases. This will end up calling `vec_type()`, which for S3 objects calls `vec_slice(<bare-factor>, NULL)`. An improved factor slicing method might help here, but I'm not sure yet. We could also special case our "known" classes in the `s3_type()` routine that `vec_type()` calls, avoiding the slice entirely.

``` r
library(vctrs)

na <- NA
uns <- unspecified()

x <- 1
y <- factor("x")
```

```r
# before
bench::mark(vec_ptype2(uns, uns))
#> # A tibble: 1 x 6
#>   expression                min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>           <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(uns, uns)   12.4µs     16µs    52382.    15.1KB     15.7

# after
bench::mark(vec_ptype2(uns, uns))
#> # A tibble: 1 x 6
#>   expression                min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>           <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(uns, uns)    945ns   1.23µs   564630.        0B        0
```

```r
# before
bench::mark(vec_ptype2(na, y))
#> # A tibble: 1 x 6
#>   expression             min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(na, y)   12.7µs   16.3µs    60953.    26.7KB     24.4

# after
bench::mark(vec_ptype2(na, y))
#> # A tibble: 1 x 6
#>   expression             min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(na, y)   7.79µs   10.3µs    91157.    10.7KB     18.2
```

```r
# before
bench::mark(vec_ptype2(uns, x))
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(uns, x)   3.78µs   5.07µs   194677.        0B     19.5

# after
bench::mark(vec_ptype2(uns, x))
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(uns, x)    758ns   1.01µs   866591.        0B        0
```

```r
# before
bench::mark(vec_ptype2(uns, y))
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(uns, y)   10.7µs   12.7µs    73955.        0B     22.2

# after
bench::mark(vec_ptype2(uns, y))
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(uns, y)   7.37µs   8.44µs   113308.        0B     34.0
```

```r
# before
bench::mark(vec_cast(na, y))
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast(NA, y)   16.7µs   19.7µs    47827.    33.4KB     23.9

# after
bench::mark(vec_cast(na, y))
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast(na, y)   5.89µs   6.88µs   133945.        0B     26.8
```

```r
# before
bench::mark(vec_cast(uns, x))
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast(uns, x)   13.5µs   15.6µs    61904.    7.01KB     24.8

# after
bench::mark(vec_cast(uns, x))
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast(uns, x)   1.19µs   1.66µs   590555.        0B        0
```

```r
# before
bench::mark(vec_cast(uns, y))
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast(uns, y)   18.9µs   21.6µs    44425.        0B     17.8

# after
bench::mark(vec_cast(uns, y))
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast(uns, y)   6.08µs   7.18µs   132693.        0B     26.5
```