### PR TITLE
Implement `vec_is_coercible()` in C

### DIFF
--- a/R/type2.R
+++ b/R/type2.R
@@ -73,14 +73,11 @@ vec_typeof2_s3 <- function(x, y) {
 }
 
 # https://github.com/r-lib/vctrs/issues/571
-vec_is_coercible <- function(x, to, ..., x_arg = "x", to_arg = "to") {
-  tryCatch(
-    vctrs_error_incompatible_type = function(...) FALSE,
-    {
-      vctrs::vec_ptype2(x, to, ..., x_arg = x_arg, y_arg = to_arg)
-      TRUE
-    }
-  )
+vec_is_coercible <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+  if (!missing(...)) {
+    ellipsis::check_dots_empty()
+  }
+  .Call(vctrs_is_coercible, x, y, x_arg, y_arg)
 }
 
 vec_is_subtype <- function(x, super, ..., x_arg = "x", super_arg = "super") {

--- a/R/utils.R
+++ b/R/utils.R
@@ -141,3 +141,15 @@ data.frame <- function(..., stringsAsFactors = NULL) {
   stringsAsFactors <- stringsAsFactors %||% FALSE
   base::data.frame(..., stringsAsFactors = stringsAsFactors)
 }
+
+try_catch_hnd <- function(data) {
+  function(cnd) {
+    .Call(vctrs_try_catch_callback, data, cnd)
+  }
+}
+try_catch_impl <- function(data, ...) {
+  tryCatch(
+    .Call(vctrs_try_catch_callback, data, NULL),
+    ...
+  )
+}

--- a/src/init.c
+++ b/src/init.c
@@ -91,6 +91,7 @@ extern SEXP vctrs_as_names(SEXP, SEXP, SEXP);
 extern SEXP vctrs_is_partial(SEXP);
 extern SEXP vctrs_is_list(SEXP);
 extern SEXP vctrs_try_catch_callback(SEXP, SEXP);
+extern SEXP vctrs_is_coercible(SEXP, SEXP, SEXP, SEXP);
 
 // Very experimental
 // Available in the API header
@@ -200,6 +201,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_is_partial",                 (DL_FUNC) &vctrs_is_partial, 1},
   {"vctrs_is_list",                    (DL_FUNC) &vctrs_is_list, 1},
   {"vctrs_try_catch_callback",         (DL_FUNC) &vctrs_try_catch_callback, 2},
+  {"vctrs_is_coercible",               (DL_FUNC) &vctrs_is_coercible, 4},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -90,6 +90,7 @@ extern SEXP vctrs_validate_minimal_names(SEXP, SEXP);
 extern SEXP vctrs_as_names(SEXP, SEXP, SEXP);
 extern SEXP vctrs_is_partial(SEXP);
 extern SEXP vctrs_is_list(SEXP);
+extern SEXP vctrs_try_catch_callback(SEXP, SEXP);
 
 // Very experimental
 // Available in the API header
@@ -198,6 +199,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_as_names",                   (DL_FUNC) &vctrs_as_names, 3},
   {"vctrs_is_partial",                 (DL_FUNC) &vctrs_is_partial, 1},
   {"vctrs_is_list",                    (DL_FUNC) &vctrs_is_list, 1},
+  {"vctrs_try_catch_callback",         (DL_FUNC) &vctrs_try_catch_callback, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1291,6 +1291,7 @@ SEXP syms_subscript_type = NULL;
 SEXP syms_repair = NULL;
 SEXP syms_tzone = NULL;
 SEXP syms_data = NULL;
+SEXP syms_vctrs_error_incompatible_type = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -1547,6 +1548,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_data = Rf_install("data");
   syms_try_catch_impl = Rf_install("try_catch_impl");
   syms_try_catch_hnd = Rf_install("try_catch_hnd");
+  syms_vctrs_error_incompatible_type = Rf_install("vctrs_error_incompatible_type");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1160,7 +1160,7 @@ struct r_try_catch_data {
   void (*hnd)(void*);
   void* hnd_data;
 
-  bool err;
+  ERR err;
 };
 
 // [[ register() ]]
@@ -1168,12 +1168,11 @@ SEXP vctrs_try_catch_callback(SEXP ptr, SEXP cnd) {
   struct r_try_catch_data* data = (struct r_try_catch_data*) R_ExternalPtrAddr(ptr);
 
   if (cnd == R_NilValue) {
-    data->err = false;
     if (data->fn) {
       data->fn(data->fn_data);
     }
   } else {
-    data->err = true;
+    data->err = cnd;
     if (data->hnd) {
       data->hnd(data->hnd_data);
     }
@@ -1185,11 +1184,11 @@ SEXP vctrs_try_catch_callback(SEXP ptr, SEXP cnd) {
 static SEXP syms_try_catch_impl = NULL;
 
 // [[ include("utils.h") ]]
-bool r_try_catch(void (*fn)(void*),
-                 void* fn_data,
-                 SEXP cnd_sym,
-                 void (*hnd)(void*),
-                 void* hnd_data) {
+ERR r_try_catch(void (*fn)(void*),
+                void* fn_data,
+                SEXP cnd_sym,
+                void (*hnd)(void*),
+                void* hnd_data) {
 
   struct r_try_catch_data data = {
     .fn = fn,
@@ -1197,7 +1196,7 @@ bool r_try_catch(void (*fn)(void*),
     .cnd_sym = cnd_sym,
     .hnd = hnd,
     .hnd_data = hnd_data,
-    .err = false
+    .err = NULL
   };
   SEXP xptr = PROTECT(R_MakeExternalPtr(&data, R_NilValue, R_NilValue));
   SEXP hnd_fn = PROTECT(try_catch_hnd(xptr));

--- a/src/utils.c
+++ b/src/utils.c
@@ -1143,6 +1143,83 @@ SEXP r_as_function(SEXP x, const char* arg) {
   }
 }
 
+static SEXP syms_try_catch_hnd = NULL;
+static inline SEXP try_catch_hnd(SEXP ptr) {
+  SEXP call = PROTECT(Rf_lang2(syms_try_catch_hnd, ptr));
+  SEXP out = Rf_eval(call, vctrs_ns_env);
+  UNPROTECT(1);
+  return out;
+}
+
+struct r_try_catch_data {
+  void (*fn)(void*);
+  void* fn_data;
+
+  SEXP cnd_sym;
+
+  void (*hnd)(void*);
+  void* hnd_data;
+
+  bool err;
+};
+
+// [[ register() ]]
+SEXP vctrs_try_catch_callback(SEXP ptr, SEXP cnd) {
+  struct r_try_catch_data* data = (struct r_try_catch_data*) R_ExternalPtrAddr(ptr);
+
+  if (cnd == R_NilValue) {
+    data->err = false;
+    if (data->fn) {
+      data->fn(data->fn_data);
+    }
+  } else {
+    data->err = true;
+    if (data->hnd) {
+      data->hnd(data->hnd_data);
+    }
+  }
+
+  return R_NilValue;
+}
+
+static SEXP syms_try_catch_impl = NULL;
+
+// [[ include("utils.h") ]]
+bool r_try_catch(void (*fn)(void*),
+                 void* fn_data,
+                 SEXP cnd_sym,
+                 void (*hnd)(void*),
+                 void* hnd_data) {
+
+  struct r_try_catch_data data = {
+    .fn = fn,
+    .fn_data = fn_data,
+    .cnd_sym = cnd_sym,
+    .hnd = hnd,
+    .hnd_data = hnd_data,
+    .err = false
+  };
+  SEXP xptr = PROTECT(R_MakeExternalPtr(&data, R_NilValue, R_NilValue));
+  SEXP hnd_fn = PROTECT(try_catch_hnd(xptr));
+
+  SEXP syms[3] = {
+    syms_data,
+    cnd_sym,
+    NULL
+  };
+  SEXP args[3] = {
+    xptr,
+    hnd_fn,
+    NULL
+  };
+
+  SEXP call = PROTECT(r_call(syms_try_catch_impl, syms, args));
+  Rf_eval(call, vctrs_ns_env);
+
+  UNPROTECT(3);
+  return data.err;
+}
+
 
 SEXP vctrs_ns_env = NULL;
 SEXP vctrs_shared_empty_str = NULL;
@@ -1213,6 +1290,7 @@ SEXP syms_subscript_action = NULL;
 SEXP syms_subscript_type = NULL;
 SEXP syms_repair = NULL;
 SEXP syms_tzone = NULL;
+SEXP syms_data = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -1466,6 +1544,9 @@ void vctrs_init_utils(SEXP ns) {
   syms_subscript_type = Rf_install("subscript_type");
   syms_repair = Rf_install("repair");
   syms_tzone = Rf_install("tzone");
+  syms_data = Rf_install("data");
+  syms_try_catch_impl = Rf_install("try_catch_impl");
+  syms_try_catch_hnd = Rf_install("try_catch_hnd");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.h
+++ b/src/utils.h
@@ -253,11 +253,11 @@ static inline void r_dbg_save(SEXP x, const char* name) {
   Rf_defineVar(Rf_install(name), x, R_GlobalEnv);
 }
 
-bool r_try_catch(void (*fn)(void*),
-                 void* fn_data,
-                 SEXP cnd_sym,
-                 void (*hnd)(void*),
-                 void* hnd_data);
+ERR r_try_catch(void (*fn)(void*),
+                void* fn_data,
+                SEXP cnd_sym,
+                void (*hnd)(void*),
+                void* hnd_data);
 
 
 extern SEXP vctrs_ns_env;

--- a/src/utils.h
+++ b/src/utils.h
@@ -338,6 +338,7 @@ extern SEXP syms_subscript_type;
 extern SEXP syms_repair;
 extern SEXP syms_tzone;
 extern SEXP syms_data;
+extern SEXP syms_vctrs_error_incompatible_type;
 
 #define syms_names R_NamesSymbol
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -253,6 +253,12 @@ static inline void r_dbg_save(SEXP x, const char* name) {
   Rf_defineVar(Rf_install(name), x, R_GlobalEnv);
 }
 
+bool r_try_catch(void (*fn)(void*),
+                 void* fn_data,
+                 SEXP cnd_sym,
+                 void (*hnd)(void*),
+                 void* hnd_data);
+
 
 extern SEXP vctrs_ns_env;
 extern SEXP vctrs_shared_empty_str;
@@ -331,6 +337,7 @@ extern SEXP syms_subscript_action;
 extern SEXP syms_subscript_type;
 extern SEXP syms_repair;
 extern SEXP syms_tzone;
+extern SEXP syms_data;
 
 #define syms_names R_NamesSymbol
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -356,6 +356,7 @@ R_len_t vec_bare_dim_n(SEXP x);
 SEXP vec_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_cast_common(SEXP xs, SEXP to);
 SEXP vec_coercible_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
+bool vec_is_coercible(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg, int* dir);
 SEXP vec_slice(SEXP x, SEXP index);
 SEXP vec_chop(SEXP x, SEXP indices);
 SEXP vec_slice_shaped(enum vctrs_type type, SEXP x, SEXP index);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -10,6 +10,10 @@ typedef R_xlen_t r_ssize_t;
 
 #define VCTRS_ASSERT(condition) ((void)sizeof(char[1 - 2*!(condition)]))
 
+// An ERR indicates either a C NULL in case of no error, or a
+// condition object otherwise
+#define ERR SEXP
+
 
 // Vector types -------------------------------------------------
 


### PR DESCRIPTION
Adds `r_try_catch()` to the internal API. It is inspired by the R API function `R_tryCatch()` and has the advantage of being available in all R versions with the same implementation (`R_tryCatch()` is buggy or non-available in older Rs).

```c
ERR r_try_catch(void (*fn)(void*),
                void* fn_data,
                SEXP cnd_sym,
                void (*hnd)(void*),
                void* hnd_data);
```

* It takes callbacks and data for the normal and catch case, and a symbol of the handled condition class.

* It returns `ERR`, which is a simple alias to `SEXP`. The goal of this alias is to indicate a NULL-able `SEXP`. The C NULL is easier to work with for error handling and is made use of in an upcoming PR.

`vec_is_coercible()` is implemented with `r_try_catch()` and now available in the C API as well. Its performance is slightly improved in the normal path:

```r
bench::mark(
  r = vec_is_coercible_old(1, 1L),
  c = vec_is_coercible(1, 1L)
)
#> # A tibble: 2 x 13
#>   expression     min  median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result
#>   <bch:expr> <bch:t> <bch:t>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>
#> 1 r          14.11µs 17.23µs    54937.        0B     16.5  9997     3      182ms <lgl …
#> 2 c           7.93µs  9.72µs    98114.        0B     19.6  9998     2      102ms <lgl …
```

The error path is still very slow but that's mostly because we haven't switched to lazy errors yet:

```r
# All the time is spent in `stop_incompatible()`
bench::mark(
  r = vec_is_coercible_old(1, ""),
  c = vec_is_coercible(1, "")
)
#> # A tibble: 2 x 13
#>   expression    min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result
#>   <bch:expr> <bch:> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>
#> 1 r          1.86ms 2.22ms      442.    3.77KB     37.3   178    15      402ms <lgl …
#> 2 c          1.85ms 2.19ms      448.    3.77KB     36.7   183    15      409ms <lgl …
#> # … with 3 more variables: memory <list>, time <list>, gc <list>
```