### PR TITLE
Move fallback handling into `vec_assign_impl()`

### DIFF
--- a/inst/include/vctrs.c
+++ b/inst/include/vctrs.c
@@ -2,7 +2,7 @@
 
 SEXP (*vec_proxy)(SEXP) = NULL;
 SEXP (*vec_restore)(SEXP, SEXP, SEXP) = NULL;
-SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP) = NULL;
+SEXP (*vec_proxy_assign)(SEXP, SEXP, SEXP) = NULL;
 SEXP (*vec_slice_impl)(SEXP, SEXP) = NULL;
 SEXP (*vec_names)(SEXP) = NULL;
 SEXP (*vec_set_names)(SEXP, SEXP) = NULL;
@@ -11,7 +11,7 @@ SEXP (*vec_chop)(SEXP, SEXP) = NULL;
 void vctrs_init_api() {
   vec_proxy = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_proxy");
   vec_restore = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vec_restore");
-  vec_assign_impl = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vec_assign_impl");
+  vec_proxy_assign = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "vec_proxy_assign");
   vec_slice_impl = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_slice_impl");
   vec_names = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "vec_names");
   vec_set_names = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "vec_set_names");

--- a/inst/include/vctrs.h
+++ b/inst/include/vctrs.h
@@ -7,7 +7,7 @@
 
 extern SEXP (*vec_proxy)(SEXP);
 extern SEXP (*vec_restore)(SEXP, SEXP, SEXP);
-extern SEXP (*vec_assign_impl)(SEXP, SEXP, SEXP);
+extern SEXP (*vec_proxy_assign)(SEXP, SEXP, SEXP);
 extern SEXP (*vec_slice_impl)(SEXP, SEXP);
 extern SEXP (*vec_names)(SEXP);
 extern SEXP (*vec_set_names)(SEXP, SEXP);

--- a/src/c.c
+++ b/src/c.c
@@ -97,7 +97,7 @@ SEXP vec_c(SEXP xs,
       SEXP inner = PROTECT(vec_names(x));
       SEXP x_nms = PROTECT(apply_name_spec(name_spec, outer, inner, size));
       if (x_nms != R_NilValue) {
-        out_names = vec_assign_impl(out_names, idx, x_nms);
+        out_names = chr_assign(out_names, idx, x_nms);
         REPROTECT(out_names, out_names_pi);
       }
       UNPROTECT(2);

--- a/src/c.c
+++ b/src/c.c
@@ -5,7 +5,7 @@
 SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype);
 
 // From slice-assign.c
-SEXP vec_assign_impl(SEXP proxy, SEXP index, SEXP value);
+SEXP vec_proxy_assign(SEXP proxy, SEXP index, SEXP value);
 
 
 // [[ register(external = TRUE) ]]
