### PR TITLE
Make `vec_ptype()` error on scalars

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # vctrs (development version)
 
+* `vec_ptype()` now errors on scalar inputs (#807).
+
 * `vec_ptype_finalise()` is now recursive over all data frame types, ensuring
   that unspecified columns are correctly finalised to logical (#800).
 

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -279,8 +279,6 @@ vec_ptype2.logical.list <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 #' @export
 vec_ptype2.logical.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   if (is_unspecified(x)) {
-    # # FIXME: Should `vec_ptype()` make that check?
-    # vec_assert(y)
     vec_ptype(y)
   } else {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)

--- a/R/type2.R
+++ b/R/type2.R
@@ -56,8 +56,6 @@ vec_ptype2.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 #' @export
 vec_default_ptype2 <- function(x, y, ..., x_arg = "x", y_arg = "y") {
   if (is_unspecified(y)) {
-    # FIXME: Should `vec_ptype()` make that check?
-    vec_assert(x)
     return(vec_ptype(x))
   }
   if (is_same_type(x, y)) {

--- a/src/type.c
+++ b/src/type.c
@@ -13,7 +13,6 @@ static SEXP s3_type(SEXP x);
 // [[ include("vctrs.h"); register() ]]
 SEXP vec_type(SEXP x) {
   switch (vec_typeof(x)) {
-  case vctrs_type_scalar:      return x;
   case vctrs_type_null:        return R_NilValue;
   case vctrs_type_unspecified: return vctrs_shared_empty_uns;
   case vctrs_type_logical:     return vec_type_slice(x, vctrs_shared_empty_lgl);
@@ -25,6 +24,7 @@ SEXP vec_type(SEXP x) {
   case vctrs_type_list:        return vec_type_slice(x, vctrs_shared_empty_list);
   case vctrs_type_dataframe:   return bare_df_map(x, &vec_type);
   case vctrs_type_s3:          return s3_type(x);
+  case vctrs_type_scalar:      stop_scalar_type(x, args_empty);
   }
   never_reached("vec_type_impl");
 }

--- a/src/type.c
+++ b/src/type.c
@@ -55,12 +55,12 @@ static SEXP s3_type(SEXP x) {
     break;
   }
 
-  if (vec_is_vector(x)) {
-    return vec_slice(x, R_NilValue);
-  } else {
-    // FIXME: Only used for partial frames
+  if (vec_is_partial(x)) {
     return x;
   }
+
+  vec_assert(x, args_empty);
+  return vec_slice(x, R_NilValue);
 }
 
 static SEXP vec_ptype_finalise_unspecified(SEXP x);

--- a/tests/testthat/test-type-unspecified.R
+++ b/tests/testthat/test-type-unspecified.R
@@ -31,6 +31,11 @@ test_that("common type of unspecified and NULL is unspecified", {
   expect_identical(vec_ptype2(NULL, NA), unspecified())
 })
 
+test_that("cannot take the common type of unspecified and a scalar list", {
+  expect_error(vec_ptype2(unspecified(), foobar()), class = "vctrs_error_scalar_type")
+  expect_error(vec_ptype2(foobar(), unspecified()), class = "vctrs_error_scalar_type")
+})
+
 test_that("subsetting works", {
   expect_identical(unspecified(4)[2:3], unspecified(2))
 })

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -104,9 +104,10 @@ test_that("proxied types are have s3 bare type", {
 
 test_that("vec_ptype() preserves attributes of unproxied structures", {
   expect_identical(vec_ptype(foobar(dbl(1))), foobar(dbl()))
+})
 
-  # Here `foobar()` is treated as a scalar so is returned as is
-  expect_identical(vec_ptype(foobar(list(1))), foobar(list(1)))
+test_that("vec_ptype() errors on scalar lists", {
+  expect_error(vec_ptype(foobar(list())), class = "vctrs_error_scalar_type")
 })
 
 test_that("can retrieve type info", {

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -1,10 +1,18 @@
 context("test-type")
 
 
-test_that("vec_ptype() is a no-op for non-vectors", {
+test_that("vec_ptype() is a no-op for NULL", {
   expect_null(vec_ptype(NULL))
-  expect_identical(vec_ptype(quote(name)), quote(name))
+})
+
+test_that("vec_ptype() is a no-op for partial types", {
+  expect_identical(vec_ptype(partial_factor("x")), partial_factor("x"))
   expect_identical(vec_ptype(partial_frame(x = 1)), partial_frame(x = 1))
+})
+
+test_that("vec_ptype() errors on scalars", {
+  expect_error(vec_ptype(quote(name)), class = "vctrs_error_scalar_type")
+  expect_error(vec_ptype(quote(fn())), class = "vctrs_error_scalar_type")
 })
 
 test_that(".ptype argument overrides others", {


### PR DESCRIPTION
Closes #807 

Currently we allow both non-object scalars like `quote(name)` and object scalars like `foobar()` to slip through `vec_ptype()`. I think that `vec_ptype()` should error on all scalar inputs, since it is used in things like `vec_ptype2(NULL, x)` and `vec_ptype2(NA, x)` and we don't want to allow scalar common types there.


As a follow up to this PR, I think it would be useful to also add a `x_arg` argument to `vec_type()`. Then we could replace the `stop_scalar_type(x, args_empty)` and `vec_assert(x, args_empty)` I've just added with more informative errors. There are a few other uses of `vec_type()` that would benefit from this:

We wouldn't need the `vec_assert()` here, and could pass the arg through to `vec_type()`
https://github.com/r-lib/vctrs/blob/20c7fc13a25dee51357a4816c56f322d62f95138/src/type2.c#L18-L31

We could pass through `y_arg` here
https://github.com/r-lib/vctrs/blob/20c7fc13a25dee51357a4816c56f322d62f95138/src/type2.c#L51

We could use the `named_x_arg` technique here
https://github.com/r-lib/vctrs/blob/20c7fc13a25dee51357a4816c56f322d62f95138/src/type2.c#L159

We could use a `ptype_arg` here
https://github.com/r-lib/vctrs/blob/20c7fc13a25dee51357a4816c56f322d62f95138/src/type.c#L97

This would remove the need for all the FIXME comments like this one, and we could pass `x_arg` through:
https://github.com/r-lib/vctrs/blob/1c1907a4d719ab865e6127ec26e3edec30363970/R/type2.R#L59-L61