### PR TITLE
Restrict `vec_unchop()` and `vec_chop()` to positive integer locations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 
 # vctrs (development version)
 
+* `vec_chop()`'s `indices` argument has been restricted to positive integer
+  vectors. Character and logical subscripts haven't proven useful, and this
+  aligns `vec_chop()` with `vec_unchop()`, for which only positive integer
+  vectors make sense.
+
 * New `vec_unchop()` for combining a list of vectors into a single vector. It
   is similar to `vec_c()`, but gives greater control over how the elements
   are placed in the output through the use of a secondary `indices` argument.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # vctrs (development version)
 
+* New `vec_unchop()` for combining a list of vectors into a single vector. It
+  is similar to `vec_c()`, but gives greater control over how the elements
+  are placed in the output through the use of a secondary `indices` argument.
+  
 * Breaking change: When `.id` is supplied, `vec_rbind()` now creates
   the identifier column at the start of the data frame rather than at
   the end.

--- a/R/slice-chop.R
+++ b/R/slice-chop.R
@@ -98,8 +98,3 @@ vec_chop_seq <- function(x, starts, sizes, increasings = TRUE) {
   args <- vec_recycle_common(starts, sizes, increasings)
   .Call(vctrs_chop_seq, x, args[[1]], args[[2]], args[[3]])
 }
-
-# Callable from C level `vec_as_indices()` if the index is S3
-vec_as_chop_subscript <- function(index) {
-  vec_as_subscript(index, logical = "error", numeric = "cast", character = "error")
-}

--- a/R/slice-chop.R
+++ b/R/slice-chop.R
@@ -99,3 +99,7 @@ vec_chop_seq <- function(x, starts, sizes, increasings = TRUE) {
   .Call(vctrs_chop_seq, x, args[[1]], args[[2]], args[[3]])
 }
 
+# Callable from C level `vec_as_indices()` if the index is S3
+vec_as_chop_subscript <- function(index) {
+  vec_as_subscript(index, logical = "error", numeric = "cast", character = "error")
+}

--- a/R/slice-chop.R
+++ b/R/slice-chop.R
@@ -20,17 +20,15 @@
 #'
 #' @inheritParams vec_c
 #' @param x A vector
-#' @param indices For `vec_chop()`, a list of index values to slice `x` with,
-#'   or `NULL`. Each element of the list must be an integer, character or
-#'   logical vector that would be valid as an index in [vec_slice()]. If `NULL`,
-#'   `x` is split into its individual elements, equivalent to using an
-#'   `indices` of `as.list(vec_seq_along(x))`.
+#' @param indices For `vec_chop()`, a list of positive integer vectors to
+#'   slice `x` with, or `NULL`. If `NULL`, `x` is split into its individual
+#'   elements, equivalent to using an `indices` of `as.list(vec_seq_along(x))`.
 #'
-#'   For `vec_unchop()`, a list of integer vectors specifying the locations to
-#'   place elements of `x` in. Each element of `x` is recycled to the size
-#'   of the corresponding index vector. The size of `indices` must match the
-#'   size of `x`. If `NULL`, `x` is combined in the order it is provided in,
-#'   which is equivalent to using [vec_c()].
+#'   For `vec_unchop()`, a list of positive integer vectors specifying the
+#'   locations to place elements of `x` in. Each element of `x` is recycled to
+#'   the size of the corresponding index vector. The size of `indices` must
+#'   match the size of `x`. If `NULL`, `x` is combined in the order it is
+#'   provided in, which is equivalent to using [vec_c()].
 #' @param ptype If `NULL`, the default, the output type is determined by
 #'   computing the common type across all elements of `x`. Alternatively, you
 #'   can supply `ptype` to give the output a known type.

