### PR TITLE
Tibble performance - `vec_ptype2()` and `vec_cast()`

### DIFF
--- a/src/cast-dispatch.c
+++ b/src/cast-dispatch.c
@@ -29,6 +29,18 @@ SEXP vec_cast_dispatch(SEXP x,
       break;
     }
 
+  case vctrs_type_dataframe:
+    switch(class_type(x)) {
+    case vctrs_class_bare_data_frame:
+      Rf_errorcall(R_NilValue, "`x` should have been classified as a `vctrs_type_dataframe`");
+
+    case vctrs_class_bare_tibble:
+      return df_as_dataframe(x, to, x_arg, to_arg);
+
+    default:
+      break;
+    }
+
   case vctrs_type_s3:
     return vec_cast_dispatch2(x, to, x_type, lossy, x_arg, to_arg);
 
@@ -81,6 +93,30 @@ static SEXP vec_cast_dispatch2(SEXP x, SEXP to,
     default:
       break;
     }
+
+  case vctrs_class_bare_tibble:
+    switch (x_type) {
+    case vctrs_type_dataframe:
+      return df_as_dataframe(x, to, x_arg, to_arg);
+
+    case vctrs_type_s3:
+      switch (class_type(x)) {
+      case vctrs_class_bare_data_frame:
+        Rf_errorcall(R_NilValue, "`x` should have been classified as a `vctrs_type_dataframe`");
+
+      case vctrs_class_bare_tibble:
+        return df_as_dataframe(x, to, x_arg, to_arg);
+
+      default:
+        break;
+      }
+
+    default:
+      break;
+    }
+
+  case vctrs_class_bare_data_frame:
+    Rf_errorcall(R_NilValue, "`to` should have been classified as a `vctrs_type_dataframe`");
 
   default:
     break;

