### PR TITLE
Add backticks around types

### DIFF
--- a/R/subscript.R
+++ b/R/subscript.R
@@ -215,7 +215,7 @@ collapse_subscript_type <- function(cnd) {
     last <- ", or "
   }
 
-  glue::glue_collapse(types, sep = ", ", last = last)
+  glue::glue_collapse(tick(types), sep = ", ", last = last)
 }
 
 new_error_subscript_size <- function(i,

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -83,17 +83,17 @@ x The subscript has the wrong type `data.frame<
   gear: double
   carb: double
 >`.
-i It must be logical, numeric, or character.
+i It must be `logical`, `numeric`, or `character`.
 
 > vec_as_location(env(), 10L)
 Error: Must subset elements with a valid subscript vector.
 x The subscript has the wrong type `environment`.
-i It must be logical, numeric, or character.
+i It must be `logical`, `numeric`, or `character`.
 
 > vec_as_location(foobar(), 10L)
 Error: Must subset elements with a valid subscript vector.
 x The subscript has the wrong type `vctrs_foobar`.
-i It must be logical, numeric, or character.
+i It must be `logical`, `numeric`, or `character`.
 
 > vec_as_location(2.5, 3L)
 Error: Must subset elements with a valid subscript vector.
@@ -102,23 +102,23 @@ x Lossy cast from <double> to <integer>.
 > vec_as_location(list(), 10L)
 Error: Must subset elements with a valid subscript vector.
 x The subscript has the wrong type `list`.
-i It must be logical, numeric, or character.
+i It must be `logical`, `numeric`, or `character`.
 
 > vec_as_location(function() NULL, 10L)
 Error: Must subset elements with a valid subscript vector.
 x The subscript has the wrong type `closure`.
-i It must be logical, numeric, or character.
+i It must be `logical`, `numeric`, or `character`.
 
 > # Idem with custom `arg`
 > vec_as_location(env(), 10L, arg = "foo")
 Error: Must subset elements with a valid subscript vector.
 x The subscript `foo` has the wrong type `environment`.
-i It must be logical, numeric, or character.
+i It must be `logical`, `numeric`, or `character`.
 
 > vec_as_location(foobar(), 10L, arg = "foo")
 Error: Must subset elements with a valid subscript vector.
 x The subscript `foo` has the wrong type `vctrs_foobar`.
-i It must be logical, numeric, or character.
+i It must be `logical`, `numeric`, or `character`.
 
 > vec_as_location(2.5, 3L, arg = "foo")
 Error: Must subset elements with a valid subscript vector.
@@ -131,7 +131,7 @@ vec_as_location2() requires integer or character inputs
 > vec_as_location2(TRUE, 10L)
 Error: Must extract element with a single valid subscript.
 x The subscript has the wrong type `logical`.
-i It must be numeric or character.
+i It must be `numeric` or `character`.
 
 > vec_as_location2(mtcars, 10L)
 Error: Must extract element with a single valid subscript.
@@ -148,17 +148,17 @@ x The subscript has the wrong type `data.frame<
   gear: double
   carb: double
 >`.
-i It must be numeric or character.
+i It must be `numeric` or `character`.
 
 > vec_as_location2(env(), 10L)
 Error: Must extract element with a single valid subscript.
 x The subscript has the wrong type `environment`.
-i It must be numeric or character.
+i It must be `numeric` or `character`.
 
 > vec_as_location2(foobar(), 10L)
 Error: Must extract element with a single valid subscript.
 x The subscript has the wrong type `vctrs_foobar`.
-i It must be numeric or character.
+i It must be `numeric` or `character`.
 
 > vec_as_location2(2.5, 3L)
 Error: Must extract element with a single valid subscript.
@@ -168,7 +168,7 @@ x Lossy cast from <double> to <integer>.
 > vec_as_location2(foobar(), 10L, arg = "foo")
 Error: Must extract element with a single valid subscript.
 x The subscript `foo` has the wrong type `vctrs_foobar`.
-i It must be numeric or character.
+i It must be `numeric` or `character`.
 
 > vec_as_location2(2.5, 3L, arg = "foo")
 Error: Must extract element with a single valid subscript.
@@ -197,7 +197,7 @@ x The subscript has the wrong type `data.frame<
   gear: double
   carb: double
 >`.
-i It must be numeric or character.
+i It must be `numeric` or `character`.
 
 > # Idem with custom `arg`
 > vec_as_location2(1:2, 2L, arg = "foo")
@@ -219,7 +219,7 @@ x The subscript `foo` has the wrong type `data.frame<
   gear: double
   carb: double
 >`.
-i It must be numeric or character.
+i It must be `numeric` or `character`.
 
 > vec_as_location2(1:2, 2L, arg = "foo")
 Error: Must extract element with a single valid subscript.

--- a/tests/testthat/error/test-subscript.txt
+++ b/tests/testthat/error/test-subscript.txt
@@ -5,32 +5,32 @@ vec_as_subscript() forbids subscript types
 > vec_as_subscript(1L, logical = "error", numeric = "error")
 Error: Must subset elements with a valid subscript vector.
 x The subscript has the wrong type `integer`.
-i It must be character.
+i It must be `character`.
 
 > vec_as_subscript("foo", logical = "error", character = "error")
 Error: Must subset elements with a valid subscript vector.
 x The subscript has the wrong type `character`.
-i It must be numeric.
+i It must be `numeric`.
 
 > vec_as_subscript(TRUE, logical = "error")
 Error: Must subset elements with a valid subscript vector.
 x The subscript has the wrong type `logical`.
-i It must be numeric or character.
+i It must be `numeric` or `character`.
 
 > vec_as_subscript("foo", character = "error")
 Error: Must subset elements with a valid subscript vector.
 x The subscript has the wrong type `character`.
-i It must be logical or numeric.
+i It must be `logical` or `numeric`.
 
 > vec_as_subscript(NULL, numeric = "error")
 Error: Must subset elements with a valid subscript vector.
 x The subscript has the wrong type `NULL`.
-i It must be logical or character.
+i It must be `logical` or `character`.
 
 > vec_as_subscript(quote(foo), character = "error")
 Error: Must subset elements with a valid subscript vector.
 x The subscript has the wrong type `symbol`.
-i It must be logical or numeric.
+i It must be `logical` or `numeric`.
 
 
 vec_as_subscript2() forbids subscript types
@@ -39,17 +39,17 @@ vec_as_subscript2() forbids subscript types
 > vec_as_subscript2(1L, numeric = "error", logical = "error")
 Error: Must extract element with a single valid subscript.
 x The subscript has the wrong type `integer`.
-i It must be character.
+i It must be `character`.
 
 > vec_as_subscript2("foo", character = "error", logical = "error")
 Error: Must extract element with a single valid subscript.
 x The subscript has the wrong type `character`.
-i It must be numeric.
+i It must be `numeric`.
 
 > vec_as_subscript2(TRUE, logical = "error")
 Error: Must extract element with a single valid subscript.
 x The subscript has the wrong type `logical`.
-i It must be numeric or character.
+i It must be `numeric` or `character`.
 
 
 can customise subscript errors
@@ -58,5 +58,5 @@ can customise subscript errors
 > with_tibble_cols(vec_as_subscript(env()))
 Error: Must rename columns with a valid subscript vector.
 x The subscript `foo(bar)` has the wrong type `environment`.
-i It must be logical, numeric, or character.
+i It must be `logical`, `numeric`, or `character`.
 

--- a/tests/testthat/error/test-unchop.txt
+++ b/tests/testthat/error/test-unchop.txt
@@ -41,10 +41,10 @@ vec_unchop() does not support non-numeric S3 indices
 > vec_unchop(list(1), list(factor("x")))
 Error: Must subset elements with a valid subscript vector.
 x The subscript has the wrong type `character`.
-i It must be numeric.
+i It must be `numeric`.
 
 > vec_unchop(list(1), list(foobar(1L)))
 Error: Must subset elements with a valid subscript vector.
 x The subscript has the wrong type `vctrs_foobar`.
-i It must be numeric.
+i It must be `numeric`.
 


### PR DESCRIPTION
in error messages, for consistency.