### PR TITLE
Always call `r_maybe_duplicate()` in `vec_assign_impl()`

### DIFF
--- a/inst/include/vctrs.c
+++ b/inst/include/vctrs.c
@@ -2,7 +2,7 @@
 
 SEXP (*vec_proxy)(SEXP) = NULL;
 SEXP (*vec_restore)(SEXP, SEXP, SEXP) = NULL;
-SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool) = NULL;
+SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP) = NULL;
 SEXP (*vec_slice_impl)(SEXP, SEXP) = NULL;
 SEXP (*vec_names)(SEXP) = NULL;
 SEXP (*vec_set_names)(SEXP, SEXP) = NULL;
@@ -11,7 +11,7 @@ SEXP (*vec_chop)(SEXP, SEXP) = NULL;
 void vctrs_init_api() {
   vec_proxy = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_proxy");
   vec_restore = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vec_restore");
-  vec_assign_impl = (SEXP (*)(SEXP, SEXP, SEXP, bool)) R_GetCCallable("vctrs", "vec_assign_impl");
+  vec_assign_impl = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vec_assign_impl");
   vec_slice_impl = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_slice_impl");
   vec_names = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_names");
   vec_set_names = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_set_names");

--- a/inst/include/vctrs.h
+++ b/inst/include/vctrs.h
@@ -7,7 +7,7 @@
 
 extern SEXP (*vec_proxy)(SEXP);
 extern SEXP (*vec_restore)(SEXP, SEXP, SEXP);
-extern SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP, bool);
+extern SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP);
 extern SEXP (*vec_slice_impl)(SEXP, SEXP);
 extern SEXP (*vec_names)(SEXP);
 extern SEXP (*vec_set_names)(SEXP, SEXP);

--- a/src/bind.c
+++ b/src/bind.c
@@ -135,7 +135,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
 
     SEXP tbl = PROTECT(vec_cast(x, ptype, args_empty, args_empty));
     init_compact_seq(idx_ptr, counter, size, true);
-    df_assign(out, idx, tbl, false);
+    out = PROTECT(df_assign(out, idx, tbl));
 
     if (has_rownames) {
       SEXP rn = df_rownames(x);
@@ -152,11 +152,12 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
       PROTECT(rn);
 
       if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
-        chr_assign(rownames, idx, rn, false);
+        rownames = chr_assign(rownames, idx, rn);
       }
 
       UNPROTECT(1);
     }
+    PROTECT(rownames);
 
     // Assign current name to group vector, if supplied
     if (has_names_to) {
@@ -165,7 +166,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
     }
 
     counter += size;
-    UNPROTECT(1);
+    UNPROTECT(3);
   }
 
   if (has_rownames) {
@@ -358,15 +359,16 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
 
     R_len_t xn = Rf_length(x);
     init_compact_seq(idx_ptr, counter, xn, true);
-    list_assign(out, idx, x, false);
+    out = PROTECT(list_assign(out, idx, x));
 
     SEXP xnms = PROTECT(r_names(x));
     if (xnms != R_NilValue) {
-      chr_assign(names, idx, xnms, false);
+      names = chr_assign(names, idx, xnms);
     }
+    PROTECT(names);
 
     counter += xn;
-    UNPROTECT(1);
+    UNPROTECT(3);
   }
 
   names = PROTECT(vec_as_names(names, name_repair));

--- a/src/init.c
+++ b/src/init.c
@@ -94,7 +94,7 @@ extern SEXP vctrs_is_list(SEXP);
 // Available in the API header
 extern R_len_t vec_size(SEXP);
 extern SEXP vec_init(SEXP, R_len_t);
-extern SEXP vec_assign_impl(SEXP, SEXP, SEXP, bool);
+extern SEXP vec_assign_impl(SEXP, SEXP, SEXP);
 extern SEXP vec_slice_impl(SEXP, SEXP);
 extern SEXP vec_names(SEXP);
 extern SEXP vec_recycle(SEXP, R_len_t, struct vctrs_arg*);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -414,9 +414,9 @@ R_len_t df_raw_size_from_list(SEXP x);
 SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n);
 SEXP vec_df_restore(SEXP x, SEXP to, SEXP n);
 
-SEXP chr_assign(SEXP out, SEXP index, SEXP value, bool clone);
-SEXP list_assign(SEXP out, SEXP index, SEXP value, bool clone);
-SEXP df_assign(SEXP out, SEXP index, SEXP value, bool clone);
+SEXP chr_assign(SEXP out, SEXP index, SEXP value);
+SEXP list_assign(SEXP out, SEXP index, SEXP value);
+SEXP df_assign(SEXP out, SEXP index, SEXP value);
 
 // equal_object() never propagates missingness, so
 // it can return a `bool`


### PR DESCRIPTION
After adding ALTREP support in `vec_slice_impl()` in #837, I discovered that we are going to need to change `vec_assign_impl()` if we want to merge that PR.

The issue is that, if `clone = false`, we modify `x` directly by accessing it with the corresponding `DATAPTR()` regardless of its NAMED status. This causes a problem with ALTREP reps.

Consider `vec_rbind()`. It calls `vec_init()` to initialize the output. Integer and double columns here are initialized as ALTREP reps.

When it goes to assign into these with `df_assign()` (and `vec_assign_impl()` for each column) it sets `clone = false`. When it hits an ALTREP `vctrs_compact_rep_int` column, it _should_ call the Duplicate method to generate the full column because we shouldn't be modifying this compact data (it is marked as not mutable). Instead it bypasses `Rf_shallow_duplicate()` and calls the corresponding `DEREF()`, which calls my `DATAPTR()` method. This expands the values, sets them in the ALTREP data2 slot, and then returns the `DATAPTR()` to that (exactly what the compact_intseq method does). So we end up overwriting this data, which I don't think is correct and ends up causing problems because we have a `vctrs_compact_rep_int` column that isn't guaranteed to always be a rep of the same value.

This note from R core explains the reasoning used in compact_intseq a little more. I think that what we are doing here would be classified as "mis-behaving C code" to them, since we have an object with NAMED-ness of 7, but we assign directly into it. https://github.com/wch/r-source/blob/8e1209bd032c8a3f88925221e4247ad019b8ebed/src/main/altclasses.c#L60-L67

My solution is to remove the `clone` argument to `vec_assign_impl()` and always call `r_maybe_duplicate()`. This should have the correct behavior, and shouldn't be any slower.

I think we should think about `vec_assign_impl()` as: _"it clones the proxy if it needs to, i.e. if it is referenced or marked as not mutable. otherwise it assigns directly into the proxy."_

I think this reasoning would actually allow us to refactor `vec_assign()` and `vec_assign_impl()` in a way that pushes the fallback handling into `vec_assign_impl()`, along with the coercible casting, value proxying, and value recycling. This would help with https://github.com/r-lib/vctrs/issues/625, fixing a few bugs that result from that, and make @romainfrancois's job in dplyr easier since the edge cases are all handled by `vec_assign_impl()` directly.

This would break {slider} because I use the `vec_assign_impl()` callable, but the benefits are more than worth it if we also make `vec_assign_impl()` able to handle the fallback cases