--- a/src/cast-dispatch.c
+++ b/src/cast-dispatch.c
@@ -33,7 +33,7 @@ SEXP vec_cast_dispatch(SEXP x,
   case vctrs_type_dataframe:
     switch(class_type(x)) {
     case vctrs_class_bare_data_frame:
-      Rf_errorcall(R_NilValue, "`x` should have been classified as a `vctrs_type_dataframe`");
+      Rf_errorcall(R_NilValue, "Internal error: `x` should have been classified as a `vctrs_type_dataframe`");
 
     case vctrs_class_bare_tibble:
       return df_as_dataframe(x, to, x_arg, to_arg);
@@ -106,7 +106,7 @@ static SEXP vec_cast_dispatch2(SEXP x, SEXP to,
     case vctrs_type_s3:
       switch (class_type(x)) {
       case vctrs_class_bare_data_frame:
-        Rf_errorcall(R_NilValue, "`x` should have been classified as a `vctrs_type_dataframe`");
+        Rf_errorcall(R_NilValue, "Internal error: `x` should have been classified as a `vctrs_type_dataframe`");
 
       case vctrs_class_bare_tibble:
         return df_as_dataframe(x, to, x_arg, to_arg);
@@ -121,7 +121,7 @@ static SEXP vec_cast_dispatch2(SEXP x, SEXP to,
     break;
 
   case vctrs_class_bare_data_frame:
-    Rf_errorcall(R_NilValue, "`to` should have been classified as a `vctrs_type_dataframe`");
+    Rf_errorcall(R_NilValue, "Internal error: `to` should have been classified as a `vctrs_type_dataframe`");
 
   default:
     break;

--- a/src/cast-dispatch.c
+++ b/src/cast-dispatch.c
@@ -28,6 +28,7 @@ SEXP vec_cast_dispatch(SEXP x,
     default:
       break;
     }
+    break;
 
   case vctrs_type_dataframe:
     switch(class_type(x)) {
@@ -40,6 +41,7 @@ SEXP vec_cast_dispatch(SEXP x,
     default:
       break;
     }
+    break;
 
   case vctrs_type_s3:
     return vec_cast_dispatch2(x, to, x_type, lossy, x_arg, to_arg);
@@ -75,6 +77,7 @@ static SEXP vec_cast_dispatch2(SEXP x, SEXP to,
     default:
       break;
     }
+    break;
 
   case vctrs_class_bare_ordered:
     switch (x_type) {
@@ -93,6 +96,7 @@ static SEXP vec_cast_dispatch2(SEXP x, SEXP to,
     default:
       break;
     }
+    break;
 
   case vctrs_class_bare_tibble:
     switch (x_type) {
@@ -114,6 +118,7 @@ static SEXP vec_cast_dispatch2(SEXP x, SEXP to,
     default:
       break;
     }
+    break;
 
   case vctrs_class_bare_data_frame:
     Rf_errorcall(R_NilValue, "`to` should have been classified as a `vctrs_type_dataframe`");

--- a/src/cast.c
+++ b/src/cast.c
@@ -190,9 +190,6 @@ static SEXP int_as_double(SEXP x, bool* lossy) {
   return out;
 }
 
-// Defined below
-static SEXP df_as_dataframe(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
-
 // [[ register() ]]
 SEXP vctrs_df_as_dataframe(SEXP x, SEXP to, SEXP x_arg_, SEXP to_arg_) {
   if (!r_is_string(x_arg_)) {
@@ -212,7 +209,8 @@ SEXP vctrs_df_as_dataframe(SEXP x, SEXP to, SEXP x_arg_, SEXP to_arg_) {
 // cast to their types in `to`. Extra `x` columns are dropped and
 // cause a lossy cast. Extra `to` columns are filled with missing
 // values.
-static SEXP df_as_dataframe(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg) {
+// [[ include("vctrs.h") ]]
+SEXP df_as_dataframe(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg) {
   SEXP x_names = PROTECT(r_names(x));
   SEXP to_names = PROTECT(r_names(to));
 

--- a/src/ptype2-dispatch.c
+++ b/src/ptype2-dispatch.c
@@ -33,6 +33,10 @@ SEXP vec_ptype2_dispatch(SEXP x, SEXP y,
   case vctrs_type2_s3_bare_posixlt_bare_posixlt:
     return datetime_datetime_ptype2(x, y);
 
+  case vctrs_type2_s3_dataframe_bare_tibble:
+  case vctrs_type2_s3_bare_tibble_bare_tibble:
+    return tibble_ptype2(x, y, x_arg, y_arg);
+
   default:
     return vec_ptype2_dispatch_s3(x, y, x_arg, y_arg);
   }

--- a/src/type-tibble.c
+++ b/src/type-tibble.c
@@ -3,7 +3,7 @@
 
 // [[ include("vctrs.h") ]]
 SEXP tibble_ptype2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) {
-  SEXP out = PROTECT(df_type2(x, y, x_arg, y_arg));
+  SEXP out = PROTECT(df_ptype2(x, y, x_arg, y_arg));
 
   Rf_setAttrib(out, R_ClassSymbol, classes_tibble);
 

--- a/src/type-tibble.c
+++ b/src/type-tibble.c
@@ -1,0 +1,12 @@
+#include "vctrs.h"
+#include "utils.h"
+
+// [[ include("vctrs.h") ]]
+SEXP tibble_ptype2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) {
+  SEXP out = PROTECT(df_type2(x, y, x_arg, y_arg));
+
+  Rf_setAttrib(out, R_ClassSymbol, classes_tibble);
+
+  UNPROTECT(1);
+  return out;
+}

--- a/src/type2.c
+++ b/src/type2.c
@@ -8,8 +8,6 @@ static SEXP vec_ptype2_dispatch_unspecified_list(SEXP x,
                                                  struct vctrs_arg* y_arg,
                                                  bool left_unspecified);
 
-static SEXP df_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
-
 // [[ include("vctrs.h") ]]
 SEXP vec_type2(SEXP x, SEXP y,
                struct vctrs_arg* x_arg,
@@ -121,7 +119,7 @@ static SEXP vec_ptype2_dispatch_unspecified_list(SEXP x,
   stop_incompatible_type(x, y, x_arg, y_arg);
 }
 
-
+// [[ include("vctrs.h") ]]
 SEXP df_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) {
   SEXP x_names = PROTECT(r_names(x));
   SEXP y_names = PROTECT(r_names(y));

--- a/src/type2.c
+++ b/src/type2.c
@@ -89,7 +89,7 @@ SEXP vec_type2(SEXP x, SEXP y,
     return vctrs_shared_empty_list;
 
   case vctrs_type2_dataframe_dataframe:
-    return df_type2(x, y, x_arg, y_arg);
+    return df_ptype2(x, y, x_arg, y_arg);
 
   default:
     return vec_ptype2_dispatch_s3(x, y, x_arg, y_arg);
@@ -120,7 +120,7 @@ static SEXP vec_ptype2_dispatch_unspecified_list(SEXP x,
 }
 
 // [[ include("vctrs.h") ]]
-SEXP df_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) {
+SEXP df_ptype2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) {
   SEXP x_names = PROTECT(r_names(x));
   SEXP y_names = PROTECT(r_names(y));
 
@@ -217,5 +217,5 @@ SEXP vctrs_type2_df_df(SEXP x, SEXP y, SEXP x_arg, SEXP y_arg) {
   struct vctrs_arg x_arg_ = new_wrapper_arg(NULL, r_chr_get_c_string(x_arg, 0));
   struct vctrs_arg y_arg_ = new_wrapper_arg(NULL, r_chr_get_c_string(y_arg, 0));
 
-  return df_type2(x, y, &x_arg_, &y_arg_);
+  return df_ptype2(x, y, &x_arg_, &y_arg_);
 }

--- a/src/typeof2-s3.c
+++ b/src/typeof2-s3.c
@@ -20,6 +20,7 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_null_bare_date;
     case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_null_bare_posixct;
     case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_null_bare_posixlt;
+    case vctrs_class_bare_tibble:  *left = 0; return vctrs_type2_s3_null_bare_tibble;
     default:                       *left = 0; return vctrs_type2_s3_null_unknown;
     }
   }
@@ -30,6 +31,7 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_unspecified_bare_date;
     case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_unspecified_bare_posixct;
     case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_unspecified_bare_posixlt;
+    case vctrs_class_bare_tibble:  *left = 0; return vctrs_type2_s3_unspecified_bare_tibble;
     default:                       *left = 0; return vctrs_type2_s3_unspecified_unknown;
     }
   }
@@ -40,6 +42,7 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_logical_bare_date;
     case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_logical_bare_posixct;
     case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_logical_bare_posixlt;
+    case vctrs_class_bare_tibble:  *left = 0; return vctrs_type2_s3_logical_bare_tibble;
     default:                       *left = 0; return vctrs_type2_s3_logical_unknown;
     }
   }
@@ -50,6 +53,7 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_integer_bare_date;
     case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_integer_bare_posixct;
     case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_integer_bare_posixlt;
+    case vctrs_class_bare_tibble:  *left = 0; return vctrs_type2_s3_integer_bare_tibble;
     default:                       *left = 0; return vctrs_type2_s3_integer_unknown;
     }
   }
@@ -60,6 +64,7 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_double_bare_date;
     case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_double_bare_posixct;
     case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_double_bare_posixlt;
+    case vctrs_class_bare_tibble:  *left = 0; return vctrs_type2_s3_double_bare_tibble;
     default:                       *left = 0; return vctrs_type2_s3_double_unknown;
     }
   }
@@ -70,6 +75,7 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_complex_bare_date;
     case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_complex_bare_posixct;
     case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_complex_bare_posixlt;
+    case vctrs_class_bare_tibble:  *left = 0; return vctrs_type2_s3_complex_bare_tibble;
     default:                       *left = 0; return vctrs_type2_s3_complex_unknown;
     }
   }
@@ -80,6 +86,7 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_character_bare_date;
     case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_character_bare_posixct;
     case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_character_bare_posixlt;
+    case vctrs_class_bare_tibble:  *left = 0; return vctrs_type2_s3_character_bare_tibble;
     default:                       *left = 0; return vctrs_type2_s3_character_unknown;
     }
   }
@@ -90,6 +97,7 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_raw_bare_date;
     case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_raw_bare_posixct;
     case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_raw_bare_posixlt;
+    case vctrs_class_bare_tibble:  *left = 0; return vctrs_type2_s3_raw_bare_tibble;
     default:                       *left = 0; return vctrs_type2_s3_raw_unknown;
     }
   }
