### PR TITLE
Implement `zero` handling in `num_as_location()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # vctrs (development version)
 
+* `num_as_location()` gains a new argument, `zero`, for controlling whether
+  to `"remove"`, `"ignore"`, or `"error"` on zero values (#852).
 
 # vctrs 0.2.3
 

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -361,7 +361,7 @@ cnd_bullets_location_need_non_zero <- function(cnd, ...) {
   arg <- append_arg("The subscript", cnd$subscript_arg)
 
   if (zero_loc_size == 1) {
-    loc <- glue::glue("It had a `0` value at location {zero_loc}.")
+    loc <- glue::glue("It has a `0` value at location {zero_loc}.")
   } else {
     zero_loc <- ensure_full_stop(enumerate(zero_loc))
     loc <- glue::glue(

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -361,11 +361,11 @@ cnd_bullets_location_need_non_zero <- function(cnd, ...) {
   arg <- append_arg("The subscript", cnd$subscript_arg)
 
   if (zero_loc_size == 1) {
-    loc <- glue::glue("It had a zero value at location {zero_loc}.")
+    loc <- glue::glue("It had a `0` value at location {zero_loc}.")
   } else {
     zero_loc <- ensure_full_stop(enumerate(zero_loc))
     loc <- glue::glue(
-      "It has {zero_loc_size} zero values at locations {zero_loc}"
+      "It has {zero_loc_size} `0` values at locations {zero_loc}"
     )
   }
   format_error_bullets(c(

--- a/R/vctrs-deprecated.R
+++ b/R/vctrs-deprecated.R
@@ -79,6 +79,7 @@ vec_as_index <- function(i, n, names = NULL) {
     names = names,
     loc_negative = "invert",
     loc_oob = "error",
+    loc_zero = "remove",
     missing = "propagate",
     arg = NULL
   )

--- a/man/vec_as_location.Rd
+++ b/man/vec_as_location.Rd
@@ -23,6 +23,7 @@ num_as_location(
   missing = c("propagate", "error"),
   negative = c("invert", "error", "ignore"),
   oob = c("error", "extend"),
+  zero = c("remove", "error", "ignore"),
   arg = NULL
 )
 
@@ -73,6 +74,9 @@ negative location value, or \code{"ignore"} it.}
 elements are out-of-bounds. If \code{"extend"}, out-of-bounds
 locations are allowed if they are consecutive after the end. This
 can be used to implement extendable vectors like \code{letters[1:30]}.}
+
+\item{zero}{Whether to \code{"remove"} zero values, throw an informative
+\code{"error"}, or \code{"ignore"} them.}
 }
 \value{
 \code{vec_as_location()} returns an integer vector that can be used

--- a/src/init.c
+++ b/src/init.c
@@ -45,7 +45,7 @@ extern SEXP vctrs_type2(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_typeof2(SEXP, SEXP);
 extern SEXP vctrs_typeof2_s3(SEXP, SEXP);
 extern SEXP vctrs_cast(SEXP, SEXP, SEXP, SEXP);
-extern SEXP vctrs_as_location(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_as_location(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_slice(SEXP, SEXP);
 extern SEXP vctrs_init(SEXP, SEXP);
 extern SEXP vctrs_chop(SEXP, SEXP);
@@ -152,7 +152,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_typeof2",                    (DL_FUNC) &vctrs_typeof2, 2},
   {"vctrs_typeof2_s3",                 (DL_FUNC) &vctrs_typeof2_s3, 2},
   {"vctrs_cast",                       (DL_FUNC) &vctrs_cast, 4},
-  {"vctrs_as_location",                (DL_FUNC) &vctrs_as_location, 7},
+  {"vctrs_as_location",                (DL_FUNC) &vctrs_as_location, 8},
   {"vctrs_slice",                      (DL_FUNC) &vctrs_slice, 2},
   {"vctrs_init",                       (DL_FUNC) &vctrs_init, 2},
   {"vctrs_chop",                       (DL_FUNC) &vctrs_chop, 2},

--- a/src/subscript-loc.h
+++ b/src/subscript-loc.h
@@ -26,11 +26,17 @@ enum num_as_location_loc_oob {
   LOC_OOB_EXTEND,
   LOC_OOB_ERROR
 };
+enum num_as_location_loc_zero {
+  LOC_ZERO_REMOVE,
+  LOC_ZERO_ERROR,
+  LOC_ZERO_IGNORE
+};
 
 struct vec_as_location_opts {
   enum subscript_action action;
   enum num_as_location_loc_negative loc_negative;
   enum num_as_location_loc_oob loc_oob;
+  enum num_as_location_loc_zero loc_zero;
   enum subscript_missing missing;
   SEXP subscript_arg;
 };

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -41,12 +41,12 @@ num_as_location() optionally forbids zero indices
 > num_as_location(0L, 1L, zero = "error")
 Error: Must subset elements with a valid subscript vector.
 x The subscript can't contain `0` values.
-i It had a zero value at location 1.
+i It had a `0` value at location 1.
 
 > num_as_location(c(0, 0, 0, 0, 0, 0), 1, zero = "error")
 Error: Must subset elements with a valid subscript vector.
 x The subscript can't contain `0` values.
-i It has 6 zero values at locations 1, 2, 3, 4, 5, etc.
+i It has 6 `0` values at locations 1, 2, 3, 4, 5, etc.
 
 
 logical subscripts must match size of indexed vector
@@ -371,7 +371,7 @@ x The subscript `foo` contains non-consecutive location 4.
 > num_as_location(0, 1, zero = "error", arg = "foo")
 Error: Must subset elements with a valid subscript vector.
 x The subscript `foo` can't contain `0` values.
-i It had a zero value at location 1.
+i It had a `0` value at location 1.
 
 > # With tibble columns
 > with_tibble_cols(num_as_location(-1, 2, negative = "error"))
@@ -417,7 +417,7 @@ x The subscript `foo(bar)` contains non-consecutive location 4.
 > with_tibble_cols(num_as_location(0, 1, zero = "error"))
 Error: Must rename columns with a valid subscript vector.
 x The subscript `foo(bar)` can't contain `0` values.
-i It had a zero value at location 1.
+i It had a `0` value at location 1.
 
 
 can customise OOB errors

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -35,6 +35,20 @@ Error: Must subset elements with a valid subscript vector.
 x The subscript can't contain negative locations.
 
 
+num_as_location() optionally forbids zero indices
+=================================================
+
+> num_as_location(0L, 1L, zero = "error")
+Error: Must subset elements with a valid subscript vector.
+x The subscript can't contain `0` values.
+i It had a zero value at location 1.
+
+> num_as_location(c(0, 0, 0, 0, 0, 0), 1, zero = "error")
+Error: Must subset elements with a valid subscript vector.
+x The subscript can't contain `0` values.
+i It has 6 zero values at locations 1, 2, 3, 4, 5, etc.
+
+
 logical subscripts must match size of indexed vector
 ====================================================
 
@@ -354,6 +368,11 @@ Error: Can't subset elements beyond the end with non-consecutive locations.
 i The input has size 2.
 x The subscript `foo` contains non-consecutive location 4.
 
+> num_as_location(0, 1, zero = "error", arg = "foo")
+Error: Must subset elements with a valid subscript vector.
+x The subscript `foo` can't contain `0` values.
+i It had a zero value at location 1.
+
 > # With tibble columns
 > with_tibble_cols(num_as_location(-1, 2, negative = "error"))
 Error: Must rename columns with a valid subscript vector.
@@ -394,6 +413,11 @@ i The subscript `foo(bar)` has a positive value at location 2.
 Error: Can't rename columns beyond the end with non-consecutive locations.
 i The input has size 2.
 x The subscript `foo(bar)` contains non-consecutive location 4.
+
+> with_tibble_cols(num_as_location(0, 1, zero = "error"))
+Error: Must rename columns with a valid subscript vector.
+x The subscript `foo(bar)` can't contain `0` values.
+i It had a zero value at location 1.
 
 
 can customise OOB errors

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -41,7 +41,7 @@ num_as_location() optionally forbids zero indices
 > num_as_location(0L, 1L, zero = "error")
 Error: Must subset elements with a valid subscript vector.
 x The subscript can't contain `0` values.
-i It had a `0` value at location 1.
+i It has a `0` value at location 1.
 
 > num_as_location(c(0, 0, 0, 0, 0, 0), 1, zero = "error")
 Error: Must subset elements with a valid subscript vector.
@@ -371,7 +371,7 @@ x The subscript `foo` contains non-consecutive location 4.
 > num_as_location(0, 1, zero = "error", arg = "foo")
 Error: Must subset elements with a valid subscript vector.
 x The subscript `foo` can't contain `0` values.
-i It had a `0` value at location 1.
+i It has a `0` value at location 1.
 
 > # With tibble columns
 > with_tibble_cols(num_as_location(-1, 2, negative = "error"))
@@ -417,7 +417,7 @@ x The subscript `foo(bar)` contains non-consecutive location 4.
 > with_tibble_cols(num_as_location(0, 1, zero = "error"))
 Error: Must rename columns with a valid subscript vector.
 x The subscript `foo(bar)` can't contain `0` values.
-i It had a `0` value at location 1.
+i It has a `0` value at location 1.
 
 
 can customise OOB errors

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -166,13 +166,21 @@ test_that("num_as_location() optionally forbids negative indices", {
   expect_error(num_as_location(c(1, -10), 2L, negative = "error"), class = "vctrs_error_subscript_type")
 })
 
-test_that("num_as_location() optionally ignores zero values", {
+test_that("num_as_location() optionally ignores zero indices", {
   expect_identical(num_as_location(c(1, 0), 2L, zero = "ignore"), c(1L, 0L))
 })
 
-test_that("num_as_location() optionally forbids zero values", {
-  expect_error(num_as_location(c(1, 0), 2L, zero = "error"), class = "vctrs_error_subscript_type")
-  expect_error(num_as_location(c(0, 0, 0, 0, 0, 0), 1, zero = "error"), class = "vctrs_error_subscript_type")
+test_that("num_as_location() optionally forbids zero indices", {
+  verify_errors({
+    expect_error(
+      num_as_location(0L, 1L, zero = "error"),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      num_as_location(c(0, 0, 0, 0, 0, 0), 1, zero = "error"),
+      class = "vctrs_error_subscript_type"
+    )
+  })
 })
 
 test_that("vec_as_location() handles NULL", {

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -166,6 +166,15 @@ test_that("num_as_location() optionally forbids negative indices", {
   expect_error(num_as_location(c(1, -10), 2L, negative = "error"), class = "vctrs_error_subscript_type")
 })
 
+test_that("num_as_location() optionally ignores zero values", {
+  expect_identical(num_as_location(c(1, 0), 2L, zero = "ignore"), c(1L, 0L))
+})
+
+test_that("num_as_location() optionally forbids zero values", {
+  expect_error(num_as_location(c(1, 0), 2L, zero = "error"), class = "vctrs_error_subscript_type")
+  expect_error(num_as_location(c(0, 0, 0, 0, 0, 0), 1, zero = "error"), class = "vctrs_error_subscript_type")
+})
+
 test_that("vec_as_location() handles NULL", {
   expect_identical(
     vec_as_location(NULL, 10),
@@ -309,6 +318,10 @@ test_that("can customise subscript type errors", {
       num_as_location(c(1, 4), 2, oob = "extend", arg = "foo"),
       class = "vctrs_error_subscript_oob"
     )
+    expect_error(
+      num_as_location(0, 1, zero = "error", arg = "foo"),
+      class = "vctrs_error_subscript_type"
+    )
 
     "With tibble columns"
     expect_error(
@@ -346,6 +359,10 @@ test_that("can customise subscript type errors", {
     expect_error(
       with_tibble_cols(num_as_location(c(1, 4), 2, oob = "extend")),
       class = "vctrs_error_subscript_oob"
+    )
+    expect_error(
+      with_tibble_cols(num_as_location(0, 1, zero = "error")),
+      class = "vctrs_error_subscript_type"
     )
   })
 })
@@ -409,6 +426,10 @@ test_that("conversion to locations has informative error messages", {
 
     "# num_as_location() optionally forbids negative indices"
     num_as_location(dbl(1, -1), 2L, negative = "error")
+
+    "# num_as_location() optionally forbids zero indices"
+    num_as_location(0L, 1L, zero = "error")
+    num_as_location(c(0, 0, 0, 0, 0, 0), 1, zero = "error")
 
     "# logical subscripts must match size of indexed vector"
     vec_as_location(c(TRUE, FALSE), 3)
@@ -488,6 +509,7 @@ test_that("conversion to locations has informative error messages", {
     vec_as_location(c(-1, NA), 3, arg = "foo")
     vec_as_location(c(-1, 1), 3, arg = "foo")
     num_as_location(c(1, 4), 2, oob = "extend", arg = "foo")
+    num_as_location(0, 1, zero = "error", arg = "foo")
     "With tibble columns"
     with_tibble_cols(num_as_location(-1, 2, negative = "error"))
     with_tibble_cols(num_as_location2(-1, 2, negative = "error"))
@@ -498,6 +520,7 @@ test_that("conversion to locations has informative error messages", {
     with_tibble_cols(vec_as_location(c(-1, NA), 3))
     with_tibble_cols(vec_as_location(c(-1, 1), 3))
     with_tibble_cols(num_as_location(c(1, 4), 2, oob = "extend"))
+    with_tibble_cols(num_as_location(0, 1, zero = "error"))
 
     "# can customise OOB errors"
     vec_slice(set_names(letters), "foo")


### PR DESCRIPTION
Closes #852 

Adds a `zero` argument to `num_as_location()` with the ability to `"remove"`, `"ignore"`, or `"error"`. Will be used in the C level call to `vec_as_location()` to validate locations in #846