### PR TITLE
Flatten df-cols in equality proxy

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -95,6 +95,7 @@ extern SEXP vctrs_is_coercible(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_as_subscript(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_as_subscript_result(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_df_flat_width(SEXP);
+extern SEXP df_flatten(SEXP);
 
 // Very experimental
 // Available in the API header
@@ -208,6 +209,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_as_subscript",               (DL_FUNC) &vctrs_as_subscript, 5},
   {"vctrs_as_subscript_result",        (DL_FUNC) &vctrs_as_subscript_result, 5},
   {"vctrs_df_flat_width",              (DL_FUNC) &vctrs_df_flat_width, 1},
+  {"vctrs_df_flatten",                 (DL_FUNC) &df_flatten, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -94,6 +94,7 @@ extern SEXP vctrs_try_catch_callback(SEXP, SEXP);
 extern SEXP vctrs_is_coercible(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_as_subscript(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_as_subscript_result(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_df_flat_width(SEXP);
 
 // Very experimental
 // Available in the API header
@@ -206,6 +207,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_is_coercible",               (DL_FUNC) &vctrs_is_coercible, 4},
   {"vctrs_as_subscript",               (DL_FUNC) &vctrs_as_subscript, 5},
   {"vctrs_as_subscript_result",        (DL_FUNC) &vctrs_as_subscript_result, 5},
+  {"vctrs_df_flat_width",              (DL_FUNC) &vctrs_df_flat_width, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -9,6 +9,7 @@ SEXP fns_vec_proxy_equal_dispatch = NULL;
 // Defined below
 SEXP vec_proxy_method(SEXP x);
 SEXP vec_proxy_invoke(SEXP x, SEXP method);
+static SEXP vec_proxy_unwrap(SEXP x);
 
 
 // [[ register(); include("vctrs.h") ]]
@@ -35,7 +36,7 @@ SEXP vec_proxy_equal(SEXP x) {
   UNPROTECT(1);
   return res;
 }
-SEXP vec_proxy_unwrap(SEXP x) {
+static SEXP vec_proxy_unwrap(SEXP x) {
   if (TYPEOF(x) == VECSXP && XLENGTH(x) == 1 && is_data_frame(x)) {
     x = vec_proxy_unwrap(VECTOR_ELT(x, 0));
   }

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -241,3 +241,23 @@ SEXP df_poke_at(SEXP x, SEXP name, SEXP value) {
   UNPROTECT(1);
   return x;
 }
+
+// [[ include("type-data-frame.h") ]]
+R_len_t df_flat_width(SEXP x) {
+  R_len_t n = Rf_length(x);
+  R_len_t out = n;
+
+  for (R_len_t i = 0; i < n; ++i) {
+    SEXP col = VECTOR_ELT(x, i);
+    if (is_data_frame(col)) {
+      out = out + df_flat_width(col) - 1;
+    }
+  }
+
+  return out;
+}
+
+// [[ register() ]]
+SEXP vctrs_df_flat_width(SEXP x) {
+  return r_int(df_flat_width(x));
+}

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -5,6 +5,10 @@
 
 // [[ include("type-data-frame.h") ]]
 bool is_data_frame(SEXP x) {
+  if (TYPEOF(x) != VECSXP) {
+    return false;
+  }
+
   enum vctrs_class_type type = class_type(x);
   return
     type == vctrs_class_bare_data_frame ||

--- a/src/type-data-frame.h
+++ b/src/type-data-frame.h
@@ -13,6 +13,7 @@ R_len_t compact_rownames_length(SEXP x);
 SEXP df_container_type(SEXP x);
 SEXP df_poke(SEXP x, R_len_t i, SEXP value);
 SEXP df_poke_at(SEXP x, SEXP name, SEXP value);
+R_len_t df_flat_width(SEXP x);
 
 enum rownames_type {
   ROWNAMES_AUTOMATIC,

--- a/src/type-data-frame.h
+++ b/src/type-data-frame.h
@@ -14,6 +14,7 @@ SEXP df_container_type(SEXP x);
 SEXP df_poke(SEXP x, R_len_t i, SEXP value);
 SEXP df_poke_at(SEXP x, SEXP name, SEXP value);
 R_len_t df_flat_width(SEXP x);
+SEXP df_flatten(SEXP x);
 
 enum rownames_type {
   ROWNAMES_AUTOMATIC,

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -349,7 +349,6 @@ enum vctrs_proxy_kind {
 SEXP vec_proxy(SEXP x);
 SEXP vec_proxy_equal(SEXP x);
 SEXP vec_proxy_recursive(SEXP x, enum vctrs_proxy_kind kind);
-SEXP vec_proxy_unwrap(SEXP x);
 SEXP vec_restore(SEXP x, SEXP to, SEXP i);
 R_len_t vec_size(SEXP x);
 R_len_t vec_size_common(SEXP xs, R_len_t absent);

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -235,3 +235,13 @@ test_that("if supplied, `n` must be an integer of size 1", {
 test_that("`class` must be a character vector", {
   expect_error(new_data_frame(class = 1), "must be NULL or a character vector")
 })
+
+test_that("flat width is computed", {
+  df_flat_width <- function(x) {
+    .Call(vctrs_df_flat_width, x)
+  }
+  expect_identical(df_flat_width(mtcars), ncol(mtcars))
+
+  df <- tibble(x = 1, y = tibble(x = 2, y = tibble(x = 3), z = 4), z = 5)
+  expect_identical(df_flat_width(df), 5L)
+})

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -245,3 +245,13 @@ test_that("flat width is computed", {
   df <- tibble(x = 1, y = tibble(x = 2, y = tibble(x = 3), z = 4), z = 5)
   expect_identical(df_flat_width(df), 5L)
 })
+
+test_that("can flatten data frames", {
+  df_flatten <- function(x) {
+    .Call(vctrs_df_flatten, x)
+  }
+  expect_identical(df_flatten(mtcars), as.data.frame(as.list(mtcars)))
+
+  df <- tibble(x = 1, y = tibble(x = 2, y = tibble(x = 3), z = 4), z = 5)
+  expect_identical(df_flatten(df), new_data_frame(list(x = 1, x = 2, x = 3, z = 4, z = 5)))
+})


### PR DESCRIPTION
So that dictionary operations don't need to deal with recursion. This is to simplify code in an upcoming PR.

Data frames of 1 columns are unwrapped as before.