### PR TITLE
`vec_ptype()` and `vec_ptype_finalise()` improvements with data frames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # vctrs (development version)
 
+* `vec_ptype_finalise()` is now recursive over all data frame types, ensuring
+  that unspecified columns are correctly finalised to logical (#800).
+
+* `vec_ptype()` now correctly handles unspecified columns in data frames, and
+  will always return an unspecified column type (#800).
+
 * `vec_slice()` and `vec_chop()` now work correctly with `bit64::integer64()`
   objects when an `NA` subscript is supplied. By extension, this means that
   `vec_init()` now works with these objects as well (#813).

--- a/R/partial.R
+++ b/R/partial.R
@@ -43,7 +43,7 @@ vec_ptype_finalise <- function(x, ...) {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
-  return(.Call(vctrs_type_finalise, x))
+  return(.Call(vctrs_ptype_finalise, x))
   UseMethod("vec_ptype_finalise")
 }
 vec_ptype_finalise_dispatch <- function(x, ...) {

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -107,7 +107,7 @@ vec_cast.data.frame.default <- function(x, to, ..., x_arg = "x", to_arg = "to") 
 
 #' @export
 vec_restore.data.frame <- function(x, to, ..., n = NULL) {
-  .Call(vctrs_df_restore, x, to, n)
+  .Call(vctrs_bare_df_restore, x, to, n)
 }
 
 

--- a/src/init.c
+++ b/src/init.c
@@ -70,7 +70,7 @@ extern SEXP vctrs_type2_df_df(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_type_info(SEXP);
 extern SEXP vctrs_proxy_info(SEXP);
 extern SEXP vctrs_class_type(SEXP);
-extern SEXP vctrs_bare_df_restore(SEXP, SEXP, SEXP);
+extern SEXP vec_bare_df_restore(SEXP, SEXP, SEXP);
 extern SEXP vctrs_recycle(SEXP, SEXP, SEXP);
 extern SEXP vctrs_coercible_cast(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_assign(SEXP, SEXP, SEXP);
@@ -176,7 +176,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_type_info",                  (DL_FUNC) &vctrs_type_info, 1},
   {"vctrs_proxy_info",                 (DL_FUNC) &vctrs_proxy_info, 1},
   {"vctrs_class_type",                 (DL_FUNC) &vctrs_class_type, 1},
-  {"vctrs_bare_df_restore",            (DL_FUNC) &vctrs_bare_df_restore, 3},
+  {"vctrs_bare_df_restore",            (DL_FUNC) &vec_bare_df_restore, 3},
   {"vctrs_recycle",                    (DL_FUNC) &vctrs_recycle, 3},
   {"vctrs_coercible_cast",             (DL_FUNC) &vctrs_coercible_cast, 4},
   {"vctrs_assign",                     (DL_FUNC) &vec_assign, 3},

--- a/src/init.c
+++ b/src/init.c
@@ -57,7 +57,7 @@ extern SEXP vec_proxy(SEXP);
 extern SEXP vec_proxy_equal(SEXP);
 extern SEXP vctrs_unspecified(SEXP);
 extern SEXP vec_type(SEXP);
-extern SEXP vec_type_finalise(SEXP);
+extern SEXP vec_ptype_finalise(SEXP);
 extern SEXP vctrs_minimal_names(SEXP);
 extern SEXP vctrs_unique_names(SEXP, SEXP);
 extern SEXP vctrs_as_minimal_names(SEXP);
@@ -163,7 +163,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_proxy_equal",                (DL_FUNC) &vec_proxy_equal, 1},
   {"vctrs_unspecified",                (DL_FUNC) &vctrs_unspecified, 1},
   {"vctrs_type",                       (DL_FUNC) &vec_type, 1},
-  {"vctrs_type_finalise",              (DL_FUNC) &vec_type_finalise, 1},
+  {"vctrs_ptype_finalise",             (DL_FUNC) &vec_ptype_finalise, 1},
   {"vctrs_minimal_names",              (DL_FUNC) &vctrs_minimal_names, 1},
   {"vctrs_unique_names",               (DL_FUNC) &vctrs_unique_names, 2},
   {"vctrs_as_minimal_names",           (DL_FUNC) &vctrs_as_minimal_names, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -70,7 +70,7 @@ extern SEXP vctrs_type2_df_df(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_type_info(SEXP);
 extern SEXP vctrs_proxy_info(SEXP);
 extern SEXP vctrs_class_type(SEXP);
-extern SEXP vctrs_df_restore(SEXP, SEXP, SEXP);
+extern SEXP vctrs_bare_df_restore(SEXP, SEXP, SEXP);
 extern SEXP vctrs_recycle(SEXP, SEXP, SEXP);
 extern SEXP vctrs_coercible_cast(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_assign(SEXP, SEXP, SEXP);
@@ -176,7 +176,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_type_info",                  (DL_FUNC) &vctrs_type_info, 1},
   {"vctrs_proxy_info",                 (DL_FUNC) &vctrs_proxy_info, 1},
   {"vctrs_class_type",                 (DL_FUNC) &vctrs_class_type, 1},
-  {"vctrs_df_restore",                 (DL_FUNC) &vctrs_df_restore, 3},
+  {"vctrs_bare_df_restore",            (DL_FUNC) &vctrs_bare_df_restore, 3},
   {"vctrs_recycle",                    (DL_FUNC) &vctrs_recycle, 3},
   {"vctrs_coercible_cast",             (DL_FUNC) &vctrs_coercible_cast, 4},
   {"vctrs_assign",                     (DL_FUNC) &vec_assign, 3},

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -91,17 +91,11 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
   return x;
 }
 
-static SEXP bare_df_restore_impl(SEXP x, SEXP to, R_len_t size);
-
-// [[ include("vctrs.h"); register() ]]
-SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n) {
-  if (TYPEOF(x) != VECSXP) {
-    Rf_errorcall(R_NilValue, "Internal error: Attempt to restore data frame from a %s.",
-                 Rf_type2char(TYPEOF(x)));
-  }
-
-  R_len_t size = (n == R_NilValue) ? df_raw_size(x) : r_int_get(n, 0);
-  return bare_df_restore_impl(x, to, size);
+static SEXP vec_restore_dispatch(SEXP x, SEXP to, SEXP n) {
+  return vctrs_dispatch3(syms_vec_restore_dispatch, fns_vec_restore_dispatch,
+                         syms_x, x,
+                         syms_to, to,
+                         syms_n, n);
 }
 
 static SEXP bare_df_restore_impl(SEXP x, SEXP to, R_len_t size) {
@@ -121,8 +115,16 @@ static SEXP bare_df_restore_impl(SEXP x, SEXP to, R_len_t size) {
   return x;
 }
 
+// [[ include("vctrs.h"); register() ]]
+SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n) {
+  if (TYPEOF(x) != VECSXP) {
+    Rf_errorcall(R_NilValue, "Internal error: Attempt to restore data frame from a %s.",
+                 Rf_type2char(TYPEOF(x)));
+  }
 
-static SEXP vec_restore_dispatch(SEXP x, SEXP to, SEXP n);
+  R_len_t size = (n == R_NilValue) ? df_raw_size(x) : r_int_get(n, 0);
+  return bare_df_restore_impl(x, to, size);
+}
 
 // Restore methods are passed the original atomic type back, so we
 // first restore data frames as such before calling the restore
@@ -143,13 +145,6 @@ SEXP vec_restore(SEXP x, SEXP to, SEXP n) {
   case vctrs_class_bare_tibble: return vec_bare_df_restore(x, to, n);
   case vctrs_class_data_frame: return vec_df_restore(x, to, n);
   }
-}
-
-static SEXP vec_restore_dispatch(SEXP x, SEXP to, SEXP n) {
-  return vctrs_dispatch3(syms_vec_restore_dispatch, fns_vec_restore_dispatch,
-                         syms_x, x,
-                         syms_to, to,
-                         syms_n, n);
 }
 
 

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -91,19 +91,19 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
   return x;
 }
 
-static SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size);
+static SEXP bare_df_restore_impl(SEXP x, SEXP to, R_len_t size);
 
-SEXP vctrs_df_restore(SEXP x, SEXP to, SEXP n) {
+SEXP vctrs_bare_df_restore(SEXP x, SEXP to, SEXP n) {
   if (TYPEOF(x) != VECSXP) {
     Rf_errorcall(R_NilValue, "Internal error: Attempt to restore data frame from a %s.",
                  Rf_type2char(TYPEOF(x)));
   }
 
   R_len_t size = (n == R_NilValue) ? df_raw_size(x) : r_int_get(n, 0);
-  return df_restore_impl(x, to, size);
+  return bare_df_restore_impl(x, to, size);
 }
 
-static SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size) {
+static SEXP bare_df_restore_impl(SEXP x, SEXP to, R_len_t size) {
   x = PROTECT(r_maybe_duplicate(x));
   x = PROTECT(vec_restore_default(x, to));
 
@@ -128,12 +128,12 @@ SEXP vec_restore(SEXP x, SEXP to, SEXP n) {
   default: return vec_restore_dispatch(x, to, n);
   case vctrs_class_none: return vec_restore_default(x, to);
   case vctrs_class_bare_data_frame:
-  case vctrs_class_bare_tibble: return vctrs_df_restore(x, to, n);
+  case vctrs_class_bare_tibble: return vctrs_bare_df_restore(x, to, n);
   case vctrs_class_data_frame: {
     // Restore methods are passed the original atomic type back, so we
     // first restore data frames as such before calling the restore
     // method, if any
-    SEXP out = PROTECT(vctrs_df_restore(x, to, n));
+    SEXP out = PROTECT(vctrs_bare_df_restore(x, to, n));
     out = vec_restore_dispatch(out, to, n);
     UNPROTECT(1);
     return out;

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -93,6 +93,7 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
 
 static SEXP bare_df_restore_impl(SEXP x, SEXP to, R_len_t size);
 
+// [[ include("vctrs.h"); register() ]]
 SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n) {
   if (TYPEOF(x) != VECSXP) {
     Rf_errorcall(R_NilValue, "Internal error: Attempt to restore data frame from a %s.",

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -93,7 +93,7 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
 
 static SEXP bare_df_restore_impl(SEXP x, SEXP to, R_len_t size);
 
-SEXP vctrs_bare_df_restore(SEXP x, SEXP to, SEXP n) {
+SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n) {
   if (TYPEOF(x) != VECSXP) {
     Rf_errorcall(R_NilValue, "Internal error: Attempt to restore data frame from a %s.",
                  Rf_type2char(TYPEOF(x)));
@@ -128,12 +128,12 @@ SEXP vec_restore(SEXP x, SEXP to, SEXP n) {
   default: return vec_restore_dispatch(x, to, n);
   case vctrs_class_none: return vec_restore_default(x, to);
   case vctrs_class_bare_data_frame:
-  case vctrs_class_bare_tibble: return vctrs_bare_df_restore(x, to, n);
+  case vctrs_class_bare_tibble: return vec_bare_df_restore(x, to, n);
   case vctrs_class_data_frame: {
     // Restore methods are passed the original atomic type back, so we
     // first restore data frames as such before calling the restore
     // method, if any
-    SEXP out = PROTECT(vctrs_bare_df_restore(x, to, n));
+    SEXP out = PROTECT(vec_bare_df_restore(x, to, n));
     out = vec_restore_dispatch(out, to, n);
     UNPROTECT(1);
     return out;

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -91,6 +91,8 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
   return x;
 }
 
+static SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size);
+
 SEXP vctrs_df_restore(SEXP x, SEXP to, SEXP n) {
   if (TYPEOF(x) != VECSXP) {
     Rf_errorcall(R_NilValue, "Internal error: Attempt to restore data frame from a %s.",
@@ -101,7 +103,7 @@ SEXP vctrs_df_restore(SEXP x, SEXP to, SEXP n) {
   return df_restore_impl(x, to, size);
 }
 
-SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size) {
+static SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size) {
   x = PROTECT(r_maybe_duplicate(x));
   x = PROTECT(vec_restore_default(x, to));
 

--- a/src/type.c
+++ b/src/type.c
@@ -38,6 +38,23 @@ static SEXP vec_type_slice(SEXP x, SEXP empty) {
   }
 }
 static SEXP s3_type(SEXP x) {
+  switch(class_type(x)) {
+  case vctrs_class_bare_tibble:
+    return bare_df_map(x, &vec_type);
+
+  case vctrs_class_data_frame:
+    return df_map(x, &vec_type);
+
+  case vctrs_class_bare_data_frame:
+    Rf_errorcall(R_NilValue, "Internal error: Bare data frames should be handled by `vec_type()`");
+
+  case vctrs_class_none:
+    Rf_errorcall(R_NilValue, "Internal error: Non-S3 classes should be handled by `vec_type()`");
+
+  default:
+    break;
+  }
+
   if (vec_is_vector(x)) {
     return vec_slice(x, R_NilValue);
   } else {

--- a/src/type.c
+++ b/src/type.c
@@ -63,6 +63,7 @@ static SEXP s3_type(SEXP x) {
   }
 }
 
+static SEXP vec_type_finalise_unspecified(SEXP x);
 static SEXP vec_type_finalise_dispatch(SEXP x);
 
 // [[ include("vctrs.h"); register() ]]
@@ -72,11 +73,7 @@ SEXP vec_type_finalise(SEXP x) {
   }
 
   if (vec_is_unspecified(x)) {
-    R_len_t n = Rf_length(x);
-    SEXP out = PROTECT(Rf_allocVector(LGLSXP, n));
-    r_lgl_fill(out, NA_LOGICAL, n);
-    UNPROTECT(1);
-    return out;
+    return vec_type_finalise_unspecified(x);
   }
 
   if (vec_is_partial(x)) {
@@ -90,6 +87,20 @@ SEXP vec_type_finalise(SEXP x) {
   case vctrs_type_s3:        return vec_type_finalise_dispatch(x);
   default:                   return x;
   }
+}
+
+static SEXP vec_type_finalise_unspecified(SEXP x) {
+  R_len_t size = Rf_length(x);
+
+  if (size == 0) {
+    return vctrs_shared_empty_lgl;
+  }
+
+  SEXP out = PROTECT(Rf_allocVector(LGLSXP, size));
+  r_lgl_fill(out, NA_LOGICAL, size);
+
+  UNPROTECT(1);
+  return out;
 }
 
 static SEXP vec_type_finalise_dispatch(SEXP x) {

--- a/src/type.c
+++ b/src/type.c
@@ -87,10 +87,19 @@ SEXP vec_type_finalise(SEXP x) {
 
   vec_assert(x, args_empty);
 
-  switch (vec_typeof(x)) {
-  case vctrs_type_dataframe: return bare_df_map(x, &vec_type_finalise);
-  case vctrs_type_s3:        return vec_type_finalise_dispatch(x);
-  default:                   return x;
+  switch(class_type(x)) {
+  case vctrs_class_bare_tibble:
+  case vctrs_class_bare_data_frame:
+    return bare_df_map(x, &vec_type_finalise);
+
+  case vctrs_class_data_frame:
+    return df_map(x, &vec_type_finalise);
+
+  case vctrs_class_none:
+    Rf_errorcall(R_NilValue, "Internal error: Non-S3 classes should have returned by now");
+
+  default:
+    return vec_type_finalise_dispatch(x);
   }
 }
 

--- a/src/type.c
+++ b/src/type.c
@@ -63,6 +63,7 @@ static SEXP s3_type(SEXP x) {
   }
 }
 
+static SEXP vec_type_finalise_dispatch(SEXP x);
 
 // [[ include("vctrs.h"); register() ]]
 SEXP vec_type_finalise(SEXP x) {
@@ -86,10 +87,16 @@ SEXP vec_type_finalise(SEXP x) {
 
   switch (vec_typeof(x)) {
   case vctrs_type_dataframe: return bare_df_map(x, &vec_type_finalise);
-  case vctrs_type_s3:        return vctrs_dispatch1(syms_vec_type_finalise_dispatch, fns_vec_type_finalise_dispatch,
-                                                    syms_x, x);
+  case vctrs_type_s3:        return vec_type_finalise_dispatch(x);
   default:                   return x;
   }
+}
+
+static SEXP vec_type_finalise_dispatch(SEXP x) {
+  return vctrs_dispatch1(
+    syms_vec_type_finalise_dispatch, fns_vec_type_finalise_dispatch,
+    syms_x, x
+  );
 }
 
 

--- a/src/type.c
+++ b/src/type.c
@@ -68,7 +68,12 @@ static SEXP vec_type_finalise_dispatch(SEXP x);
 
 // [[ include("vctrs.h"); register() ]]
 SEXP vec_type_finalise(SEXP x) {
+  if (x == R_NilValue) {
+    return x;
+  }
+
   if (!OBJECT(x)) {
+    vec_assert(x, args_empty);
     return x;
   }
 

--- a/src/type.c
+++ b/src/type.c
@@ -23,7 +23,7 @@ SEXP vec_type(SEXP x) {
   case vctrs_type_character:   return vec_type_slice(x, vctrs_shared_empty_chr);
   case vctrs_type_raw:         return vec_type_slice(x, vctrs_shared_empty_raw);
   case vctrs_type_list:        return vec_type_slice(x, vctrs_shared_empty_list);
-  case vctrs_type_dataframe:   return df_map(x, &vec_type);
+  case vctrs_type_dataframe:   return bare_df_map(x, &vec_type);
   case vctrs_type_s3:          return s3_type(x);
   }
   never_reached("vec_type_impl");
@@ -68,7 +68,7 @@ SEXP vec_type_finalise(SEXP x) {
   }
 
   switch (vec_typeof(x)) {
-  case vctrs_type_dataframe: return df_map(x, &vec_type_finalise);
+  case vctrs_type_dataframe: return bare_df_map(x, &vec_type_finalise);
   case vctrs_type_s3:        return vctrs_dispatch1(syms_vec_type_finalise_dispatch, fns_vec_type_finalise_dispatch,
                                                     syms_x, x);
   default:                   return x;

--- a/src/type.c
+++ b/src/type.c
@@ -3,8 +3,8 @@
 #include "arg-counter.h"
 
 // Initialised at load time
-static SEXP syms_vec_type_finalise_dispatch = NULL;
-static SEXP fns_vec_type_finalise_dispatch = NULL;
+static SEXP syms_vec_ptype_finalise_dispatch = NULL;
+static SEXP fns_vec_ptype_finalise_dispatch = NULL;
 
 
 static SEXP vec_type_slice(SEXP x, SEXP empty);
@@ -63,8 +63,8 @@ static SEXP s3_type(SEXP x) {
   }
 }
 
-static SEXP vec_type_finalise_unspecified(SEXP x);
-static SEXP vec_type_finalise_dispatch(SEXP x);
+static SEXP vec_ptype_finalise_unspecified(SEXP x);
+static SEXP vec_ptype_finalise_dispatch(SEXP x);
 
 // [[ include("vctrs.h"); register() ]]
 SEXP vec_type_finalise(SEXP x) {
@@ -78,11 +78,11 @@ SEXP vec_type_finalise(SEXP x) {
   }
 
   if (vec_is_unspecified(x)) {
-    return vec_type_finalise_unspecified(x);
+    return vec_ptype_finalise_unspecified(x);
   }
 
   if (vec_is_partial(x)) {
-    return vec_type_finalise_dispatch(x);
+    return vec_ptype_finalise_dispatch(x);
   }
 
   vec_assert(x, args_empty);
@@ -99,11 +99,11 @@ SEXP vec_type_finalise(SEXP x) {
     Rf_errorcall(R_NilValue, "Internal error: Non-S3 classes should have returned by now");
 
   default:
-    return vec_type_finalise_dispatch(x);
+    return vec_ptype_finalise_dispatch(x);
   }
 }
 
-static SEXP vec_type_finalise_unspecified(SEXP x) {
+static SEXP vec_ptype_finalise_unspecified(SEXP x) {
   R_len_t size = Rf_length(x);
 
   if (size == 0) {
@@ -117,9 +117,9 @@ static SEXP vec_type_finalise_unspecified(SEXP x) {
   return out;
 }
 
-static SEXP vec_type_finalise_dispatch(SEXP x) {
+static SEXP vec_ptype_finalise_dispatch(SEXP x) {
   return vctrs_dispatch1(
-    syms_vec_type_finalise_dispatch, fns_vec_type_finalise_dispatch,
+    syms_vec_ptype_finalise_dispatch, fns_vec_ptype_finalise_dispatch,
     syms_x, x
   );
 }
@@ -176,6 +176,6 @@ static SEXP vctrs_type2_common(SEXP current, SEXP next, struct counters* counter
 
 
 void vctrs_init_type(SEXP ns) {
-  syms_vec_type_finalise_dispatch = Rf_install("vec_ptype_finalise_dispatch");
-  fns_vec_type_finalise_dispatch = Rf_findVar(syms_vec_type_finalise_dispatch, ns);
+  syms_vec_ptype_finalise_dispatch = Rf_install("vec_ptype_finalise_dispatch");
+  fns_vec_ptype_finalise_dispatch = Rf_findVar(syms_vec_ptype_finalise_dispatch, ns);
 }

--- a/src/type.c
+++ b/src/type.c
@@ -67,23 +67,23 @@ static SEXP vec_type_finalise_dispatch(SEXP x);
 
 // [[ include("vctrs.h"); register() ]]
 SEXP vec_type_finalise(SEXP x) {
-  if (x == R_NilValue) {
+  if (!OBJECT(x)) {
     return x;
   }
 
-  if (OBJECT(x)) {
-    if (vec_is_unspecified(x)) {
-      R_len_t n = Rf_length(x);
-      SEXP out = PROTECT(Rf_allocVector(LGLSXP, n));
-      r_lgl_fill(out, NA_LOGICAL, n);
-      UNPROTECT(1);
-      return out;
-    }
+  if (vec_is_unspecified(x)) {
+    R_len_t n = Rf_length(x);
+    SEXP out = PROTECT(Rf_allocVector(LGLSXP, n));
+    r_lgl_fill(out, NA_LOGICAL, n);
+    UNPROTECT(1);
+    return out;
   }
 
-  if (!vec_is_partial(x)) {
-    vec_assert(x, args_empty);
+  if (vec_is_partial(x)) {
+    return vec_type_finalise_dispatch(x);
   }
+
+  vec_assert(x, args_empty);
 
   switch (vec_typeof(x)) {
   case vctrs_type_dataframe: return bare_df_map(x, &vec_type_finalise);

--- a/src/type.c
+++ b/src/type.c
@@ -67,7 +67,7 @@ static SEXP vec_ptype_finalise_unspecified(SEXP x);
 static SEXP vec_ptype_finalise_dispatch(SEXP x);
 
 // [[ include("vctrs.h"); register() ]]
-SEXP vec_type_finalise(SEXP x) {
+SEXP vec_ptype_finalise(SEXP x) {
   if (x == R_NilValue) {
     return x;
   }
@@ -90,10 +90,10 @@ SEXP vec_type_finalise(SEXP x) {
   switch(class_type(x)) {
   case vctrs_class_bare_tibble:
   case vctrs_class_bare_data_frame:
-    return bare_df_map(x, &vec_type_finalise);
+    return bare_df_map(x, &vec_ptype_finalise);
 
   case vctrs_class_data_frame:
-    return df_map(x, &vec_type_finalise);
+    return df_map(x, &vec_ptype_finalise);
 
   case vctrs_class_none:
     Rf_errorcall(R_NilValue, "Internal error: Non-S3 classes should have returned by now");
@@ -154,7 +154,7 @@ SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype) {
   struct vctrs_arg ptype_arg = new_wrapper_arg(NULL, ".ptype");
 
   SEXP type = PROTECT(reduce(ptype, &ptype_arg, dots, &vctrs_type2_common));
-  type = vec_type_finalise(type);
+  type = vec_ptype_finalise(type);
 
   UNPROTECT(1);
   return type;

--- a/src/utils.c
+++ b/src/utils.c
@@ -256,7 +256,7 @@ SEXP map(SEXP x, SEXP (*fn)(SEXP)) {
 
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
-  out = vctrs_bare_df_restore(out, df, vctrs_shared_zero_int);
+  out = vec_bare_df_restore(out, df, vctrs_shared_zero_int);
 
   UNPROTECT(1);
   return out;

--- a/src/utils.c
+++ b/src/utils.c
@@ -254,7 +254,7 @@ SEXP map(SEXP x, SEXP (*fn)(SEXP)) {
   return out;
 }
 
-SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
+SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
   out = vec_bare_df_restore(out, df, vctrs_shared_zero_int);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -239,6 +239,7 @@ SEXP vctrs_set_attributes(SEXP x, SEXP attrib) {
   return x;
 }
 
+// [[ include("utils.h") ]]
 SEXP map(SEXP x, SEXP (*fn)(SEXP)) {
   R_len_t n = Rf_length(x);
   SEXP out = PROTECT(Rf_allocVector(VECSXP, n));
@@ -254,6 +255,7 @@ SEXP map(SEXP x, SEXP (*fn)(SEXP)) {
   return out;
 }
 
+// [[ include("utils.h") ]]
 SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
   out = vec_bare_df_restore(out, df, vctrs_shared_zero_int);

--- a/src/utils.c
+++ b/src/utils.c
@@ -256,7 +256,7 @@ SEXP map(SEXP x, SEXP (*fn)(SEXP)) {
 
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
-  out = vctrs_df_restore(out, df, vctrs_shared_zero_int);
+  out = vctrs_bare_df_restore(out, df, vctrs_shared_zero_int);
 
   UNPROTECT(1);
   return out;

--- a/src/utils.c
+++ b/src/utils.c
@@ -264,6 +264,15 @@ SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP)) {
   return out;
 }
 
+// [[ include("utils.h") ]]
+SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
+  SEXP out = PROTECT(map(df, fn));
+  out = vec_df_restore(out, df, vctrs_shared_zero_int);
+
+  UNPROTECT(1);
+  return out;
+}
+
 inline void never_reached(const char* fn) {
   Rf_error("Internal error in `%s()`: Reached the unreachable.", fn);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -76,7 +76,7 @@ SEXP vctrs_dispatch4(SEXP fn_sym, SEXP fn,
                      SEXP z_sym, SEXP z);
 
 SEXP map(SEXP x, SEXP (*fn)(SEXP));
-SEXP df_map(SEXP df, SEXP (*fn)(SEXP));
+SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP));
 
 enum vctrs_class_type class_type(SEXP x);
 bool is_data_frame(SEXP x);

--- a/src/utils.h
+++ b/src/utils.h
@@ -77,6 +77,7 @@ SEXP vctrs_dispatch4(SEXP fn_sym, SEXP fn,
 
 SEXP map(SEXP x, SEXP (*fn)(SEXP));
 SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP));
+SEXP df_map(SEXP df, SEXP (*fn)(SEXP));
 
 enum vctrs_class_type class_type(SEXP x);
 bool is_data_frame(SEXP x);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -389,7 +389,6 @@ R_len_t df_rownames_size(SEXP x);
 R_len_t df_raw_size(SEXP x);
 R_len_t df_raw_size_from_list(SEXP x);
 SEXP vctrs_df_restore(SEXP x, SEXP to, SEXP n);
-SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size);
 
 SEXP chr_assign(SEXP out, SEXP index, SEXP value, bool clone);
 SEXP list_assign(SEXP out, SEXP index, SEXP value, bool clone);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -388,7 +388,7 @@ R_len_t df_size(SEXP x);
 R_len_t df_rownames_size(SEXP x);
 R_len_t df_raw_size(SEXP x);
 R_len_t df_raw_size_from_list(SEXP x);
-SEXP vctrs_df_restore(SEXP x, SEXP to, SEXP n);
+SEXP vctrs_bare_df_restore(SEXP x, SEXP to, SEXP n);
 
 SEXP chr_assign(SEXP out, SEXP index, SEXP value, bool clone);
 SEXP list_assign(SEXP out, SEXP index, SEXP value, bool clone);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -389,6 +389,7 @@ R_len_t df_rownames_size(SEXP x);
 R_len_t df_raw_size(SEXP x);
 R_len_t df_raw_size_from_list(SEXP x);
 SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n);
+SEXP vec_df_restore(SEXP x, SEXP to, SEXP n);
 
 SEXP chr_assign(SEXP out, SEXP index, SEXP value, bool clone);
 SEXP list_assign(SEXP out, SEXP index, SEXP value, bool clone);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -342,7 +342,7 @@ SEXP vec_assign(SEXP x, SEXP index, SEXP value);
 bool vec_requires_fallback(SEXP x, struct vctrs_proxy_info info);
 SEXP vec_init(SEXP x, R_len_t n);
 SEXP vec_type(SEXP x);
-SEXP vec_type_finalise(SEXP x);
+SEXP vec_ptype_finalise(SEXP x);
 bool vec_is_unspecified(SEXP x);
 SEXP vec_recycle(SEXP x, R_len_t size, struct vctrs_arg* x_arg);
 SEXP vec_recycle_common(SEXP xs, R_len_t size);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -388,7 +388,7 @@ R_len_t df_size(SEXP x);
 R_len_t df_rownames_size(SEXP x);
 R_len_t df_raw_size(SEXP x);
 R_len_t df_raw_size_from_list(SEXP x);
-SEXP vctrs_bare_df_restore(SEXP x, SEXP to, SEXP n);
+SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n);
 
 SEXP chr_assign(SEXP out, SEXP index, SEXP value, bool clone);
 SEXP list_assign(SEXP out, SEXP index, SEXP value, bool clone);

--- a/tests/testthat/test-proxy-restore.R
+++ b/tests/testthat/test-proxy-restore.R
@@ -80,7 +80,7 @@ test_that("arguments are not inlined in the dispatch call (#300)", {
   expect_equal(call, quote(vec_restore.vctrs_foobar(x = x, to = to, n = n)))
 })
 
-test_that("restoring to non-bare data frames calls `vctrs_bare_df_restore()` before dispatching", {
+test_that("restoring to non-bare data frames calls `vec_bare_df_restore()` before dispatching", {
   x <- list(x = numeric())
   to <- new_data_frame(x, class = "tbl_foobar")
 

--- a/tests/testthat/test-proxy-restore.R
+++ b/tests/testthat/test-proxy-restore.R
@@ -80,7 +80,7 @@ test_that("arguments are not inlined in the dispatch call (#300)", {
   expect_equal(call, quote(vec_restore.vctrs_foobar(x = x, to = to, n = n)))
 })
 
-test_that("restoring to non-bare data frames calls `vctrs_df_restore()` before dispatching", {
+test_that("restoring to non-bare data frames calls `vctrs_bare_df_restore()` before dispatching", {
   x <- list(x = numeric())
   to <- new_data_frame(x, class = "tbl_foobar")
 

--- a/tests/testthat/test-type-tibble.R
+++ b/tests/testthat/test-type-tibble.R
@@ -49,3 +49,12 @@ test_that("vec_restore restores tibbles", {
 
   expect_s3_class(df2, "tbl_df")
 })
+
+test_that("the type of a tibble with an unspecified column retains unspecifiedness", {
+  df1 <- tibble::tibble(x = 1, y = NA)
+  df2 <- tibble::tibble(x = 1, y = unspecified(1))
+  expect <- tibble::tibble(x = numeric(), y = unspecified())
+
+  expect_identical(vec_ptype(df1), expect)
+  expect_identical(vec_ptype(df2), expect)
+})

--- a/tests/testthat/test-type-tibble.R
+++ b/tests/testthat/test-type-tibble.R
@@ -58,3 +58,17 @@ test_that("the type of a tibble with an unspecified column retains unspecifiedne
   expect_identical(vec_ptype(df1), expect)
   expect_identical(vec_ptype(df2), expect)
 })
+
+test_that("vec_ptype_finalise() works recursively over tibbles", {
+  df <- tibble(x = numeric(), y = unspecified())
+  expect <- tibble(x = numeric(), y = logical())
+
+  expect_identical(vec_ptype_finalise(df), expect)
+})
+
+test_that("vec_ptype_finalise() can handle tibble df columns", {
+  df <- tibble(x = numeric(), y = tibble(z = unspecified()))
+  expect <- tibble(x = numeric(), y = tibble(z = logical()))
+
+  expect_identical(vec_ptype_finalise(df), expect)
+})

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -188,3 +188,8 @@ test_that("vec_ptype_finalise() can handle data frame columns", {
 
   expect_identical(vec_ptype_finalise(df), expect)
 })
+
+test_that("vec_ptype_finalise() requires vector types", {
+  expect_error(vec_ptype_finalise(quote(name)), class = "vctrs_error_scalar_type")
+  expect_error(vec_ptype_finalise(foobar()), class = "vctrs_error_scalar_type")
+})

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -170,3 +170,21 @@ test_that("explicit list subclasses are vectors", {
 
   expect_identical(vec_slice(df, 1)$z, list_subclass(list(1)))
 })
+
+test_that("vec_ptype_finalise() works with NULL", {
+  expect_identical(vec_ptype_finalise(NULL), NULL)
+})
+
+test_that("vec_ptype_finalise() works recursively over bare data frames", {
+  df <- data_frame(x = numeric(), y = unspecified(), z = partial_factor())
+  expect <- data_frame(x = numeric(), y = logical(), z = factor())
+
+  expect_identical(vec_ptype_finalise(df), expect)
+})
+
+test_that("vec_ptype_finalise() can handle data frame columns", {
+  df <- data_frame(x = numeric(), y = data_frame(z = unspecified()))
+  expect <- data_frame(x = numeric(), y = data_frame(z = logical()))
+
+  expect_identical(vec_ptype_finalise(df), expect)
+})

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -171,6 +171,15 @@ test_that("explicit list subclasses are vectors", {
   expect_identical(vec_slice(df, 1)$z, list_subclass(list(1)))
 })
 
+test_that("the type of a classed data frame with an unspecified column retains unspecifiedness", {
+  df1 <- subclass(data_frame(x = 1, y = NA))
+  df2 <- subclass(data_frame(x = 1, y = unspecified(1)))
+  expect <- subclass(data_frame(x = numeric(), y = unspecified()))
+
+  expect_identical(vec_ptype(df1), expect)
+  expect_identical(vec_ptype(df2), expect)
+})
+
 test_that("vec_ptype_finalise() works with NULL", {
   expect_identical(vec_ptype_finalise(NULL), NULL)
 })

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -182,6 +182,13 @@ test_that("vec_ptype_finalise() works recursively over bare data frames", {
   expect_identical(vec_ptype_finalise(df), expect)
 })
 
+test_that("vec_ptype_finalise() works recursively over classed data frames", {
+  df <- subclass(data_frame(x = numeric(), y = unspecified(), z = partial_factor()))
+  expect <- subclass(data_frame(x = numeric(), y = logical(), z = factor()))
+
+  expect_identical(vec_ptype_finalise(df), expect)
+})
+
 test_that("vec_ptype_finalise() can handle data frame columns", {
   df <- data_frame(x = numeric(), y = data_frame(z = unspecified()))
   expect <- data_frame(x = numeric(), y = data_frame(z = logical()))


### PR DESCRIPTION
Closes #800 

This PR has two goals:

- Rework `vec_type()` to be recursive over all data frame classes, rather than calling `vec_slice(x, NULL)`. This ensures unspecified columns are handled correctly.

- Rework `vec_ptype_finalise()` to be recursive over all data frame classes. This ensures that unspecified columns are finalised to logicals.

Along the way I changed:

- Renamed `vctrs_df_restore()` -> `vec_bare_df_restore()`

- New `vec_df_restore()` that restores generically by dispatching to the R method if one exists

- These two things make `vec_restore()` a bit cleaner to follow

- Similarly, renamed `df_map()` to `bare_df_map()`

- New `df_map()` that restores with the generic `vec_df_restore()`. We use this to map over classed data frames

- `s3_type()` now uses `class_type()` to allow us to recursively map over data frames. Bare tibbles are optimized, and data frames with unknown classes go through the generic map. This fixes the first problem above.

- `vec_ptype_finalise()` has been simplified a bit, and now uses `class_type()` to be recursive over all data frame classes. This fixes the second problem. `vec_ptype_finalise()` also didn't have many tests, so I added a few more.

Mainly this now works correctly:

``` r
library(vctrs)
library(tibble, warn.conflicts = FALSE)

internal_ptype <- vec_ptype(tibble(x = 2, y = NA))
internal_ptype
#> # A tibble: 0 x 2
#> # … with 2 variables: x <dbl>, y <???>

vec_ptype_finalise(internal_ptype)
#> # A tibble: 0 x 2
#> # … with 2 variables: x <dbl>, y <lgl>
```

We get nice performance improvements in determining the type of tibbles. This isn't done directly that often, but is still useful:

```r
library(vctrs)
library(tibble, warn.conflicts = FALSE)
library(rlang)

# 1 row, 100 cols
x <- as_tibble(set_names(rep_len(list(1), 100), paste0("a", 1:100)))
dim(x)
#> [1]   1 100

# before
bench::mark(vec_ptype(x))
#> # A tibble: 1 x 6
#>   expression        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype(x)   17.5µs   19.6µs    48136.    7.15KB     24.1

# after
bench::mark(vec_ptype(x))
#> # A tibble: 1 x 6
#>   expression        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype(x)   2.99µs   3.63µs   253962.    7.15KB     25.4
```