### PR TITLE
Switch to `data_frame()` when `data.frame()` is not required

### DIFF
--- a/tests/testthat/helper-rational.R
+++ b/tests/testthat/helper-rational.R
@@ -25,7 +25,7 @@ vec_proxy_equal.vctrs_rational <- function(x) {
   n <- field(x, "n")
   d <- field(x, "d")
   gcd <- gcd(n, d)
-  data.frame(n = n / gcd, d = d / gcd)
+  data_frame(n = n / gcd, d = d / gcd)
 }
 gcd <- function(x, y) {
   r <- x %% y

--- a/tests/testthat/helper-types.R
+++ b/tests/testthat/helper-types.R
@@ -1,5 +1,5 @@
 # Don't call tibble::tibble() to avoid catch-22, because tibble now uses vctrs
-bare_tibble <- structure(data.frame(), class = c("tbl_df", "tbl", "data.frame"))
+bare_tibble <- structure(data_frame(), class = c("tbl_df", "tbl", "data.frame"))
 
 base_empty_types <- list(
   null = NULL,
@@ -10,7 +10,7 @@ base_empty_types <- list(
   character = chr(),
   raw = bytes(),
   list = list(),
-  dataframe = data.frame()
+  dataframe = data_frame()
 )
 
 base_s3_empty_types <- list(
@@ -25,7 +25,7 @@ base_s3_empty_types <- list(
 proxied_empty_types <- list(
   double = new_hidden(),
   dataframe = bare_tibble,
-  dataframe = structure(data.frame(), class = c("vctrs_foobar", "data.frame"))
+  dataframe = structure(data_frame(), class = c("vctrs_foobar", "data.frame"))
 )
 
 empty_types <- c(
@@ -39,7 +39,7 @@ empty_types <- c(
 atomics <- list(TRUE, 1L, 1.0, 1i, "foo", bytes(1))
 vectors <- c(atomics, list(list()))
 records <- list(
-  df = data.frame(x = 1),
+  df = data_frame(x = 1),
   rcrd = new_rcrd(list(x = 1)),
   posixlt = as.POSIXlt("2020-01-01")
 )

--- a/tests/testthat/test-assert-explanations.txt
+++ b/tests/testthat/test-assert-explanations.txt
@@ -33,21 +33,21 @@ Instead, it has type <factor<>>.
 
 
 
-> vec_assert(lgl(), data.frame()):
+> vec_assert(lgl(), data_frame()):
 
 Error: `lgl()` must be a vector with type <data.frame<>>.
 Instead, it has type <logical>.
 
 
 
-> vec_assert(lgl(), data.frame(x = 1)):
+> vec_assert(lgl(), data_frame(x = 1)):
 
 Error: `lgl()` must be a vector with type <data.frame<x:double>>.
 Instead, it has type <logical>.
 
 
 
-> vec_assert(lgl(), data.frame(x = 1, y = 2)):
+> vec_assert(lgl(), data_frame(x = 1, y = 2)):
 
 Error: `lgl()` must be a vector with type:
 
@@ -60,30 +60,30 @@ Instead, it has type <logical>.
 
 
 
-> vec_assert(data.frame(), chr()):
+> vec_assert(data_frame(), chr()):
 
-Error: `data.frame()` must be a vector with type <character>.
+Error: `data_frame()` must be a vector with type <character>.
 Instead, it has type <data.frame<>>.
 
 
 
-> vec_assert(data.frame(x = 1), chr()):
+> vec_assert(data_frame(x = 1), chr()):
 
-Error: `data.frame(x = 1)` must be a vector with type <character>.
+Error: `data_frame(x = 1)` must be a vector with type <character>.
 Instead, it has type <data.frame<x:double>>.
 
 
 
-> vec_assert(data.frame(x = 1), data.frame(x = "foo")):
+> vec_assert(data_frame(x = 1), data_frame(x = "foo")):
 
-Error: `data.frame(x = 1)` must be a vector with type <data.frame<x:character>>.
+Error: `data_frame(x = 1)` must be a vector with type <data.frame<x:character>>.
 Instead, it has type <data.frame<x:double>>.
 
 
 
-> vec_assert(data.frame(x = 1), data.frame(x = "foo", y = 2)):
+> vec_assert(data_frame(x = 1), data_frame(x = "foo", y = 2)):
 
-Error: `data.frame(x = 1)` must be a vector with type:
+Error: `data_frame(x = 1)` must be a vector with type:
 
   <data.frame<
     x: character
@@ -94,9 +94,9 @@ Instead, it has type <data.frame<x:double>>.
 
 
 
-> vec_assert(data.frame(x = 1, y = 2), chr()):
+> vec_assert(data_frame(x = 1, y = 2), chr()):
 
-Error: `data.frame(x = 1, y = 2)` must be a vector with type <character>.
+Error: `data_frame(x = 1, y = 2)` must be a vector with type <character>.
 Instead, it has type:
 
   <data.frame<
@@ -106,9 +106,9 @@ Instead, it has type:
 
 
 
-> vec_assert(data.frame(x = 1, y = 2), data.frame(x = "foo")):
+> vec_assert(data_frame(x = 1, y = 2), data_frame(x = "foo")):
 
-Error: `data.frame(x = 1, y = 2)` must be a vector with type <data.frame<x:character>>.
+Error: `data_frame(x = 1, y = 2)` must be a vector with type <data.frame<x:character>>.
 Instead, it has type:
 
   <data.frame<
@@ -118,9 +118,9 @@ Instead, it has type:
 
 
 
-> vec_assert(data.frame(x = 1, y = 2), data.frame(x = "foo", y = 2)):
+> vec_assert(data_frame(x = 1, y = 2), data_frame(x = "foo", y = 2)):
 
-Error: `data.frame(x = 1, y = 2)` must be a vector with type:
+Error: `data_frame(x = 1, y = 2)` must be a vector with type:
 
   <data.frame<
     x: character

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -185,10 +185,10 @@ test_that("attributes of unclassed vectors are asserted", {
 
 test_that("unspecified is finalised before assertion", {
   expect_true(vec_is(NA, TRUE))
-  expect_true(vec_is(data.frame(x = NA), data.frame(x = lgl())))
+  expect_true(vec_is(data_frame(x = NA), data_frame(x = lgl())))
 
   expect_error(regexp = NA, vec_assert(NA, TRUE))
-  expect_error(regexp = NA, vec_assert(data.frame(x = NA), data.frame(x = lgl())))
+  expect_error(regexp = NA, vec_assert(data_frame(x = NA), data_frame(x = lgl())))
 })
 
 test_that("assertion failures are explained", {
@@ -204,19 +204,19 @@ test_that("assertion failures are explained", {
     try_cat(vec_assert(factor(levels = "bar"), factor(levels = "foo")))
     try_cat(vec_assert(factor(), chr()))
 
-    try_cat(vec_assert(lgl(), data.frame()))
-    try_cat(vec_assert(lgl(), data.frame(x = 1)))
-    try_cat(vec_assert(lgl(), data.frame(x = 1, y = 2)))
+    try_cat(vec_assert(lgl(), data_frame()))
+    try_cat(vec_assert(lgl(), data_frame(x = 1)))
+    try_cat(vec_assert(lgl(), data_frame(x = 1, y = 2)))
 
-    try_cat(vec_assert(data.frame(), chr()))
+    try_cat(vec_assert(data_frame(), chr()))
 
-    try_cat(vec_assert(data.frame(x = 1), chr()))
-    try_cat(vec_assert(data.frame(x = 1), data.frame(x = "foo")))
-    try_cat(vec_assert(data.frame(x = 1), data.frame(x = "foo", y = 2)))
+    try_cat(vec_assert(data_frame(x = 1), chr()))
+    try_cat(vec_assert(data_frame(x = 1), data_frame(x = "foo")))
+    try_cat(vec_assert(data_frame(x = 1), data_frame(x = "foo", y = 2)))
 
-    try_cat(vec_assert(data.frame(x = 1, y = 2), chr()))
-    try_cat(vec_assert(data.frame(x = 1, y = 2), data.frame(x = "foo")))
-    try_cat(vec_assert(data.frame(x = 1, y = 2), data.frame(x = "foo", y = 2)))
+    try_cat(vec_assert(data_frame(x = 1, y = 2), chr()))
+    try_cat(vec_assert(data_frame(x = 1, y = 2), data_frame(x = "foo")))
+    try_cat(vec_assert(data_frame(x = 1, y = 2), data_frame(x = "foo", y = 2)))
   })
 })
 
@@ -269,7 +269,7 @@ test_that("non-explicitly classed lists that implement a proxy are lists", {
 })
 
 test_that("data frames of all types are not lists", {
-  expect_false(vec_is_list(data.frame()))
-  expect_false(vec_is_list(subclass(data.frame())))
+  expect_false(vec_is_list(data_frame()))
+  expect_false(vec_is_list(subclass(data_frame())))
   expect_false(vec_is_list(tibble::tibble()))
 })

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -64,37 +64,37 @@ test_that("names are supplied if needed", {
 
 test_that("matrix becomes data frame and has names properly repaired", {
   x <- matrix(1:4, nrow = 2)
-  expect_equal(vec_rbind(x), data.frame(...1 = 1:2, ...2 = 3:4))
+  expect_equal(vec_rbind(x), data_frame(...1 = 1:2, ...2 = 3:4))
 })
 
 test_that("can bind data.frame columns", {
-  df <- data.frame(x = NA, y = 1:2)
-  df$x <- data.frame(a = 1:2)
+  df <- data_frame(x = c(NA, NA), y = 1:2)
+  df$x <- data_frame(a = 1:2)
 
-  expected <- data.frame(x = NA, y = c(1:2, 1:2))
-  expected$x <- data.frame(a = c(1:2, 1:2))
+  expected <- data_frame(x = rep(NA, 4), y = c(1:2, 1:2))
+  expected$x <- data_frame(a = c(1:2, 1:2))
 
   expect_equal(vec_rbind(df, df), expected)
 })
 
 test_that("can rbind unspecified vectors", {
-  df <- data.frame(x = 1)
-  expect_identical(vec_rbind(NA, df), data.frame(x = c(NA, 1)))
-  expect_identical(vec_rbind(df, NA), data.frame(x = c(1, NA)))
-  expect_identical(vec_rbind(NA, df, NA), data.frame(x = c(NA, 1, NA)))
-  expect_identical(vec_rbind(c(x = NA), data.frame(x = 1)), data.frame(x = c(NA, 1)))
-  expect_identical(vec_rbind(c(y = NA), df), data.frame(y = c(NA, NA), x = c(NA, 1)))
+  df <- data_frame(x = 1)
+  expect_identical(vec_rbind(NA, df), data_frame(x = c(NA, 1)))
+  expect_identical(vec_rbind(df, NA), data_frame(x = c(1, NA)))
+  expect_identical(vec_rbind(NA, df, NA), data_frame(x = c(NA, 1, NA)))
+  expect_identical(vec_rbind(c(x = NA), data_frame(x = 1)), data_frame(x = c(NA, 1)))
+  expect_identical(vec_rbind(c(y = NA), df), data_frame(y = c(NA, NA), x = c(NA, 1)))
 
   out <- suppressMessages(vec_rbind(c(x = NA, x = NA), df))
-  exp <- data.frame(x...1 = c(NA, NA), x...2 = c(NA, NA), x = c(NA, 1))
+  exp <- data_frame(x...1 = c(NA, NA), x...2 = c(NA, NA), x = c(NA, 1))
   expect_identical(out, exp)
 })
 
 test_that("as_df_row() tidies the names of unspecified vectors", {
   expect_identical(as_df_row(c(NA, NA)), c(NA, NA))
   expect_identical(as_df_row(unspecified(2)), unspecified(2))
-  expect_identical(as_df_row(c(a = NA, a = NA), quiet = TRUE), data.frame(a...1 = NA, a...2 = NA))
-  expect_identical(as_df_row(c(a = TRUE, a = TRUE), quiet = TRUE), data.frame(a...1 = TRUE, a...2 = TRUE))
+  expect_identical(as_df_row(c(a = NA, a = NA), quiet = TRUE), data_frame(a...1 = NA, a...2 = NA))
+  expect_identical(as_df_row(c(a = TRUE, a = TRUE), quiet = TRUE), data_frame(a...1 = TRUE, a...2 = TRUE))
 })
 
 test_that("can rbind spliced lists", {
@@ -175,7 +175,7 @@ test_that("can repair names in `vec_rbind()` (#229)", {
 })
 
 test_that("can construct an id column", {
-  df <- data.frame(x = 1)
+  df <- data_frame(x = 1)
 
   expect_named(vec_rbind(df, df, .names_to = "id"), c("x", "id"))
   expect_equal(vec_rbind(df, df, .names_to = "id")$id, c(1L, 2L))
@@ -234,7 +234,7 @@ test_that("can assign row names in vec_rbind()", {
 test_that("empty inputs give data frame", {
   expect_equal(vec_cbind(), data_frame())
   expect_equal(vec_cbind(NULL), data_frame())
-  expect_equal(vec_cbind(data.frame(a = 1), NULL), data_frame(a = 1))
+  expect_equal(vec_cbind(data_frame(a = 1), NULL), data_frame(a = 1))
 })
 
 test_that("NULL is idempotent", {
@@ -244,7 +244,7 @@ test_that("NULL is idempotent", {
 
 test_that("outer names are respected", {
   expect_named(vec_cbind(x = 1, y = 4), c("x", "y"))
-  expect_named(vec_cbind(a = data.frame(x = 1)), "a")
+  expect_named(vec_cbind(a = data_frame(x = 1)), "a")
 })
 
 test_that("inner names are respected", {
@@ -257,7 +257,7 @@ test_that("nameless vectors get tidy defaults", {
 
 test_that("matrix becomes data frame", {
   x <- matrix(1:4, nrow = 2)
-  expect_equal(vec_cbind(x), data.frame(...1 = 1:2, ...2 = 3:4))
+  expect_equal(vec_cbind(x), data_frame(...1 = 1:2, ...2 = 3:4))
 
   # Packed if named
   expect_equal(vec_cbind(x = x), data_frame(x = x))
@@ -269,20 +269,20 @@ test_that("duplicate names are de-deduplicated", {
     "x -> x...1",
     fixed = TRUE
   )
-  expect_named(vec_cbind(data.frame(x = 1), data.frame(x = 1)), c("x...1", "x...2"))
+  expect_named(vec_cbind(data_frame(x = 1), data_frame(x = 1)), c("x...1", "x...2"))
 })
 
 test_that("rows recycled to longest", {
-  df <- data.frame(x = 1:3)
+  df <- data_frame(x = 1:3)
 
   expect_dim(vec_cbind(df), c(3, 1))
   expect_dim(vec_cbind(df, NULL), c(3, 1))
   expect_dim(vec_cbind(df, y = 1), c(3, 2))
-  expect_dim(vec_cbind(data.frame(x = 1), y = 1:3), c(3, 2))
+  expect_dim(vec_cbind(data_frame(x = 1), y = 1:3), c(3, 2))
 
   expect_dim(
     vec_cbind(
-      data.frame(a = 1, b = 2),
+      data_frame(a = 1, b = 2),
       y = 1:3
     ),
     c(3, 3)
@@ -290,7 +290,7 @@ test_that("rows recycled to longest", {
 })
 
 test_that("output is tibble if any input is tibble", {
-  df <- data.frame(x = 1)
+  df <- data_frame(x = 1)
   dt <- tibble::tibble(y = 2)
 
   expect_s3_class(vec_cbind(dt), "tbl_df")
@@ -404,7 +404,7 @@ test_that("vec_rbind() consistently handles unnamed outputs", {
   # Name repair of columns is a little weird but unclear we can do better
   expect_identical(
     vec_rbind(1, 2),
-    data.frame(...1 = c(1, 2))
+    data_frame(...1 = c(1, 2))
   )
   expect_identical(
     vec_rbind(1, 2, ...10 = 3),
@@ -417,22 +417,22 @@ test_that("vec_rbind() consistently handles unnamed outputs", {
   )
   expect_identical(
     vec_rbind(c(a = 1), c(b = 2)),
-    data.frame(a = c(1, NA), b = c(NA, 2))
+    data_frame(a = c(1, NA), b = c(NA, 2))
   )
 })
 
 test_that("vec_cbind() consistently handles unnamed outputs", {
   expect_identical(
     vec_cbind(1, 2),
-    data.frame(...1 = 1, ...2 = 2)
+    data_frame(...1 = 1, ...2 = 2)
   )
   expect_identical(
     vec_cbind(1, 2, ...10 = 3),
-    data.frame(...1 = 1, ...2 = 2, ...3 = 3)
+    data_frame(...1 = 1, ...2 = 2, ...3 = 3)
   )
   expect_identical(
     vec_cbind(a = 1, b = 2),
-    data.frame(a = 1, b = 2)
+    data_frame(a = 1, b = 2)
   )
   expect_identical(
     vec_cbind(c(a = 1), c(b = 2)),

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -46,11 +46,11 @@ test_that("combines outer an inner names", {
 })
 
 test_that("can bind data.frame columns", {
-  df <- data.frame(x = NA, y = 1:2)
-  df$x <- data.frame(a = 1:2)
+  df <- data_frame(x = c(NA, NA), y = 1:2)
+  df$x <- data_frame(a = 1:2)
 
-  expected <- data.frame(x = NA, y = c(1:2, 1:2))
-  expected$x <- data.frame(a = c(1:2, 1:2))
+  expected <- data_frame(x = rep(NA, 4), y = c(1:2, 1:2))
+  expected$x <- data_frame(a = c(1:2, 1:2))
 
   expect_equal(vec_c(df, df), expected)
 })
@@ -86,7 +86,7 @@ test_that("vec_c() handles record classes", {
 
   expect_true(vec_is(out, rational(1, 2)))
   expect_size(out, 3)
-  expect_identical(vec_proxy(out), data.frame(n = c(1L, 1L, NA), d = c(2L, 1L, NA)))
+  expect_identical(vec_proxy(out), data_frame(n = c(1L, 1L, NA), d = c(2L, 1L, NA)))
 })
 
 test_that("can mix named and unnamed vectors (#271)", {
@@ -109,12 +109,12 @@ test_that("vec_c() repairs names", {
 })
 
 test_that("vec_c() doesn't use outer names for data frames (#524)", {
-  x <- data.frame(inner = 1)
+  x <- data_frame(inner = 1)
   expect_equal(vec_c(outer = x), x)
 
-  a <- data.frame(x = 1L)
-  b <- data.frame(x = 2L)
-  expect_equal(vec_c(foo = a, bar = b), data.frame(x = 1:2))
+  a <- data_frame(x = 1L)
+  b <- data_frame(x = 2L)
+  expect_equal(vec_c(foo = a, bar = b), data_frame(x = 1:2))
 })
 
 test_that("vec_c() drops data frame row names", {

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -47,7 +47,7 @@ test_that("NAs equal when requested", {
 })
 
 test_that("data frames are compared column by column", {
-  df1 <- data.frame(x = c(1, 1, 1), y = c(-1, 0, 1))
+  df1 <- data_frame(x = c(1, 1, 1), y = c(-1, 0, 1))
 
   expect_equal(vec_compare(df1, df1[2, ]), c(-1, 0, 1))
   expect_equal(vec_compare(df1[1], df1[2, 1, drop = FALSE]), c(0, 0, 0))
@@ -92,7 +92,7 @@ test_that("can compare data frames with list columns because of `vec_proxy_compa
 })
 
 test_that("C code doesn't crash with bad inputs", {
-  df <- data.frame(x = c(1, 1, 1), y = c(-1, 0, 1))
+  df <- data_frame(x = c(1, 1, 1), y = c(-1, 0, 1))
 
   expect_error(.Call(vctrs_compare, df, df[1], TRUE), "not comparable")
 
@@ -107,7 +107,7 @@ test_that("C code doesn't crash with bad inputs", {
 })
 
 test_that("xtfrm.vctrs_vctr works for variety of base classes", {
-  df <- data.frame(x = c(NA, 1, 1), y = c(1, 2, 1))
+  df <- data_frame(x = c(NA, 1, 1), y = c(1, 2, 1))
   expect_equal(xtfrm.vctrs_vctr(df), c(3, 2, 1))
 
   x <- c(2, 3, 1)
@@ -139,7 +139,7 @@ test_that("vec_proxy_compare() preserves data frames and vectors", {
 })
 
 test_that("vec_proxy_compare() handles data frame with a POSIXlt column", {
-  df <- data.frame(times = 1:5, x = 1:5)
+  df <- data_frame(times = 1:5, x = 1:5)
   df$times <- as.POSIXlt(seq.Date(as.Date("2019-12-30"), as.Date("2020-01-03"), by = "day"))
 
   df2 <- df
@@ -226,20 +226,20 @@ test_that("can request NAs sorted first", {
 })
 
 test_that("can sort data frames", {
-  df <- data.frame(x = c(1, 2, 1), y = c(1, 2, 2))
+  df <- data_frame(x = c(1, 2, 1), y = c(1, 2, 2))
 
   out1 <- vec_sort(df)
-  expect_equal(out1, data.frame(x = c(1, 1, 2), y = c(1, 2, 2)))
+  expect_equal(out1, data_frame(x = c(1, 1, 2), y = c(1, 2, 2)))
 
   out2 <- vec_sort(df, "desc")
-  expect_equal(out2, data.frame(x = c(2, 1, 1), y = c(2, 2, 1)))
+  expect_equal(out2, data_frame(x = c(2, 1, 1), y = c(2, 2, 1)))
 })
 
 test_that("can sort empty data frames (#356)", {
-  df1 <- data.frame()
+  df1 <- data_frame()
   expect_equal(vec_sort(df1), df1)
 
-  df2 <- data.frame(x = numeric(), y = integer())
+  df2 <- data_frame(x = numeric(), y = integer())
   expect_equal(vec_sort(df2), df2)
 })
 
@@ -258,10 +258,10 @@ test_that("can order matrices and arrays (#306)", {
 })
 
 test_that("can order empty data frames (#356)", {
-  df1 <- data.frame()
+  df1 <- data_frame()
   expect_equal(vec_order(df1), integer())
 
-  df2 <- data.frame(x = numeric(), y = integer())
+  df2 <- data_frame(x = numeric(), y = integer())
   expect_equal(vec_order(df2), integer())
 })
 

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -5,7 +5,7 @@ context("test-dictionary")
 
 test_that("vec_count counts number observations", {
   x <- vec_count(rep(1:3, 1:3), sort = "key")
-  expect_equal(x, data.frame(key = 1:3, count = 1:3))
+  expect_equal(x, data_frame(key = 1:3, count = 1:3))
 })
 
 test_that("vec_count works with matrices", {
@@ -20,14 +20,14 @@ test_that("vec_count works with matrices", {
 
 test_that("vec_count works with arrays", {
   x <- array(c(rep(1, 3), rep(2, 3)), dim = c(3, 2, 1))
-  expect <- data.frame(key = NA, count = 3)
+  expect <- data_frame(key = NA, count = 3)
   expect$key <- vec_slice(x, 1L)
   expect_equal(vec_count(x), expect)
 })
 
 test_that("vec_count works for zero-length input", {
   x <- vec_count(integer(), sort = "none")
-  expect_equal(x, data.frame(key = integer(), count = integer()))
+  expect_equal(x, data_frame(key = integer(), count = integer()))
 })
 
 test_that("vec_count works with different encodings", {
@@ -78,7 +78,7 @@ test_that("vec_unique_count matches length + unique", {
 })
 
 test_that("also works for data frames", {
-  df <- data.frame(x = 1:3, y = letters[3:1], stringsAsFactors = FALSE)
+  df <- data_frame(x = 1:3, y = letters[3:1])
   idx <- c(1L, 1L, 1L, 2L, 2L, 3L)
   df2 <- df[idx, , drop = FALSE]
   rownames(df2) <- NULL

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -46,7 +46,7 @@ test_that("`list(NULL)` is considered a missing value (#653)", {
 })
 
 test_that("can compare data frames", {
-  df <- data.frame(x = 1:2, y = letters[2:1], stringsAsFactors = FALSE)
+  df <- data_frame(x = 1:2, y = letters[2:1])
   expect_equal(vec_equal(df, df[1, ]), c(TRUE, FALSE))
 })
 
@@ -94,16 +94,16 @@ test_that("can compare data frames with list columns", {
 
 test_that("data frames must have same size and columns", {
   expect_error(.Call(vctrs_equal,
-    data.frame(x = 1),
-    data.frame(x = 1, y = 2),
+    data_frame(x = 1),
+    data_frame(x = 1, y = 2),
     TRUE
   ),
     "must have same types and lengths"
   )
 
   expect_error(.Call(vctrs_equal,
-    data.frame(x = 1, y = 2, z = 2),
-    data.frame(x = 1, y = 2),
+    data_frame(x = 1, y = 2, z = 2),
+    data_frame(x = 1, y = 2),
     TRUE
     ),
     "must have the same number of columns"
@@ -113,27 +113,27 @@ test_that("data frames must have same size and columns", {
   # So if `vec_cast_common()` is not called, or is improperly specified, then
   # this could result in false equality.
   expect_true(.Call(vctrs_equal,
-    data.frame(x = 1),
-    data.frame(y = 1),
+    data_frame(x = 1),
+    data_frame(y = 1),
     TRUE
   ))
 
   expect_error(.Call(vctrs_equal,
-    data.frame(x = 1:2, y = 3:4),
-    data.frame(x = 1, y = 2),
+    data_frame(x = 1:2, y = 3:4),
+    data_frame(x = 1, y = 2),
     TRUE
     ),
     "must have same types and lengths"
   )
 
   expect_false(.Call(vctrs_equal,
-    data.frame(x = 1),
-    data.frame(x = 2),
+    data_frame(x = 1),
+    data_frame(x = 2),
     TRUE
   ))
 
   expect_false(.Call(vctrs_equal,
-    list(data.frame(x = 1)),
+    list(data_frame(x = 1)),
     list(10),
     TRUE
   ))
@@ -153,7 +153,7 @@ test_that("can compare lists of scalars (#643)", {
   lst <- list(new_sclr(y = NA))
   expect_true(vec_equal(lst, lst))
 
-  df <- data.frame(x = c(1, 4, 3), y = c(2, 8, 9))
+  df <- data_frame(x = c(1, 4, 3), y = c(2, 8, 9))
   model <- lm(y ~ x, df)
   lst <- list(model)
   expect_true(vec_equal(lst, lst))
@@ -265,13 +265,13 @@ test_that("can detect different types of NA", {
 })
 
 test_that("vectorised over rows of a data frame", {
-  df <- data.frame(x = c(1, 1, NA, NA), y = c(1, NA, 1, NA))
+  df <- data_frame(x = c(1, 1, NA, NA), y = c(1, NA, 1, NA))
   expect_equal(vec_equal_na(df), c(FALSE, FALSE, FALSE, TRUE))
 })
 
 test_that("works recursively with data frame columns", {
-  df <- data.frame(x = c(1, 1, NA, NA))
-  df$df <- data.frame(y = c(NA, 1, 1, NA), z = c(1, NA, 1, NA))
+  df <- data_frame(x = c(1, 1, NA, NA))
+  df$df <- data_frame(y = c(NA, 1, 1, NA), z = c(1, NA, 1, NA))
   expect_equal(vec_equal_na(df), c(FALSE, FALSE, FALSE, TRUE))
 })
 
@@ -290,8 +290,8 @@ test_that("NA propagate symmetrically (#204)", {
 })
 
 test_that("NA propagate from data frames columns", {
-  x <- data.frame(x = 1:3)
-  y <- data.frame(x = c(1L, NA, 2L))
+  x <- data_frame(x = 1:3)
+  y <- data_frame(x = c(1L, NA, 2L))
 
   expect_identical(vec_equal(x, y), c(TRUE, NA, FALSE))
   expect_identical(vec_equal(y, x), c(TRUE, NA, FALSE))
@@ -299,8 +299,8 @@ test_that("NA propagate from data frames columns", {
   expect_identical(vec_equal(x, y, na_equal = TRUE), c(TRUE, FALSE, FALSE))
   expect_identical(vec_equal(y, x, na_equal = TRUE), c(TRUE, FALSE, FALSE))
 
-  x <- data.frame(x = 1:3, y = 1:3)
-  y <- data.frame(x = c(1L, NA, 2L), y = c(NA, 2L, 3L))
+  x <- data_frame(x = 1:3, y = 1:3)
+  y <- data_frame(x = c(1L, NA, 2L), y = c(NA, 2L, 3L))
 
   expect_identical(vec_equal(x, y), c(NA, NA, FALSE))
   expect_identical(vec_equal(y, x), c(NA, NA, FALSE))

--- a/tests/testthat/test-fields.R
+++ b/tests/testthat/test-fields.R
@@ -79,7 +79,7 @@ test_that("field<- checks inputs", {
 
 test_that("field<- respects size, not length (#450)", {
   r1 <- new_rcrd(list(df = new_data_frame(n = 2L)))
-  new_df <- data.frame(x = 1:2)
+  new_df <- data_frame(x = 1:2)
 
   field(r1, 'df') <- new_df
   expect_equal(field(r1, "df"), new_df)

--- a/tests/testthat/test-group.R
+++ b/tests/testthat/test-group.R
@@ -25,7 +25,7 @@ test_that("vec_group_id works on base S3 objects", {
 })
 
 test_that("vec_group_id works row wise on data frames", {
-  df <- data.frame(x = c(1, 2, 1, 1), y = c(2, 3, 2, 3))
+  df <- data_frame(x = c(1, 2, 1, 1), y = c(2, 3, 2, 3))
   expect <- structure(c(1L, 2L, 1L, 3L), n = 3L)
   expect_equal(vec_group_id(df), expect)
 })
@@ -103,7 +103,7 @@ test_that("vec_group_rle takes the equality proxy", {
 })
 
 test_that("vec_group_rle works row wise on data frames", {
-  df <- data.frame(x = c(1, 1, 2, 1), y = c(2, 2, 3, 2))
+  df <- data_frame(x = c(1, 1, 2, 1), y = c(2, 2, 3, 2))
   expect <- new_group_rle(c(1L, 2L, 1L), c(2L, 1L, 1L), 2L)
   expect_equal(vec_group_rle(df), expect)
 })

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -41,7 +41,7 @@ test_that("list hashes to values of individual values", {
 })
 
 test_that("hash of data frame works down rows", {
-  df <- data.frame(x = 1:3, y = 1:3)
+  df <- data_frame(x = 1:3, y = 1:3)
   x <- vec_hash(df)
   expect_length(x, 4 * vec_size(df))
   expect_identical(x[1:4], vec_hash(df[1, ]))

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -148,7 +148,7 @@ test_that("vec_repair_names() repairs names", {
 })
 
 test_that("vec_repair_names() handles data frames and arrays", {
-  df <- data.frame(x = 1:2)
+  df <- data_frame(x = 1:2)
   expect_identical(vec_repair_names(df), df)
   expect_identical(row.names(vec_repair_names(as.matrix(df))), c("", ""))
   expect_identical(row.names(vec_repair_names(as.matrix(df), "unique")), c("...1", "...2"))
@@ -177,7 +177,7 @@ test_that("vec_set_names() sets matrix/array names", {
 })
 
 test_that("vec_set_names() does not set row names on data frames", {
-  x <- data.frame(a = 1, b = 2)
+  x <- data_frame(a = 1, b = 2)
   expect_equal(vec_set_names(x, "r1"), x)
 })
 

--- a/tests/testthat/test-partial-frame.R
+++ b/tests/testthat/test-partial-frame.R
@@ -1,7 +1,7 @@
 context("test-partial-frame")
 
 test_that("has ok print method", {
-  pf <- vec_ptype2(partial_frame(x = 1L), data.frame(y = 2))
+  pf <- vec_ptype2(partial_frame(x = 1L), data_frame(y = 2))
   expect_known_output(
     print(pf),
     test_path("test-partial-frame-print.txt")
@@ -12,7 +12,7 @@ test_that("has ok print method", {
 
 test_that("order of variables comes from data", {
   pf <- partial_frame(y = 1, x = 2)
-  df <- data.frame(x = 1, y = 2)
+  df <- data_frame(x = 1, y = 2)
 
   expect_named(vec_ptype_common(pf, df), c("x", "y"))
   expect_named(vec_ptype_common(df, pf), c("x", "y"))
@@ -20,7 +20,7 @@ test_that("order of variables comes from data", {
 
 test_that("partial variables added to end if not in data", {
   pf <- partial_frame(y = 1)
-  df <- data.frame(x = 1)
+  df <- data_frame(x = 1)
   expect_named(vec_ptype_common(pf, df), c("x", "y"))
   expect_named(vec_ptype_common(df, pf), c("x", "y"))
 })
@@ -28,29 +28,29 @@ test_that("partial variables added to end if not in data", {
 test_that("can assert partial frames based on column presence", {
   pf <- partial_frame(y = 1)
 
-  expect_true(vec_is(data.frame(y = 2), pf))
-  expect_false(vec_is(data.frame(x = 1), pf))
+  expect_true(vec_is(data_frame(y = 2), pf))
+  expect_false(vec_is(data_frame(x = 1), pf))
 
-  expect_true(vec_is(data.frame(x = 1, y = 2), pf))
-  expect_true(vec_is(data.frame(x = 1, y = 2, z = 3), pf))
+  expect_true(vec_is(data_frame(x = 1, y = 2), pf))
+  expect_true(vec_is(data_frame(x = 1, y = 2, z = 3), pf))
 
   pf <- partial_frame(y = 1, z = 3)
 
-  expect_false(vec_is(data.frame(y = 2), pf))
-  expect_false(vec_is(data.frame(x = 1), pf))
-  expect_false(vec_is(data.frame(x = 1, y = 2), pf))
-  expect_true(vec_is(data.frame(x = 1, y = 2, z = 3), pf))
+  expect_false(vec_is(data_frame(y = 2), pf))
+  expect_false(vec_is(data_frame(x = 1), pf))
+  expect_false(vec_is(data_frame(x = 1, y = 2), pf))
+  expect_true(vec_is(data_frame(x = 1, y = 2, z = 3), pf))
 })
 
 test_that("can assert partial frames based on column type", {
   pf <- partial_frame(y = 1)
-  expect_false(vec_is(data.frame(y = "2"), pf))
+  expect_false(vec_is(data_frame(y = "2"), pf))
 })
 
 test_that("incompatible data frames are an error", {
-  df <- data.frame(y = 1)
+  df <- data_frame(y = 1)
   expect_error(vec_ptype2(df, partial_frame(y = chr())), class = "vctrs_error_incompatible_type")
-  expect_error(new_partial_frame(df, data.frame(y = chr())), class = "vctrs_error_incompatible_type")
+  expect_error(new_partial_frame(df, data_frame(y = chr())), class = "vctrs_error_incompatible_type")
 })
 
 test_that("dispatch is symmetric with tibbles", {

--- a/tests/testthat/test-print-str.R
+++ b/tests/testthat/test-print-str.R
@@ -1,7 +1,7 @@
 context("test-print-str")
 
 test_that("show attributes", {
-  x <- structure(1:100, x = "a string", y = 1:20, z = data.frame(x = 1:3))
+  x <- structure(1:100, x = "a string", y = 1:20, z = data_frame(x = 1:3))
   expect_known_output(
     obj_str(x),
     test_path("test-print-str-attr.txt")

--- a/tests/testthat/test-ptype-abbr-full.R
+++ b/tests/testthat/test-ptype-abbr-full.R
@@ -47,7 +47,7 @@ test_that("I() wraps contents", {
 })
 
 test_that("AsIs class stripped from I()", {
-  df <- data.frame(x = 1, y = 1:2)
+  df <- data_frame(x = 1, y = 1:2)
   class(df) <- c("myclass", "data.frame")
 
   expect_equal(vec_ptype_full(I(df)), "I<myclass<\n  x: double\n  y: integer\n>>")

--- a/tests/testthat/test-recycle.R
+++ b/tests/testthat/test-recycle.R
@@ -98,7 +98,7 @@ test_that("recycling matrices respects incompatible sizes", {
 })
 
 test_that("can vec_recycle_common data frames", {
-  x <- data.frame(a = rep(1, 3), b = rep(2, 3))
+  x <- data_frame(a = rep(1, 3), b = rep(2, 3))
   x1 <- vec_slice(x, 1L)
 
   expect_equal(vec_recycle_common(x, x), list(x, x))
@@ -106,7 +106,7 @@ test_that("can vec_recycle_common data frames", {
 })
 
 test_that("recycling data frames respects incompatible sizes", {
-  x <- data.frame(a = rep(1, 3), b = rep(2, 3))
+  x <- data_frame(a = rep(1, 3), b = rep(2, 3))
   x2 <- vec_slice(x, 1:2)
   x0 <- vec_slice(x, integer())
 
@@ -116,7 +116,7 @@ test_that("recycling data frames respects incompatible sizes", {
 
 test_that("can vec_recycle_common matrix and data frame", {
   mt <- matrix(nrow = 2, ncol = 2)
-  df <- data.frame(x = c(1, 1), y = c(2, 2))
+  df <- data_frame(x = c(1, 1), y = c(2, 2))
 
   expect_equal(
     vec_recycle_common(vec_slice(mt, 1L), df),
@@ -131,7 +131,7 @@ test_that("can vec_recycle_common matrix and data frame", {
 
 test_that("recycling data frames with matrices respects incompatible sizes", {
   mt <- matrix(nrow = 2, ncol = 2)
-  df <- data.frame(x = c(1, 1), y = c(2, 2))
+  df <- data_frame(x = c(1, 1), y = c(2, 2))
 
   expect_error(
     vec_recycle_common(vec_slice(mt, integer()), df),

--- a/tests/testthat/test-size.R
+++ b/tests/testthat/test-size.R
@@ -23,7 +23,7 @@ test_that("length of record is number of rows, not fields", {
 })
 
 test_that("handles three types of data frame rownames", {
-  df1 <- df2 <- df3 <- data.frame(x = 1:3)
+  df1 <- df2 <- df3 <- data_frame(x = 1:3)
   rownames(df1) <- NULL
   rownames(df2) <- 3:1
   rownames(df3) <- letters[1:3]
@@ -102,7 +102,7 @@ test_that("provided size is cast to an integer", {
 
 test_that("vec_seq_along returns size-0 output for size-0 input", {
   expect_equal(vec_seq_along(character()), integer())
-  expect_equal(vec_seq_along(data.frame()), integer())
+  expect_equal(vec_seq_along(data_frame()), integer())
 })
 
 test_that("vec_init_along can be called with single argument", {

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -103,16 +103,16 @@ test_that("monitoring test - unspecified() can be assigned in lists", {
 })
 
 test_that("can assign and slice-assign data frames", {
-  df <- data.frame(x = 1:2)
-  df$y <- data.frame(a = 2:1)
+  df <- data_frame(x = 1:2)
+  df$y <- data_frame(a = 2:1)
 
   orig <- duplicate(df, shallow = FALSE)
 
-  other <- data.frame(x = 3)
-  other$y <- data.frame(a = 3)
+  other <- data_frame(x = 3)
+  other$y <- data_frame(a = 3)
 
-  exp <- data.frame(x = int(3, 2))
-  exp$y <- data.frame(a = int(3, 1))
+  exp <- data_frame(x = int(3, 2))
+  exp$y <- data_frame(a = int(3, 1))
 
   expect_identical(vec_assign(df, 1, other), exp)
   expect_identical(df, orig)

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -111,7 +111,7 @@ test_that("size 0 `indices` list is allowed", {
 test_that("individual index values of size 0 are allowed", {
   expect_equal(vec_chop(1, list(integer())), list(numeric()))
 
-  df <- data.frame(a = 1, b = "1")
+  df <- data_frame(a = 1, b = "1")
   expect_equal(vec_chop(df, list(integer())), list(vec_ptype(df)))
 })
 
@@ -129,7 +129,7 @@ test_that("vec_chop(<atomic>, indices =) can be equivalent to the default", {
 })
 
 test_that("vec_chop(<data.frame>, indices =) can be equivalent to the default", {
-  x <- data.frame(x = 1:5)
+  x <- data_frame(x = 1:5)
   indices <- as.list(vec_seq_along(x))
   expect_equal(vec_chop(x, indices), vec_chop(x))
 })
@@ -221,12 +221,12 @@ test_that("can chop S3 objects using the fallback method with compact seqs", {
 
 test_that("`x` must be a list", {
   expect_error(vec_unchop(1, list(1)), "`x` must be a list")
-  expect_error(vec_unchop(data.frame(x=1), list(1)), "`x` must be a list")
+  expect_error(vec_unchop(data_frame(x=1), list(1)), "`x` must be a list")
 })
 
 test_that("`indices` must be a list", {
   expect_error(vec_unchop(list(1), 1), "`indices` must be a list of integers, or `NULL`")
-  expect_error(vec_unchop(list(1), data.frame(x=1)), "`indices` must be a list of integers, or `NULL`")
+  expect_error(vec_unchop(list(1), data_frame(x=1)), "`indices` must be a list of integers, or `NULL`")
 })
 
 test_that("`indices` must be a list of integers", {

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -114,8 +114,8 @@ test_that("can subset using logical subscript", {
 })
 
 test_that("can subset data frame columns", {
-  df <- data.frame(x = 1:2)
-  df$y <- data.frame(a = 2:1)
+  df <- data_frame(x = 1:2)
+  df$y <- data_frame(a = 2:1)
 
   expect_equal(vec_slice(df, 1L)$y, vec_slice(df$y, 1L))
 })

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -9,14 +9,14 @@ test_that("can split empty vector", {
 })
 
 test_that("split data frame with data frame", {
-  df <- data.frame(x = c(1, 1, 2), y = c(1, 1, 1))
+  df <- data_frame(x = c(1, 1, 2), y = c(1, 1, 1))
   out <- vec_split(df, df)
 
   expect_s3_class(out, "data.frame")
-  expect_equal(out$key, data.frame(x = c(1, 2), y = c(1, 1)))
+  expect_equal(out$key, data_frame(x = c(1, 2), y = c(1, 1)))
   expect_equal(out$val, list(
-    data.frame(x = c(1, 1), y = c(1, 1)),
-    data.frame(x = 2, y = 1)
+    data_frame(x = c(1, 1), y = c(1, 1)),
+    data_frame(x = 2, y = 1)
   ))
 })
 

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -341,13 +341,13 @@ test_that("dimensionality matches to" ,{
 
 test_that("data frames are cast to list row wise (#639)", {
   x <- data.frame(x = 1:2, row.names = c("a", "b"))
-  expect <- list(data.frame(x = 1L), data.frame(x = 2L))
+  expect <- list(data_frame(x = 1L), data_frame(x = 2L))
   expect_equal(vec_cast(x, list()), expect)
 })
 
 test_that("data frames can be cast to shaped lists", {
   to <- array(list(), dim = c(0, 2, 1))
-  x <- data.frame(x = 1:2, y = 3:4)
+  x <- data_frame(x = 1:2, y = 3:4)
 
   expect <- list(vec_slice(x, 1), vec_slice(x, 2))
   expect <- array(expect, dim = c(2, 2, 1))
@@ -362,7 +362,7 @@ test_that("Casting atomic `NA` values to list results in a `NULL`", {
 })
 
 test_that("Casting data frame `NA` rows to list results in a `NULL`", {
-  x <- data.frame(x = c(NA, NA, 1), y = c(NA, 1, 2))
+  x <- data_frame(x = c(NA, NA, 1), y = c(NA, 1, 2))
   expect <- list(NULL, vec_slice(x, 2), vec_slice(x, 3))
   expect_equal(vec_cast(x, list()), expect)
 })

--- a/tests/testthat/test-type-data-frame-embedded.txt
+++ b/tests/testthat/test-type-data-frame-embedded.txt
@@ -4,14 +4,14 @@ Prototype: data.frame<
   a: 
     data.frame<
       a: integer
-      b: factor<38ce1>
+      b: character
     >
   b: list_of<double>
   c: 
     list_of<
       data.frame<
         x: integer
-        y: factor<38ce1>
+        y: character
       >
     >
 >

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -12,10 +12,10 @@ test_that("data frames print nicely", {
 })
 
 test_that("embedded data frames print nicely", {
-  df <- data.frame(x = 1:3)
-  df$a <- data.frame(a = 1:3, b = letters[1:3])
+  df <- data_frame(x = 1:3)
+  df$a <- data_frame(a = 1:3, b = letters[1:3])
   df$b <- list_of(1, 2, 3)
-  df$c <- as_list_of(split(data.frame(x = 1:3, y = letters[1:3]), 1:3))
+  df$c <- as_list_of(split(data_frame(x = 1:3, y = letters[1:3]), 1:3))
 
   verify_output(test_path("test-type-data-frame-embedded.txt"), {
     vec_ptype_show(df)
@@ -25,26 +25,26 @@ test_that("embedded data frames print nicely", {
 # coercing ----------------------------------------------------------------
 
 test_that("data frame only combines with other data frames or NULL", {
-  dt <- data.frame(x = 1)
+  dt <- data_frame(x = 1)
   expect_equal(vec_ptype_common(dt, NULL), vec_ptype(dt))
   expect_error(vec_ptype_common(dt, 1:10), class = "vctrs_error_incompatible_type")
 })
 
 test_that("data frame takes max of individual variables", {
-  dt1 <- data.frame(x = FALSE, y = 1L)
-  dt2 <- data.frame(x = 1.5, y = 1.5)
+  dt1 <- data_frame(x = FALSE, y = 1L)
+  dt2 <- data_frame(x = 1.5, y = 1.5)
 
   expect_equal(vec_ptype_common(dt1, dt2), vec_ptype_common(dt2))
 })
 
 test_that("data frame combines variables", {
-  dt1 <- data.frame(x = 1)
-  dt2 <- data.frame(y = 1)
+  dt1 <- data_frame(x = 1)
+  dt2 <- data_frame(y = 1)
 
   dt3 <- max(dt1, dt2)
   expect_equal(
     vec_ptype_common(dt1, dt2),
-    vec_ptype_common(data.frame(x = double(), y = double()))
+    vec_ptype_common(data_frame(x = double(), y = double()))
   )
 })
 
@@ -58,20 +58,20 @@ test_that("empty data frame still has names", {
 # casting -----------------------------------------------------------------
 
 test_that("safe casts work as expected", {
-  df <- data.frame(x = 1, y = 0)
+  df <- data_frame(x = 1, y = 0)
 
   expect_equal(vec_cast(NULL, df), NULL)
   expect_equal(vec_cast(df, df), df)
 
-  expect_equal(vec_cast(data.frame(x = TRUE, y = FALSE), df), df)
+  expect_equal(vec_cast(data_frame(x = TRUE, y = FALSE), df), df)
 })
 
 test_that("warn about lossy coercions", {
-  df1 <- data.frame(x = 1, y = 1)
-  df2 <- data.frame(x = c("a", 1), stringsAsFactors = FALSE)
+  df1 <- data_frame(x = 1, y = 1)
+  df2 <- data_frame(x = c("a", 1))
 
   expect_lossy(vec_cast(df1, df1[1]), df1[1], x = df1, to = df1[1])
-  expect_lossy(vec_cast(df2, df1), data.frame(x = dbl(NA, 1), y = dbl(NA, NA)), x = chr(), to = dbl())
+  expect_lossy(vec_cast(df2, df1), data_frame(x = dbl(NA, 1), y = dbl(NA, NA)), x = chr(), to = dbl())
 
   out <-
     allow_lossy_cast(
@@ -82,23 +82,23 @@ test_that("warn about lossy coercions", {
       df2, df1
     )
 
-  expect_identical(out, data.frame(x = dbl(NA, 1), y = dbl(NA, NA)))
+  expect_identical(out, data_frame(x = dbl(NA, 1), y = dbl(NA, NA)))
 })
 
 test_that("invalid cast generates error", {
-  expect_error(vec_cast(1L, data.frame()), class = "vctrs_error_incompatible_cast")
+  expect_error(vec_cast(1L, data_frame()), class = "vctrs_error_incompatible_cast")
 })
 
 test_that("column order matches type", {
-  df1 <- data.frame(x = 1, y = "a")
-  df2 <- data.frame(x = TRUE, z = 3)
+  df1 <- data_frame(x = 1, y = "a")
+  df2 <- data_frame(x = TRUE, z = 3)
 
   df3 <- vec_cast(df2, vec_ptype_common(df1, df2))
   expect_named(df3, c("x", "y", "z"))
 })
 
 test_that("casts preserve outer class", {
-  df <- data.frame(x = 1)
+  df <- data_frame(x = 1)
   dt <- tibble::tibble(x = 1)
 
   expect_s3_class(vec_cast(df, dt), "tbl_df")
@@ -106,8 +106,8 @@ test_that("casts preserve outer class", {
 })
 
 test_that("restore generates correct row/col names", {
-  df1 <- data.frame(x = NA, y = 1:4, z = 1:4)
-  df1$x <- data.frame(a = 1:4, b = 1:4)
+  df1 <- data_frame(x = rep(NA, 4), y = 1:4, z = 1:4)
+  df1$x <- data_frame(a = 1:4, b = 1:4)
 
   df2 <- vec_restore(lapply(df1[1:3], vec_slice, 1:2), df1)
 
@@ -116,8 +116,8 @@ test_that("restore generates correct row/col names", {
 })
 
 test_that("restore keeps automatic row/col names", {
-  df1 <- data.frame(x = NA, y = 1:4, z = 1:4)
-  df1$x <- data.frame(a = 1:4, b = 1:4)
+  df1 <- data_frame(x = rep(NA, 4), y = 1:4, z = 1:4)
+  df1$x <- data_frame(a = 1:4, b = 1:4)
 
   df2 <- vec_restore(df1, df1)
 
@@ -131,30 +131,30 @@ test_that("cast to empty data frame preserves number of rows", {
 })
 
 test_that("can cast unspecified to data frame", {
-  df <- data.frame(x = 1, y = 2L)
+  df <- data_frame(x = 1, y = 2L)
   expect_identical(vec_cast(unspecified(3), df), vec_init(df, 3))
 })
 
 test_that("can cast list of data frames to data frame", {
-  df <- data.frame(x = 1, y = 2L)
+  df <- data_frame(x = 1, y = 2L)
   expect_equal(vec_cast(list(df, df), df), vec_slice(df, c(1, 1)))
 })
 
 test_that("can only cast list of data frames to data frame if they are all size 1", {
-  df <- data.frame(x = 1:2)
+  df <- data_frame(x = 1:2)
   expect_error(vec_cast(list(df), df), class = "vctrs_error_cast_lossy")
 })
 
 test_that("can restore lists with empty names", {
-  expect_identical(vec_restore(list(), data.frame()), data.frame())
+  expect_identical(vec_restore(list(), data_frame()), data_frame())
 })
 
 test_that("can restore subclasses of data frames", {
-  expect_identical(vec_restore(list(), subclass(data.frame())), subclass(data.frame()))
+  expect_identical(vec_restore(list(), subclass(data_frame())), subclass(data_frame()))
   local_methods(
     vec_restore.vctrs_foobar = function(x, to, ..., i) "dispatched"
   )
-  expect_identical(vec_restore(list(), subclass(data.frame())), "dispatched")
+  expect_identical(vec_restore(list(), subclass(data_frame())), "dispatched")
 })
 
 test_that("df_as_dataframe() checks for names", {
@@ -191,7 +191,7 @@ test_that("can add additional classes", {
 })
 
 test_that("can add additional attributes", {
-  expect <- data.frame()
+  expect <- data_frame()
   attr(expect, "foo") <- "bar"
   attr(expect, "a") <- "b"
 

--- a/tests/testthat/test-type-date-time.R
+++ b/tests/testthat/test-type-date-time.R
@@ -33,7 +33,7 @@ test_that("vec_c() converts POSIXct with int representation to double representa
 
 test_that("vec_c() and vec_rbind() convert Dates with int representation to double representation (#396)", {
   x <- structure(0L, class = "Date")
-  df <- data.frame(x = x)
+  df <- data_frame(x = x)
 
   expect_true(is.double(vec_c(x)))
   expect_true(is.double(vec_c(x, x)))

--- a/tests/testthat/test-type-integer64.R
+++ b/tests/testthat/test-type-integer64.R
@@ -45,8 +45,8 @@ test_that("vec_ptype2 for integer64 works", {
   expect_error(vec_ptype2(x, ""))
   expect_error(vec_ptype2("", x))
 
-  expect_error(vec_ptype2(data.frame(), x))
-  expect_error(vec_ptype2(x, data.frame()))
+  expect_error(vec_ptype2(data_frame(), x))
+  expect_error(vec_ptype2(x, data_frame()))
 })
 
 test_that("vec_ptype_abbr.integer64", {

--- a/tests/testthat/test-type-unspecified.R
+++ b/tests/testthat/test-type-unspecified.R
@@ -49,7 +49,7 @@ test_that("has useful print method", {
 })
 
 test_that("can finalise data frame containing unspecified columns", {
-  df <- data.frame(y = NA, x = c(1, 2, NA))
+  df <- data_frame(y = NA, x = c(1, 2, NA))
 
   ptype <- vec_ptype(df)
   expect_identical(ptype$y, unspecified())
@@ -62,7 +62,7 @@ test_that("can finalise data frame containing unspecified columns", {
 })
 
 test_that("can cast to common type data frame containing unspecified columns", {
-  df <- data.frame(y = NA, x = c(1, 2, NA))
+  df <- data_frame(y = NA, x = c(1, 2, NA))
   expect_identical(vec_cast_common(df, df), list(df, df))
 })
 

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -372,7 +372,7 @@ test_that("can put in data frame", {
   h <- new_hidden(1:4)
 
   expect_named(as.data.frame(h), "h")
-  expect_named(data.frame(x = h), "x")
+  expect_named(data_frame(x = h), "x")
 })
 
 test_that("base coercions default to vec_cast", {
@@ -420,10 +420,10 @@ test_that("can't transpose", {
 
 test_that("shaped vctrs can be cast to data frames", {
   x <- new_vctr(1:4, dim = 4)
-  expect_identical(as.data.frame(x), data.frame(V1 = 1:4))
+  expect_identical(as.data.frame(x), data_frame(V1 = 1:4))
 
   x <- new_vctr(1:4, dim = c(2, 2))
-  expect_identical(as.data.frame(x), data.frame(V1 = 1:2, V2 = 3:4))
+  expect_identical(as.data.frame(x), data_frame(V1 = 1:2, V2 = 3:4))
 })
 
 

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -40,7 +40,7 @@ test_that("finalised prototypes created from under specified inputs", {
 })
 
 test_that("finalised prototypes created from under specified data frame cols", {
-  df <- data.frame(x = NA)
+  df <- data_frame(x = NA)
   expect_equal(vec_ptype_common(df)$x, logical())
 })
 
@@ -143,9 +143,9 @@ test_that("class_type() detects classes", {
   expect_identical(class_type(new_list_of()), "list_of")
   expect_identical(class_type(subclass(new_list_of())), "list_of")
 
-  expect_identical(class_type(data.frame()), "bare_data_frame")
+  expect_identical(class_type(data_frame()), "bare_data_frame")
   expect_identical(class_type(tibble::tibble()), "bare_tibble")
-  expect_identical(class_type(subclass(data.frame())), "data_frame")
+  expect_identical(class_type(subclass(data_frame())), "data_frame")
 
   expect_identical(class_type(new_factor()), "bare_factor")
   expect_identical(class_type(new_ordered()), "bare_ordered")
@@ -181,7 +181,7 @@ test_that("explicit list subclasses are vectors", {
   x <- list_subclass(list())
   expect_true(vec_is(x))
 
-  df <- data.frame(x = 1:2)
+  df <- data_frame(x = 1:2)
   df$z <- list_subclass(list(1, 2))
 
   expect_identical(vec_slice(df, 1)$z, list_subclass(list(1)))

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -110,7 +110,7 @@ test_that("vec_ptype2() methods forward args to stop_incompatible_type()", {
   expect_args(chr(), new_hidden(), x_arg = "foo", y_arg = "bar")
   expect_args(list(), new_hidden(), x_arg = "foo", y_arg = "bar")
   expect_args(new_rcrd(list(x = NA)), new_hidden(), x_arg = "foo", y_arg = "bar")
-  expect_args(data.frame(), new_hidden(), x_arg = "foo", y_arg = "bar")
+  expect_args(data_frame(), new_hidden(), x_arg = "foo", y_arg = "bar")
   expect_args(Sys.Date(), new_hidden(), x_arg = "foo", y_arg = "bar")
   expect_args(as.difftime(1, units = "hours"), new_hidden(), x_arg = "foo", y_arg = "bar")
   expect_args(factor(), new_hidden(), x_arg = "foo", y_arg = "bar")
@@ -147,12 +147,12 @@ test_that("Subclasses of data.frame dispatch to `vec_ptype2()` methods", {
     vec_ptype2.data.frame.quuxframe = function(x, y, ...) "dispatched!"
   )
 
-  quux <- structure(data.frame(), class = c("quuxframe", "data.frame"))
+  quux <- structure(data_frame(), class = c("quuxframe", "data.frame"))
 
   expect_identical(vec_ptype2(quux, mtcars), "dispatched!")
   expect_identical(vec_ptype2(mtcars, quux), "dispatched!")
 
-  quux <- structure(data.frame(), class = c("quuxframe", "tbl_df", "data.frame"))
+  quux <- structure(data_frame(), class = c("quuxframe", "tbl_df", "data.frame"))
 
   expect_identical(vec_ptype2(quux, mtcars), "dispatched!")
   expect_identical(vec_ptype2(mtcars, quux), "dispatched!")


### PR DESCRIPTION
One of the R devel builds is failing because of the following, which it seems is a direct result of `stringsAsFactors` being flipped to `FALSE` by default in R 4.0.0.

To avoid any fallout, this PR preemptively swaps usage of `data.frame()` with `data_frame()` when it is not explicitly required (i.e. when we don't use row names, or when we aren't explicitly trying to check against the result of `data.frame()`)

```r
Result: ERROR
     Running 'testthat.R' [36s/41s]
    Running the tests in 'tests/testthat.R' failed.
    Complete output:
     > library(testthat)
     > library(vctrs)
     >
     > if (requireNamespace("xml2")) {
     + test_check("vctrs", reporter = MultiReporter$new(reporters = list(JunitReporter$new(file = "test-results.xml"), CheckReporter$new())))
     + } else {
     + test_check("vctrs")
     + }
     Loading required namespace: xml2
     -- 1. Failure: embedded data frames print nicely (@test-type-data-frame.R#26) -
     Results have changed from known value recorded in 'test-type-data-frame-embedded.txt'.
     2/16 mismatches
     x[6]: " b: character"
     y[6]: " b: factor<38ce1>"
    
     x[13]: " y: character"
     y[13]: " y: factor<38ce1>"
    
     == testthat results ===========================================================
     [ OK: 2618 | SKIPPED: 9 | WARNINGS: 0 | FAILED: 1 ]
     1. Failure: embedded data frames print nicely (@test-type-data-frame.R#26)
```