### PR TITLE
Improve `vec_equal_na()` performance with data frames

### DIFF
--- a/src/compare.c
+++ b/src/compare.c
@@ -234,7 +234,7 @@ static struct vctrs_df_rowwise_info df_compare_impl(SEXP x,
                                                     struct vctrs_df_rowwise_info info,
                                                     R_len_t n_row);
 
-static struct vctrs_df_rowwise_info init_rowwise_compare_info(R_len_t n_row) {
+static struct vctrs_df_rowwise_info new_rowwise_compare_info(R_len_t n_row) {
   struct vctrs_df_rowwise_info info;
 
   // Initialize to "equality" value
@@ -257,7 +257,7 @@ static struct vctrs_df_rowwise_info init_rowwise_compare_info(R_len_t n_row) {
 static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t n_row) {
   int nprot = 0;
 
-  struct vctrs_df_rowwise_info info = init_rowwise_compare_info(n_row);
+  struct vctrs_df_rowwise_info info = new_rowwise_compare_info(n_row);
   PROTECT_DF_ROWWISE_INFO(&info, &nprot);
 
   info = df_compare_impl(x, y, na_equal, info, n_row);

--- a/src/equal.c
+++ b/src/equal.c
@@ -500,6 +500,7 @@ static int lgl_equal_na_scalar(const int* x);
 static int int_equal_na_scalar(const int* x);
 static int dbl_equal_na_scalar(const double* x);
 static int cpl_equal_na_scalar(const Rcomplex* x);
+static int raw_equal_na_scalar(const Rbyte* x);
 static int chr_equal_na_scalar(const SEXP* x);
 static int list_equal_na_scalar(SEXP x, R_len_t i);
 static int df_equal_na_scalar(SEXP x, R_len_t i);
@@ -512,6 +513,7 @@ int equal_na(SEXP x, R_len_t i) {
   case INTSXP: return int_equal_na_scalar(INTEGER(x) + i);
   case REALSXP: return dbl_equal_na_scalar(REAL(x) + i);
   case CPLXSXP: return cpl_equal_na_scalar(COMPLEX(x) + i);
+  case RAWSXP: return raw_equal_na_scalar(RAW(x) + i);
   case STRSXP: return chr_equal_na_scalar(STRING_PTR(x) + i);
   default: break;
   }
@@ -570,6 +572,7 @@ SEXP vctrs_equal_na(SEXP x) {
   case vctrs_type_integer:   EQUAL_NA(int, INTEGER_RO, int_equal_na_scalar);
   case vctrs_type_double:    EQUAL_NA(double, REAL_RO, dbl_equal_na_scalar);
   case vctrs_type_complex:   EQUAL_NA(Rcomplex, COMPLEX_RO, cpl_equal_na_scalar);
+  case vctrs_type_raw:       EQUAL_NA(Rbyte, RAW_RO, raw_equal_na_scalar);
   case vctrs_type_character: EQUAL_NA(SEXP, STRING_PTR_RO, chr_equal_na_scalar);
   case vctrs_type_list:      EQUAL_NA_BARRIER(list_equal_na_scalar);
   case vctrs_type_dataframe: {
@@ -602,6 +605,11 @@ static int dbl_equal_na_scalar(const double* x) {
 
 static int cpl_equal_na_scalar(const Rcomplex* x) {
   return ISNAN(x->r) || ISNAN(x->i);
+}
+
+// Raw vectors can never be `NA`
+static int raw_equal_na_scalar(const Rbyte* x) {
+  return false;
 }
 
 static int chr_equal_na_scalar(const SEXP* x) {
@@ -722,6 +730,7 @@ static struct vctrs_df_rowwise_info vec_equal_na_col(SEXP x,
   case vctrs_type_integer:   EQUAL_NA_COL(int, INTEGER_RO, int_equal_na_scalar);
   case vctrs_type_double:    EQUAL_NA_COL(double, REAL_RO, dbl_equal_na_scalar);
   case vctrs_type_complex:   EQUAL_NA_COL(Rcomplex, COMPLEX_RO, cpl_equal_na_scalar);
+  case vctrs_type_raw:       EQUAL_NA_COL(Rbyte, RAW_RO, raw_equal_na_scalar);
   case vctrs_type_character: EQUAL_NA_COL(SEXP, STRING_PTR_RO, chr_equal_na_scalar);
   case vctrs_type_list:      EQUAL_NA_COL_BARRIER(list_equal_na_scalar);
   case vctrs_type_dataframe: return df_equal_na_impl(x, info, n_row);

--- a/src/equal.c
+++ b/src/equal.c
@@ -648,7 +648,7 @@ static struct vctrs_df_rowwise_info df_equal_na_impl(SEXP x,
 
     info = vec_equal_na_col(col, info, n_row);
 
-    // If we know all comparison values, break
+    // If all rows have at least one non-missing value, break
     if (info.remaining == 0) {
       break;
     }

--- a/src/equal.c
+++ b/src/equal.c
@@ -354,7 +354,7 @@ static struct vctrs_df_rowwise_info df_equal_impl(SEXP x,
                                                   struct vctrs_df_rowwise_info info,
                                                   R_len_t n_row);
 
-static struct vctrs_df_rowwise_info init_rowwise_equal_info(R_len_t n_row) {
+static struct vctrs_df_rowwise_info new_rowwise_equal_info(R_len_t n_row) {
   struct vctrs_df_rowwise_info info;
 
   // Initialize to "equality" value
@@ -380,7 +380,7 @@ static struct vctrs_df_rowwise_info init_rowwise_equal_info(R_len_t n_row) {
 static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t n_row) {
   int nprot = 0;
 
-  struct vctrs_df_rowwise_info info = init_rowwise_equal_info(n_row);
+  struct vctrs_df_rowwise_info info = new_rowwise_equal_info(n_row);
   PROTECT_DF_ROWWISE_INFO(&info, &nprot);
 
   info = df_equal_impl(x, y, na_equal, info, n_row);
@@ -653,7 +653,7 @@ static SEXP df_equal_na(SEXP x, R_len_t n_row) {
   int nprot = 0;
 
   // Same rowwise info as `df_equal()`
-  struct vctrs_df_rowwise_info info = init_rowwise_equal_info(n_row);
+  struct vctrs_df_rowwise_info info = new_rowwise_equal_info(n_row);
   PROTECT_DF_ROWWISE_INFO(&info, &nprot);
 
   info = df_equal_na_impl(x, info, n_row);

--- a/src/equal.c
+++ b/src/equal.c
@@ -496,14 +496,14 @@ static struct vctrs_df_rowwise_info vec_equal_col(SEXP x,
 
 // -----------------------------------------------------------------------------
 
-static int lgl_equal_na_scalar(const int* x);
-static int int_equal_na_scalar(const int* x);
-static int dbl_equal_na_scalar(const double* x);
-static int cpl_equal_na_scalar(const Rcomplex* x);
-static int raw_equal_na_scalar(const Rbyte* x);
-static int chr_equal_na_scalar(const SEXP* x);
-static int list_equal_na_scalar(SEXP x, R_len_t i);
-static int df_equal_na_scalar(SEXP x, R_len_t i);
+static inline int lgl_equal_na_scalar(const int* x);
+static inline int int_equal_na_scalar(const int* x);
+static inline int dbl_equal_na_scalar(const double* x);
+static inline int cpl_equal_na_scalar(const Rcomplex* x);
+static inline int raw_equal_na_scalar(const Rbyte* x);
+static inline int chr_equal_na_scalar(const SEXP* x);
+static inline int list_equal_na_scalar(SEXP x, R_len_t i);
+static inline int df_equal_na_scalar(SEXP x, R_len_t i);
 
 // If `x` is a data frame, it must have been recursively proxied
 // beforehand so we can safely use `TYPEOF(x)`
@@ -588,39 +588,39 @@ SEXP vctrs_equal_na(SEXP x) {
 #undef EQUAL_NA
 #undef EQUAL_NA_BARRIER
 
-static int lgl_equal_na_scalar(const int* x) {
+static inline int lgl_equal_na_scalar(const int* x) {
   return *x == NA_LOGICAL;
 }
 
-static int int_equal_na_scalar(const int* x) {
+static inline int int_equal_na_scalar(const int* x) {
   return *x == NA_INTEGER;
 }
 
-static int dbl_equal_na_scalar(const double* x) {
+static inline int dbl_equal_na_scalar(const double* x) {
   // is.na(NaN) is TRUE
   // isnan() does not consistently return 1 and 0 on all platforms,
   // but R's ISNAN() does
   return ISNAN(*x);
 }
 
-static int cpl_equal_na_scalar(const Rcomplex* x) {
+static inline int cpl_equal_na_scalar(const Rcomplex* x) {
   return ISNAN(x->r) || ISNAN(x->i);
 }
 
 // Raw vectors can never be `NA`
-static int raw_equal_na_scalar(const Rbyte* x) {
+static inline int raw_equal_na_scalar(const Rbyte* x) {
   return false;
 }
 
-static int chr_equal_na_scalar(const SEXP* x) {
+static inline int chr_equal_na_scalar(const SEXP* x) {
   return *x == NA_STRING;
 }
 
-static int list_equal_na_scalar(SEXP x, R_len_t i) {
+static inline int list_equal_na_scalar(SEXP x, R_len_t i) {
   return Rf_isNull(VECTOR_ELT(x, i));
 }
 
-static int df_equal_na_scalar(SEXP x, R_len_t i) {
+static inline int df_equal_na_scalar(SEXP x, R_len_t i) {
   int n_col = Rf_length(x);
 
   for (int k = 0; k < n_col; ++k) {

--- a/src/equal.c
+++ b/src/equal.c
@@ -527,46 +527,59 @@ int equal_na(SEXP x, R_len_t i) {
 
 #define EQUAL_NA(CTYPE, CONST_DEREF, SCALAR_EQUAL_NA)     \
   do {                                                    \
-    const CTYPE* xp = CONST_DEREF(x);                     \
+    SEXP out = PROTECT(Rf_allocVector(LGLSXP, size));     \
+    int* p_out = LOGICAL(out);                            \
                                                           \
-    for (R_len_t i = 0; i < n; ++i, ++xp) {               \
-      p[i] = SCALAR_EQUAL_NA(xp);                         \
+    const CTYPE* p_x = CONST_DEREF(x);                    \
+                                                          \
+    for (R_len_t i = 0; i < size; ++i, ++p_x) {           \
+      p_out[i] = SCALAR_EQUAL_NA(p_x);                    \
     }                                                     \
+                                                          \
+    UNPROTECT(2);                                         \
+    return out;                                           \
   }                                                       \
   while (0)
 
 #define EQUAL_NA_BARRIER(SCALAR_EQUAL_NA)                 \
   do {                                                    \
-    for (R_len_t i = 0; i < n; ++i) {                     \
-      p[i] = SCALAR_EQUAL_NA(x, i);                       \
+    SEXP out = PROTECT(Rf_allocVector(LGLSXP, size));     \
+    int* p_out = LOGICAL(out);                            \
+                                                          \
+    for (R_len_t i = 0; i < size; ++i) {                  \
+      p_out[i] = SCALAR_EQUAL_NA(x, i);                   \
     }                                                     \
+                                                          \
+    UNPROTECT(2);                                         \
+    return out;                                           \
   }                                                       \
   while (0)
 
+static SEXP df_equal_na(SEXP x, R_len_t n_row);
+
 // [[ register() ]]
 SEXP vctrs_equal_na(SEXP x) {
-  R_len_t n = vec_size(x);
-  SEXP out = PROTECT(Rf_allocVector(LGLSXP, n));
-  int32_t* p = LOGICAL(out);
+  R_len_t size = vec_size(x);
 
   x = PROTECT(vec_proxy_equal(x));
 
   enum vctrs_type type = vec_proxy_typeof(x);
 
   switch (type) {
-  case vctrs_type_logical:   EQUAL_NA(int, LOGICAL_RO, lgl_equal_na_scalar); break;
-  case vctrs_type_integer:   EQUAL_NA(int, INTEGER_RO, int_equal_na_scalar); break;
-  case vctrs_type_double:    EQUAL_NA(double, REAL_RO, dbl_equal_na_scalar); break;
-  case vctrs_type_complex:   EQUAL_NA(Rcomplex, COMPLEX_RO, cpl_equal_na_scalar); break;
-  case vctrs_type_character: EQUAL_NA(SEXP, STRING_PTR_RO, chr_equal_na_scalar); break;
-  case vctrs_type_list:      EQUAL_NA_BARRIER(list_equal_na_scalar); break;
-  case vctrs_type_dataframe: EQUAL_NA_BARRIER(df_equal_na_scalar); break;
+  case vctrs_type_logical:   EQUAL_NA(int, LOGICAL_RO, lgl_equal_na_scalar);
+  case vctrs_type_integer:   EQUAL_NA(int, INTEGER_RO, int_equal_na_scalar);
+  case vctrs_type_double:    EQUAL_NA(double, REAL_RO, dbl_equal_na_scalar);
+  case vctrs_type_complex:   EQUAL_NA(Rcomplex, COMPLEX_RO, cpl_equal_na_scalar);
+  case vctrs_type_character: EQUAL_NA(SEXP, STRING_PTR_RO, chr_equal_na_scalar);
+  case vctrs_type_list:      EQUAL_NA_BARRIER(list_equal_na_scalar);
+  case vctrs_type_dataframe: {
+    SEXP out = df_equal_na(x, size);
+    UNPROTECT(1);
+    return out;
+  }
   case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't detect `NA` values in scalars with `vctrs_equal_na()`.");
   default:                   Rf_error("Unimplemented type in `vctrs_equal_na()`.");
   }
-
-  UNPROTECT(2);
-  return out;
 }
 
 #undef EQUAL_NA
@@ -610,3 +623,112 @@ static int df_equal_na_scalar(SEXP x, R_len_t i) {
 
   return true;
 }
+
+// -----------------------------------------------------------------------------
+
+static struct vctrs_df_rowwise_info vec_equal_na_col(SEXP x,
+                                                     struct vctrs_df_rowwise_info info,
+                                                     R_len_t n_row);
+
+static struct vctrs_df_rowwise_info df_equal_na_impl(SEXP x,
+                                                     struct vctrs_df_rowwise_info info,
+                                                     R_len_t n_row) {
+  int n_col = Rf_length(x);
+
+  for (R_len_t i = 0; i < n_col; ++i) {
+    SEXP col = VECTOR_ELT(x, i);
+
+    info = vec_equal_na_col(col, info, n_row);
+
+    // If we know all comparison values, break
+    if (info.remaining == 0) {
+      break;
+    }
+  }
+
+  return info;
+}
+
+static SEXP df_equal_na(SEXP x, R_len_t n_row) {
+  int nprot = 0;
+
+  // Same rowwise info as `df_equal()`
+  struct vctrs_df_rowwise_info info = init_rowwise_equal_info(n_row);
+  PROTECT_DF_ROWWISE_INFO(&info, &nprot);
+
+  info = df_equal_na_impl(x, info, n_row);
+
+  UNPROTECT(nprot);
+  return info.out;
+}
+
+// -----------------------------------------------------------------------------
+
+#define EQUAL_NA_COL(CTYPE, CONST_DEREF, SCALAR_EQUAL_NA) \
+do {                                                      \
+  int* p_out = LOGICAL(info.out);                         \
+                                                          \
+  const CTYPE* p_x = CONST_DEREF(x);                      \
+                                                          \
+  for (R_len_t i = 0; i < n_row; ++i, ++p_x) {            \
+    if (info.p_row_known[i]) {                            \
+      continue;                                           \
+    }                                                     \
+                                                          \
+    if (!SCALAR_EQUAL_NA(p_x)) {                          \
+      p_out[i] = 0;                                       \
+      info.p_row_known[i] = true;                         \
+      --info.remaining;                                   \
+                                                          \
+      if (info.remaining == 0) {                          \
+        break;                                            \
+      }                                                   \
+    }                                                     \
+  }                                                       \
+                                                          \
+  return info;                                            \
+}                                                         \
+while (0)
+
+#define EQUAL_NA_COL_BARRIER(SCALAR_EQUAL_NA) \
+do {                                          \
+  int* p_out = LOGICAL(info.out);             \
+                                              \
+  for (R_len_t i = 0; i < n_row; ++i) {       \
+    if (info.p_row_known[i]) {                \
+      continue;                               \
+    }                                         \
+                                              \
+    if (!SCALAR_EQUAL_NA(x, i)) {             \
+      p_out[i] = 0;                           \
+      info.p_row_known[i] = true;             \
+      --info.remaining;                       \
+                                              \
+      if (info.remaining == 0) {              \
+        break;                                \
+      }                                       \
+    }                                         \
+  }                                           \
+                                              \
+  return info;                                \
+}                                             \
+while (0)
+
+static struct vctrs_df_rowwise_info vec_equal_na_col(SEXP x,
+                                                     struct vctrs_df_rowwise_info info,
+                                                     R_len_t n_row) {
+  switch (vec_proxy_typeof(x)) {
+  case vctrs_type_logical:   EQUAL_NA_COL(int, LOGICAL_RO, lgl_equal_na_scalar);
+  case vctrs_type_integer:   EQUAL_NA_COL(int, INTEGER_RO, int_equal_na_scalar);
+  case vctrs_type_double:    EQUAL_NA_COL(double, REAL_RO, dbl_equal_na_scalar);
+  case vctrs_type_complex:   EQUAL_NA_COL(Rcomplex, COMPLEX_RO, cpl_equal_na_scalar);
+  case vctrs_type_character: EQUAL_NA_COL(SEXP, STRING_PTR_RO, chr_equal_na_scalar);
+  case vctrs_type_list:      EQUAL_NA_COL_BARRIER(list_equal_na_scalar);
+  case vctrs_type_dataframe: return df_equal_na_impl(x, info, n_row);
+  case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vec_equal_na()`");
+  default:                   Rf_error("Unimplemented type in `vec_equal_na()`");
+  }
+}
+
+#undef EQUAL_NA_COL
+#undef EQUAL_NA_COL_BARRIER

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -288,9 +288,20 @@ test_that("can detect different types of NA", {
   expect_true(vec_equal_na(list(NULL)))
 })
 
+test_that("can detect different types of NA in data frames", {
+  # using multiple columns to prevent proxy unwrapping
+  expect_true(vec_equal_na(data.frame(x = NA, y = NA)))
+  expect_true(vec_equal_na(data.frame(x = NA_integer_, y = NA_integer_)))
+  expect_true(vec_equal_na(data.frame(x = NA_real_, y = NaN)))
+  expect_true(vec_equal_na(data.frame(x = NA_complex_, y = NA_complex_)))
+  expect_true(vec_equal_na(data.frame(x = complex(real = NA, imaginary = 1), y = complex(real = 1, imaginary = NA))))
+  expect_true(vec_equal_na(data.frame(x = NA_character_, y = NA_character_)))
+  expect_true(vec_equal_na(new_data_frame(list(x = list(NULL), y = list(NULL)))))
+})
+
 test_that("raw vectors can never be NA", {
   expect_false(vec_equal_na(raw(1)))
-  expect_false(vec_equal_na(data.frame(x = raw(1))))
+  expect_false(vec_equal_na(data.frame(x = raw(1), y = raw(1))))
 })
 
 test_that("vectorised over rows of a data frame", {

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -288,6 +288,11 @@ test_that("can detect different types of NA", {
   expect_true(vec_equal_na(list(NULL)))
 })
 
+test_that("raw vectors can never be NA", {
+  expect_false(vec_equal_na(raw(1)))
+  expect_false(vec_equal_na(data.frame(x = raw(1))))
+})
+
 test_that("vectorised over rows of a data frame", {
   df <- data.frame(x = c(1, 1, NA, NA), y = c(1, NA, 1, NA))
   expect_equal(vec_equal_na(df), c(FALSE, FALSE, FALSE, TRUE))


### PR DESCRIPTION
This PR updates `vec_equal_na()` to use the faster traversal method with data frames (looping over the columns one at a time, and early exiting if we know all the results).

It also adds support for `vec_equal_na()` with raw vectors. This always returns `FALSE`, but it doesn't error now.

This worst case scenario below only happens when all elements are `NA`. Even that is much faster than the current master implementation.

```r
library(vctrs)

# worst case
x <- data.frame(x = rep(NA, 1e5), y = rep(NA, 1e5), z = rep(NA, 1e5))

bench::mark(vec_equal_na(x))

# master
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(x)   2.57ms   2.75ms      349.     395KB     2.14

# this PR
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(x)    300µs    358µs     2596.     492KB     22.7
```

```r
# short circuit after the first column
y <- data.frame(x = rep(1, 1e5), y = rep(2, 1e5), z = rep(3, 1e5))

bench::mark(vec_equal_na(y))

# master
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(y)    894µs    953µs     1017.     391KB     6.24

# this PR
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(y)    117µs    150µs     6091.     488KB     54.7
```