### PR TITLE
Consistently use `switch (` not `switch(`

### DIFF
--- a/src/cast-dispatch.c
+++ b/src/cast-dispatch.c
@@ -31,7 +31,7 @@ SEXP vec_cast_dispatch(SEXP x,
     break;
 
   case vctrs_type_dataframe:
-    switch(class_type(x)) {
+    switch (class_type(x)) {
     case vctrs_class_bare_data_frame:
       Rf_errorcall(R_NilValue, "Internal error: `x` should have been classified as a `vctrs_type_dataframe`");
 

--- a/src/equal.c
+++ b/src/equal.c
@@ -281,7 +281,7 @@ bool equal_object(SEXP x, SEXP y) {
     return true;
   }
 
-  switch(type) {
+  switch (type) {
   // Handled below
   case LGLSXP:
   case INTSXP:

--- a/src/hash.c
+++ b/src/hash.c
@@ -130,7 +130,7 @@ SEXP vctrs_hash_object(SEXP x) {
 
 
 static uint32_t sexp_hash(SEXP x) {
-  switch(TYPEOF(x)) {
+  switch (TYPEOF(x)) {
   case NILSXP: return 0;
   case LGLSXP: return lgl_hash(x);
   case INTSXP: return int_hash(x);

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -103,7 +103,7 @@ bool vec_is_list(SEXP x) {
     return false;
   }
 
-  switch(class_type(x)) {
+  switch (class_type(x)) {
   // Bare list
   case vctrs_class_none:
     return true;

--- a/src/type.c
+++ b/src/type.c
@@ -38,7 +38,7 @@ static SEXP vec_type_slice(SEXP x, SEXP empty) {
   }
 }
 static SEXP s3_type(SEXP x) {
-  switch(class_type(x)) {
+  switch (class_type(x)) {
   case vctrs_class_bare_tibble:
     return bare_df_map(x, &vec_type);
 
@@ -87,7 +87,7 @@ SEXP vec_ptype_finalise(SEXP x) {
 
   vec_assert(x, args_empty);
 
-  switch(class_type(x)) {
+  switch (class_type(x)) {
   case vctrs_class_bare_tibble:
   case vctrs_class_bare_data_frame:
     return bare_df_map(x, &vec_ptype_finalise);


### PR DESCRIPTION
Just stylistic tweaks