@@ -100,6 +108,7 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_list_bare_date;
     case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_list_bare_posixct;
     case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_list_bare_posixlt;
+    case vctrs_class_bare_tibble:  *left = 0; return vctrs_type2_s3_list_bare_tibble;
     default:                       *left = 0; return vctrs_type2_s3_list_unknown;
     }
   }
@@ -110,6 +119,7 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_dataframe_bare_date;
     case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_dataframe_bare_posixct;
     case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_dataframe_bare_posixlt;
+    case vctrs_class_bare_tibble:  *left = 0; return vctrs_type2_s3_dataframe_bare_tibble;
     default:                       *left = 0; return vctrs_type2_s3_dataframe_unknown;
     }
   }
@@ -120,6 +130,7 @@ enum vctrs_type2_s3 vec_typeof2_s3_impl(SEXP x,
     case vctrs_class_bare_date:    *left = 0; return vctrs_type2_s3_scalar_bare_date;
     case vctrs_class_bare_posixct: *left = 0; return vctrs_type2_s3_scalar_bare_posixct;
     case vctrs_class_bare_posixlt: *left = 0; return vctrs_type2_s3_scalar_bare_posixlt;
+    case vctrs_class_bare_tibble:  *left = 0; return vctrs_type2_s3_scalar_bare_tibble;
     default:                       *left = 0; return vctrs_type2_s3_scalar_unknown;
     }
   }
@@ -156,6 +167,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
       case vctrs_class_bare_date:    *left =  0; return vctrs_type2_s3_bare_factor_bare_date;
       case vctrs_class_bare_posixct: *left =  0; return vctrs_type2_s3_bare_factor_bare_posixct;
       case vctrs_class_bare_posixlt: *left =  0; return vctrs_type2_s3_bare_factor_bare_posixlt;
+      case vctrs_class_bare_tibble:  *left =  0; return vctrs_type2_s3_bare_factor_bare_tibble;
       default:                       *left =  0; return vctrs_type2_s3_bare_factor_unknown;
       }
     }}
@@ -180,6 +192,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
       case vctrs_class_bare_date:    *left =  0; return vctrs_type2_s3_bare_ordered_bare_date;
       case vctrs_class_bare_posixct: *left =  0; return vctrs_type2_s3_bare_ordered_bare_posixct;
       case vctrs_class_bare_posixlt: *left =  0; return vctrs_type2_s3_bare_ordered_bare_posixlt;
+      case vctrs_class_bare_tibble:  *left =  0; return vctrs_type2_s3_bare_ordered_bare_tibble;
       default:                       *left =  0; return vctrs_type2_s3_bare_ordered_unknown;
       }
     }}
@@ -204,6 +217,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
       case vctrs_class_bare_date:    *left = -1; return vctrs_type2_s3_bare_date_bare_date;
       case vctrs_class_bare_posixct: *left =  0; return vctrs_type2_s3_bare_date_bare_posixct;
       case vctrs_class_bare_posixlt: *left =  0; return vctrs_type2_s3_bare_date_bare_posixlt;
+      case vctrs_class_bare_tibble:  *left =  0; return vctrs_type2_s3_bare_date_bare_tibble;
       default:                       *left =  0; return vctrs_type2_s3_bare_date_unknown;
       }
     }}
