### PR TITLE
Custom integer64 slicing support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # vctrs (development version)
 
+* `vec_slice()` and `vec_chop()` now work correctly with `bit64::integer64()`
+  objects when an `NA` subscript is supplied. By extension, this means that
+  `vec_init()` now works with these objects as well (#813).
+  
 * `vec_rbind()` now binds row names. When named inputs are supplied
   and `names_to` is `NULL`, the names define row names. If `names_to`
   is supplied, they are assigned in the column name as before.

--- a/R/slice.R
+++ b/R/slice.R
@@ -103,6 +103,49 @@ vec_slice_fallback <- function(x, i) {
   vec_restore(out, x)
 }
 
+vec_slice_fallback_integer64 <- function(x, i) {
+  d <- vec_dim_n(x)
+
+  if (d == 2) {
+    out <- x[i, , drop = FALSE]
+  } else {
+    miss_args <- rep(list(missing_arg()), d - 1)
+    out <- eval_bare(expr(x[i, !!!miss_args, drop = FALSE]))
+  }
+
+  is_na <- is.na(i)
+
+  if (!any(is_na)) {
+    return(out)
+  }
+
+  if (d == 2) {
+    out[is_na,] <- bit64::NA_integer64_
+  } else {
+    eval_bare(expr(out[is_na, !!!miss_args] <- bit64::NA_integer64_))
+  }
+
+  out
+}
+
+# bit64::integer64() objects do not have support for `NA_integer_`
+# slicing. This manually replaces the garbage values that are created
+# any time a slice with `NA_integer_` is made.
+vec_slice_dispatch_integer64 <- function(x, i) {
+  out <- x[i]
+
+  is_na <- is.na(i)
+
+  if (!any(is_na)) {
+    return(out)
+  }
+
+  out[is_na] <- bit64::NA_integer64_
+
+  out
+}
+
+
 #' @rdname vec_slice
 #' @export
 `vec_slice<-` <- function(x, i, value) {

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -322,7 +322,9 @@ static SEXP chop_fallback(SEXP x, SEXP indices, struct vctrs_chop_info info) {
   Rf_defineVar(syms_x, x, env);
   Rf_defineVar(syms_i, info.index, env);
 
-  // Construct call with symbols, not values, for performance
+  // Construct call with symbols, not values, for performance.
+  // TODO - Remove once bit64 is updated on CRAN. Special casing integer64
+  // objects to ensure correct slicing with `NA_integer_`.
   SEXP call;
   if (is_integer64(x)) {
     call = PROTECT(Rf_lang3(syms_vec_slice_dispatch_integer64, syms_x, syms_i));

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -324,7 +324,7 @@ static SEXP chop_fallback(SEXP x, SEXP indices, struct vctrs_chop_info info) {
 
   // Construct call with symbols, not values, for performance
   SEXP call;
-  if (Rf_inherits(x, "integer64")) {
+  if (is_integer64(x)) {
     call = PROTECT(Rf_lang3(syms_vec_slice_dispatch_integer64, syms_x, syms_i));
     Rf_defineVar(syms_vec_slice_dispatch_integer64, fns_vec_slice_dispatch_integer64, env);
   } else {

--- a/src/slice.c
+++ b/src/slice.c
@@ -213,7 +213,7 @@ static SEXP df_slice(SEXP x, SEXP subscript) {
 
 
 SEXP vec_slice_fallback(SEXP x, SEXP subscript) {
-  if (Rf_inherits(x, "integer64")) {
+  if (is_integer64(x)) {
     return vctrs_dispatch2(syms_vec_slice_fallback_integer64, fns_vec_slice_fallback_integer64,
                            syms_x, x,
                            syms_i, subscript);
@@ -225,7 +225,7 @@ SEXP vec_slice_fallback(SEXP x, SEXP subscript) {
 }
 
 static SEXP vec_slice_dispatch(SEXP x, SEXP subscript) {
-  if (Rf_inherits(x, "integer64")) {
+  if (is_integer64(x)) {
     return vctrs_dispatch2(syms_vec_slice_dispatch_integer64, fns_vec_slice_dispatch_integer64,
                            syms_x, x,
                            syms_i, subscript);

--- a/src/slice.c
+++ b/src/slice.c
@@ -213,6 +213,8 @@ static SEXP df_slice(SEXP x, SEXP subscript) {
 
 
 SEXP vec_slice_fallback(SEXP x, SEXP subscript) {
+  // TODO - Remove once bit64 is updated on CRAN. Special casing integer64
+  // objects to ensure correct slicing with `NA_integer_`.
   if (is_integer64(x)) {
     return vctrs_dispatch2(syms_vec_slice_fallback_integer64, fns_vec_slice_fallback_integer64,
                            syms_x, x,
@@ -225,6 +227,8 @@ SEXP vec_slice_fallback(SEXP x, SEXP subscript) {
 }
 
 static SEXP vec_slice_dispatch(SEXP x, SEXP subscript) {
+  // TODO - Remove once bit64 is updated on CRAN. Special casing integer64
+  // objects to ensure correct slicing with `NA_integer_`.
   if (is_integer64(x)) {
     return vctrs_dispatch2(syms_vec_slice_dispatch_integer64, fns_vec_slice_dispatch_integer64,
                            syms_x, x,

--- a/src/slice.h
+++ b/src/slice.h
@@ -1,6 +1,8 @@
 #ifndef VCTRS_SLICE_H
 #define VCTRS_SLICE_H
 
+extern SEXP syms_vec_slice_dispatch_integer64;
+extern SEXP fns_vec_slice_dispatch_integer64;
 
 SEXP slice_names(SEXP names, SEXP subscript);
 SEXP slice_rownames(SEXP names, SEXP subscript);

--- a/src/utils.c
+++ b/src/utils.c
@@ -594,6 +594,11 @@ SEXP arg_validate(SEXP arg, const char* arg_nm) {
   }
 }
 
+// [[ include("utils.h") ]]
+bool is_integer64(SEXP x) {
+  return TYPEOF(x) == REALSXP && Rf_inherits(x, "integer64");
+}
+
 
 void* r_vec_deref(SEXP x) {
   switch (TYPEOF(x)) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -126,6 +126,8 @@ bool is_compact(SEXP x);
 SEXP compact_materialize(SEXP x);
 R_len_t vec_subscript_size(SEXP x);
 
+bool is_integer64(SEXP x);
+
 SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n);
 SEXP outer_names(SEXP names, SEXP outer, R_len_t n);
 SEXP vec_set_names(SEXP x, SEXP names);

--- a/tests/testthat/test-type-integer64.R
+++ b/tests/testthat/test-type-integer64.R
@@ -106,3 +106,35 @@ test_that("can init integer64 objects", {
   dim(x) <- c(2, 2, 2)
   expect_identical(vec_init(x, 2), vec_slice(x, idx))
 })
+
+test_that("can chop integer64 objects with `NA_integer_` indices", {
+  idx <- list(NA_integer_, 1)
+
+  x <- bit64::as.integer64(1:8)
+  expect <- list(
+    bit64::as.integer64(NA),
+    bit64::as.integer64(1)
+  )
+
+  expect_identical(vec_chop(x, idx), expect)
+
+  dim(x) <- c(4, 2)
+  expect <- list(
+    bit64::as.integer64(c(NA, NA)),
+    bit64::as.integer64(c(1, 5))
+  )
+  dim(expect[[1]]) <- c(1, 2)
+  dim(expect[[2]]) <- c(1, 2)
+
+  expect_identical(vec_chop(x, idx), expect)
+
+  dim(x) <- c(2, 2, 2)
+  expect <- list(
+    bit64::as.integer64(c(NA, NA, NA, NA)),
+    bit64::as.integer64(c(1, 3, 5, 7))
+  )
+  dim(expect[[1]]) <- c(1, 2, 2)
+  dim(expect[[2]]) <- c(1, 2, 2)
+
+  expect_identical(vec_chop(x, idx), expect)
+})

--- a/tests/testthat/test-type-integer64.R
+++ b/tests/testthat/test-type-integer64.R
@@ -59,3 +59,50 @@ test_that("can sort integer64", {
   expect_identical(vec_order(x), int(2, 3, 1, 4))
   expect_identical(x[vec_order(x)], bit64::as.integer64(c(-3, -2, -1, 1)))
 })
+
+test_that("can slice integer64 objects of all dimensions", {
+  x <- bit64::as.integer64(1:8)
+  expect <- bit64::as.integer64(c(1, 3))
+  expect_identical(vec_slice(x, c(1, 3)), expect)
+
+  dim(x) <- c(4, 2)
+  expect <- bit64::as.integer64(c(1, 3, 5, 7))
+  dim(expect) <- c(2, 2)
+  expect_identical(vec_slice(x, c(1, 3)), expect)
+
+  dim(x) <- c(2, 2, 2)
+  expect <- bit64::as.integer64(c(2, 4, 6, 8))
+  dim(expect) <- c(1, 2, 2)
+  expect_identical(vec_slice(x, 2), expect)
+})
+
+test_that("can slice integer64 objects with `NA_integer_`", {
+  idx <- c(NA_integer_, 1)
+
+  x <- bit64::as.integer64(1:8)
+  expect <- bit64::as.integer64(c(NA, 1))
+  expect_identical(vec_slice(x, idx), expect)
+
+  dim(x) <- c(4, 2)
+  expect <- bit64::as.integer64(c(NA, 1, NA, 5))
+  dim(expect) <- c(2, 2)
+  expect_identical(vec_slice(x, idx), expect)
+
+  dim(x) <- c(2, 2, 2)
+  expect <- bit64::as.integer64(c(NA, 1, NA, 3, NA, 5, NA, 7))
+  dim(expect) <- c(2, 2, 2)
+  expect_identical(vec_slice(x, idx), expect)
+})
+
+test_that("can init integer64 objects", {
+  idx <- c(NA_integer_, NA_integer_)
+
+  x <- bit64::as.integer64(1:8)
+  expect_identical(vec_init(x, 2), vec_slice(x, idx))
+
+  dim(x) <- c(4, 2)
+  expect_identical(vec_init(x, 2), vec_slice(x, idx))
+
+  dim(x) <- c(2, 2, 2)
+  expect_identical(vec_init(x, 2), vec_slice(x, idx))
+})


### PR DESCRIPTION
Closes tidyverse/tidyr#846 

This PR adds integer64 support for `vec_chop()` and `vec_slice()`, repairing the object whenever it is sliced with `NA_integer_`, which is unsupported by the cran version of bit64.

By extension this allows us to use `vec_init()` with these objects, freeing us to hard-code casting of `unspecified()` objects to any `to` type with `vec_init(to, vec_size(x))` in #812 

This adds two new R functions:

- `vec_slice_fallback_integer64()` for use with shaped integer64 objects
- `vec_slice_dispatch_integer64()` for use with 1D integer64 objects

When slicing with shaped objects, the C level `vec_slice_fallback()` will switch to calling the R level `vec_slice_fallback_integer64()` if the input is integer64.

When slicing 1D objects with `[`, I've added a new C level `vec_slice_dispatch()` that either calls out to `vec_slice_dispatch_integer64()` or does our original behavior of calling to `[`.

The rationale for doing the `inherits(x, "integer64")` check at the C level is for speed with `vec_chop()`. We don't want to slow down `vec_chop()` on things like factors by making it repeatedly call `inherits(x, "integer64")` to decide which slicing path to take. We can determine whether we need `[` or `vec_slice_dispatch_integer64()` once up front, and then construct the slice call using that function. It feels a little invasive because now `chop_fallback()` has to "know" about integer64 objects, but the benefits seem worth it

This makes the assumption that if `inherits(x, "integer64")` is true, then the user has bit64 installed. I can add an `is_installed("bit64")` check to `vec_slice_fallback_integer64()` and `vec_slice_dispatch_integer64()` if you feel it is worth it.