### PR TITLE
Ensure that scalar types are not allowed in `vec_cast()`

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -379,7 +379,16 @@ SEXP vctrs_cast(SEXP x, SEXP to, SEXP x_arg_, SEXP to_arg_) {
 
 // [[ include("vctrs.h") ]]
 SEXP vec_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg) {
-  if (x == R_NilValue || to == R_NilValue) {
+  if (x == R_NilValue) {
+    if (!vec_is_partial(to)) {
+      vec_assert(to, to_arg);
+    }
+    return x;
+  }
+  if (to == R_NilValue) {
+    if (!vec_is_partial(x)) {
+      vec_assert(x, x_arg);
+    }
     return x;
   }
 

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -8,15 +8,19 @@ test_that("new classes are uncoercible by default", {
   expect_error(vec_cast(x, 1), class = "vctrs_error_incompatible_cast")
 })
 
-# TODO - Uncomment the NULL tests after #814 is fixed
 test_that("casting requires vectors", {
-  #expect_error(vec_cast(NULL, quote(name)), class = "vctrs_error_scalar_type")
+  expect_error(vec_cast(NULL, quote(name)), class = "vctrs_error_scalar_type")
   expect_error(vec_cast(NA, quote(name)), class = "vctrs_error_scalar_type")
   expect_error(vec_cast(list(), quote(name)), class = "vctrs_error_scalar_type")
-  #expect_error(vec_cast(quote(name), NULL), class = "vctrs_error_scalar_type")
+  expect_error(vec_cast(quote(name), NULL), class = "vctrs_error_scalar_type")
   expect_error(vec_cast(quote(name), NA), class = "vctrs_error_scalar_type")
   expect_error(vec_cast(quote(name), list()), class = "vctrs_error_scalar_type")
   expect_error(vec_cast(quote(name), quote(name)), class = "vctrs_error_scalar_type")
+})
+
+test_that("casting between `NULL` and partial types is allowed", {
+  expect_identical(vec_cast(NULL, partial_factor()), NULL)
+  expect_identical(vec_cast(partial_factor(), NULL), partial_factor())
 })
 
 test_that("dimensionality matches output" ,{


### PR DESCRIPTION
Closes #814 

Already approved in https://github.com/DavisVaughan/vctrs/pull/4, which I screwed up. This should be clean though.