### PR TITLE
Cache vector types and pointers in dictionaries

### DIFF
--- a/R/equal.R
+++ b/R/equal.R
@@ -76,3 +76,7 @@ vec_equal_na <- function(x) {
 obj_equal <- function(x, y) {
   .Call(vctrs_equal_object, x, y)
 }
+
+test_equal_scalar <- function(x, i, y, j, na_equal = FALSE) {
+  .Call(vctrs_equal_scalar, x, i, y, j, na_equal)
+}

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -1,5 +1,6 @@
 #include "vctrs.h"
 #include "dictionary.h"
+#include "equal.h"
 #include "utils.h"
 
 // Initialised at load time
@@ -21,23 +22,174 @@ int32_t ceil2(int32_t x) {
 
 // Dictonary object ------------------------------------------------------------
 
-// Dictionary functions assume that `x` has been proxied recursively because:
-// - `dict_init_impl()` uses `hash_fill()`
-// - `dict_hash_with()` uses `equal_scalar()`
+static struct dictionary* new_dictionary_impl(SEXP x, bool partial);
 
-static void dict_init_impl(struct dictionary* d, SEXP x, bool partial);
 
-// Dictionaries must be protected and unprotected in consistent stack
-// order with `PROTECT_DICT()` and `UNPROTECT_DICT()`.
-void dict_init(struct dictionary* d, SEXP x) {
-  dict_init_impl(d, x, false);
+static int nil_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+  Rf_error("Internal error: Shouldn't compare NULL in dictionary.");
 }
-void dict_init_partial(struct dictionary* d, SEXP x) {
-  dict_init_impl(d, x, true);
+static int lgl_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+  return lgl_equal_scalar(((const int*) x) + i, ((const int*) y) + j, true);
+}
+static int int_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+  return int_equal_scalar(((const int*) x) + i, ((const int*) y) + j, true);
+}
+static int dbl_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+  return dbl_equal_scalar(((const double*) x) + i, ((const double*) y) + j, true);
+}
+static int cpl_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+  return cpl_equal_scalar(((const Rcomplex*) x) + i, ((const Rcomplex*) y) + j, true);
+}
+static int chr_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+  return chr_equal_scalar(((const SEXP*) x) + i, ((const SEXP*) y) + j, true);
+}
+static int raw_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+  return raw_equal_scalar(((const Rbyte*) x) + i, ((const Rbyte*) y) + j, true);
+}
+static int list_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+  return list_equal_scalar(((const SEXP) x), i, ((const SEXP) y), j, true);
 }
 
