### PR TITLE
Fix corner case in new_data_frame(n = NULL)

### DIFF
--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -86,10 +86,8 @@ SEXP vctrs_new_data_frame(SEXP args) {
 
     if (tag == R_RowNamesSymbol) {
       // "row.names" is checked for consistency with n (if provided)
-      if (size != rownames_size(CAR(node))) {
-        if (n != R_NilValue) {
-          Rf_errorcall(R_NilValue, "`n` and `row.names` must be consistent.");
-        }
+      if (size != rownames_size(CAR(node)) && n != R_NilValue) {
+        Rf_errorcall(R_NilValue, "`n` and `row.names` must be consistent.");
       }
 
       has_rownames = true;

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -87,7 +87,9 @@ SEXP vctrs_new_data_frame(SEXP args) {
     if (tag == R_RowNamesSymbol) {
       // "row.names" is checked for consistency with n (if provided)
       if (size != rownames_size(CAR(node))) {
-        Rf_errorcall(R_NilValue, "`n` and `row.names` must be consistent.");
+        if (n != R_NilValue) {
+          Rf_errorcall(R_NilValue, "`n` and `row.names` must be consistent.");
+        }
       }
 
       has_rownames = true;

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -280,11 +280,17 @@ test_that("attributes with special names are merged", {
     attr(new_data_frame(list(), n = 1L, row.names = "rowname"), "row.names"),
     "rowname"
   )
+})
 
+test_that("n and row.names (#894)", {
   # Can omit n if row.names attribute is given
   expect_identical(
-    new_data_frame(list(), row.names = "rowname"),
-    new_data_frame(list(), n = 1L, row.names = "rowname")
+    row.names(new_data_frame(list(), row.names = "rowname")),
+    "rowname"
+  )
+  expect_identical(
+    attr(new_data_frame(list(), row.names = 2L), "row.names"),
+    2L
   )
   expect_identical(
     row.names(new_data_frame(list(), row.names = chr())),

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -228,9 +228,9 @@ test_that("class attribute", {
     class(new_data_frame(list(a = 1), class = "foo_frame")),
     c("foo_frame", "data.frame")
   )
-  expect_error(
+  expect_identical(
     class(exec(new_data_frame, list(a = 1), !!!attributes(new_data_frame(list(), class = "tbl_df")))),
-    "`n` and `row.names` must be consistent"
+    c("tbl_df", "data.frame", "data.frame")
   )
   expect_identical(
     class(exec(new_data_frame, list(a = 1), !!!attributes(new_data_frame(list(b = 1), class = "tbl_df")))),
@@ -281,9 +281,10 @@ test_that("attributes with special names are merged", {
     "rowname"
   )
 
-  expect_error(
+  # Can omit n if row.names attribute is given
+  expect_identical(
     new_data_frame(list(), row.names = "rowname"),
-    "must be consistent"
+    new_data_frame(list(), n = 1L, row.names = "rowname")
   )
   expect_identical(
     row.names(new_data_frame(list(), row.names = chr())),


### PR DESCRIPTION
We should allow omitting `n` if `row.names` attribute is given.

Current behavior:

``` r
rlang::exec(
  vctrs::new_data_frame,
  list(),
  n = NULL, !!!attributes(data.frame(a = 1)[0])
)
#> Error: `n` and `row.names` must be consistent.
```

<sup>Created on 2020-03-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

With this patch:

``` r
rlang::exec(
  vctrs::new_data_frame,
  list(),
  n = NULL, !!!attributes(data.frame(a = 1)[0])
)
#> data frame with 0 columns and 1 row
```

<sup>Created on 2020-03-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>