@@ -228,6 +242,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
       case vctrs_class_bare_date:    *left =  1; return vctrs_type2_s3_bare_date_bare_posixct;
       case vctrs_class_bare_posixct: *left = -1; return vctrs_type2_s3_bare_posixct_bare_posixct;
       case vctrs_class_bare_posixlt: *left =  0; return vctrs_type2_s3_bare_posixct_bare_posixlt;
+      case vctrs_class_bare_tibble:  *left =  0; return vctrs_type2_s3_bare_posixct_bare_tibble;
       default:                       *left =  0; return vctrs_type2_s3_bare_posixct_unknown;
       }
     }}
@@ -252,7 +267,33 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
       case vctrs_class_bare_date:    *left =  1; return vctrs_type2_s3_bare_date_bare_posixlt;
       case vctrs_class_bare_posixct: *left =  1; return vctrs_type2_s3_bare_posixct_bare_posixlt;
       case vctrs_class_bare_posixlt: *left = -1; return vctrs_type2_s3_bare_posixlt_bare_posixlt;
+      case vctrs_class_bare_tibble:  *left =  0; return vctrs_type2_s3_bare_posixlt_bare_tibble;
       default:                       *left =  0; return vctrs_type2_s3_bare_posixlt_unknown;
+      }
+    }}
+  }
+  case vctrs_class_bare_tibble: {
+    switch (type_y) {
+    case vctrs_type_null:            *left =  1; return vctrs_type2_s3_null_bare_tibble;
+    case vctrs_type_unspecified:     *left =  1; return vctrs_type2_s3_unspecified_bare_tibble;
+    case vctrs_type_logical:         *left =  1; return vctrs_type2_s3_logical_bare_tibble;
+    case vctrs_type_integer:         *left =  1; return vctrs_type2_s3_integer_bare_tibble;
+    case vctrs_type_double:          *left =  1; return vctrs_type2_s3_double_bare_tibble;
+    case vctrs_type_complex:         *left =  1; return vctrs_type2_s3_complex_bare_tibble;
+    case vctrs_type_character:       *left =  1; return vctrs_type2_s3_character_bare_tibble;
+    case vctrs_type_raw:             *left =  1; return vctrs_type2_s3_raw_bare_tibble;
+    case vctrs_type_list:            *left =  1; return vctrs_type2_s3_list_bare_tibble;
+    case vctrs_type_dataframe:       *left =  1; return vctrs_type2_s3_dataframe_bare_tibble;
+    case vctrs_type_scalar:          *left =  1; return vctrs_type2_s3_scalar_bare_tibble;
+    case vctrs_type_s3: {
+      switch (class_type(y)) {
+      case vctrs_class_bare_factor:  *left =  1; return vctrs_type2_s3_bare_factor_bare_tibble;
+      case vctrs_class_bare_ordered: *left =  1; return vctrs_type2_s3_bare_ordered_bare_tibble;
+      case vctrs_class_bare_date:    *left =  1; return vctrs_type2_s3_bare_date_bare_tibble;
+      case vctrs_class_bare_posixct: *left =  1; return vctrs_type2_s3_bare_posixct_bare_tibble;
+      case vctrs_class_bare_posixlt: *left =  1; return vctrs_type2_s3_bare_posixlt_bare_tibble;
+      case vctrs_class_bare_tibble:  *left = -1; return vctrs_type2_s3_bare_tibble_bare_tibble;
+      default:                       *left =  0; return vctrs_type2_s3_bare_tibble_unknown;
       }
     }}
   }
@@ -276,6 +317,7 @@ static enum vctrs_type2_s3 vec_typeof2_s3_impl2(SEXP x,
       case vctrs_class_bare_date:    *left =  1; return vctrs_type2_s3_bare_date_unknown;
       case vctrs_class_bare_posixct: *left =  1; return vctrs_type2_s3_bare_posixct_unknown;
       case vctrs_class_bare_posixlt: *left =  1; return vctrs_type2_s3_bare_posixlt_unknown;
+      case vctrs_class_bare_tibble:  *left =  1; return vctrs_type2_s3_bare_tibble_unknown;
       default:                       *left = -1; return vctrs_type2_s3_unknown_unknown;
       }
     }}
@@ -296,6 +338,7 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_null_bare_date:              return "vctrs_type2_s3_null_bare_date";
   case vctrs_type2_s3_null_bare_posixct:           return "vctrs_type2_s3_null_bare_posixct";
   case vctrs_type2_s3_null_bare_posixlt:           return "vctrs_type2_s3_null_bare_posixlt";
+  case vctrs_type2_s3_null_bare_tibble:            return "vctrs_type2_s3_null_bare_tibble";
   case vctrs_type2_s3_null_unknown:                return "vctrs_type2_s3_null_unknown";
 
   case vctrs_type2_s3_unspecified_bare_factor:     return "vctrs_type2_s3_unspecified_bare_factor";
@@ -303,6 +346,7 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_unspecified_bare_date:       return "vctrs_type2_s3_unspecified_bare_date";
   case vctrs_type2_s3_unspecified_bare_posixct:    return "vctrs_type2_s3_unspecified_bare_posixct";
   case vctrs_type2_s3_unspecified_bare_posixlt:    return "vctrs_type2_s3_unspecified_bare_posixlt";