-static void dict_init_impl(struct dictionary* d, SEXP x, bool partial) {
+
+static void init_dictionary_nil(struct dictionary* d) {
+  d->vec_p = NULL;
+  d->equal = &nil_equal;
+}
+static void init_dictionary_lgl(struct dictionary* d) {
+  d->vec_p = (const void*) LOGICAL_RO(d->vec);
+  d->equal = &lgl_equal;
+}
+static void init_dictionary_int(struct dictionary* d) {
+  d->vec_p = (const void*) INTEGER_RO(d->vec);
+  d->equal = &int_equal;
+}
+static void init_dictionary_dbl(struct dictionary* d) {
+  d->vec_p = (const void*) REAL_RO(d->vec);
+  d->equal = dbl_equal;
+}
+static void init_dictionary_cpl(struct dictionary* d) {
+  d->vec_p = (const void*) COMPLEX_RO(d->vec);
+  d->equal = &cpl_equal;
+}
+static void init_dictionary_chr(struct dictionary* d) {
+  d->vec_p = (const void*) STRING_PTR_RO(d->vec);
+  d->equal = &chr_equal;
+}
+static void init_dictionary_raw(struct dictionary* d) {
+  d->vec_p = (const void*) RAW_RO(d->vec);
+  d->equal = &raw_equal;
+}
+static void init_dictionary_list(struct dictionary* d) {
+  d->vec_p = (const void*) d->vec;
+  d->equal = &list_equal;
+}
+
+struct dictionary_df_data {
+  enum vctrs_type* col_types;
+  void** col_ptrs;
+  R_len_t n_col;
+};
+
+static int df_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+  struct dictionary_df_data* x_data = (struct dictionary_df_data*) x;
+  struct dictionary_df_data* y_data = (struct dictionary_df_data*) y;
+
+  R_len_t n_col = x_data->n_col;
+  if (n_col != y_data->n_col) {
+    Rf_errorcall(R_NilValue, "Internal error: `x` and `y` must have the same number of columns.");
+  }
+
+  enum vctrs_type* types = x_data->col_types;
+  void** x_ptrs = x_data->col_ptrs;
+  void** y_ptrs = y_data->col_ptrs;
+
+  // `vec_proxy_equal()` flattens data frames so we don't need to
+  // worry about df-cols
+  for (R_len_t col = 0; col < n_col; ++col) {
+    if (!equal_scalar_p(types[col],
+                        R_NilValue, x_ptrs[col], i,
+                        R_NilValue, y_ptrs[col], j,
+                        true)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+static void init_dictionary_df(struct dictionary* d) {
+  SEXP df = d->vec;
+  R_len_t n_col = Rf_length(df);
+
+  SEXP data_handle = PROTECT(Rf_allocVector(RAWSXP, sizeof(struct dictionary_df_data)));
+  SEXP col_types_handle = PROTECT(Rf_allocVector(RAWSXP, n_col * sizeof(enum vctrs_type)));
+  SEXP col_ptrs_handle = PROTECT(Rf_allocVector(RAWSXP, n_col * sizeof(void*)));
+
+  SEXP handle = PROTECT(Rf_allocVector(VECSXP, 4));
+  SET_VECTOR_ELT(handle, 0, d->protect);
+  SET_VECTOR_ELT(handle, 1, data_handle);
+  SET_VECTOR_ELT(handle, 2, col_types_handle);
+  SET_VECTOR_ELT(handle, 3, col_ptrs_handle);
+
+
+  struct dictionary_df_data* data = (struct dictionary_df_data*) RAW(data_handle);
+  enum vctrs_type* col_types = (enum vctrs_type*) RAW(col_types_handle);
+  void** col_ptrs = (void**) RAW(col_ptrs_handle);
+
+  data->col_types = col_types;
+  data->col_ptrs = col_ptrs;
+  data->n_col = n_col;
+
+  for (R_len_t i = 0; i < n_col; ++i) {
+    SEXP col = VECTOR_ELT(df, i);
+    enum vctrs_type col_type = vec_proxy_typeof(col);
+
+    col_types[i] = col_type;
+
+    if (col_type == vctrs_type_list) {
+      col_ptrs[i] = col;
+    } else {
+      col_ptrs[i] = r_vec_deref(col);
+    }
+  }
+
+  d->protect = handle;
+  d->vec_p = data;
+  d->equal = df_equal;
+
+  UNPROTECT(4);
+}
+
+
+// Dictionaries must be protected in consistent stack order with
+// `PROTECT_DICT()`
+struct dictionary* new_dictionary(SEXP x) {
+  return new_dictionary_impl(x, false);
+}
+struct dictionary* new_dictionary_partial(SEXP x) {
+  return new_dictionary_impl(x, true);
+}
+
+static struct dictionary* new_dictionary_impl(SEXP x, bool partial) {
+  SEXP out = PROTECT(Rf_allocVector(RAWSXP, sizeof(struct dictionary)));
+  struct dictionary* d = (struct dictionary*) RAW(out);
+
   d->vec = x;
+  d->type = vec_proxy_typeof(x);
+  d->protect = out;
+
+  switch (d->type) {
+  case vctrs_type_null: init_dictionary_nil(d); break;
+  case vctrs_type_logical: init_dictionary_lgl(d); break;
+  case vctrs_type_integer: init_dictionary_int(d); break;
+  case vctrs_type_double: init_dictionary_dbl(d); break;
+  case vctrs_type_complex: init_dictionary_cpl(d); break;
+  case vctrs_type_character: init_dictionary_chr(d); break;
+  case vctrs_type_raw: init_dictionary_raw(d); break;
+  case vctrs_type_list: init_dictionary_list(d); break;
+  case vctrs_type_dataframe: init_dictionary_df(d); break;
+  default: Rf_error("Internal error: Unimplemented type in `new_dictionary()`.");
+  }
+
   d->used = 0;
 
   if (partial) {
@@ -70,8 +222,15 @@ static void dict_init_impl(struct dictionary* d, SEXP x, bool partial) {
   } else {
     d->hash = NULL;
   }
+
+  UNPROTECT(1);
+  return d;
 }
 
+
+// Use hash from `x` but value from `d`. `x` does not need a full
+// initialisation of the key vector and can be created with
+// `new_dictionary_partial()`.
 uint32_t dict_hash_with(struct dictionary* d, struct dictionary* x, R_len_t i) {
   uint32_t hash = x->hash[i];
 
@@ -92,12 +251,13 @@ uint32_t dict_hash_with(struct dictionary* d, struct dictionary* x, R_len_t i) {
       return probe;
     }
 
-    // Check for same value as there might be a collision. If there is
-    // a collision, next iteration will find another spot using
-    // quadratic probing.
-    if (equal_scalar(d->vec, idx, x->vec, i, true)) {
+    // Check for same value as there might be a collision
+    if (d->equal(d->vec_p, idx, x->vec_p, i)) {
       return probe;
     }
+
+    // Collision. next iteration will find another spot using
+    // quadratic probing.
   }
 
   Rf_errorcall(R_NilValue, "Internal error: Dictionary is full!");
@@ -125,18 +285,17 @@ SEXP vctrs_unique_loc(SEXP x) {
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
-  struct dictionary d;
-  dict_init(&d, x);
-  PROTECT_DICT(&d, &nprot);
+  struct dictionary* d = new_dictionary(x);
+  PROTECT_DICT(d, &nprot);
 
   struct growable g = new_growable(INTSXP, 256);
   PROTECT_GROWABLE(&g, &nprot);
 
   for (int i = 0; i < n; ++i) {
-    uint32_t hash = dict_hash_scalar(&d, i);
+    uint32_t hash = dict_hash_scalar(d, i);
 
-    if (d.key[hash] == DICT_EMPTY) {
-      dict_put(&d, hash, i);
+    if (d->key[hash] == DICT_EMPTY) {
+      dict_put(d, hash, i);
       growable_push_int(&g, i + 1);
     }
   }
@@ -169,17 +328,16 @@ bool duplicated_any(SEXP x) {
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
-  struct dictionary d;
-  dict_init(&d, x);
-  PROTECT_DICT(&d, &nprot);
+  struct dictionary* d = new_dictionary(x);
+  PROTECT_DICT(d, &nprot);
 
   bool out = false;
 
   for (int i = 0; i < n; ++i) {
-    uint32_t hash = dict_hash_scalar(&d, i);
+    uint32_t hash = dict_hash_scalar(d, i);
 
-    if (d.key[hash] == DICT_EMPTY) {
-      dict_put(&d, hash, i);
+    if (d->key[hash] == DICT_EMPTY) {
+      dict_put(d, hash, i);
     } else {
       out = true;
       break;
@@ -198,19 +356,19 @@ SEXP vctrs_n_distinct(SEXP x) {
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
-  struct dictionary d;
-  dict_init(&d, x);
-  PROTECT_DICT(&d, &nprot);
+  struct dictionary* d = new_dictionary(x);
+  PROTECT_DICT(d, &nprot);
 
   for (int i = 0; i < n; ++i) {
-    uint32_t hash = dict_hash_scalar(&d, i);
+    uint32_t hash = dict_hash_scalar(d, i);
 
-    if (d.key[hash] == DICT_EMPTY)
-      dict_put(&d, hash, i);
+    if (d->key[hash] == DICT_EMPTY) {
+      dict_put(d, hash, i);
+    }
   }
 
   UNPROTECT(nprot);
-  return Rf_ScalarInteger(d.used);
+  return Rf_ScalarInteger(d->used);
 }
 
 SEXP vctrs_id(SEXP x) {
@@ -221,20 +379,19 @@ SEXP vctrs_id(SEXP x) {
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
-  struct dictionary d;
-  dict_init(&d, x);
-  PROTECT_DICT(&d, &nprot);
+  struct dictionary* d = new_dictionary(x);
+  PROTECT_DICT(d, &nprot);
 
   SEXP out = PROTECT_N(Rf_allocVector(INTSXP, n), &nprot);
   int* p_out = INTEGER(out);
 
   for (int i = 0; i < n; ++i) {
-    uint32_t hash = dict_hash_scalar(&d, i);
+    uint32_t hash = dict_hash_scalar(d, i);
 
-    if (d.key[hash] == DICT_EMPTY) {
-      dict_put(&d, hash, i);
+    if (d->key[hash] == DICT_EMPTY) {
+      dict_put(d, hash, i);
     }
-    p_out[i] = d.key[hash] + 1;
+    p_out[i] = d->key[hash] + 1;
   }
 
   UNPROTECT(nprot);
@@ -260,32 +417,30 @@ SEXP vec_match(SEXP needles, SEXP haystack) {
   needles = VECTOR_ELT(translated, 0);
   haystack = VECTOR_ELT(translated, 1);
 
-  struct dictionary d;
-  dict_init(&d, haystack);
-  PROTECT_DICT(&d, &nprot);
+  struct dictionary* d = new_dictionary(haystack);
+  PROTECT_DICT(d, &nprot);
 
   // Load dictionary with haystack
   for (int i = 0; i < n_haystack; ++i) {
-    uint32_t hash = dict_hash_scalar(&d, i);
+    uint32_t hash = dict_hash_scalar(d, i);
 
-    if (d.key[hash] == DICT_EMPTY) {
-      dict_put(&d, hash, i);
+    if (d->key[hash] == DICT_EMPTY) {
+      dict_put(d, hash, i);
     }
   }
 
-  struct dictionary d_needles;
-  dict_init_partial(&d_needles, needles);
+  struct dictionary* d_needles = new_dictionary_partial(needles);
 
   // Locate needles
   SEXP out = PROTECT_N(Rf_allocVector(INTSXP, n_needle), &nprot);
   int* p_out = INTEGER(out);
 
   for (int i = 0; i < n_needle; ++i) {
-    uint32_t hash = dict_hash_with(&d, &d_needles, i);
-    if (d.key[hash] == DICT_EMPTY) {
+    uint32_t hash = dict_hash_with(d, d_needles, i);
+    if (d->key[hash] == DICT_EMPTY) {
       p_out[i] = NA_INTEGER;
     } else {
-      p_out[i] = d.key[hash] + 1;
+      p_out[i] = d->key[hash] + 1;
     }
   }
 
@@ -313,30 +468,28 @@ SEXP vctrs_in(SEXP needles, SEXP haystack) {
   needles = VECTOR_ELT(translated, 0);
   haystack = VECTOR_ELT(translated, 1);
 
-  struct dictionary d;
-  dict_init(&d, haystack);
-  PROTECT_DICT(&d, &nprot);
+  struct dictionary* d = new_dictionary(haystack);
+  PROTECT_DICT(d, &nprot);
 
   // Load dictionary with haystack
   for (int i = 0; i < n_haystack; ++i) {
-    uint32_t hash = dict_hash_scalar(&d, i);
+    uint32_t hash = dict_hash_scalar(d, i);
 
-    if (d.key[hash] == DICT_EMPTY) {
-      dict_put(&d, hash, i);
+    if (d->key[hash] == DICT_EMPTY) {
+      dict_put(d, hash, i);
     }
   }
 
-  struct dictionary d_needles;
-  dict_init_partial(&d_needles, needles);
-  PROTECT_DICT(&d_needles, &nprot);
+  struct dictionary* d_needles = new_dictionary_partial(needles);
+  PROTECT_DICT(d_needles, &nprot);
 
   // Locate needles
   SEXP out = PROTECT_N(Rf_allocVector(LGLSXP, n_needle), &nprot);
   int* p_out = LOGICAL(out);
 
   for (int i = 0; i < n_needle; ++i) {
-    uint32_t hash = dict_hash_with(&d, &d_needles, i);
-    p_out[i] = (d.key[hash] != DICT_EMPTY);
+    uint32_t hash = dict_hash_with(d, d_needles, i);
+    p_out[i] = (d->key[hash] != DICT_EMPTY);
   }
 
   UNPROTECT(nprot);
@@ -351,35 +504,34 @@ SEXP vctrs_count(SEXP x) {
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
-  struct dictionary d;
-  dict_init(&d, x);
-  PROTECT_DICT(&d, &nprot);
+  struct dictionary* d = new_dictionary(x);
+  PROTECT_DICT(d, &nprot);
 
-  SEXP val = PROTECT_N(Rf_allocVector(INTSXP, d.size), &nprot);
+  SEXP val = PROTECT_N(Rf_allocVector(INTSXP, d->size), &nprot);
   int* p_val = INTEGER(val);
 
   for (int i = 0; i < n; ++i) {
-    int32_t hash = dict_hash_scalar(&d, i);
+    int32_t hash = dict_hash_scalar(d, i);
 
-    if (d.key[hash] == DICT_EMPTY) {
-      dict_put(&d, hash, i);
+    if (d->key[hash] == DICT_EMPTY) {
+      dict_put(d, hash, i);
       p_val[hash] = 0;
     }
     p_val[hash]++;
   }
 
   // Create output
-  SEXP out_key = PROTECT_N(Rf_allocVector(INTSXP, d.used), &nprot);
-  SEXP out_val = PROTECT_N(Rf_allocVector(INTSXP, d.used), &nprot);
+  SEXP out_key = PROTECT_N(Rf_allocVector(INTSXP, d->used), &nprot);
+  SEXP out_val = PROTECT_N(Rf_allocVector(INTSXP, d->used), &nprot);
   int* p_out_key = INTEGER(out_key);
   int* p_out_val = INTEGER(out_val);
 
   int i = 0;
-  for (int hash = 0; hash < d.size; ++hash) {
-    if (d.key[hash] == DICT_EMPTY)
+  for (int hash = 0; hash < d->size; ++hash) {
+    if (d->key[hash] == DICT_EMPTY)
       continue;
 
-    p_out_key[i] = d.key[hash] + 1;
+    p_out_key[i] = d->key[hash] + 1;
     p_out_val[i] = p_val[hash];
     i++;
   }
@@ -404,18 +556,17 @@ SEXP vctrs_duplicated(SEXP x) {
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
   x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
 
-  struct dictionary d;
-  dict_init(&d, x);
-  PROTECT_DICT(&d, &nprot);
+  struct dictionary* d = new_dictionary(x);
+  PROTECT_DICT(d, &nprot);
 
-  SEXP val = PROTECT_N(Rf_allocVector(INTSXP, d.size), &nprot);
+  SEXP val = PROTECT_N(Rf_allocVector(INTSXP, d->size), &nprot);
   int* p_val = INTEGER(val);
 
   for (int i = 0; i < n; ++i) {
-    int32_t hash = dict_hash_scalar(&d, i);
+    int32_t hash = dict_hash_scalar(d, i);
 
-    if (d.key[hash] == DICT_EMPTY) {
-      dict_put(&d, hash, i);
+    if (d->key[hash] == DICT_EMPTY) {
+      dict_put(d, hash, i);
       p_val[hash] = 0;
     }
     p_val[hash]++;
@@ -426,7 +577,7 @@ SEXP vctrs_duplicated(SEXP x) {
   int* p_out = LOGICAL(out);
 
   for (int i = 0; i < n; ++i) {
-    int32_t hash = dict_hash_scalar(&d, i);
+    int32_t hash = dict_hash_scalar(d, i);
     p_out[i] = p_val[hash] != 1;
   }
 

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -9,9 +9,17 @@
 // at the R-level).
 
 struct dictionary {
+  SEXP protect;
+
   SEXP vec;
-  R_len_t* key;
+  enum vctrs_type type;
+
+  int (*equal)(const void*, R_len_t i, const void*, R_len_t j);
+  const void* vec_p;
+
   uint32_t* hash;
+  R_len_t* key;
+
   uint32_t size;
   uint32_t used;
 };
@@ -19,21 +27,22 @@ struct dictionary {
 /**
  * Initialise a dictionary
  *
- * - `dict_init()` creates a dictionary and precaches the hashes for
+ * - `new_dictionary()` creates a dictionary and precaches the hashes for
  *   each element of `x`.
  *
- * - `dict_init_partial()` creates a dictionary with precached hashes
+ * - `new_dictionary_partial()` creates a dictionary with precached hashes
  *   as well, but does not allocate an array of keys. This is useful
  *   for finding a key in another dictionary with `dict_hash_with()`.
  */
-void dict_init(struct dictionary* d, SEXP x);
-void dict_init_partial(struct dictionary* d, SEXP x);
+struct dictionary* new_dictionary(SEXP x);
+struct dictionary* new_dictionary_partial(SEXP x);
 
 #define PROTECT_DICT(d, n) do {                 \
-    PROTECT((d)->vec);                          \
-    *(n) += 1;                                  \
+    struct dictionary* d_ = (d);                \
+    PROTECT(d_->vec);                           \
+    PROTECT(d_->protect);                       \
+    *(n) += 2;                                  \
   } while(0)
-
 
 /**
  * Find key hash for a vector element

--- a/src/equal.c
+++ b/src/equal.c
@@ -1,6 +1,7 @@
 #include <math.h>
 #include "equal.h"
 #include "vctrs.h"
+#include "utils.h"
 
 
 // If `x` is a data frame, it must have been recursively proxied
@@ -33,6 +34,14 @@ int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
   }
 
   return equal_scalar_p(proxy_type, x, x_p, i, y, y_p, j, na_equal);
+}
+
+// [[ register() ]]
+SEXP vctrs_equal_scalar(SEXP x, SEXP i_, SEXP y, SEXP j_, SEXP na_equal_) {
+  R_len_t i = Rf_asInteger(i_);
+  R_len_t j = Rf_asInteger(j_);
+  bool na_equal = Rf_asLogical(na_equal_);
+  return r_lgl(equal_scalar(x, i, y, j, na_equal));
 }
 
 // [[ include("vctrs.h") ]]

--- a/src/equal.c
+++ b/src/equal.c
@@ -13,6 +13,14 @@ int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
   const void* y_p = NULL;
 
   switch (proxy_type) {
+  case vctrs_type_dataframe: {
+    int n_col = Rf_length(x);
+    if (n_col != Rf_length(y)) {
+      Rf_errorcall(R_NilValue, "`x` and `y` must have the same number of columns");
+    }
+    return df_equal_scalar(x, i, y, j, na_equal, n_col);
+  }
+
   case vctrs_type_logical:   x_p = LOGICAL_RO(x);    y_p = LOGICAL_RO(y);    break;
   case vctrs_type_integer:   x_p = INTEGER_RO(x);    y_p = INTEGER_RO(y);    break;
   case vctrs_type_double:    x_p = REAL_RO(x);       y_p = REAL_RO(y);       break;
@@ -20,7 +28,8 @@ int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
   case vctrs_type_character: x_p = STRING_PTR_RO(x); y_p = STRING_PTR_RO(y); break;
   case vctrs_type_raw:       x_p = RAW_RO(x);        y_p = RAW_RO(y);        break;
   case vctrs_type_list:      x_p = x;                y_p = y;                break;
-  default: break;
+
+  default: vctrs_stop_unsupported_type(vec_typeof(x), "equal_scalar()");
   }
 
   return equal_scalar_p(proxy_type, x, x_p, i, y, y_p, j, na_equal);
@@ -31,35 +40,16 @@ int equal_scalar_p(enum vctrs_type proxy_type,
                    SEXP x, const void* x_p, R_len_t i,
                    SEXP y, const void* y_p, R_len_t j,
                    bool na_equal) {
-  // Rprintf("i: %d\n", i);
-  // Rprintf("j: %d\n", j);
-  if (x_p) {
-    switch (proxy_type) {
-    case vctrs_type_logical: return lgl_equal_scalar(((const int*) x_p) + i, ((const int*) y_p) + j, na_equal);
-    case vctrs_type_integer: return int_equal_scalar(((const int*) x_p) + i, ((const int*) y_p) + j, na_equal);
-    case vctrs_type_double: return dbl_equal_scalar(((const double*) x_p) + i, ((const double*) y_p) + j, na_equal);
-    case vctrs_type_complex: return cpl_equal_scalar(((const Rcomplex*) x_p) + i, ((const Rcomplex*) y_p) + j, na_equal);
-    case vctrs_type_character: return chr_equal_scalar(((const SEXP*) x_p) + i, ((const SEXP*) y_p) + j, na_equal);
-    case vctrs_type_raw: return raw_equal_scalar(((const Rbyte*) x_p) + i, ((const Rbyte*) y_p) + j, na_equal);
-    case vctrs_type_list: return list_equal_scalar(((const SEXP) x_p), i, ((const SEXP) y_p), j, na_equal);
-    default: break;
-    }
-  }
-
   switch (proxy_type) {
-  case vctrs_type_dataframe: {
-    int n_col = Rf_length(x);
-
-    if (n_col != Rf_length(y)) {
-      Rf_errorcall(R_NilValue, "`x` and `y` must have the same number of columns");
-    }
-
-    return df_equal_scalar(x, i, y, j, na_equal, n_col);
+  case vctrs_type_logical: return lgl_equal_scalar(((const int*) x_p) + i, ((const int*) y_p) + j, na_equal);
+  case vctrs_type_integer: return int_equal_scalar(((const int*) x_p) + i, ((const int*) y_p) + j, na_equal);
+  case vctrs_type_double: return dbl_equal_scalar(((const double*) x_p) + i, ((const double*) y_p) + j, na_equal);
+  case vctrs_type_complex: return cpl_equal_scalar(((const Rcomplex*) x_p) + i, ((const Rcomplex*) y_p) + j, na_equal);
+  case vctrs_type_character: return chr_equal_scalar(((const SEXP*) x_p) + i, ((const SEXP*) y_p) + j, na_equal);
+  case vctrs_type_raw: return raw_equal_scalar(((const Rbyte*) x_p) + i, ((const Rbyte*) y_p) + j, na_equal);
+  case vctrs_type_list: return list_equal_scalar(((const SEXP) x_p), i, ((const SEXP) y_p), j, na_equal);
+  default: vctrs_stop_unsupported_type(vec_typeof(x), "equal_scalar_p()");
   }
-  default: break;
-  }
-
-  vctrs_stop_unsupported_type(vec_typeof(x), "equal_scalar()");
 }
 
 // -----------------------------------------------------------------------------

--- a/src/equal.h
+++ b/src/equal.h
@@ -1,0 +1,121 @@
+#ifndef VCTRS_EQUAL_H
+#define VCTRS_EQUAL_H
+
+#include "vctrs.h"
+
+
+// Storing pointed values on the stack helps performance for the
+// `!na_equal` cases
+static inline int lgl_equal_scalar(const int* x, const int* y, bool na_equal) {
+  const int xi = *x;
+  const int yj = *y;
+  if (na_equal) {
+    return xi == yj;
+  } else {
+    return (xi == NA_LOGICAL || yj == NA_LOGICAL) ? NA_LOGICAL : xi == yj;
+  }
+}
+
+static inline int int_equal_scalar(const int* x, const int* y, bool na_equal) {
+  const int xi = *x;
+  const int yj = *y;
+  if (na_equal) {
+    return xi == yj;
+  } else {
+    return (xi == NA_INTEGER || yj == NA_INTEGER) ? NA_LOGICAL : xi == yj;
+  }
+}
+
+static inline int dbl_equal_scalar(const double* x, const double* y, bool na_equal) {
+  const double xi = *x;
+  const double yj = *y;
+
+  if (na_equal) {
+    switch (dbl_classify(xi)) {
+    case vctrs_dbl_number: break;
+    case vctrs_dbl_missing: return dbl_classify(yj) == vctrs_dbl_missing;
+    case vctrs_dbl_nan: return dbl_classify(yj) == vctrs_dbl_nan;
+    }
+
+    if (isnan(yj)) {
+      return false;
+    }
+  } else {
+    if (isnan(xi) || isnan(yj)) return NA_LOGICAL;
+  }
+  return xi == yj;
+}
+
+static inline int cpl_equal_scalar(const Rcomplex* x, const Rcomplex* y, bool na_equal) {
+  int real_equal = dbl_equal_scalar(&x->r, &y->r, na_equal);
+  int imag_equal = dbl_equal_scalar(&x->i, &y->i, na_equal);
+  if (real_equal == NA_LOGICAL || imag_equal == NA_LOGICAL) {
+    return NA_LOGICAL;
+  } else {
+    return real_equal && imag_equal;
+  }
+}
+
+// UTF-8 translation is successful in these cases:
+// - (utf8 + latin1), (unknown + utf8), (unknown + latin1)
+// UTF-8 translation fails purposefully in these cases:
+// - (bytes + utf8), (bytes + latin1), (bytes + unknown)
+// UTF-8 translation is not attempted in these cases:
+// - (utf8 + utf8), (latin1 + latin1), (unknown + unknown), (bytes + bytes)
+
+static inline int chr_equal_scalar_impl(const SEXP x, const SEXP y) {
+  if (x == y) {
+    return 1;
+  }
+
+  if (Rf_getCharCE(x) != Rf_getCharCE(y)) {
+    const void *vmax = vmaxget();
+    int out = !strcmp(Rf_translateCharUTF8(x), Rf_translateCharUTF8(y));
+    vmaxset(vmax);
+    return out;
+  }
+
+  return 0;
+}
+
+static inline int chr_equal_scalar(const SEXP* x, const SEXP* y, bool na_equal) {
+  const SEXP xi = *x;
+  const SEXP yj = *y;
+  if (na_equal) {
+    return chr_equal_scalar_impl(xi, yj);
+  } else {
+    return (xi == NA_STRING || yj == NA_STRING) ? NA_LOGICAL : chr_equal_scalar_impl(xi, yj);
+  }
+}
+
+static inline int list_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
+  const SEXP xi = VECTOR_ELT(x, i);
+  const SEXP yj = VECTOR_ELT(y, j);
+
+  if (na_equal) {
+    return equal_object(xi, yj);
+  } else {
+    return (xi == R_NilValue || yj == R_NilValue) ? NA_LOGICAL : equal_object(xi, yj);
+  }
+}
+
+static inline int raw_equal_scalar(const Rbyte* x, const Rbyte* y, bool na_equal) {
+  // Raw vectors have no notion of missing value
+  return *x == *y;
+}
+
+static inline int df_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal, int n_col) {
+  for (int k = 0; k < n_col; ++k) {
+    int eq = equal_scalar(VECTOR_ELT(x, k), i, VECTOR_ELT(y, k), j, na_equal);
+
+    if (eq <= 0) {
+      return eq;
+    }
+  }
+
+  return true;
+}
+
+
+
+#endif

--- a/src/init.c
+++ b/src/init.c
@@ -96,6 +96,8 @@ extern SEXP vctrs_as_subscript(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_as_subscript_result(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_df_flat_width(SEXP);
 extern SEXP df_flatten(SEXP);
+extern SEXP vctrs_equal_scalar(SEXP, SEXP, SEXP, SEXP, SEXP);
+
 
 // Very experimental
 // Available in the API header
@@ -210,6 +212,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_as_subscript_result",        (DL_FUNC) &vctrs_as_subscript_result, 5},
   {"vctrs_df_flat_width",              (DL_FUNC) &vctrs_df_flat_width, 1},
   {"vctrs_df_flatten",                 (DL_FUNC) &df_flatten, 1},
+  {"vctrs_equal_scalar",               (DL_FUNC) &vctrs_equal_scalar, 5},
   {NULL, NULL, 0}
 };
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -640,11 +640,16 @@ bool is_integer64(SEXP x) {
 
 void* r_vec_deref(SEXP x) {
   switch (TYPEOF(x)) {
+  case LGLSXP: return LOGICAL(x);
   case INTSXP: return INTEGER(x);
+  case REALSXP: return REAL(x);
+  case CPLXSXP: return COMPLEX(x);
   case STRSXP: return STRING_PTR(x);
+  case RAWSXP: return RAW(x);
   default: Rf_error("Unimplemented type in `r_vec_deref()`.");
   }
 }
+
 const void* r_vec_const_deref(SEXP x) {
   switch (TYPEOF(x)) {
   case INTSXP: return INTEGER_RO(x);

--- a/src/utils.h
+++ b/src/utils.h
@@ -149,6 +149,7 @@ extern SEXP (*rlang_env_dots_list)(SEXP);
 
 void* r_vec_deref(SEXP x);
 const void* r_vec_const_deref(SEXP x);
+
 void r_vec_ptr_inc(SEXPTYPE type, void** p, R_len_t i);
 void r_vec_fill(SEXPTYPE type, void* p, const void* value_p, R_len_t value_i, R_len_t n);
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -1,3 +1,7 @@
+#ifndef VCTRS_H
+#define VCTRS_H
+
+
 #define R_NO_REMAP
 #include <R.h>
 #include <Rinternals.h>
@@ -618,4 +622,7 @@ void stop_corrupt_ordered_levels(SEXP x, struct vctrs_arg* arg) __attribute__((n
 # define COMPLEX_RO(x) ((const Rcomplex*) COMPLEX(x))
 # define STRING_PTR_RO(x) ((const SEXP*) STRING_PTR(x))
 # define RAW_RO(x) ((const Rbyte*) RAW(x))
+#endif
+
+
 #endif

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -443,6 +443,10 @@ bool equal_names(SEXP x, SEXP y);
  * The behaviour is undefined if these conditions are not true.
  */
 int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal);
+int equal_scalar_p(SEXPTYPE type,
+                   SEXP x, const void* x_p, R_len_t i,
+                   SEXP y, const void* y_p, R_len_t j,
+                   bool na_equal);
 int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal);
 
 uint32_t hash_object(SEXP x);

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -65,6 +65,7 @@ test_that("vec_duplicate_id gives position of first found", {
 test_that("vec_unique matches unique", {
   x <- sample(100, 1000, replace = TRUE)
   expect_equal(vec_unique(x), unique(x))
+  expect_equal(vec_unique(c("x", "x")), "x")
 })
 
 test_that("vec_unique matches unique for matrices", {
@@ -194,13 +195,21 @@ test_that("vec_unique() works with glm objects (#643)", {
   expect_equal(vec_unique(list(model, model)), list(model))
 })
 
+test_that("can take the unique locations of dfs with list-cols", {
+  df <- tibble(x = list(1, 2, 1, 3), y = list(1, 2, 1, 3))
+  expect_identical(vec_unique_loc(df), c(1L, 2L, 4L))
+})
+
+
 # matching ----------------------------------------------------------------
 
 test_that("vec_match() matches match()", {
   n <- c(1:3, NA)
   h <- c(4, 2, 1, NA)
-
   expect_equal(vec_match(n, h), match(n, h))
+
+  expect_equal(vec_match(1.5, c(2, 1.5, NA)), match(1.5, c(2, 1.5, NA)))
+  expect_equal(vec_match("x", "x"), match("x", "x"))
 })
 
 test_that("vec_in() matches %in%", {

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -198,6 +198,30 @@ test_that("can compare lists of expressions", {
   expect_equal(vec_equal(x, y), c(TRUE, FALSE))
 })
 
+test_that("equal_scalar() compares", {
+  expect_equal_implemented <- function(x, na) {
+    expect_false(test_equal_scalar(x, 0, x, 1))
+    expect_true(test_equal_scalar(x, 1, x, 1))
+
+    if (!is_null(na)) {
+      expect_false(test_equal_scalar(na, 0, x, 1, na_equal = TRUE))
+      expect_true(is.na(test_equal_scalar(na, 0, x, 1, na_equal = FALSE)))
+    }
+  }
+
+  expect_equal_implemented(c(FALSE, TRUE), NA)
+  expect_equal_implemented(c(0L, 1L), na_int)
+  expect_equal_implemented(c(0, 1), na_dbl)
+  expect_equal_implemented(c(0i, 1i), na_cpl)
+  expect_equal_implemented(c("foo", "bar"), na_chr)
+  expect_equal_implemented(as.raw(c(0, 1)), NULL)
+  expect_equal_implemented(list(0, 1), NULL)
+  expect_equal_implemented(mtcars, vec_init(mtcars))
+
+  expect_error(test_equal_scalar(expression(0), 0, expression(1), 1), "Unsupported")
+})
+
+
 # object ------------------------------------------------------------------
 
 test_that("can compare NULL",{


### PR DESCRIPTION
Branched from #847. 

This caches the `enum vctrs_type`, the array pointers, and the comparison operation (as in Davis' experiment https://github.com/r-lib/vctrs/compare/master...DavisVaughan:type-remember) in the dictionaries. This avoids the need for dereferencing the `SEXP` multiple times when comparing elements for equality.

For data frames we store an array of types and pointers, one for each column. I also tried caching a slice of the data frame in row-major order to improve locality when many comparisons are required. This improved performance in specific cases but was disappointing overall.

```r
## 200 uniques
## Number of comparisons: 999800
## Number of collisions: 0
x <- sample(1:1e2, 1e6, TRUE) + 0L
df <- data.frame(x = x, y = rep(1:2, length.out = length(x)))
bench::mark(
  uloc = vec_unique_loc(df$x),
  df_uloc = vec_unique_loc(df),
  check = FALSE,
  iterations = 100
)[1:8]

#> # master
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 uloc         10.3ms   11.4ms      85.2    11.8MB    10.5     89    11
#> 2 df_uloc      66.8ms   68.7ms      14.4    11.8MB     1.78    89    11

#> # perf-dict-mem
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 uloc         4.72ms   5.08ms     188.     11.8MB    125.     60    40
#> 2 df_uloc     16.08ms  17.08ms      58.2    11.8MB     28.7    67    33


## Many columns - 200 uniques
x <- sample(1:1e2, 1e6, TRUE) + 0L
df <- data.frame(
  x = x,
  y = rep(1:2, length.out = length(x)),
  z1 = duplicate(x),
  z2 = duplicate(x),
  z3 = duplicate(x),
  z4 = duplicate(x)
)
bench::mark(
  uloc = vec_unique_loc(df$x),
  df_uloc = vec_unique_loc(df),
  check = FALSE,
  iterations = 100
)[1:8]

#> # master
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 uloc         11.1ms   12.2ms     81.8     11.8MB    28.7     74    26
#> 2 df_uloc     128.2ms  130.9ms      7.64    11.8MB     2.41    76    24

#> # perf-dict-mem
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 uloc         4.67ms   5.78ms     174.     11.8MB    67.8     72    28
#> 2 df_uloc     39.31ms  40.84ms      24.2    11.8MB     8.06    75    25


## 20000 unique
## Number of comparisons: 985192
## Number of collisions: 5192
x <- sample(1:1e4, 1e6, TRUE) + 0L
df <- data.frame(x = x, y = rep(1:2, length.out = length(x)))
bench::mark(
  uloc = vec_unique_loc(df$x),
  df_uloc = vec_unique_loc(df),
  check = FALSE,
  iterations = 100
)[1:8]

#> # master
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 uloc         16.3ms   18.1ms      52.9      12MB    17.6     75    25
#> 2 df_uloc      82.4ms   87.2ms      11.3    12.1MB     3.78    75    25

#> # perf-dict-mem
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 uloc         8.71ms   11.2ms      82.9      12MB    27.6     75    25
#> 2 df_uloc     30.74ms   37.3ms      26.7    12.1MB     8.89    75    25


## All unique
## Number of comparisons: 401667
## Number of collisions: 401667
df <- data.frame(x = 1:1e6, y = 1e6:1)
bench::mark(
  uloc = vec_unique_loc(df$x),
  df_uloc = vec_unique_loc(df),
  check = FALSE,
  iterations = 100
)[1:8]

#> # master
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 uloc         46.6ms   53.4ms      18.7    23.6MB    14.7     56    44
#> 2 df_uloc        67ms   72.9ms      13.6    23.6MB     7.32    65    35

#> # perf-dict-mem
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 uloc         36.1ms   42.4ms      23.5    27.4MB    21.7     52    48
#> 2 df_uloc      44.2ms   50.9ms      19.9    27.4MB     9.81    67    33
```