@@ -89,7 +89,7 @@ SEXP vec_c(SEXP xs,
 
     init_compact_seq(idx_ptr, counter, size, true);
 
-    out = vec_assign_impl(out, idx, elt);
+    out = vec_proxy_assign(out, idx, elt);
     REPROTECT(out, out_pi);
 
     if (has_names) {

--- a/src/c.c
+++ b/src/c.c
@@ -74,8 +74,6 @@ SEXP vec_c(SEXP xs,
   SEXP out_names = has_names ? Rf_allocVector(STRSXP, out_size) : R_NilValue;
   PROTECT_WITH_INDEX(out_names, &out_names_pi);
 
-  bool is_shaped = has_dim(ptype);
-
   // Compact sequences use 0-based counters
   R_len_t counter = 0;
 
@@ -91,15 +89,8 @@ SEXP vec_c(SEXP xs,
 
     init_compact_seq(idx_ptr, counter, size, true);
 
-    if (is_shaped) {
-      SEXP idx = PROTECT(r_seq(counter + 1, counter + size + 1));
-      out = vec_assign(out, idx, elt);
-      REPROTECT(out, out_pi);
-      UNPROTECT(1);
-    } else {
-      out = vec_assign_impl(out, idx, elt);
-      REPROTECT(out, out_pi);
-    }
+    out = vec_assign_impl(out, idx, elt);
+    REPROTECT(out, out_pi);
 
     if (has_names) {
       SEXP outer = xs_names == R_NilValue ? R_NilValue : STRING_ELT(xs_names, i);

--- a/src/init.c
+++ b/src/init.c
@@ -103,7 +103,7 @@ extern SEXP vctrs_equal_scalar(SEXP, SEXP, SEXP, SEXP, SEXP);
 // Available in the API header
 extern R_len_t vec_size(SEXP);
 extern SEXP vec_init(SEXP, R_len_t);
-extern SEXP vec_assign_impl(SEXP, SEXP, SEXP);
+extern SEXP vec_proxy_assign(SEXP, SEXP, SEXP);
 extern SEXP vec_slice_impl(SEXP, SEXP);
 extern SEXP vec_names(SEXP);
 extern SEXP vec_recycle(SEXP, R_len_t, struct vctrs_arg*);
@@ -245,7 +245,7 @@ export void R_init_vctrs(DllInfo *dll)
     // Very experimental
     R_RegisterCCallable("vctrs", "vec_proxy", (DL_FUNC) &vec_proxy);
     R_RegisterCCallable("vctrs", "vec_restore", (DL_FUNC) &vec_restore);
-    R_RegisterCCallable("vctrs", "vec_assign_impl", (DL_FUNC) &vec_assign_impl);
+    R_RegisterCCallable("vctrs", "vec_proxy_assign", (DL_FUNC) &vec_proxy_assign);
     R_RegisterCCallable("vctrs", "vec_slice_impl", (DL_FUNC) &vec_slice_impl);
     R_RegisterCCallable("vctrs", "vec_names", (DL_FUNC) &vec_names);
     R_RegisterCCallable("vctrs", "vec_set_names", (DL_FUNC) &vec_set_names);

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -483,8 +483,6 @@ static SEXP vec_unchop(SEXP x,
 
   indices = PROTECT(vec_as_indices(indices, out_size, R_NilValue));
 
-  const bool is_shaped = has_dim(ptype);
-
   PROTECT_INDEX proxy_pi;
   SEXP proxy = vec_proxy(ptype);
   PROTECT_WITH_INDEX(proxy, &proxy_pi);
@@ -507,13 +505,8 @@ static SEXP vec_unchop(SEXP x,
 
     SEXP index = VECTOR_ELT(indices, i);
 
-    if (is_shaped) {
-      proxy = vec_assign(proxy, index, elt);
-      REPROTECT(proxy, proxy_pi);
-    } else {
-      proxy = vec_assign_impl(proxy, index, elt);
-      REPROTECT(proxy, proxy_pi);
-    }
+    proxy = vec_assign_impl(proxy, index, elt);
+    REPROTECT(proxy, proxy_pi);
 
     if (has_names) {
       R_len_t size = p_sizes[i];

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -386,7 +386,7 @@ static SEXP chop_fallback_shaped(SEXP x, SEXP indices, struct vctrs_chop_info in
 SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype);
 
 // From slice-assign.c
-SEXP vec_assign_impl(SEXP proxy, SEXP index, SEXP value);
+SEXP vec_proxy_assign(SEXP proxy, SEXP index, SEXP value);
 
 static SEXP vec_unchop(SEXP x,
                        SEXP indices,
@@ -505,7 +505,7 @@ static SEXP vec_unchop(SEXP x,
 
     SEXP index = VECTOR_ELT(indices, i);
 
-    proxy = vec_assign_impl(proxy, index, elt);
+    proxy = vec_proxy_assign(proxy, index, elt);
     REPROTECT(proxy, proxy_pi);
 
     if (has_names) {

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -514,7 +514,7 @@ static SEXP vec_unchop(SEXP x,
       SEXP inner = PROTECT(vec_names(elt));
       SEXP elt_names = PROTECT(apply_name_spec(name_spec, outer, inner, size));
       if (elt_names != R_NilValue) {
-        out_names = vec_assign_impl(out_names, index, elt_names);
+        out_names = chr_assign(out_names, index, elt_names);
         REPROTECT(out_names, out_names_pi);
       }
       UNPROTECT(2);

--- a/src/utils-dispatch.c
+++ b/src/utils-dispatch.c
@@ -30,6 +30,13 @@ enum vctrs_class_type class_type(SEXP x) {
   }
 
   SEXP class = PROTECT(Rf_getAttrib(x, R_ClassSymbol));
+
+  // Avoid corrupt objects where `x` is an OBJECT(), but the class is NULL
+  if (class == R_NilValue) {
+    UNPROTECT(1);
+    return vctrs_class_none;
+  }
+
   enum vctrs_class_type type = class_type_impl(class);
 
   UNPROTECT(1);

--- a/src/utils.c
+++ b/src/utils.c
@@ -336,6 +336,13 @@ SEXP s3_find_method(const char* generic, SEXP x, SEXP table) {
   }
 
   SEXP class = PROTECT(Rf_getAttrib(x, R_ClassSymbol));
+
+  // Avoid corrupt objects where `x` is an OBJECT(), but the class is NULL
+  if (class == R_NilValue) {
+    UNPROTECT(1);
+    return R_NilValue;
+  }
+
   SEXP* class_ptr = STRING_PTR(class);
   int n_class = Rf_length(class);
 

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -500,3 +500,8 @@ test_that("cbind() deals with row names", {
     "different row names"
   )
 })
+
+test_that("can rbind data frames with matrix columns (#625)", {
+  df <- tibble(x = 1:2, y = matrix(1:4, nrow = 2))
+  expect_identical(vec_rbind(df, df), vec_slice(df, c(1, 2, 1, 2)))
+})

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -337,6 +337,17 @@ test_that("can assign to data frame", {
   expect_identical(vec_assign(x, 2, y), data_frame(x = int(1, 20, 3)))
 })
 
+test_that("assigning to a factor doesn't produce corrupt levels (#853)", {
+  x <- factor(c("a", NA), levels = c("a", "b"))
+  value <- factor("b", levels = "b")
+
+  res <- vec_assign(x, 2, value)
+  expect_identical(res, factor(c("a", "b")))
+
+  res <- vec_assign(x, 1:2, value)
+  expect_identical(res, factor(c("b", "b"), levels = c("a", "b")))
+})
+
 test_that("can slice-assign unspecified vectors with default type2 method", {
   local_rational_class()
   x <- rational(1:2, 2:3)

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -288,12 +288,12 @@ test_that("slice-assign falls back to `[<-` when proxy is not implemented", {
     },
     vec_ptype2.logical.vctrs_foobar = function(...) foobar(""),
     vec_ptype2.vctrs_foobar = function(...) foobar(""),
-    vec_cast.vctrs_foobar = function(x, to, ...) x
+    vec_cast.vctrs_foobar = function(x, to, ...) foobar(rep("", length(x)))
   )
 
   obj <- foobar(c("foo", "bar", "baz"))
   vec_slice(obj, 1:2) <- TRUE
-  expect_identical(obj, c("dispatched", "dispatched", "baz"))
+  expect_identical(obj, foobar(c("dispatched", "dispatched", "baz")))
 })
 
 test_that("vec_assign() can always assign unspecified values into foreign vector types", {
@@ -304,17 +304,16 @@ test_that("vec_assign() can always assign unspecified values into foreign vector
   expect_identical(vec_assign(obj, 1, unspecified(1)), expect)
 })
 
-test_that("slice-assign restores value before falling back to `[<-` (#443)", {
+test_that("slice-assign casts to `to` before falling back to `[<-` (#443)", {
   called <- FALSE
 
   local_methods(
     vec_proxy.vctrs_proxy = proxy_deref,
-    vec_restore.vctrs_proxy = function(x, to, ...) new_proxy(x),
     vec_ptype2.vctrs_proxy = function(...) new_proxy(NA),
-    vec_cast.vctrs_foobar = function(x, ...) proxy_deref(x),
+    vec_cast.vctrs_foobar = function(x, ...) foobar(proxy_deref(x)),
     `[<-.vctrs_foobar` = function(x, i, value) {
       called <<- TRUE
-      expect_is(value, "vctrs_proxy")
+      expect_identical(value, foobar(10))
     }
   )
 

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -337,6 +337,11 @@ test_that("can assign to data frame", {
   expect_identical(vec_assign(x, 2, y), data_frame(x = int(1, 20, 3)))
 })
 
+test_that("can assign to a data frame with matrix columns (#625)", {
+  df <- tibble(x = 1:2, y = matrix(1:4, nrow = 2))
+  expect_identical(vec_assign(df, 2L, df[1,]), vec_slice(df, c(1, 1)))
+})
+
 test_that("assigning to a factor doesn't produce corrupt levels (#853)", {
   x <- factor(c("a", NA), levels = c("a", "b"))
   value <- factor("b", levels = "b")

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -171,6 +171,8 @@ test_that("vec_ptype() handles class-less yet OBJECT gremlins", {
   gremlin <- stats::model.frame(freeny)
   expect_error(vec_ptype(gremlin), NA)
   expect_error(vec_c(gremlin), NA)
+  expect_error(vec_init(gremlin), NA)
+  expect_error(vec_slice(gremlin, 1), NA)
 })
 
 test_that("explicit list subclasses are vectors", {


### PR DESCRIPTION
Closes #853 
Closes #625 
Closes tidyverse/tidyr#788
Solves (partially) DavisVaughan/slider#2, will be completely solved with additional slider work on my end

This PR moves the fallback handling of `vec_assign()` into `vec_assign_impl()`. The separation is:

-  The caller of `vec_assign_impl()` handles
   - Coercible casting of `value`. If you already know the type is correct you don't have to cast.
   - Recycling `value`. Same reasoning as above.
   - Proxying and restoring the output container, so it is only done once. (Useful for things like `vec_c()`)

- `vec_assign_impl()` handles:
   - proxy-ing `value`. Required to be able to fallback using the non-proxied `value`
   - Handling fallback behavior

This PR also fixes a few bugs that came up with the awful corrupt objects that are `OBJECT()`s but don't have a class.

The one drawback here is that `vec_assign()` now calls `vec_recycle()` on the un-proxied `value`, then hands off to `vec_assign_impl()`, which proxies and might allocate. This is slightly less efficient than proxying first, then recycling, but I can live with this tradeoff to have a clear separation of responsibility.

The other change here is that we now `vec_restore()` after calling the fallback to `[<-`. I feel like this is the correct thing to do, and probably won't hurt, but it did require a tweak to a test that "expected" the object to not be restored.