+  case vctrs_type2_s3_unspecified_bare_tibble:     return "vctrs_type2_s3_unspecified_bare_tibble";
   case vctrs_type2_s3_unspecified_unknown:         return "vctrs_type2_s3_unspecified_unknown";
 
   case vctrs_type2_s3_logical_bare_factor:         return "vctrs_type2_s3_logical_bare_factor";
@@ -310,6 +354,7 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_logical_bare_date:           return "vctrs_type2_s3_logical_bare_date";
   case vctrs_type2_s3_logical_bare_posixct:        return "vctrs_type2_s3_logical_bare_posixct";
   case vctrs_type2_s3_logical_bare_posixlt:        return "vctrs_type2_s3_logical_bare_posixlt";
+  case vctrs_type2_s3_logical_bare_tibble:         return "vctrs_type2_s3_logical_bare_tibble";
   case vctrs_type2_s3_logical_unknown:             return "vctrs_type2_s3_logical_unknown";
 
   case vctrs_type2_s3_integer_bare_factor:         return "vctrs_type2_s3_integer_bare_factor";
@@ -317,6 +362,7 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_integer_bare_date:           return "vctrs_type2_s3_integer_bare_date";
   case vctrs_type2_s3_integer_bare_posixct:        return "vctrs_type2_s3_integer_bare_posixct";
   case vctrs_type2_s3_integer_bare_posixlt:        return "vctrs_type2_s3_integer_bare_posixlt";
+  case vctrs_type2_s3_integer_bare_tibble:         return "vctrs_type2_s3_integer_bare_tibble";
   case vctrs_type2_s3_integer_unknown:             return "vctrs_type2_s3_integer_unknown";
 
   case vctrs_type2_s3_double_bare_factor:          return "vctrs_type2_s3_double_bare_factor";
@@ -324,6 +370,7 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_double_bare_date:            return "vctrs_type2_s3_double_bare_date";
   case vctrs_type2_s3_double_bare_posixct:         return "vctrs_type2_s3_double_bare_posixct";
   case vctrs_type2_s3_double_bare_posixlt:         return "vctrs_type2_s3_double_bare_posixlt";
+  case vctrs_type2_s3_double_bare_tibble:          return "vctrs_type2_s3_double_bare_tibble";
   case vctrs_type2_s3_double_unknown:              return "vctrs_type2_s3_double_unknown";
 
   case vctrs_type2_s3_complex_bare_factor:         return "vctrs_type2_s3_complex_bare_factor";
@@ -331,6 +378,7 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_complex_bare_date:           return "vctrs_type2_s3_complex_bare_date";
   case vctrs_type2_s3_complex_bare_posixct:        return "vctrs_type2_s3_complex_bare_posixct";
   case vctrs_type2_s3_complex_bare_posixlt:        return "vctrs_type2_s3_complex_bare_posixlt";
+  case vctrs_type2_s3_complex_bare_tibble:         return "vctrs_type2_s3_complex_bare_tibble";
   case vctrs_type2_s3_complex_unknown:             return "vctrs_type2_s3_complex_unknown";
 
   case vctrs_type2_s3_character_bare_factor:       return "vctrs_type2_s3_character_bare_factor";
@@ -338,6 +386,7 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_character_bare_date:         return "vctrs_type2_s3_character_bare_date";
   case vctrs_type2_s3_character_bare_posixct:      return "vctrs_type2_s3_character_bare_posixct";
   case vctrs_type2_s3_character_bare_posixlt:      return "vctrs_type2_s3_character_bare_posixlt";
+  case vctrs_type2_s3_character_bare_tibble:       return "vctrs_type2_s3_character_bare_tibble";
   case vctrs_type2_s3_character_unknown:           return "vctrs_type2_s3_character_unknown";
 
   case vctrs_type2_s3_raw_bare_factor:             return "vctrs_type2_s3_raw_bare_factor";
@@ -345,6 +394,7 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_raw_bare_date:               return "vctrs_type2_s3_raw_bare_date";
   case vctrs_type2_s3_raw_bare_posixct:            return "vctrs_type2_s3_raw_bare_posixct";
   case vctrs_type2_s3_raw_bare_posixlt:            return "vctrs_type2_s3_raw_bare_posixlt";
+  case vctrs_type2_s3_raw_bare_tibble:             return "vctrs_type2_s3_raw_bare_tibble";
   case vctrs_type2_s3_raw_unknown:                 return "vctrs_type2_s3_raw_unknown";
 
   case vctrs_type2_s3_list_bare_factor:            return "vctrs_type2_s3_list_bare_factor";
@@ -352,6 +402,7 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_list_bare_date:              return "vctrs_type2_s3_list_bare_date";
   case vctrs_type2_s3_list_bare_posixct:           return "vctrs_type2_s3_list_bare_posixct";
   case vctrs_type2_s3_list_bare_posixlt:           return "vctrs_type2_s3_list_bare_posixlt";
+  case vctrs_type2_s3_list_bare_tibble:            return "vctrs_type2_s3_list_bare_tibble";
   case vctrs_type2_s3_list_unknown:                return "vctrs_type2_s3_list_unknown";
 
   case vctrs_type2_s3_dataframe_bare_factor:       return "vctrs_type2_s3_dataframe_bare_factor";