--- a/man/vec_chop.Rd
+++ b/man/vec_chop.Rd
@@ -18,17 +18,15 @@ vec_unchop(
 \arguments{
 \item{x}{A vector}
 
-\item{indices}{For \code{vec_chop()}, a list of index values to slice \code{x} with,
-or \code{NULL}. Each element of the list must be an integer, character or
-logical vector that would be valid as an index in \code{\link[=vec_slice]{vec_slice()}}. If \code{NULL},
-\code{x} is split into its individual elements, equivalent to using an
-\code{indices} of \code{as.list(vec_seq_along(x))}.
+\item{indices}{For \code{vec_chop()}, a list of positive integer vectors to
+slice \code{x} with, or \code{NULL}. If \code{NULL}, \code{x} is split into its individual
+elements, equivalent to using an \code{indices} of \code{as.list(vec_seq_along(x))}.
 
-For \code{vec_unchop()}, a list of integer vectors specifying the locations to
-place elements of \code{x} in. Each element of \code{x} is recycled to the size
-of the corresponding index vector. The size of \code{indices} must match the
-size of \code{x}. If \code{NULL}, \code{x} is combined in the order it is provided in,
-which is equivalent to using \code{\link[=vec_c]{vec_c()}}.}
+For \code{vec_unchop()}, a list of positive integer vectors specifying the
+locations to place elements of \code{x} in. Each element of \code{x} is recycled to
+the size of the corresponding index vector. The size of \code{indices} must
+match the size of \code{x}. If \code{NULL}, \code{x} is combined in the order it is
+provided in, which is equivalent to using \code{\link[=vec_c]{vec_c()}}.}
 
 \item{ptype}{If \code{NULL}, the default, the output type is determined by
 computing the common type across all elements of \code{x}. Alternatively, you

--- a/src/init.c
+++ b/src/init.c
@@ -276,7 +276,6 @@ void vctrs_init_dictionary(SEXP ns);
 void vctrs_init_names(SEXP ns);
 void vctrs_init_proxy_restore(SEXP ns);
 void vctrs_init_slice(SEXP ns);
-void vctrs_init_slice_chop(SEXP ns);
 void vctrs_init_slice_assign(SEXP ns);
 void vctrs_init_subscript(SEXP ns);
 void vctrs_init_subscript_loc(SEXP ns);
@@ -293,7 +292,6 @@ SEXP vctrs_init_library(SEXP ns) {
   vctrs_init_names(ns);
   vctrs_init_proxy_restore(ns);
   vctrs_init_slice(ns);
-  vctrs_init_slice_chop(ns);
   vctrs_init_slice_assign(ns);
   vctrs_init_subscript(ns);
   vctrs_init_subscript_loc(ns);

--- a/src/init.c
+++ b/src/init.c
@@ -276,6 +276,7 @@ void vctrs_init_dictionary(SEXP ns);
 void vctrs_init_names(SEXP ns);
 void vctrs_init_proxy_restore(SEXP ns);
 void vctrs_init_slice(SEXP ns);
+void vctrs_init_slice_chop(SEXP ns);
 void vctrs_init_slice_assign(SEXP ns);
 void vctrs_init_subscript(SEXP ns);
 void vctrs_init_subscript_loc(SEXP ns);
@@ -292,6 +293,7 @@ SEXP vctrs_init_library(SEXP ns) {
   vctrs_init_names(ns);
   vctrs_init_proxy_restore(ns);
   vctrs_init_slice(ns);
+  vctrs_init_slice_chop(ns);
   vctrs_init_slice_assign(ns);
   vctrs_init_subscript(ns);
   vctrs_init_subscript_loc(ns);

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -600,7 +600,6 @@ static SEXP vec_as_indices(SEXP indices, R_len_t n, SEXP names) {
     Rf_errorcall(R_NilValue, "`indices` must be a list of index values, or `NULL`.");
   }
 
-  SEXP index;
   indices = PROTECT(r_maybe_duplicate(indices));
 
   R_len_t size = vec_size(indices);
@@ -623,7 +622,7 @@ static SEXP vec_as_indices(SEXP indices, R_len_t n, SEXP names) {
   };
 
   for (int i = 0; i < size; ++i) {
-    index = VECTOR_ELT(indices, i);
+    SEXP index = VECTOR_ELT(indices, i);
     index = vec_as_location_opts(index, n, names, &opts, &subscript_opts);
     SET_VECTOR_ELT(indices, i, index);
   }

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -624,15 +624,7 @@ static SEXP vec_as_indices(SEXP indices, R_len_t n, SEXP names) {
 
   for (int i = 0; i < size; ++i) {
     index = VECTOR_ELT(indices, i);
-
-    switch (TYPEOF(index)) {
-    case INTSXP: break;
-    case REALSXP: break;
-    default: Rf_errorcall(R_NilValue, "All elements of `indices` must be numeric vectors.");
-    }
-
     index = vec_as_location_opts(index, n, names, &opts, &subscript_opts);
-
     SET_VECTOR_ELT(indices, i, index);
   }
 

--- a/tests/testthat/error/test-unchop.txt
+++ b/tests/testthat/error/test-unchop.txt
@@ -21,3 +21,17 @@ Error: Can't specify a prototype with non-vctrs types.
 vctrs methods must be implemented for class `vctrs_foobar`.
 See <https://vctrs.r-lib.org/articles/s3-vector.html>.
 
+
+vec_unchop() does not support non-numeric S3 indices
+====================================================
+
+> vec_unchop(list(1), list(factor("x")))
+Error: Must subset elements with a valid subscript vector.
+x The subscript has the wrong type `character`.
+i It must be numeric.
+
+> vec_unchop(list(1), list(foobar(1L)))
+Error: Must subset elements with a valid subscript vector.
+x The subscript has the wrong type `vctrs_foobar`.
+i It must be numeric.
+

--- a/tests/testthat/error/test-unchop.txt
+++ b/tests/testthat/error/test-unchop.txt
@@ -1,4 +1,17 @@
 
+vec_unchop() errors on unsupported location values
+==================================================
+
+> vec_unchop(list(1, 2), list(c(1, 2), 0))
+Error: Must subset elements with a valid subscript vector.
+x The subscript can't contain `0` values.
+i It has a `0` value at location 1.
+
+> vec_unchop(list(1), list(-1))
+Error: Must subset elements with a valid subscript vector.
+x The subscript can't contain negative locations.
+
+
 vec_unchop() falls back to c() for foreign classes
 ==================================================
 

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -142,13 +142,13 @@ test_that("vec_chop(<array>, indices =) can be equivalent to the default", {
 
 test_that("`indices` cannot use names", {
   x <- set_names(1:3, c("a", "b", "c"))
-  expect_error(vec_chop(x, list("a", c("b", "c"))), "must be numeric vectors")
+  expect_error(vec_chop(x, list("a", c("b", "c"))), class = "vctrs_error_subscript_type")
 
   x <- array(1:4, c(2, 2), dimnames = list(c("r1", "r2")))
-  expect_error(vec_chop(x, list("r1")), "must be numeric vectors")
+  expect_error(vec_chop(x, list("r1")), class = "vctrs_error_subscript_type")
 
   x <- data.frame(x = 1, row.names = "r1")
-  expect_error(vec_chop(x, list("r1")), "must be numeric vectors")
+  expect_error(vec_chop(x, list("r1")), class = "vctrs_error_subscript_type")
 })
 
 test_that("fallback method with `indices` works", {
@@ -218,8 +218,8 @@ test_that("`indices` must be a list", {
 })
 
 test_that("`indices` must be a list of integers", {
-  expect_error(vec_unchop(list(1), list("x")), "must be numeric vectors")
-  expect_error(vec_unchop(list(1), list(TRUE)), "must be numeric vectors")
+  expect_error(vec_unchop(list(1), list("x")), class = "vctrs_error_subscript_type")
+  expect_error(vec_unchop(list(1), list(TRUE)), class = "vctrs_error_subscript_type")
   expect_error(vec_unchop(list(1), list(quote(name))), class = "vctrs_error_scalar_type")
 })
 
@@ -319,8 +319,9 @@ test_that("can unchop with some size 0 elements", {
   expect_identical(vec_unchop(x, indices), 2:1)
 })
 
-test_that("NULL is not a valid index", {
-  expect_error(vec_unchop(list(1, 2), list(NULL, 1)), "must be numeric vectors")
+test_that("NULL is a valid index", {
+  expect_equal(vec_unchop(list(1, 2), list(NULL, 1)), 2)
+  expect_error(vec_unchop(list(1, 2), list(NULL, 2)), class = "vctrs_error_subscript_oob")
 })
 
 test_that("unchopping recycles elements of x to the size of the index", {

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -550,6 +550,30 @@ test_that("vec_unchop() fallback doesn't support `name_spec` or `ptype`", {
   })
 })
 
+test_that("vec_unchop() supports numeric S3 indices", {
+  local_methods(
+    vec_ptype2.vctrs_foobar = function(x, y, ...) UseMethod("vec_ptype2.vctrs_foobar", y),
+    vec_ptype2.vctrs_foobar.default = function(x, y, ...) vec_default_ptype2(x, y),
+    vec_ptype2.vctrs_foobar.integer = function(x, y, ...) foobar(integer()),
+    vec_cast.integer.vctrs_foobar = function(x, to, ...) vec_data(x)
+  )
+
+  expect_identical(vec_unchop(list(1), list(foobar(1L))), 1)
+})
+
+test_that("vec_unchop() does not support non-numeric S3 indices", {
+  verify_errors({
+    expect_error(
+      vec_unchop(list(1), list(factor("x"))),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      vec_unchop(list(1), list(foobar(1L))),
+      class = "vctrs_error_subscript_type"
+    )
+  })
+})
+
 test_that("vec_unchop() has informative error messages", {
   verify_output(test_path("error", "test-unchop.txt"), {
     "# vec_unchop() falls back to c() for foreign classes"
@@ -558,5 +582,9 @@ test_that("vec_unchop() has informative error messages", {
     "# vec_unchop() fallback doesn't support `name_spec` or `ptype`"
     vec_unchop(list(foobar(1)), name_spec = "{outer}_{inner}")
     vec_unchop(list(foobar(1)), ptype = "")
+
+    "# vec_unchop() does not support non-numeric S3 indices"
+    vec_unchop(list(1), list(factor("x")))
+    vec_unchop(list(1), list(foobar(1L)))
   })
 })

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -441,7 +441,7 @@ test_that("missing values propagate", {
 test_that("vec_unchop() falls back to c() for foreign classes", {
   verify_errors({
     expect_error(
-      vec_unchop(list(foobar(1), foobar(2)), list(2, 1)),
+      vec_unchop(list(foobar(1), foobar(2))),
       "concatenation"
     )
   })

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -417,18 +417,17 @@ test_that("name repair is respected and happens after ordering according to `ind
   expect_named(vec_unchop(x, indices, name_repair = "unique"), c("a...1", "a...2"))
 })
 
-test_that("errors on `0` locations", {
-  expect_error(
-    vec_unchop(list(1, 2), list(c(1, 2), 0)),
-    class = "vctrs_error_subscript_type"
-  )
-})
-
-test_that("errors on negative locations", {
-  expect_error(
-    vec_unchop(list(1), list(-1)),
-    class = "vctrs_error_subscript_type"
-  )
+test_that("vec_unchop() errors on unsupported location values", {
+  verify_errors({
+    expect_error(
+      vec_unchop(list(1, 2), list(c(1, 2), 0)),
+      class = "vctrs_error_subscript_type"
+    )
+    expect_error(
+      vec_unchop(list(1), list(-1)),
+      class = "vctrs_error_subscript_type"
+    )
+  })
 })
 
 test_that("missing values propagate", {
@@ -576,6 +575,10 @@ test_that("vec_unchop() does not support non-numeric S3 indices", {
 
 test_that("vec_unchop() has informative error messages", {
   verify_output(test_path("error", "test-unchop.txt"), {
+    "# vec_unchop() errors on unsupported location values"
+    vec_unchop(list(1, 2), list(c(1, 2), 0))
+    vec_unchop(list(1), list(-1))
+
     "# vec_unchop() falls back to c() for foreign classes"
     vec_unchop(list(foobar(1), foobar(2)))
 


### PR DESCRIPTION
Closes #846 

As discussed at https://github.com/r-lib/vctrs/pull/834#issuecomment-589435201, since `vec_unchop()`'s `indices` argument is all about placing elements of `x` in specified _locations_, it doesn't make sense to allow character/logical subscripts in that function. To align `vec_chop()` with `vec_unchop()`, I've restricted `vec_chop()` to only allow positive integer locations as well. `vec_unchop()` could technically allow character and logical, but it doesn't feel useful.

`NA_integer_` is still a valid location.

In the next PR I will rename `indices` to `locations`