### PR TITLE
Fix `repair_na_names()` with `compact_rep()`s

### DIFF
--- a/src/slice.c
+++ b/src/slice.c
@@ -281,17 +281,20 @@ static void repair_na_names(SEXP names, SEXP subscript) {
   }
 
   SEXP* p_names = STRING_PTR(names);
+  const int* p_subscript = INTEGER_RO(subscript);
 
   // Special handling for a compact_rep object with repeated `NA`
   if (is_compact_rep(subscript)) {
+    if (p_subscript[0] != NA_INTEGER) {
+      return;
+    }
+
     for (R_len_t i = 0; i < n; ++i) {
       p_names[i] = strings_empty;
     }
 
     return;
   }
-
-  const int* p_subscript = INTEGER_RO(subscript);
 
   for (R_len_t i = 0; i < n; ++i) {
     if (p_subscript[i] == NA_INTEGER) {

--- a/src/slice.c
+++ b/src/slice.c
@@ -291,10 +291,10 @@ static void repair_na_names(SEXP names, SEXP subscript) {
     return;
   }
 
-  const int* p_i = INTEGER_RO(subscript);
+  const int* p_subscript = INTEGER_RO(subscript);
 
   for (R_len_t i = 0; i < n; ++i) {
-    if (p_i[i] == NA_INTEGER) {
+    if (p_subscript[i] == NA_INTEGER) {
       p_names[i] = strings_empty;
     }
   }

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -498,6 +498,10 @@ test_that("names are repaired correctly with compact reps and `NA_integer_`", {
   expect_equal(vec_slice_rep(x, NA_integer_, 2L), expect)
 })
 
+test_that("names are recycled correctly with compact reps", {
+  expect_named(vec_slice_rep(c(x = 1L), 1L, 3L), c("x", "x", "x"))
+})
+
 test_that("vec_slice() with compact_reps work with Altrep classes", {
   skip_if(getRversion() < "3.5")
 


### PR DESCRIPTION
`repair_na_names()` was accidentally _always_ setting names to the empty string whenever the original input had any names and a `compact_rep()` was used to do the slicing