@@ -359,6 +410,7 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_dataframe_bare_date:         return "vctrs_type2_s3_dataframe_bare_date";
   case vctrs_type2_s3_dataframe_bare_posixct:      return "vctrs_type2_s3_dataframe_bare_posixct";
   case vctrs_type2_s3_dataframe_bare_posixlt:      return "vctrs_type2_s3_dataframe_bare_posixlt";
+  case vctrs_type2_s3_dataframe_bare_tibble:       return "vctrs_type2_s3_dataframe_bare_tibble";
   case vctrs_type2_s3_dataframe_unknown:           return "vctrs_type2_s3_dataframe_unknown";
 
   case vctrs_type2_s3_scalar_bare_factor:          return "vctrs_type2_s3_scalar_bare_factor";
@@ -366,6 +418,7 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_scalar_bare_date:            return "vctrs_type2_s3_scalar_bare_date";
   case vctrs_type2_s3_scalar_bare_posixct:         return "vctrs_type2_s3_scalar_bare_posixct";
   case vctrs_type2_s3_scalar_bare_posixlt:         return "vctrs_type2_s3_scalar_bare_posixlt";
+  case vctrs_type2_s3_scalar_bare_tibble:          return "vctrs_type2_s3_scalar_bare_tibble";
   case vctrs_type2_s3_scalar_unknown:              return "vctrs_type2_s3_scalar_unknown";
 
   case vctrs_type2_s3_bare_factor_bare_factor:     return "vctrs_type2_s3_bare_factor_bare_factor";
@@ -373,25 +426,33 @@ const char* vctrs_type2_s3_as_str(enum vctrs_type2_s3 type) {
   case vctrs_type2_s3_bare_factor_bare_date:       return "vctrs_type2_s3_bare_factor_bare_date";
   case vctrs_type2_s3_bare_factor_bare_posixct:    return "vctrs_type2_s3_bare_factor_bare_posixct";
   case vctrs_type2_s3_bare_factor_bare_posixlt:    return "vctrs_type2_s3_bare_factor_bare_posixlt";
+  case vctrs_type2_s3_bare_factor_bare_tibble:     return "vctrs_type2_s3_bare_factor_bare_tibble";
   case vctrs_type2_s3_bare_factor_unknown:         return "vctrs_type2_s3_bare_factor_unknown";
 
   case vctrs_type2_s3_bare_ordered_bare_ordered:   return "vctrs_type2_s3_bare_ordered_bare_ordered";
   case vctrs_type2_s3_bare_ordered_bare_date:      return "vctrs_type2_s3_bare_ordered_bare_date";
   case vctrs_type2_s3_bare_ordered_bare_posixct:   return "vctrs_type2_s3_bare_ordered_bare_posixct";
   case vctrs_type2_s3_bare_ordered_bare_posixlt:   return "vctrs_type2_s3_bare_ordered_bare_posixlt";
+  case vctrs_type2_s3_bare_ordered_bare_tibble:    return "vctrs_type2_s3_bare_ordered_bare_tibble";
   case vctrs_type2_s3_bare_ordered_unknown:        return "vctrs_type2_s3_bare_ordered_unknown";
 
   case vctrs_type2_s3_bare_date_bare_date:         return "vctrs_type2_s3_bare_date_bare_date";
   case vctrs_type2_s3_bare_date_bare_posixct:      return "vctrs_type2_s3_bare_date_bare_posixct";
   case vctrs_type2_s3_bare_date_bare_posixlt:      return "vctrs_type2_s3_bare_date_bare_posixlt";
+  case vctrs_type2_s3_bare_date_bare_tibble:       return "vctrs_type2_s3_bare_date_bare_tibble";
   case vctrs_type2_s3_bare_date_unknown:           return "vctrs_type2_s3_bare_date_unknown";
 
   case vctrs_type2_s3_bare_posixct_bare_posixct:   return "vctrs_type2_s3_bare_posixct_bare_posixct";
   case vctrs_type2_s3_bare_posixct_bare_posixlt:   return "vctrs_type2_s3_bare_posixct_bare_posixlt";
+  case vctrs_type2_s3_bare_posixct_bare_tibble:    return "vctrs_type2_s3_bare_posixct_bare_tibble";
   case vctrs_type2_s3_bare_posixct_unknown:        return "vctrs_type2_s3_bare_posixct_unknown";
 
   case vctrs_type2_s3_bare_posixlt_bare_posixlt:   return "vctrs_type2_s3_bare_posixlt_bare_posixlt";
+  case vctrs_type2_s3_bare_posixlt_bare_tibble:    return "vctrs_type2_s3_bare_posixlt_bare_tibble";
   case vctrs_type2_s3_bare_posixlt_unknown:        return "vctrs_type2_s3_bare_posixlt_unknown";
+
+  case vctrs_type2_s3_bare_tibble_bare_tibble:     return "vctrs_type2_s3_bare_tibble_bare_tibble";
+  case vctrs_type2_s3_bare_tibble_unknown:         return "vctrs_type2_s3_bare_tibble_unknown";
 
   case vctrs_type2_s3_unknown_unknown:             return "vctrs_type2_s3_unknown_unknown";
   }

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -189,6 +189,7 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_null_bare_date,
   vctrs_type2_s3_null_bare_posixct,
   vctrs_type2_s3_null_bare_posixlt,
