### PR TITLE
Implement `new_data_frame()` in C

### DIFF
--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -16,7 +16,7 @@
 #' @examples
 #' new_data_frame(list(x = 1:10, y = 10:1))
 new_data_frame <- function(x = list(), n = NULL, ..., class = character()) {
-  .Call(vctrs_new_data_frame, x, n, pairlist2(...), class)
+  .Call(vctrs_new_data_frame, x, n, pairlist(...), class)
 }
 
 # Light weight constructor used for tests - avoids having to repeatedly do

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -16,33 +16,7 @@
 #' @examples
 #' new_data_frame(list(x = 1:10, y = 10:1))
 new_data_frame <- function(x = list(), n = NULL, ..., class = character()) {
-  if (!is.list(x)) {
-    abort("`x` must be a list.")
-  }
-
-  if (is.null(n)) {
-    n <- df_size(x)
-  } else if (!is.integer(n) || length(n) != 1L) {
-    abort("`n` must be an integer of size 1.")
-  }
-
-  # names() should always be a character vector, but we can't enforce that
-  # because as.data.frame() returns a data frame with NULL names to indicate
-  # that outer names should be used
-  if (length(x) == 0) {
-    names(x) <- character()
-  }
-
-  new_attributes <- list(
-    names = names(x),
-    ...,
-    class = c(class, "data.frame"),
-    row.names = .set_row_names(n)
-  )
-
-  attributes(x) <- new_attributes
-
-  x
+  .Call(vctrs_new_data_frame, x, n, pairlist2(...), class)
 }
 
 # Light weight constructor used for tests - avoids having to repeatedly do

--- a/src/init.c
+++ b/src/init.c
@@ -87,6 +87,7 @@ extern SEXP vctrs_validate_name_repair_arg(SEXP);
 extern SEXP vctrs_validate_minimal_names(SEXP, SEXP);
 extern SEXP vctrs_as_names(SEXP, SEXP, SEXP);
 extern SEXP vctrs_is_partial(SEXP);
+extern SEXP vctrs_new_data_frame(SEXP, SEXP, SEXP, SEXP);
 
 // Very experimental
 // Available in the API header
@@ -193,6 +194,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_validate_minimal_names",     (DL_FUNC) &vctrs_validate_minimal_names, 2},
   {"vctrs_as_names",                   (DL_FUNC) &vctrs_as_names, 3},
   {"vctrs_is_partial",                 (DL_FUNC) &vctrs_is_partial, 1},
+  {"vctrs_new_data_frame",             (DL_FUNC) &vctrs_new_data_frame, 4},
   {NULL, NULL, 0}
 };
 

--- a/src/size.c
+++ b/src/size.c
@@ -132,6 +132,11 @@ R_len_t df_raw_size(SEXP x) {
     return n;
   }
 
