### PR TITLE
Fix multiple-definition error with GCC 10.

### DIFF
--- a/src/altrep-rle.c
+++ b/src/altrep-rle.c
@@ -16,6 +16,8 @@ SEXP altrep_rle_Make(SEXP input) {
 
 #else
 
+static R_altrep_class_t altrep_rle_class;
+
 SEXP altrep_rle_Make(SEXP input) {
 
   SEXP res = R_new_altrep(altrep_rle_class, input, R_NilValue);

--- a/src/altrep-rle.h
+++ b/src/altrep-rle.h
@@ -20,8 +20,6 @@ void* altrep_rle_Dataptr(SEXP vec, Rboolean writeable);
 const void* altrep_rle_Dataptr_or_null(SEXP vec);
 void vctrs_init_altrep_rle(DllInfo* dll);
 
-R_altrep_class_t altrep_rle_class;
-
 #endif
 
 #endif


### PR DESCRIPTION
This variable is only used in one file, so it really should have remained `static`. To fix the unused-variable warning, it should be moved from the header to the source file.