+  vctrs_type2_s3_null_bare_tibble,
   vctrs_type2_s3_null_unknown,
 
   vctrs_type2_s3_unspecified_bare_factor,
@@ -196,6 +197,7 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_unspecified_bare_date,
   vctrs_type2_s3_unspecified_bare_posixct,
   vctrs_type2_s3_unspecified_bare_posixlt,
+  vctrs_type2_s3_unspecified_bare_tibble,
   vctrs_type2_s3_unspecified_unknown,
 
   vctrs_type2_s3_logical_bare_factor,
@@ -203,6 +205,7 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_logical_bare_date,
   vctrs_type2_s3_logical_bare_posixct,
   vctrs_type2_s3_logical_bare_posixlt,
+  vctrs_type2_s3_logical_bare_tibble,
   vctrs_type2_s3_logical_unknown,
 
   vctrs_type2_s3_integer_bare_factor,
@@ -210,6 +213,7 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_integer_bare_date,
   vctrs_type2_s3_integer_bare_posixct,
   vctrs_type2_s3_integer_bare_posixlt,
+  vctrs_type2_s3_integer_bare_tibble,
   vctrs_type2_s3_integer_unknown,
 
   vctrs_type2_s3_double_bare_factor,
@@ -217,6 +221,7 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_double_bare_date,
   vctrs_type2_s3_double_bare_posixct,
   vctrs_type2_s3_double_bare_posixlt,
+  vctrs_type2_s3_double_bare_tibble,
   vctrs_type2_s3_double_unknown,
 
   vctrs_type2_s3_complex_bare_factor,
@@ -224,6 +229,7 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_complex_bare_date,
   vctrs_type2_s3_complex_bare_posixct,
   vctrs_type2_s3_complex_bare_posixlt,
+  vctrs_type2_s3_complex_bare_tibble,
   vctrs_type2_s3_complex_unknown,
 
   vctrs_type2_s3_character_bare_factor,
@@ -231,6 +237,7 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_character_bare_date,
   vctrs_type2_s3_character_bare_posixct,
   vctrs_type2_s3_character_bare_posixlt,
+  vctrs_type2_s3_character_bare_tibble,
   vctrs_type2_s3_character_unknown,
 
   vctrs_type2_s3_raw_bare_factor,
@@ -238,6 +245,7 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_raw_bare_date,
   vctrs_type2_s3_raw_bare_posixct,
   vctrs_type2_s3_raw_bare_posixlt,
+  vctrs_type2_s3_raw_bare_tibble,
   vctrs_type2_s3_raw_unknown,
 
   vctrs_type2_s3_list_bare_factor,
@@ -245,6 +253,7 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_list_bare_date,
   vctrs_type2_s3_list_bare_posixct,
   vctrs_type2_s3_list_bare_posixlt,
+  vctrs_type2_s3_list_bare_tibble,
   vctrs_type2_s3_list_unknown,
 
   vctrs_type2_s3_dataframe_bare_factor,
@@ -252,6 +261,7 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_dataframe_bare_date,
   vctrs_type2_s3_dataframe_bare_posixct,
   vctrs_type2_s3_dataframe_bare_posixlt,
+  vctrs_type2_s3_dataframe_bare_tibble,
   vctrs_type2_s3_dataframe_unknown,
 
   vctrs_type2_s3_scalar_bare_factor,
@@ -259,6 +269,7 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_scalar_bare_date,
   vctrs_type2_s3_scalar_bare_posixct,
   vctrs_type2_s3_scalar_bare_posixlt,
+  vctrs_type2_s3_scalar_bare_tibble,
   vctrs_type2_s3_scalar_unknown,
 
   vctrs_type2_s3_bare_factor_bare_factor,
@@ -266,25 +277,33 @@ enum vctrs_type2_s3 {
   vctrs_type2_s3_bare_factor_bare_date,
   vctrs_type2_s3_bare_factor_bare_posixct,
   vctrs_type2_s3_bare_factor_bare_posixlt,
+  vctrs_type2_s3_bare_factor_bare_tibble,
   vctrs_type2_s3_bare_factor_unknown,
 
   vctrs_type2_s3_bare_ordered_bare_ordered,
   vctrs_type2_s3_bare_ordered_bare_date,
   vctrs_type2_s3_bare_ordered_bare_posixct,
   vctrs_type2_s3_bare_ordered_bare_posixlt,
+  vctrs_type2_s3_bare_ordered_bare_tibble,
   vctrs_type2_s3_bare_ordered_unknown,
 
   vctrs_type2_s3_bare_date_bare_date,
   vctrs_type2_s3_bare_date_bare_posixct,
   vctrs_type2_s3_bare_date_bare_posixlt,
+  vctrs_type2_s3_bare_date_bare_tibble,
   vctrs_type2_s3_bare_date_unknown,
 
   vctrs_type2_s3_bare_posixct_bare_posixct,
   vctrs_type2_s3_bare_posixct_bare_posixlt,
+  vctrs_type2_s3_bare_posixct_bare_tibble,
   vctrs_type2_s3_bare_posixct_unknown,
 
   vctrs_type2_s3_bare_posixlt_bare_posixlt,
+  vctrs_type2_s3_bare_posixlt_bare_tibble,
   vctrs_type2_s3_bare_posixlt_unknown,
+
+  vctrs_type2_s3_bare_tibble_bare_tibble,
+  vctrs_type2_s3_bare_tibble_unknown,
 
   vctrs_type2_s3_unknown_unknown
 };

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -400,6 +400,8 @@ SEXP vec_cast_dispatch(SEXP x,
                        struct vctrs_arg* x_arg,
                        struct vctrs_arg* to_arg);
 
