### PR TITLE
Call `vec_as_subscript()` from `vec_as_location()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,11 @@
 * `numeric_version` and `package_version` lists are now treated as
   vectors (#723).
 
+* `vec_slice()` now properly handles symbols and S3 subscripts.
+
+* `vec_as_location()` and `vec_as_subscript()` are now fully
+  implemented in C for efficiency.
+
 * `num_as_location()` gains a new argument, `zero`, for controlling whether
   to `"remove"`, `"ignore"`, or `"error"` on zero values (#852).
 

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -61,7 +61,6 @@ vec_as_location <- function(i,
                             arg = NULL) {
   if (!missing(...)) ellipsis::check_dots_empty()
 
-  i <- vec_as_subscript(i, arg = arg)
   .Call(
     vctrs_as_location,
     i = i,

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -40,7 +40,8 @@ SEXP vec_assign(SEXP x, SEXP index, SEXP value) {
   index = PROTECT(vec_as_location_opts(index,
                                        vec_size(x),
                                        PROTECT(vec_names(x)),
-                                       vec_as_location_default_assign_opts));
+                                       vec_as_location_default_assign_opts,
+                                       NULL));
   value_proxy = PROTECT(vec_recycle(value_proxy, vec_size(index), &value_arg));
 
   struct vctrs_proxy_info info = vec_proxy_info(x);

--- a/src/subscript-loc.h
+++ b/src/subscript-loc.h
@@ -38,7 +38,7 @@ struct vec_as_location_opts {
   enum num_as_location_loc_oob loc_oob;
   enum num_as_location_loc_zero loc_zero;
   enum subscript_missing missing;
-  SEXP subscript_arg;
+  struct vctrs_arg* subscript_arg;
 };
 
 extern struct vec_as_location_opts vec_as_location_default_opts_obj;

--- a/src/subscript-loc.h
+++ b/src/subscript-loc.h
@@ -2,6 +2,7 @@
 #define VCTRS_SUBSCRIPT_LOC_H
 
 #include "utils.h"
+#include "subscript.h"
 
 
 enum subscript_action {
@@ -49,8 +50,9 @@ static const struct vec_as_location_opts* const vec_as_location_default_assign_o
 
 
 SEXP vec_as_location(SEXP i, R_len_t n, SEXP names);
-SEXP vec_as_location_opts(SEXP i, R_len_t n, SEXP names,
-                          const struct vec_as_location_opts* opts);
+SEXP vec_as_location_opts(SEXP subscript, R_len_t n, SEXP names,
+                          const struct vec_as_location_opts* location_opts,
+                          const struct vec_as_subscript_opts* subscript_opts);
 
 static inline SEXP get_opts_action(const struct vec_as_location_opts* opts) {
   switch (opts->action) {

--- a/src/subscript.c
+++ b/src/subscript.c
@@ -2,20 +2,22 @@
 #include "subscript.h"
 #include "utils.h"
 
-static SEXP new_error_subscript_type(SEXP subscript, struct vec_as_subscript_opts* opts,
-                                     SEXP body, SEXP parent);
+static SEXP new_error_subscript_type(SEXP subscript,
+                                     const struct vec_as_subscript_opts* opts,
+                                     SEXP body,
+                                     SEXP parent);
 static enum subscript_type_action parse_subscript_arg_type(SEXP x, const char* kind);
 
 static SEXP obj_cast_subscript(SEXP subscript,
-                               struct vec_as_subscript_opts* opts,
+                               const struct vec_as_subscript_opts* opts,
                                ERR* err);
 static SEXP dbl_cast_subscript(SEXP subscript,
-                               struct vec_as_subscript_opts* opts,
+                               const struct vec_as_subscript_opts* opts,
                                ERR* err);
 
 
 SEXP vec_as_subscript_opts(SEXP subscript,
-                           struct vec_as_subscript_opts* opts,
+                           const struct vec_as_subscript_opts* opts,
                            ERR* err) {
   PROTECT_INDEX subscript_pi;
   PROTECT_WITH_INDEX(subscript, &subscript_pi);
@@ -92,7 +94,7 @@ SEXP vec_as_subscript_opts(SEXP subscript,
 }
 
 static SEXP obj_cast_subscript(SEXP subscript,
-                               struct vec_as_subscript_opts* opts,
+                               const struct vec_as_subscript_opts* opts,
                                ERR* err) {
   int dir = 0;
   struct vctrs_arg* arg = opts->subscript_arg;
@@ -118,7 +120,7 @@ static SEXP obj_cast_subscript(SEXP subscript,
 
 static SEXP dbl_cast_subscript_body = NULL;
 static SEXP dbl_cast_subscript(SEXP subscript,
-                               struct vec_as_subscript_opts* opts,
+                               const struct vec_as_subscript_opts* opts,
                                ERR* err) {
   SEXP out = PROTECT(vec_coercible_cast_e(subscript,
                                           vctrs_shared_empty_int,
@@ -214,8 +216,10 @@ static enum subscript_type_action parse_subscript_arg_type(SEXP x, const char* k
 
 static SEXP syms_new_error_subscript_type = NULL;
 
-static SEXP new_error_subscript_type(SEXP subscript, struct vec_as_subscript_opts* opts,
-                                     SEXP body, SEXP parent) {
+static SEXP new_error_subscript_type(SEXP subscript,
+                                     const struct vec_as_subscript_opts* opts,
+                                     SEXP body,
+                                     SEXP parent) {
   SEXP logical = subscript_type_action_chr(opts->logical);
   SEXP numeric = subscript_type_action_chr(opts->numeric);
   SEXP character = subscript_type_action_chr(opts->character);

--- a/src/subscript.h
+++ b/src/subscript.h
@@ -16,6 +16,10 @@ struct vec_as_subscript_opts {
   struct vctrs_arg* subscript_arg;
 };
 
+SEXP vec_as_subscript_opts(SEXP subscript,
+                           struct vec_as_subscript_opts* opts,
+                           ERR* err);
+
 static inline SEXP subscript_type_action_chr(enum subscript_type_action action) {
   switch (action) {
   case SUBSCRIPT_TYPE_ACTION_CAST: return chrs_cast;

--- a/src/subscript.h
+++ b/src/subscript.h
@@ -17,7 +17,7 @@ struct vec_as_subscript_opts {
 };
 
 SEXP vec_as_subscript_opts(SEXP subscript,
-                           struct vec_as_subscript_opts* opts,
+                           const struct vec_as_subscript_opts* opts,
                            ERR* err);
 
 static inline SEXP subscript_type_action_chr(enum subscript_type_action action) {

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -100,7 +100,7 @@ test_that("vec_chop() falls back to `[` for shaped objects with no proxy", {
 
 test_that("`indices` are validated", {
   expect_error(vec_chop(1, 1), "`indices` must be a list of index values, or `NULL`")
-  expect_error(vec_chop(1, list(1.5)), class = "vctrs_error_cast_lossy")
+  expect_error(vec_chop(1, list(1.5)), class = "vctrs_error_subscript_type")
   expect_error(vec_chop(1, list(2)), class = "vctrs_error_subscript_oob")
 })
 

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -4,7 +4,7 @@ test_that("vec_slice throws error with non-vector inputs", {
 })
 
 test_that("vec_slice throws error with non-vector subscripts", {
-  expect_error(vec_slice(1:3, Sys.Date()), class = "vctrs_error_incompatible_cast")
+  expect_error(vec_slice(1:3, Sys.Date()), class = "vctrs_error_subscript_type")
   expect_error(vec_slice(1:3, matrix(TRUE, nrow = 1)), "must have one dimension")
 })
 
@@ -639,3 +639,8 @@ test_that("vec_slice() with compact_seqs work with Altrep classes", {
   expect_equal(vec_slice_seq(x, 1L, 3L), c("foo", "bar", "bar"))
 })
 
+test_that("vec_slice() handles symbols and OO objects", {
+  expect_identical(vec_slice(c(a = 1, b = 2), quote(b)), c(b = 2))
+  expect_identical(vec_slice(c(a = 1, b = 2), factor("b")), c(b = 2))
+  expect_error(vec_slice(c(a = 1, b = 2), foobar("b")), class = "vctrs_error_subscript_type")
+})


### PR DESCRIPTION
Merges R-level and C-level code paths.

Part of r-lib/rlang#836.
Closes #575.