### PR TITLE
Support row names in `vec_cbind()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,8 +33,7 @@
   is supplied, they are assigned in the column name as before.
 
 * `vec_cbind()` now binds row names if they are congruent across
-  inputs. If the row names are not identical that's an error. If some
-  inputs do not have row names, they are propagated.
+  inputs. If the row names are not identical that's an error.
 
 * The `c()` method for `vctrs_vctr` now throws an error when
   `recursive` or `use.names` is supplied (#791).

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,10 +27,14 @@
 * `vec_slice()` and `vec_chop()` now work correctly with `bit64::integer64()`
   objects when an `NA` subscript is supplied. By extension, this means that
   `vec_init()` now works with these objects as well (#813).
-  
+
 * `vec_rbind()` now binds row names. When named inputs are supplied
   and `names_to` is `NULL`, the names define row names. If `names_to`
   is supplied, they are assigned in the column name as before.
+
+* `vec_cbind()` now binds row names if they are congruent across
+  inputs. If the row names are not identical that's an error. If some
+  inputs do not have row names, they are propagated.
 
 * The `c()` method for `vctrs_vctr` now throws an error when
   `recursive` or `use.names` is supplied (#791).

--- a/src/utils.c
+++ b/src/utils.c
@@ -254,6 +254,21 @@ SEXP map(SEXP x, SEXP (*fn)(SEXP)) {
   UNPROTECT(2);
   return out;
 }
+// [[ include("utils.h") ]]
+SEXP map_with_data(SEXP x, SEXP (*fn)(SEXP, void*), void* data) {
+  R_len_t n = Rf_length(x);
+  SEXP out = PROTECT(Rf_allocVector(VECSXP, n));
+
+  for (R_len_t i = 0; i < n; ++i) {
+    SET_VECTOR_ELT(out, i, fn(VECTOR_ELT(x, i), data));
+  }
+
+  SEXP nms = PROTECT(Rf_getAttrib(x, R_NamesSymbol));
+  Rf_setAttrib(out, R_NamesSymbol, nms);
+
+  UNPROTECT(2);
+  return out;
+}
 
 // [[ include("utils.h") ]]
 SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP)) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -76,8 +76,9 @@ SEXP vctrs_dispatch4(SEXP fn_sym, SEXP fn,
                      SEXP z_sym, SEXP z);
 
 SEXP map(SEXP x, SEXP (*fn)(SEXP));
-SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP));
+SEXP map_with_data(SEXP x, SEXP (*fn)(SEXP, void*), void* data);
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP));
+SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP));
 
 enum vctrs_class_type class_type(SEXP x);
 bool is_data_frame(SEXP x);

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -460,3 +460,29 @@ test_that("rbind() and cbind() have informative outputs when repairing names", {
     vec_cbind(c(a = 1), c(b = 2))
   })
 })
+
+test_that("cbind() deals with row names", {
+  expect_identical(
+    vec_cbind(mtcars[1:3], foo = 1),
+    cbind(mtcars[1:3], foo = 1)
+  )
+  expect_identical(
+    vec_cbind(mtcars[1:3], mtcars[4]),
+    cbind(mtcars[1:3], mtcars[4])
+  )
+
+  out <- vec_cbind(
+    mtcars[1, 1, drop = FALSE],
+    unrownames(mtcars[1:3, 2, drop = FALSE])
+  )
+  exp <- mtcars[1:3, c(1, 2)]
+  exp[[1]] <- exp[[1, 1]]
+  row.names(exp) <- paste0(c("Mazda RX4..."), 1:3)
+  expect_identical(out, exp)
+
+  # Should work once we have frame prototyping
+  expect_error(
+    vec_cbind(mtcars[1:3], vec_slice(mtcars[4], nrow(mtcars):1)),
+    "different row names"
+  )
+})


### PR DESCRIPTION
Following row names support for `vec_rbind()`, `vec_cbind()` now has support as well:

```r
df <- mtcars[1:3, 1:3]
vec_cbind(df, foo = 1)
#>                mpg cyl disp foo
#> Mazda RX4     21.0   6  160   1
#> Mazda RX4 Wag 21.0   6  160   1
#> Datsun 710    22.8   4  108   1
```

Ideally we'd match row names in `vec_cbind()` the same way we match column names in `vec_rbind()`. However that require frame genericity, with the row names encoded in a frame prototype. For the moment this is an error:

```r
vec_cbind(df, df[3:1, ])
#> Error: Can't column-bind data frames with different row names.
```