### PR TITLE
Ensure that tests are compliant with upcoming `stringsAsFactors` changes

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -134,10 +134,10 @@ unstructure <- function(x) {
 
 # We almost never want `stringsAsFactors = TRUE`, and `FALSE` became
 # the default in R 4.0.0. This wrapper ensures that our tests are compliant
-# with versions of R before and after this change.
-if (getRversion() < "4.0.0") {
-  data.frame <- function(..., stringsAsFactors = NULL) {
-    stringsAsFactors <- stringsAsFactors %||% FALSE
-    base::data.frame(..., stringsAsFactors = stringsAsFactors)
-  }
+# with versions of R before and after this change. Keeping it in `utils.R`
+# rather than as a testthat helper ensures that it is sourced before any other
+# testthat helpers.
+data.frame <- function(..., stringsAsFactors = NULL) {
+  stringsAsFactors <- stringsAsFactors %||% FALSE
+  base::data.frame(..., stringsAsFactors = stringsAsFactors)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -131,3 +131,13 @@ unstructure <- function(x) {
   attributes(x) <- NULL
   x
 }
+
+# We almost never want `stringsAsFactors = TRUE`, and `FALSE` became
+# the default in R 4.0.0. This wrapper ensures that our tests are compliant
+# with versions of R before and after this change.
+if (getRversion() < "4.0.0") {
+  data.frame <- function(..., stringsAsFactors = NULL) {
+    stringsAsFactors <- stringsAsFactors %||% FALSE
+    base::data.frame(..., stringsAsFactors = stringsAsFactors)
+  }
+}

--- a/tests/testthat/helper-types.R
+++ b/tests/testthat/helper-types.R
@@ -91,3 +91,13 @@ c_na <- function(...) {
   names(x)[names(x) == ""] <- NA_character_
   x
 }
+
+# We almost never want `stringsAsFactors = TRUE`, and `FALSE` became
+# the default in R 4.0.0. This wrapper ensures that our tests are compliant
+# with versions of R before and after this change.
+if (getRversion() < "4.0.0") {
+  data.frame <- function(..., stringsAsFactors = NULL) {
+    stringsAsFactors <- stringsAsFactors %||% FALSE
+    base::data.frame(..., stringsAsFactors = stringsAsFactors)
+  }
+}

--- a/tests/testthat/helper-types.R
+++ b/tests/testthat/helper-types.R
@@ -91,13 +91,3 @@ c_na <- function(...) {
   names(x)[names(x) == ""] <- NA_character_
   x
 }
-
-# We almost never want `stringsAsFactors = TRUE`, and `FALSE` became
-# the default in R 4.0.0. This wrapper ensures that our tests are compliant
-# with versions of R before and after this change.
-if (getRversion() < "4.0.0") {
-  data.frame <- function(..., stringsAsFactors = NULL) {
-    stringsAsFactors <- stringsAsFactors %||% FALSE
-    base::data.frame(..., stringsAsFactors = stringsAsFactors)
-  }
-}

--- a/tests/testthat/test-type-data-frame-embedded.txt
+++ b/tests/testthat/test-type-data-frame-embedded.txt
@@ -4,14 +4,14 @@ Prototype: data.frame<
   a: 
     data.frame<
       a: integer
-      b: factor<38ce1>
+      b: character
     >
   b: list_of<double>
   c: 
     list_of<
       data.frame<
         x: integer
-        y: factor<38ce1>
+        y: character
       >
     >
 >


### PR DESCRIPTION
In favor of #851 

Using @lionel-'s simpler idea in https://github.com/r-lib/vctrs/pull/851#issuecomment-590427960

On R < 4.0.0, we preemptively set `stringsAsFactors = FALSE` when it is not explicitly set. This should help us avoid any test failures in R 4.0.0 with the new `stringsAsFactor = FALSE` default