### PR TITLE
Dereference `quiet` in `vctrs_as_names()`

### DIFF
--- a/src/names.c
+++ b/src/names.c
@@ -45,8 +45,9 @@ SEXP vctrs_as_names(SEXP names, SEXP repair, SEXP quiet) {
   if (!r_is_bool(quiet)) {
     Rf_errorcall(R_NilValue, "`quiet` must a boolean value.");
   }
+  bool quiet_ = LOGICAL(quiet)[0];
 
-  struct name_repair_opts repair_opts = new_name_repair_opts(repair, quiet);
+  struct name_repair_opts repair_opts = new_name_repair_opts(repair, quiet_);
   PROTECT_NAME_REPAIR_OPTS(&repair_opts);
 
   SEXP out = vec_as_names(names, &repair_opts);

--- a/tests/testthat/output/test-vec-as-names.txt
+++ b/tests/testthat/output/test-vec-as-names.txt
@@ -1,0 +1,10 @@
+> vec_as_names(c("x", "x"), repair = "unique")
+Message: New names:
+* x -> x...1
+* x -> x...2
+
+[1] "x...1" "x...2"
+
+> vec_as_names(c("x", "x"), repair = "unique", quiet = TRUE)
+[1] "x...1" "x...2"
+

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -113,6 +113,16 @@ test_that("vec_as_names() repairs names before invoking repair function", {
   expect_identical(vec_as_names(chr(NA, NA), repair = identity), c("", ""))
 })
 
+test_that("vec_as_names() is noisy by default", {
+  verify_output(test_path("output", "test-vec-as-names.txt"), {
+    # Noisy name repair
+    vec_as_names(c("x", "x"), repair = "unique")
+
+    # Quiet name repair
+    vec_as_names(c("x", "x"), repair = "unique", quiet = TRUE)
+  })
+})
+
 test_that("validate_minimal_names() checks names", {
   expect_error(validate_minimal_names(1), "must return a character vector")
   expect_error(validate_minimal_names(NULL), "can't return `NULL`")


### PR DESCRIPTION
Closes #849 

Also fixes Solaris warning:

> "names.c", line 49: warning: improper pointer/integer combination: arg #2