### PR TITLE
Add `na_equal` parameter to `vec_match()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # vctrs (development version)
 
+* `vec_match()` gains an `na_equal` argument (#718).
+
 * `vec_chop()`'s `indices` argument has been restricted to positive integer
   vectors. Character and logical subscripts haven't proven useful, and this
   aligns `vec_chop()` with `vec_unchop()`, for which only positive integer

--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -217,8 +217,9 @@ vec_unique_count <- function(x) {
 #'
 #' # Only the first index of duplicates is returned
 #' vec_match(c("a", "b"), c("a", "b", "a", "b"))
-vec_match <- function(needles, haystack) {
-  .Call(vctrs_match, needles, haystack)
+vec_match <- function(needles, haystack, ..., na_equal = TRUE) {
+  if (!missing(...)) ellipsis::check_dots_empty()
+  .Call(vctrs_match, needles, haystack, na_equal)
 }
 
 #' @export

--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -204,6 +204,11 @@ vec_unique_count <- function(x) {
 #'
 #'   `needles` and `haystack` are coerced to the same type prior to
 #'   comparison.
+#' @inheritParams ellipsis::dots_empty
+#' @param na_equal If `TRUE`, missing values in `needles` can be
+#'   matched to missing values in `haystack`. If `FALSE`, they
+#'   propagate, missing values in `needles` are represented as `NA` in
+#'   the return value.
 #' @return A vector the same length as `needles`. `vec_in()` returns a
 #'   logical vector; `vec_match()` returns an integer vector.
 #' @export

--- a/man/vec_match.Rd
+++ b/man/vec_match.Rd
@@ -5,7 +5,7 @@
 \alias{vec_in}
 \title{Find matching observations across vectors}
 \usage{
-vec_match(needles, haystack)
+vec_match(needles, haystack, ..., na_equal = TRUE)
 
 vec_in(needles, haystack)
 }
@@ -16,6 +16,13 @@ return the location of the first match.
 
 \code{needles} and \code{haystack} are coerced to the same type prior to
 comparison.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{na_equal}{If \code{TRUE}, missing values in \code{needles} can be
+matched to missing values in \code{haystack}. If \code{FALSE}, they
+propagate, missing values in \code{needles} are represented as \code{NA} in
+the return value.}
 }
 \value{
 A vector the same length as \code{needles}. \code{vec_in()} returns a

--- a/src/compare.c
+++ b/src/compare.c
@@ -197,7 +197,7 @@ while (0)
 
 // [[ register() ]]
 SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal_) {
-  bool na_equal = Rf_asLogical(na_equal_);
+  bool na_equal = r_bool_as_int(na_equal_);
 
   R_len_t size = vec_size(x);
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -485,7 +485,7 @@ SEXP vctrs_id(SEXP x) {
 
 // [[ register() ]]
 SEXP vctrs_match(SEXP needles, SEXP haystack, SEXP na_equal) {
-  return vec_match_params(needles, haystack, Rf_asLogical(na_equal));
+  return vec_match_params(needles, haystack, r_bool_as_int(na_equal));
 }
 
 SEXP vec_match_params(SEXP needles, SEXP haystack, bool na_equal) {

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -78,8 +78,7 @@ static int list_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
   return list_equal_scalar_na_equal(((const SEXP) x), i, ((const SEXP) y), j);
 }
 static int list_equal_missing(const void* x, R_len_t i) {
-  Rf_error("TODO");
-  return list_equal_scalar_na_equal(((const SEXP) x), i, R_NilValue, 0);
+  return list_equal_scalar_na_equal(((const SEXP) x), i, vctrs_shared_na_list, 0);
 }
 
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -399,7 +399,11 @@ SEXP vctrs_id(SEXP x) {
 }
 
 // [[ register() ]]
-SEXP vec_match(SEXP needles, SEXP haystack) {
+SEXP vctrs_match(SEXP needles, SEXP haystack, SEXP na_equal) {
+  return vec_match_params(needles, haystack, Rf_asLogical(na_equal));
+}
+
+SEXP vec_match_params(SEXP needles, SEXP haystack, bool na_equal) {
   int nprot = 0;
   int _;
   SEXP type = PROTECT_N(vec_type2(needles, haystack, &args_needles, &args_haystack, &_), &nprot);

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -145,10 +145,9 @@ static int df_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
   // `vec_proxy_equal()` flattens data frames so we don't need to
   // worry about df-cols
   for (R_len_t col = 0; col < n_col; ++col) {
-    if (!equal_scalar_p(types[col],
-                        R_NilValue, x_ptrs[col], i,
-                        R_NilValue, y_ptrs[col], j,
-                        true)) {
+    if (!equal_scalar_na_equal_p(types[col],
+                                 R_NilValue, x_ptrs[col], i,
+                                 R_NilValue, y_ptrs[col], j)) {
       return false;
     }
   }
@@ -171,10 +170,9 @@ static int df_equal_missing(const void* x, R_len_t i) {
       continue;
     }
 
-    if (equal_scalar_p(type,
-                       R_NilValue, x_ptrs[col], i,
-                       R_NilValue, vec_type_missing_value(type), 0,
-                       true)) {
+    if (equal_scalar_na_equal_p(type,
+                                R_NilValue, x_ptrs[col], i,
+                                R_NilValue, vec_type_missing_value(type), 0)) {
       return true;
     }
   }

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -25,102 +25,102 @@ int32_t ceil2(int32_t x) {
 static struct dictionary* new_dictionary_opts(SEXP x, struct dictionary_opts* opts);
 
 
-static int nil_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+static int nil_p_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
   Rf_error("Internal error: Shouldn't compare NULL in dictionary.");
 }
-static int nil_equal_missing(const void* x, R_len_t i) {
+static int nil_p_equal_missing(const void* x, R_len_t i) {
   Rf_error("Internal error: Shouldn't compare NULL in dictionary.");
 }
 
-static int lgl_equal_na_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+static int lgl_p_equal_na_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
   return lgl_equal_scalar_na_equal(((const int*) x) + i, ((const int*) y) + j);
 }
-static int lgl_equal_missing(const void* x, R_len_t i) {
+static int lgl_p_equal_missing(const void* x, R_len_t i) {
   return lgl_equal_scalar_na_equal(((const int*) x) + i, &NA_LOGICAL);
 }
 
-static int int_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+static int int_p_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
   return int_equal_scalar_na_equal(((const int*) x) + i, ((const int*) y) + j);
 }
-static int int_equal_missing(const void* x, R_len_t i) {
+static int int_p_equal_missing(const void* x, R_len_t i) {
   return int_equal_scalar_na_equal(((const int*) x) + i, &NA_INTEGER);
 }
 
-static int dbl_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+static int dbl_p_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
   return dbl_equal_scalar_na_equal(((const double*) x) + i, ((const double*) y) + j);
 }
-static int dbl_equal_missing(const void* x, R_len_t i) {
+static int dbl_p_equal_missing(const void* x, R_len_t i) {
   return dbl_equal_scalar_na_equal(((const double*) x) + i, &NA_REAL);
 }
 
-static int cpl_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+static int cpl_p_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
   return cpl_equal_scalar_na_equal(((const Rcomplex*) x) + i, ((const Rcomplex*) y) + j);
 }
-static int cpl_equal_missing(const void* x, R_len_t i) {
+static int cpl_p_equal_missing(const void* x, R_len_t i) {
   return cpl_equal_scalar_na_equal(((const Rcomplex*) x) + i, &vctrs_shared_na_cpl);
 }
 
-static int chr_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+static int chr_p_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
   return chr_equal_scalar_na_equal(((const SEXP*) x) + i, ((const SEXP*) y) + j);
 }
-static int chr_equal_missing(const void* x, R_len_t i) {
+static int chr_p_equal_missing(const void* x, R_len_t i) {
   return chr_equal_scalar_na_equal(((const SEXP*) x) + i, &NA_STRING);
 }
 
-static int raw_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+static int raw_p_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
   return raw_equal_scalar(((const Rbyte*) x) + i, ((const Rbyte*) y) + j, true);
 }
-static int raw_equal_missing(const void* x, R_len_t i) {
+static int raw_p_equal_missing(const void* x, R_len_t i) {
   return false;
 }
 
-static int list_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+static int list_p_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
   return list_equal_scalar_na_equal(((const SEXP) x), i, ((const SEXP) y), j);
 }
-static int list_equal_missing(const void* x, R_len_t i) {
+static int list_p_equal_missing(const void* x, R_len_t i) {
   return list_equal_scalar_na_equal(((const SEXP) x), i, vctrs_shared_na_list, 0);
 }
 
 
 static void init_dictionary_nil(struct dictionary* d) {
   d->vec_p = NULL;
-  d->equal = &nil_equal;
-  d->equal_missing = &nil_equal_missing;
+  d->equal = &nil_p_equal;
+  d->equal_missing = &nil_p_equal_missing;
 }
 static void init_dictionary_lgl(struct dictionary* d) {
   d->vec_p = (const void*) LOGICAL_RO(d->vec);
-  d->equal = &lgl_equal_na_equal;
-  d->equal_missing = &lgl_equal_missing;
+  d->equal = &lgl_p_equal_na_equal;
+  d->equal_missing = &lgl_p_equal_missing;
 }
 static void init_dictionary_int(struct dictionary* d) {
   d->vec_p = (const void*) INTEGER_RO(d->vec);
-  d->equal = &int_equal;
-  d->equal_missing = &int_equal_missing;
+  d->equal = &int_p_equal;
+  d->equal_missing = &int_p_equal_missing;
 }
 static void init_dictionary_dbl(struct dictionary* d) {
   d->vec_p = (const void*) REAL_RO(d->vec);
-  d->equal = dbl_equal;
-  d->equal_missing = &dbl_equal_missing;
+  d->equal = dbl_p_equal;
+  d->equal_missing = &dbl_p_equal_missing;
 }
 static void init_dictionary_cpl(struct dictionary* d) {
   d->vec_p = (const void*) COMPLEX_RO(d->vec);
-  d->equal = &cpl_equal;
-  d->equal_missing = &cpl_equal_missing;
+  d->equal = &cpl_p_equal;
+  d->equal_missing = &cpl_p_equal_missing;
 }
 static void init_dictionary_chr(struct dictionary* d) {
   d->vec_p = (const void*) STRING_PTR_RO(d->vec);
-  d->equal = &chr_equal;
-  d->equal_missing = &chr_equal_missing;
+  d->equal = &chr_p_equal;
+  d->equal_missing = &chr_p_equal_missing;
 }
 static void init_dictionary_raw(struct dictionary* d) {
   d->vec_p = (const void*) RAW_RO(d->vec);
-  d->equal = &raw_equal;
-  d->equal_missing = &raw_equal_missing;
+  d->equal = &raw_p_equal;
+  d->equal_missing = &raw_p_equal_missing;
 }
 static void init_dictionary_list(struct dictionary* d) {
   d->vec_p = (const void*) d->vec;
-  d->equal = &list_equal;
-  d->equal_missing = &list_equal_missing;
+  d->equal = &list_p_equal;
+  d->equal_missing = &list_p_equal_missing;
 }
 
 struct dictionary_df_data {

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -155,8 +155,31 @@ static int df_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
 
   return true;
 }
+
 static int df_equal_missing(const void* x, R_len_t i) {
-  Rf_error("TODO");
+  struct dictionary_df_data* x_data = (struct dictionary_df_data*) x;
+
+  enum vctrs_type* types = x_data->col_types;
+  void** x_ptrs = x_data->col_ptrs;
+  R_len_t n_col = x_data->n_col;
+
+  for (R_len_t col = 0; col < n_col; ++col) {
+    enum vctrs_type type = types[col];
+
+    // Raw doesn't have missing values
+    if (type == vctrs_type_raw) {
+      continue;
+    }
+
+    if (equal_scalar_p(type,
+                       R_NilValue, x_ptrs[col], i,
+                       R_NilValue, vec_type_missing_value(type), 0,
+                       true)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 static void init_dictionary_df(struct dictionary* d) {

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -33,7 +33,7 @@ static int nil_p_equal_missing(const void* x, R_len_t i) {
   Rf_error("Internal error: Shouldn't compare NULL in dictionary.");
 }
 
-static int lgl_p_equal_na_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
+static int lgl_p_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
   return lgl_equal_scalar_na_equal(((const int*) x) + i, ((const int*) y) + j);
 }
 static int lgl_p_equal_missing(const void* x, R_len_t i) {
@@ -69,7 +69,7 @@ static int chr_p_equal_missing(const void* x, R_len_t i) {
 }
 
 static int raw_p_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
-  return raw_equal_scalar(((const Rbyte*) x) + i, ((const Rbyte*) y) + j, true);
+  return raw_equal_scalar_na_equal(((const Rbyte*) x) + i, ((const Rbyte*) y) + j);
 }
 static int raw_p_equal_missing(const void* x, R_len_t i) {
   return false;
@@ -90,7 +90,7 @@ static void init_dictionary_nil(struct dictionary* d) {
 }
 static void init_dictionary_lgl(struct dictionary* d) {
   d->vec_p = (const void*) LOGICAL_RO(d->vec);
-  d->equal = &lgl_p_equal_na_equal;
+  d->equal = &lgl_p_equal;
   d->equal_missing = &lgl_p_equal_missing;
 }
 static void init_dictionary_int(struct dictionary* d) {

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -22,7 +22,7 @@ int32_t ceil2(int32_t x) {
 
 // Dictonary object ------------------------------------------------------------
 
-static struct dictionary* new_dictionary_impl(SEXP x, bool partial);
+static struct dictionary* new_dictionary_opts(SEXP x, struct dictionary_opts* opts);
 
 
 static int nil_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
@@ -163,13 +163,19 @@ static void init_dictionary_df(struct dictionary* d) {
 // Dictionaries must be protected in consistent stack order with
 // `PROTECT_DICT()`
 struct dictionary* new_dictionary(SEXP x) {
-  return new_dictionary_impl(x, false);
+  struct dictionary_opts opts = {
+    .partial = false
+  };
+  return new_dictionary_opts(x, &opts);
 }
 struct dictionary* new_dictionary_partial(SEXP x) {
-  return new_dictionary_impl(x, true);
+  struct dictionary_opts opts = {
+    .partial = true
+  };
+  return new_dictionary_opts(x, &opts);
 }
 
-static struct dictionary* new_dictionary_impl(SEXP x, bool partial) {
+static struct dictionary* new_dictionary_opts(SEXP x, struct dictionary_opts* opts) {
   SEXP out = PROTECT(Rf_allocVector(RAWSXP, sizeof(struct dictionary)));
   struct dictionary* d = (struct dictionary*) RAW(out);
 
@@ -192,7 +198,7 @@ static struct dictionary* new_dictionary_impl(SEXP x, bool partial) {
 
   d->used = 0;
 
-  if (partial) {
+  if (opts->partial) {
     d->key = NULL;
     d->size = 0;
   } else {

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -15,6 +15,7 @@ struct dictionary {
   enum vctrs_type type;
 
   int (*equal)(const void*, R_len_t i, const void*, R_len_t j);
+  int (*equal_missing)(const void*, R_len_t i);
   const void* vec_p;
 
   uint32_t* hash;
@@ -37,6 +38,7 @@ struct dictionary {
 
 struct dictionary_opts {
   bool partial;
+  bool na_equal;
 };
 
 struct dictionary* new_dictionary(SEXP x);

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -34,6 +34,11 @@ struct dictionary {
  *   as well, but does not allocate an array of keys. This is useful
  *   for finding a key in another dictionary with `dict_hash_with()`.
  */
+
+struct dictionary_opts {
+  bool partial;
+};
+
 struct dictionary* new_dictionary(SEXP x);
 struct dictionary* new_dictionary_partial(SEXP x);
 

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -62,4 +62,6 @@ struct dictionary* new_dictionary_partial(SEXP x);
 uint32_t dict_hash_scalar(struct dictionary* d, R_len_t i);
 uint32_t dict_hash_with(struct dictionary* d, struct dictionary* x, R_len_t i);
 
+bool dict_is_missing(struct dictionary* d, R_len_t i);
+
 void dict_put(struct dictionary* d, uint32_t k, R_len_t i);

--- a/src/equal.c
+++ b/src/equal.c
@@ -58,7 +58,7 @@ int equal_scalar_na_equal_p(enum vctrs_type proxy_type,
   case vctrs_type_double: return dbl_equal_scalar_na_equal(((const double*) x_p) + i, ((const double*) y_p) + j);
   case vctrs_type_complex: return cpl_equal_scalar_na_equal(((const Rcomplex*) x_p) + i, ((const Rcomplex*) y_p) + j);
   case vctrs_type_character: return chr_equal_scalar_na_equal(((const SEXP*) x_p) + i, ((const SEXP*) y_p) + j);
-  case vctrs_type_raw: return raw_equal_scalar(((const Rbyte*) x_p) + i, ((const Rbyte*) y_p) + j, true);
+  case vctrs_type_raw: return raw_equal_scalar_na_equal(((const Rbyte*) x_p) + i, ((const Rbyte*) y_p) + j);
   case vctrs_type_list: return list_equal_scalar_na_equal(((const SEXP) x_p), i, ((const SEXP) y_p), j);
   default: vctrs_stop_unsupported_type(vec_typeof(x), "equal_scalar_na_equal_p()");
   }
@@ -73,7 +73,7 @@ int equal_scalar_na_propagate_p(enum vctrs_type proxy_type,
   case vctrs_type_double: return dbl_equal_scalar_na_propagate(((const double*) x_p) + i, ((const double*) y_p) + j);
   case vctrs_type_complex: return cpl_equal_scalar_na_propagate(((const Rcomplex*) x_p) + i, ((const Rcomplex*) y_p) + j);
   case vctrs_type_character: return chr_equal_scalar_na_propagate(((const SEXP*) x_p) + i, ((const SEXP*) y_p) + j);
-  case vctrs_type_raw: return raw_equal_scalar(((const Rbyte*) x_p) + i, ((const Rbyte*) y_p) + j, true);
+  case vctrs_type_raw: return raw_equal_scalar_na_propagate(((const Rbyte*) x_p) + i, ((const Rbyte*) y_p) + j);
   case vctrs_type_list: return list_equal_scalar_na_propagate(((const SEXP) x_p), i, ((const SEXP) y_p), j);
   default: vctrs_stop_unsupported_type(vec_typeof(x), "equal_scalar_na_propagate_p()");
   }

--- a/src/equal.c
+++ b/src/equal.c
@@ -44,7 +44,7 @@ int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
 SEXP vctrs_equal_scalar(SEXP x, SEXP i_, SEXP y, SEXP j_, SEXP na_equal_) {
   R_len_t i = Rf_asInteger(i_);
   R_len_t j = Rf_asInteger(j_);
-  bool na_equal = Rf_asLogical(na_equal_);
+  bool na_equal = r_bool_as_int(na_equal_);
   return r_lgl(equal_scalar(x, i, y, j, na_equal));
 }
 
@@ -126,7 +126,7 @@ SEXP vctrs_equal(SEXP x, SEXP y, SEXP na_equal_) {
     Rf_errorcall(R_NilValue, "`x` and `y` must have same types and lengths");
   }
 
-  bool na_equal = Rf_asLogical(na_equal_);
+  bool na_equal = r_bool_as_int(na_equal_);
 
   switch (type) {
   case vctrs_type_logical:   EQUAL(int, LOGICAL_RO, lgl_equal_scalar);

--- a/src/equal.c
+++ b/src/equal.c
@@ -33,7 +33,11 @@ int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
   default: vctrs_stop_unsupported_type(vec_typeof(x), "equal_scalar()");
   }
 
-  return equal_scalar_p(proxy_type, x, x_p, i, y, y_p, j, na_equal);
+  if (na_equal) {
+    return equal_scalar_na_equal_p(proxy_type, x, x_p, i, y, y_p, j);
+  } else {
+    return equal_scalar_na_propagate_p(proxy_type, x, x_p, i, y, y_p, j);
+  }
 }
 
 // [[ register() ]]
@@ -45,19 +49,33 @@ SEXP vctrs_equal_scalar(SEXP x, SEXP i_, SEXP y, SEXP j_, SEXP na_equal_) {
 }
 
 // [[ include("vctrs.h") ]]
-int equal_scalar_p(enum vctrs_type proxy_type,
-                   SEXP x, const void* x_p, R_len_t i,
-                   SEXP y, const void* y_p, R_len_t j,
-                   bool na_equal) {
+int equal_scalar_na_equal_p(enum vctrs_type proxy_type,
+                            SEXP x, const void* x_p, R_len_t i,
+                            SEXP y, const void* y_p, R_len_t j) {
   switch (proxy_type) {
-  case vctrs_type_logical: return lgl_equal_scalar(((const int*) x_p) + i, ((const int*) y_p) + j, na_equal);
-  case vctrs_type_integer: return int_equal_scalar(((const int*) x_p) + i, ((const int*) y_p) + j, na_equal);
-  case vctrs_type_double: return dbl_equal_scalar(((const double*) x_p) + i, ((const double*) y_p) + j, na_equal);
-  case vctrs_type_complex: return cpl_equal_scalar(((const Rcomplex*) x_p) + i, ((const Rcomplex*) y_p) + j, na_equal);
-  case vctrs_type_character: return chr_equal_scalar(((const SEXP*) x_p) + i, ((const SEXP*) y_p) + j, na_equal);
-  case vctrs_type_raw: return raw_equal_scalar(((const Rbyte*) x_p) + i, ((const Rbyte*) y_p) + j, na_equal);
-  case vctrs_type_list: return list_equal_scalar(((const SEXP) x_p), i, ((const SEXP) y_p), j, na_equal);
-  default: vctrs_stop_unsupported_type(vec_typeof(x), "equal_scalar_p()");
+  case vctrs_type_logical: return lgl_equal_scalar_na_equal(((const int*) x_p) + i, ((const int*) y_p) + j);
+  case vctrs_type_integer: return int_equal_scalar_na_equal(((const int*) x_p) + i, ((const int*) y_p) + j);
+  case vctrs_type_double: return dbl_equal_scalar_na_equal(((const double*) x_p) + i, ((const double*) y_p) + j);
+  case vctrs_type_complex: return cpl_equal_scalar_na_equal(((const Rcomplex*) x_p) + i, ((const Rcomplex*) y_p) + j);
+  case vctrs_type_character: return chr_equal_scalar_na_equal(((const SEXP*) x_p) + i, ((const SEXP*) y_p) + j);
+  case vctrs_type_raw: return raw_equal_scalar(((const Rbyte*) x_p) + i, ((const Rbyte*) y_p) + j, true);
+  case vctrs_type_list: return list_equal_scalar_na_equal(((const SEXP) x_p), i, ((const SEXP) y_p), j);
+  default: vctrs_stop_unsupported_type(vec_typeof(x), "equal_scalar_na_equal_p()");
+  }
+}
+// [[ include("vctrs.h") ]]
+int equal_scalar_na_propagate_p(enum vctrs_type proxy_type,
+                                SEXP x, const void* x_p, R_len_t i,
+                                SEXP y, const void* y_p, R_len_t j) {
+  switch (proxy_type) {
+  case vctrs_type_logical: return lgl_equal_scalar_na_propagate(((const int*) x_p) + i, ((const int*) y_p) + j);
+  case vctrs_type_integer: return int_equal_scalar_na_propagate(((const int*) x_p) + i, ((const int*) y_p) + j);
+  case vctrs_type_double: return dbl_equal_scalar_na_propagate(((const double*) x_p) + i, ((const double*) y_p) + j);
+  case vctrs_type_complex: return cpl_equal_scalar_na_propagate(((const Rcomplex*) x_p) + i, ((const Rcomplex*) y_p) + j);
+  case vctrs_type_character: return chr_equal_scalar_na_propagate(((const SEXP*) x_p) + i, ((const SEXP*) y_p) + j);
+  case vctrs_type_raw: return raw_equal_scalar(((const Rbyte*) x_p) + i, ((const Rbyte*) y_p) + j, true);
+  case vctrs_type_list: return list_equal_scalar_na_propagate(((const SEXP) x_p), i, ((const SEXP) y_p), j);
+  default: vctrs_stop_unsupported_type(vec_typeof(x), "equal_scalar_na_propagate_p()");
   }
 }
 

--- a/src/equal.h
+++ b/src/equal.h
@@ -37,6 +37,9 @@ static inline int int_equal_scalar(const int* x, const int* y, bool na_equal) {
   }
 }
 
+static inline bool dbl_equal_missing(double x) {
+  return isnan(x);
+}
 static inline int dbl_equal_scalar_na_equal(const double* x, const double* y) {
   const double xi = *x;
   const double yj = *y;
@@ -56,7 +59,7 @@ static inline int dbl_equal_scalar_na_equal(const double* x, const double* y) {
 static inline int dbl_equal_scalar_na_propagate(const double* x, const double* y) {
   const double xi = *x;
   const double yj = *y;
-  if (isnan(xi) || isnan(yj)) {
+  if (dbl_equal_missing(xi) || dbl_equal_missing(yj)) {
     return NA_LOGICAL;
   } else {
     return xi == yj;
@@ -70,6 +73,9 @@ static inline int dbl_equal_scalar(const double* x, const double* y, bool na_equ
   }
 }
 
+static inline bool cpl_equal_missing(Rcomplex x) {
+  return dbl_equal_missing(x.r) || dbl_equal_missing(x.i);
+}
 static inline int cpl_equal_scalar_na_equal(const Rcomplex* x, const Rcomplex* y) {
   Rcomplex xi = *x;
   Rcomplex yj = *y;

--- a/src/equal.h
+++ b/src/equal.h
@@ -164,8 +164,14 @@ static inline int list_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool n
   }
 }
 
+// Raw vectors have no notion of missing value
 static inline int raw_equal_scalar(const Rbyte* x, const Rbyte* y, bool na_equal) {
-  // Raw vectors have no notion of missing value
+  return *x == *y;
+}
+static inline int raw_equal_scalar_na_equal(const Rbyte* x, const Rbyte* y) {
+  return *x == *y;
+}
+static inline int raw_equal_scalar_na_propagate(const Rbyte* x, const Rbyte* y) {
   return *x == *y;
 }
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -260,7 +260,7 @@ void hash_fill(uint32_t* p, R_len_t size, SEXP x, bool na_equal) {
     case vctrs_type_character: chr_hash_fill_na_equal(p, size, x); return;
     case vctrs_type_raw: raw_hash_fill_na_equal(p, size, x); return;
     case vctrs_type_list: list_hash_fill_na_equal(p, size, x); return;
-    case vctrs_type_dataframe: df_hash_fill(p, size, x, na_equal); return;
+    case vctrs_type_dataframe: df_hash_fill(p, size, x, true); return;
     default: break;
     }
   } else {
@@ -272,6 +272,7 @@ void hash_fill(uint32_t* p, R_len_t size, SEXP x, bool na_equal) {
     case vctrs_type_character: chr_hash_fill_na_propagate(p, size, x); return;
     case vctrs_type_raw: raw_hash_fill_na_propagate(p, size, x); return;
     case vctrs_type_list: list_hash_fill_na_propagate(p, size, x); return;
+    case vctrs_type_dataframe: df_hash_fill(p, size, x, false); return;
     default: break;
     }
   }

--- a/src/hash.c
+++ b/src/hash.c
@@ -293,13 +293,14 @@ void hash_fill(uint32_t* p, R_len_t size, SEXP x, bool na_equal) {
   const CTYPE* xp = CONST_DEREF(x);                                     \
                                                                         \
   for (R_len_t i = 0; i < size; ++i, ++xp) {                            \
-    if (p[i] == HASH_MISSING) {                                         \
+    uint32_t h = p[i];                                                  \
+    if (h == HASH_MISSING) {                                            \
       continue;                                                         \
     }                                                                   \
     if (*xp == NA_VALUE) {                                              \
       p[i] = HASH_MISSING;                                              \
     } else {                                                            \
-      p[i] = hash_combine(p[i], HASHER(xp));                            \
+      p[i] = hash_combine(h, HASHER(xp));                               \
     }                                                                   \
   }
 
@@ -307,13 +308,14 @@ void hash_fill(uint32_t* p, R_len_t size, SEXP x, bool na_equal) {
   const CTYPE* xp = CONST_DEREF(x);                                     \
                                                                         \
   for (R_len_t i = 0; i < size; ++i, ++xp) {                            \
-    if (p[i] == HASH_MISSING) {                                         \
+    uint32_t h = p[i];                                                  \
+    if (h == HASH_MISSING) {                                            \
       continue;                                                         \
     }                                                                   \
     if (NA_CMP(*xp)) {                                                  \
       p[i] = HASH_MISSING;                                              \
     } else {                                                            \
-      p[i] = hash_combine(p[i], HASHER(xp));                            \
+      p[i] = hash_combine(h, HASHER(xp));                               \
     }                                                                   \
   }
 
@@ -371,14 +373,15 @@ static inline void raw_hash_fill_na_propagate(uint32_t* p, R_len_t size, SEXP x)
 
 #define HASH_FILL_BARRIER_NA_PROPAGATE(HASHER)  \
   for (R_len_t i = 0; i < size; ++i) {          \
-    if (p[i] == HASH_MISSING) {                 \
+    uint32_t h = p[i];                          \
+    if (h == HASH_MISSING) {                    \
       continue;                                 \
     }                                           \
-    uint32_t hash = HASHER(x, i);               \
-    if (hash == HASH_MISSING) {                 \
+    uint32_t elt_hash = HASHER(x, i);           \
+    if (elt_hash == HASH_MISSING) {             \
       p[i] = HASH_MISSING;                      \
     } else {                                    \
-      p[i] = hash_combine(p[i], HASHER(x, i));  \
+      p[i] = hash_combine(p[i], elt_hash);      \
     }                                           \
   }
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -1,0 +1,6 @@
+#ifndef VCTRS_HASH_H
+#define VCTRS_HASH_H
+
+#define HASH_MISSING 1
+
+#endif

--- a/src/init.c
+++ b/src/init.c
@@ -33,7 +33,7 @@ extern SEXP vec_group_loc(SEXP);
 extern SEXP vctrs_equal(SEXP, SEXP, SEXP);
 extern SEXP vctrs_equal_na(SEXP);
 extern SEXP vctrs_compare(SEXP, SEXP, SEXP);
-extern SEXP vec_match(SEXP, SEXP);
+extern SEXP vctrs_match(SEXP, SEXP, SEXP);
 extern SEXP vctrs_duplicated_any(SEXP);
 extern SEXP vctrs_size(SEXP);
 extern SEXP vec_dim(SEXP);
@@ -152,7 +152,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_equal",                      (DL_FUNC) &vctrs_equal, 3},
   {"vctrs_equal_na",                   (DL_FUNC) &vctrs_equal_na, 1},
   {"vctrs_compare",                    (DL_FUNC) &vctrs_compare, 3},
-  {"vctrs_match",                      (DL_FUNC) &vec_match, 2},
+  {"vctrs_match",                      (DL_FUNC) &vctrs_match, 3},
   {"vctrs_typeof",                     (DL_FUNC) &vctrs_typeof, 2},
   {"vctrs_init_library",               (DL_FUNC) &vctrs_init_library, 1},
   {"vctrs_is_vector",                  (DL_FUNC) &vctrs_is_vector, 1},

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -187,7 +187,7 @@ SEXP vctrs_typeof(SEXP x, SEXP dispatch) {
 
 void vctrs_stop_unsupported_type(enum vctrs_type type, const char* fn) {
   Rf_errorcall(R_NilValue,
-               "Unsupported vctrs type `%s` in `%s`",
+               "Internal error: Unsupported vctrs type `%s` in `%s`",
                vec_type_as_str(type),
                fn);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -953,6 +953,14 @@ bool r_is_true(SEXP x) {
   return r_is_bool(x) && LOGICAL(x)[0] == 1;
 }
 
+// [[ include("utils.h") ]]
+int r_bool_as_int(SEXP x) {
+  if (!r_is_bool(x)) {
+    Rf_errorcall(R_NilValue, "Input must be a single `TRUE` or `FALSE`.");
+  }
+  return LOGICAL(x)[0];
+}
+
 bool r_is_string(SEXP x) {
   return TYPEOF(x) == STRSXP &&
     Rf_length(x) == 1 &&

--- a/src/utils.c
+++ b/src/utils.c
@@ -1247,10 +1247,12 @@ SEXP vctrs_shared_empty_list = NULL;
 SEXP vctrs_shared_empty_date = NULL;
 SEXP vctrs_shared_true = NULL;
 SEXP vctrs_shared_false = NULL;
+
 Rcomplex vctrs_shared_na_cpl;
+SEXP vctrs_shared_na_lgl = NULL;
+SEXP vctrs_shared_na_list = NULL;
 
 SEXP vctrs_shared_zero_int = NULL;
-SEXP vctrs_shared_na_lgl = NULL;
 
 SEXP strings = NULL;
 SEXP strings_empty = NULL;
@@ -1490,6 +1492,9 @@ void vctrs_init_utils(SEXP ns) {
 
   vctrs_shared_na_lgl = r_new_shared_vector(LGLSXP, 1);
   LOGICAL(vctrs_shared_na_lgl)[0] = NA_LOGICAL;
+
+  vctrs_shared_na_list = r_new_shared_vector(VECSXP, 1);
+  SET_VECTOR_ELT(vctrs_shared_na_list, 0, R_NilValue);
 
   vctrs_shared_zero_int = r_new_shared_vector(INTSXP, 1);
   INTEGER(vctrs_shared_zero_int)[0] = 0;

--- a/src/utils.h
+++ b/src/utils.h
@@ -31,6 +31,7 @@ enum vctrs_class_type {
 };
 
 bool r_is_bool(SEXP x);
+int r_bool_as_int(SEXP x);
 
 SEXP vctrs_eval_mask_n(SEXP fn,
                        SEXP* syms, SEXP* args,

--- a/src/utils.h
+++ b/src/utils.h
@@ -320,6 +320,18 @@ static inline SEXP expr_protect(SEXP x) {
   }
 }
 
+static inline const void* vec_type_missing_value(enum vctrs_type type) {
+  switch (type) {
+  case vctrs_type_logical: return &NA_LOGICAL;
+  case vctrs_type_integer: return &NA_INTEGER;
+  case vctrs_type_double: return &NA_REAL;
+  case vctrs_type_complex: return &vctrs_shared_na_cpl;
+  case vctrs_type_character: return &NA_STRING;
+  case vctrs_type_list: return vctrs_shared_na_list;
+  default: vctrs_stop_unsupported_type(type, "vec_missing_value");
+  }
+}
+
 
 extern SEXP vctrs_ns_env;
 extern SEXP vctrs_shared_empty_str;

--- a/src/utils.h
+++ b/src/utils.h
@@ -323,7 +323,6 @@ static inline SEXP expr_protect(SEXP x) {
 
 extern SEXP vctrs_ns_env;
 extern SEXP vctrs_shared_empty_str;
-extern SEXP vctrs_shared_na_lgl;
 extern SEXP vctrs_shared_zero_int;
 
 extern SEXP classes_data_frame;

--- a/src/utils.h
+++ b/src/utils.h
@@ -328,7 +328,7 @@ static inline const void* vec_type_missing_value(enum vctrs_type type) {
   case vctrs_type_complex: return &vctrs_shared_na_cpl;
   case vctrs_type_character: return &NA_STRING;
   case vctrs_type_list: return vctrs_shared_na_list;
-  default: vctrs_stop_unsupported_type(type, "vec_missing_value");
+  default: vctrs_stop_unsupported_type(type, "vec_type_missing_value");
   }
 }
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -379,7 +379,12 @@ SEXP vec_recycle_fallback(SEXP x, R_len_t size, struct vctrs_arg* x_arg);
 SEXP vec_recycle_common(SEXP xs, R_len_t size);
 SEXP vec_names(SEXP x);
 SEXP vec_group_loc(SEXP x);
-SEXP vec_match(SEXP needles, SEXP haystack);
+SEXP vec_match_params(SEXP needles, SEXP haystack, bool na_equal);
+
+static inline SEXP vec_match(SEXP needles, SEXP haystack) {
+  return vec_match_params(needles, haystack, true);
+}
+
 
 SEXP vec_c(SEXP xs,
            SEXP ptype,

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -334,6 +334,8 @@ extern SEXP vctrs_shared_true;
 extern SEXP vctrs_shared_false;
 
 extern Rcomplex vctrs_shared_na_cpl;
+extern SEXP vctrs_shared_na_lgl;
+extern SEXP vctrs_shared_na_list;
 
 SEXP vec_unspecified(R_len_t n);
 bool vec_is_unspecified(SEXP x);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -459,7 +459,7 @@ int equal_scalar_p(SEXPTYPE type,
 int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal);
 
 uint32_t hash_object(SEXP x);
-void hash_fill(uint32_t* p, R_len_t n, SEXP x);
+void hash_fill(uint32_t* p, R_len_t n, SEXP x, bool na_equal);
 
 SEXP vec_unique(SEXP x);
 bool duplicated_any(SEXP names);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -454,10 +454,12 @@ bool equal_names(SEXP x, SEXP y);
  * The behaviour is undefined if these conditions are not true.
  */
 int equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal);
-int equal_scalar_p(SEXPTYPE type,
-                   SEXP x, const void* x_p, R_len_t i,
-                   SEXP y, const void* y_p, R_len_t j,
-                   bool na_equal);
+int equal_scalar_na_equal_p(enum vctrs_type proxy_type,
+                            SEXP x, const void* x_p, R_len_t i,
+                            SEXP y, const void* y_p, R_len_t j);
+int equal_scalar_na_propagate_p(enum vctrs_type proxy_type,
+                                SEXP x, const void* x_p, R_len_t i,
+                                SEXP y, const void* y_p, R_len_t j);
 int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal);
 
 uint32_t hash_object(SEXP x);

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -215,6 +215,10 @@ test_that("can compare unspecified", {
   expect_equal(vec_compare(c(NA, NA), unspecified(2)), c(NA_integer_, NA_integer_))
 })
 
+test_that("can't supply NA as `na_equal`", {
+  expect_error(vec_compare(NA, NA, na_equal = NA), "single `TRUE` or `FALSE`")
+})
+
 # order/sort --------------------------------------------------------------
 
 test_that("can request NAs sorted first", {

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -283,3 +283,11 @@ test_that("can propagate missing values while matching", {
   # No missing values for raw vectors
   expect_identical(vec_match(bytes(0, 1, 0, 2), bytes(2, 0, 1), na_equal = FALSE), c(2L, 3L, 2L, 1L))
 })
+
+test_that("missing values are propagated across columns", {
+  for (na_value in list(NA, na_int, na_dbl, na_cpl, na_chr, list(NULL))) {
+    df <- data_frame(x = 1, y = data_frame(foo = 2, bar = na_value), z = 3)
+    expect_identical(vec_match(df, df), 1L)
+    expect_identical(vec_match(df, df, na_equal = FALSE), na_int)
+  }
+})

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -270,3 +270,15 @@ test_that("matching functions take the equality proxy recursively", {
   expect_equal(vec_match(df, df2), c(NA, 1))
   expect_equal(vec_in(df, df2), c(FALSE, TRUE))
 })
+
+test_that("can propagate missing values while matching", {
+  exp <- c(NA, 3L, NA, 1L)
+  expect_identical(vec_match(lgl(NA, TRUE, NA, FALSE), lgl(FALSE, NA, TRUE), na_equal = FALSE), exp)
+  expect_identical(vec_match(int(NA, 1L, NA, 2L), int(2L, NA, 1L), na_equal = FALSE), exp)
+  expect_identical(vec_match(dbl(NA, 1, NA, 2), dbl(2, NA, 1), na_equal = FALSE), exp)
+  expect_identical(vec_match(cpl(NA, 1, NA, 2), cpl(2, NA, 1), na_equal = FALSE), exp)
+  expect_identical(vec_match(chr(NA, "1", NA, "2"), chr("2", NA, "1"), na_equal = FALSE), exp)
+
+  # No missing values for raw vectors
+  expect_identical(vec_match(bytes(0, 1, 0, 2), bytes(2, 0, 1), na_equal = FALSE), c(2L, 3L, 2L, 1L))
+})

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -291,3 +291,7 @@ test_that("missing values are propagated across columns", {
     expect_identical(vec_match(df, df, na_equal = FALSE), na_int)
   }
 })
+
+test_that("can't supply NA as `na_equal`", {
+  expect_error(vec_match(NA, NA, na_equal = NA), "single `TRUE` or `FALSE`")
+})

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -278,6 +278,7 @@ test_that("can propagate missing values while matching", {
   expect_identical(vec_match(dbl(NA, 1, NA, 2), dbl(2, NA, 1), na_equal = FALSE), exp)
   expect_identical(vec_match(cpl(NA, 1, NA, 2), cpl(2, NA, 1), na_equal = FALSE), exp)
   expect_identical(vec_match(chr(NA, "1", NA, "2"), chr("2", NA, "1"), na_equal = FALSE), exp)
+  expect_identical(vec_match(list(NULL, 1, NULL, 2), list(2, NULL, 1), na_equal = FALSE), exp)
 
   # No missing values for raw vectors
   expect_identical(vec_match(bytes(0, 1, 0, 2), bytes(2, 0, 1), na_equal = FALSE), c(2L, 3L, 2L, 1L))

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -382,6 +382,11 @@ test_that("can check equality of unspecified objects", {
   expect_true(vec_equal(NA, unspecified(1), na_equal = TRUE))
 })
 
+test_that("can't supply NA as `na_equal`", {
+  expect_error(vec_equal(NA, NA, na_equal = NA), "single `TRUE` or `FALSE`")
+})
+
+
 # proxy -------------------------------------------------------------------
 
 test_that("vec_equal() takes vec_proxy() by default", {


### PR DESCRIPTION
Closes #718.

* Support propagation of `NA` in hashing functions. Elements with `NA` are hashed with the constant `HASH_MISSING`, hard-coded to 1. This way we can avoid missingness comparisons when they are not needed.

* Dictionary structure gains a `equal_missing()` method to compare elements to the missing value.

* New `na_equal` parameter for dictionary initialisation. When `false`, the dicitionary vector is hashed with `HASH_MISSING` support.

* New `dict_is_missing()` function to check whether an element of a dictionary is missing.

* `vec_equal()` now uses these features to implement `na_equal = FALSE`.

One question is whether `NA` should propagate across columns when matching data frames. The alternative is to consider that only rows full of `NA`s are missing. It seems it's more consistent and useful to propagate across columns, which is implemented here:

```r
df <- data_frame(x = 1, y = NA, z = 2)

vec_match(df, df)
#> [1] 1

vec_match(df, df, na_equal = FALSE)
#> [1] NA
```