+  return df_raw_size_from_list(x);
+}
+
+// [[ include("vctrs.h") ]]
+R_len_t df_raw_size_from_list(SEXP x) {
   if (Rf_length(x) >= 1) {
     return vec_size(VECTOR_ELT(x, 0));
   } else {

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -39,6 +39,84 @@ SEXP new_data_frame(SEXP x, R_len_t n) {
   return x;
 }
 
+static R_len_t pull_data_frame_size(SEXP x, SEXP n);
+static void set_data_frame_class(SEXP x, SEXP cls);
+
+// [[ register() ]]
+SEXP vctrs_new_data_frame(SEXP x, SEXP n, SEXP attributes, SEXP cls) {
+  if (TYPEOF(x) != VECSXP) {
+    Rf_errorcall(R_NilValue, "`x` must be a list");
+  }
+
+  R_len_t size = pull_data_frame_size(x, n);
+
+  SEXP out = PROTECT(new_data_frame(x, size));
+
+  // Set extra attributes
+  while(attributes != R_NilValue) {
+    SEXP tag = TAG(attributes);
+
+    if (tag == R_NilValue) {
+      Rf_errorcall(R_NilValue, "Attributes supplied in `...` must be named");
+    }
+
+    if (tag != R_NamesSymbol &&
+        tag != R_RowNamesSymbol &&
+        tag != R_ClassSymbol) {
+      Rf_setAttrib(out, tag, CAR(attributes));
+    }
+
+    attributes = CDR(attributes);
+  }
+
+  set_data_frame_class(out, cls);
+
+  UNPROTECT(1);
+  return out;
+}
+
+static R_len_t pull_data_frame_size(SEXP x, SEXP n) {
+  if (n == R_NilValue) {
+    return df_raw_size_from_list(x);
+  }
+
+  if (TYPEOF(n) != INTSXP || Rf_length(n) != 1) {
+    Rf_errorcall(R_NilValue, "`n` must be an integer of size 1");
+  }
+
+  return r_int_get(n, 0);
+}
+
+static void set_data_frame_class(SEXP x, SEXP cls) {
+  if (TYPEOF(cls) != STRSXP) {
+    Rf_errorcall(R_NilValue, "`class` must be a character vector");
+  }
+
+  if (Rf_length(cls) == 0) {
+    return;
+  }
+
+  SEXP args = PROTECT(Rf_allocVector(VECSXP, 2));
+  SET_VECTOR_ELT(args, 0, cls);
+  SET_VECTOR_ELT(args, 1, classes_data_frame);
+
+  const struct name_repair_opts name_repair_opts = {
+    .type = name_repair_none,
+    .fn = R_NilValue
+  };
+
+  cls = PROTECT(vec_c(
+    args,
+    vctrs_shared_empty_chr,
+    R_NilValue,
+    &name_repair_opts
+  ));
+
+  Rf_setAttrib(x, R_ClassSymbol, cls);
+
+  UNPROTECT(2);
+}
+
 // [[ include("type-data-frame.h") ]]
 enum rownames_type rownames_type(SEXP x) {
   switch (TYPEOF(x)) {

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -39,7 +39,7 @@ SEXP new_data_frame(SEXP x, R_len_t n) {
   return x;
 }
 
-static R_len_t pull_data_frame_size(SEXP x, SEXP n);
+static R_len_t df_size_from_list(SEXP x, SEXP n);
 static void set_data_frame_class(SEXP x, SEXP cls);
 
 // [[ register() ]]
@@ -48,7 +48,7 @@ SEXP vctrs_new_data_frame(SEXP x, SEXP n, SEXP attributes, SEXP cls) {
     Rf_errorcall(R_NilValue, "`x` must be a list");
   }
 
-  R_len_t size = pull_data_frame_size(x, n);
+  R_len_t size = df_size_from_list(x, n);
 
   SEXP out = PROTECT(new_data_frame(x, size));
 
@@ -75,7 +75,7 @@ SEXP vctrs_new_data_frame(SEXP x, SEXP n, SEXP attributes, SEXP cls) {
   return out;
 }
 
-static R_len_t pull_data_frame_size(SEXP x, SEXP n) {
+static R_len_t df_size_from_list(SEXP x, SEXP n) {
   if (n == R_NilValue) {
     return df_raw_size_from_list(x);
   }

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -387,6 +387,7 @@ bool is_record(SEXP x);
 R_len_t df_size(SEXP x);
 R_len_t df_rownames_size(SEXP x);
 R_len_t df_raw_size(SEXP x);
+R_len_t df_raw_size_from_list(SEXP x);
 SEXP vctrs_df_restore(SEXP x, SEXP to, SEXP n);
 SEXP df_restore_impl(SEXP x, SEXP to, R_len_t size);
 

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -230,11 +230,6 @@ test_that("attributes with special names are ignored", {
     attr(new_data_frame(list(), 0L, row.names = "rowname"), "row.names"),
     integer()
   )
-
-  # This is overkill, but splice to avoid matching on `class` argument
-  attrib <- list(class = "foo")
-  x <- new_data_frame(list(), 0L, !!! attrib)
-  expect_identical(class(x), "data.frame")
 })
 
 test_that("`x` must be a list", {

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -176,3 +176,77 @@ test_that("can slice AsIs class", {
   df <- data.frame(x = I(1:3), y = I(list(4, 5, 6)))
   expect_identical(vec_slice(df, 2:3), unrownames(df[2:3, ]))
 })
+
+# new_data_frame ----------------------------------------------------------
+
+test_that("can construct an empty data frame", {
+  expect_identical(new_data_frame(), data.frame())
+})
+
+test_that("can validly set the number of rows when there are no columns", {
+  expect <- structure(
+    list(),
+    class = "data.frame",
+    row.names = .set_row_names(2L),
+    names = character()
+  )
+
+  expect_identical(new_data_frame(n = 2L), expect)
+})
+
+test_that("can add additional classes", {
+  expect_s3_class(new_data_frame(class = "foobar"), "foobar")
+  expect_s3_class(new_data_frame(class = c("foo", "bar")), c("foo", "bar"))
+})
+
+test_that("can add additional attributes", {
+  expect <- data.frame()
+  attr(expect, "foo") <- "bar"
+  attr(expect, "a") <- "b"
+
+  expect_identical(new_data_frame(foo = "bar", a = "b"), expect)
+})
+
+test_that("size is pulled from first column if not supplied", {
+  x <- new_data_frame(list(x = 1:5, y = 1:6))
+  expect_identical(.row_names_info(x, type = 1), -5L)
+})
+
+test_that("can construct a data frame without column names", {
+  expect_named(new_data_frame(list(1, 2)), NULL)
+})
+
+test_that("attributes with special names are ignored", {
+  expect_identical(
+    names(new_data_frame(list(), 0L, names = "name")),
+    character()
+  )
+
+  expect_identical(
+    attr(new_data_frame(list(), 0L, row.names = "rowname"), "row.names"),
+    integer()
+  )
+
+  # This is overkill, but splice to avoid matching on `class` argument
+  attrib <- list(class = "foo")
+  x <- new_data_frame(list(), 0L, !!! attrib)
+  expect_identical(class(x), "data.frame")
+})
+
+test_that("`x` must be a list", {
+  expect_error(new_data_frame(1), "`x` must be a list")
+})
+
+test_that("if supplied, `n` must be an integer of size 1", {
+  expect_error(new_data_frame(n = c(1L, 2L)), "must be an integer of size 1")
+  expect_error(new_data_frame(n = "x"), "must be an integer of size 1")
+})
+
+test_that("`class` must be a character vector", {
+  expect_error(new_data_frame(class = 1), "must be a character vector")
+})
+
+test_that("attributes must be named", {
+  expect_error(new_data_frame(list(), n = 0L, 1), "supplied in `...` must be named")
+})
+

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -216,6 +216,10 @@ test_that("can construct a data frame without column names", {
   expect_named(new_data_frame(list(1, 2)), NULL)
 })
 
+test_that("the names on an empty data frame are an empty character vector", {
+  expect_identical(names(new_data_frame()), character())
+})
+
 test_that("attributes with special names are ignored", {
   expect_identical(
     names(new_data_frame(list(), 0L, names = "name")),


### PR DESCRIPTION
I have a feeling we will be using this heavily, so a C implementation will be helpful. It wasn't particularly slow before, but if we call it a lot this could be useful.

```r
library(vctrs)

lst <- list(x = 1:100, y = 1:100)
n <- 100L
```

```r
# before
bench::mark(new_data_frame(), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new_data_frame()   3.42µs   5.03µs   199830.    30.4KB     86.0

# after
bench::mark(new_data_frame(), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new_data_frame()   1.53µs   2.19µs   443495.    9.39KB     84.3
```

```r
# before
bench::mark(new_data_frame(lst), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new_data_frame(lst)   2.98µs   3.46µs   274274.        0B     21.9

# after
bench::mark(new_data_frame(lst), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new_data_frame(lst)   1.58µs   2.05µs   463825.        0B     23.2
```

```r
# before
bench::mark(new_data_frame(lst, n = n), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new_data_frame(lst, n = n)   2.77µs   3.18µs   298890.        0B     23.9

# after
bench::mark(new_data_frame(lst, n = n), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new_data_frame(lst, n = n)   1.53µs   1.78µs   532382.        0B     26.6
```