### PR TITLE
Tiny `vec_is_partial()` optimization

### DIFF
--- a/R/partial.R
+++ b/R/partial.R
@@ -33,7 +33,7 @@ obj_print_data.vctrs_partial <- function(x, ...) {
 #' @rdname new_partial
 #' @export
 is_partial <- function(x) {
-  is.null(x) || inherits(x, "vctrs_partial")
+  .Call(vctrs_is_partial, x)
 }
 
 #' @rdname new_partial

--- a/src/init.c
+++ b/src/init.c
@@ -86,6 +86,7 @@ extern SEXP vctrs_maybe_translate_encoding2(SEXP, SEXP);
 extern SEXP vctrs_validate_name_repair_arg(SEXP);
 extern SEXP vctrs_validate_minimal_names(SEXP, SEXP);
 extern SEXP vctrs_as_names(SEXP, SEXP, SEXP);
+extern SEXP vctrs_is_partial(SEXP);
 
 // Very experimental
 // Available in the API header
@@ -191,6 +192,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_validate_name_repair_arg",   (DL_FUNC) &vctrs_validate_name_repair_arg, 1},
   {"vctrs_validate_minimal_names",     (DL_FUNC) &vctrs_validate_minimal_names, 2},
   {"vctrs_as_names",                   (DL_FUNC) &vctrs_as_names, 3},
+  {"vctrs_is_partial",                 (DL_FUNC) &vctrs_is_partial, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/utils-dispatch.c
+++ b/src/utils-dispatch.c
@@ -124,3 +124,8 @@ static const char* class_type_as_str(enum vctrs_class_type type) {
 bool vec_is_partial(SEXP x) {
   return x == R_NilValue || (TYPEOF(x) == VECSXP && Rf_inherits(x, "vctrs_partial"));
 }
+
+// [[ register() ]]
+SEXP vctrs_is_partial(SEXP x) {
+  return Rf_ScalarLogical(vec_is_partial(x));
+}

--- a/src/utils-dispatch.c
+++ b/src/utils-dispatch.c
@@ -122,5 +122,5 @@ static const char* class_type_as_str(enum vctrs_class_type type) {
 
 // [[ include("vctrs.h") ]]
 bool vec_is_partial(SEXP x) {
-  return x == R_NilValue || Rf_inherits(x, "vctrs_partial");
+  return x == R_NilValue || (TYPEOF(x) == VECSXP && Rf_inherits(x, "vctrs_partial"));
 }


### PR DESCRIPTION
- Very small `vec_is_partial()` optimization of exiting early if the type of `x` is not a list
- The R level `is_partial()` now calls the C level `vec_is_partial()`, this way its easier to keep them aligned