+SEXP df_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
+
 bool is_data_frame(SEXP x);
 bool is_record(SEXP x);
 
@@ -525,6 +527,10 @@ SEXP ord_as_ordered(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_arg, struc
 
 SEXP date_datetime_ptype2(SEXP x, SEXP y);
 SEXP datetime_datetime_ptype2(SEXP x, SEXP y);
+
+// Tibble methods ----------------------------------------------
+
+SEXP tibble_ptype2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
 
 // Character translation ----------------------------------------
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -400,7 +400,7 @@ SEXP vec_cast_dispatch(SEXP x,
                        struct vctrs_arg* x_arg,
                        struct vctrs_arg* to_arg);
 
-SEXP df_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
+SEXP df_ptype2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
 SEXP df_as_dataframe(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 
 bool is_data_frame(SEXP x);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -401,6 +401,7 @@ SEXP vec_cast_dispatch(SEXP x,
                        struct vctrs_arg* to_arg);
 
 SEXP df_type2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
+SEXP df_as_dataframe(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 
 bool is_data_frame(SEXP x);
 bool is_record(SEXP x);

--- a/tests/testthat/helper-types.R
+++ b/tests/testthat/helper-types.R
@@ -16,7 +16,8 @@ base_s3_empty_types <- list(
   bare_ordered = new_ordered(),
   bare_date = new_date(),
   bare_posixct = new_datetime(tzone = "UTC"),
-  bare_posixlt = as.POSIXlt(new_datetime(tzone = "UTC"))
+  bare_posixlt = as.POSIXlt(new_datetime(tzone = "UTC")),
+  bare_tibble = tibble::tibble()
 )
 
 proxied_empty_types <- list(


### PR DESCRIPTION
Closes #592 
Related to tidyverse/tidyr#751

This PR implements C level support for bare tibbles in `vec_ptype2()` and `vec_cast()`.

I also somehow missed some `break;`s in my `vec_cast_dispatch()` switch statements, so this fixes those too.

Basic improvements:

``` r
library(vctrs)
library(tibble)

x <- tibble(x = 1)
```

ptype2

```r
# before
bench::mark(vec_ptype2(x, x))
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(x, x)   10.8µs   12.8µs    75996.    9.41KB     83.7

# after
bench::mark(vec_ptype2(x, x))
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(x, x)   2.92µs   3.53µs   264898.        0B     53.0
```

casting

```r
# before
bench::mark(vec_cast(x, x))
#> # A tibble: 1 x 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast(x, x)   8.33µs   11.8µs    78897.    8.41KB     15.8

# after
bench::mark(vec_cast(x, x))
#> # A tibble: 1 x 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast(x, x)   2.27µs    2.8µs   281384.        0B     28.1
```

Rerunning the #592 benchmarks. Finding the common type of tibbles is now as fast as data frames. So `vec_rbind()` is now close to the same speed, but a little slower most of the time. But way better than before!

``` r
library(vctrs)
library(tibble)

df <- data.frame(x = 1, y = 2)
tbl <- as_tibble(df)

lst_df <- rep(list(df), 100000)
lst_tbl <- rep(list(tbl), 100000)

bench::mark(
  vec_ptype_common(!!! lst_df),
  vec_ptype_common(!!! lst_tbl),
  check = FALSE,
  iterations = 20
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype_common(!!!lst_df)     128ms    255ms      4.05     6.5KB     9.53
#> 2 vec_ptype_common(!!!lst_tbl)    141ms    256ms      3.97    7.27KB     7.55

bench::mark(
  vec_rbind(!!! lst_df),
  vec_rbind(!!! lst_tbl),
  check = FALSE,
  iterations = 20
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                 min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>            <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_rbind(!!!lst_df)     435ms    560ms      1.78    2.68MB     9.09
#> 2 vec_rbind(!!!lst_tbl)    510ms    611ms      1.64    2.67MB     6.90
```

Running the tidyverse/tidyr#751 benchmark Hadley posted at the end against this PR and current master. Nice improvements, but still slower:

``` r
library(tidyr)
n <- 10000

df <- tibble(
  g = 1:n,
  y = rep(list(tibble(x = 1:5)), n)
)

# before
bench::mark(
  unnest(df, y),
  unnest_legacy(df, y),
  iterations = 50
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>           <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 unnest(df, y)         391.9ms  498.1ms      2.00    3.42MB     20.1
#> 2 unnest_legacy(df, y)   52.1ms   58.6ms     16.4     1.25MB     19.0

# after
bench::mark(
  unnest(df, y),
  unnest_legacy(df, y),
  iterations = 50
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>           <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 unnest(df, y)         235.2ms  325.2ms      3.03    3.41MB     13.2
#> 2 unnest_legacy(df, y)   56.9ms   65.3ms     15.1     1.25MB     14.2
```
