### PR TITLE
Light refactoring of column iteration helpers

### DIFF
--- a/src/compare.c
+++ b/src/compare.c
@@ -222,17 +222,17 @@ SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal_) {
 
 // -----------------------------------------------------------------------------
 
-static struct vctrs_df_rowwise_info vec_compare_col(int* p_out,
+static struct df_short_circuit_info vec_compare_col(int* p_out,
                                                     SEXP x,
                                                     SEXP y,
                                                     bool na_equal,
-                                                    struct vctrs_df_rowwise_info info);
+                                                    struct df_short_circuit_info info);
 
-static struct vctrs_df_rowwise_info df_compare_impl(int* p_out,
+static struct df_short_circuit_info df_compare_impl(int* p_out,
                                                     SEXP x,
                                                     SEXP y,
                                                     bool na_equal,
-                                                    struct vctrs_df_rowwise_info info);
+                                                    struct df_short_circuit_info info);
 
 static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t size) {
   int nprot = 0;
@@ -244,8 +244,8 @@ static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t size) {
   // and only change if we learn that it differs
   memset(p_out, 0, size * sizeof(int));
 
-  struct vctrs_df_rowwise_info info = new_rowwise_info(size);
-  PROTECT_DF_ROWWISE_INFO(&info, &nprot);
+  struct df_short_circuit_info info = new_df_short_circuit_info(size);
+  PROTECT_DF_SHORT_CIRCUIT_INFO(&info, &nprot);
 
   df_compare_impl(p_out, x, y, na_equal, info);
 
@@ -253,11 +253,11 @@ static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t size) {
   return out;
 }
 
-static struct vctrs_df_rowwise_info df_compare_impl(int* p_out,
+static struct df_short_circuit_info df_compare_impl(int* p_out,
                                                     SEXP x,
                                                     SEXP y,
                                                     bool na_equal,
-                                                    struct vctrs_df_rowwise_info info) {
+                                                    struct df_short_circuit_info info) {
   int n_col = Rf_length(x);
 
   if (n_col == 0) {
@@ -312,11 +312,11 @@ do {                                                                 \
 }                                                                    \
 while (0)
 
-static struct vctrs_df_rowwise_info vec_compare_col(int* p_out,
+static struct df_short_circuit_info vec_compare_col(int* p_out,
                                                     SEXP x,
                                                     SEXP y,
                                                     bool na_equal,
-                                                    struct vctrs_df_rowwise_info info) {
+                                                    struct df_short_circuit_info info) {
   switch (vec_proxy_typeof(x)) {
   case vctrs_type_logical:   COMPARE_COL(int, LOGICAL_RO, lgl_compare_scalar);
   case vctrs_type_integer:   COMPARE_COL(int, INTEGER_RO, int_compare_scalar);

--- a/src/compare.c
+++ b/src/compare.c
@@ -222,17 +222,17 @@ SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal_) {
 
 // -----------------------------------------------------------------------------
 
-static struct df_short_circuit_info* vec_compare_col(int* p_out,
-                                                     SEXP x,
-                                                     SEXP y,
-                                                     bool na_equal,
-                                                     struct df_short_circuit_info* p_info);
+static void vec_compare_col(int* p_out,
+                            SEXP x,
+                            SEXP y,
+                            bool na_equal,
+                            struct df_short_circuit_info* p_info);
 
-static struct df_short_circuit_info* df_compare_impl(int* p_out,
-                                                     SEXP x,
-                                                     SEXP y,
-                                                     bool na_equal,
-                                                     struct df_short_circuit_info* p_info);
+static void df_compare_impl(int* p_out,
+                            SEXP x,
+                            SEXP y,
+                            bool na_equal,
+                            struct df_short_circuit_info* p_info);
 
 static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t size) {
   int nprot = 0;
@@ -248,17 +248,17 @@ static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t size) {
   struct df_short_circuit_info* p_info = &info;
   PROTECT_DF_SHORT_CIRCUIT_INFO(p_info, &nprot);
 
-  p_info = df_compare_impl(p_out, x, y, na_equal, p_info);
+  df_compare_impl(p_out, x, y, na_equal, p_info);
 
   UNPROTECT(nprot);
   return out;
 }
 
-static struct df_short_circuit_info* df_compare_impl(int* p_out,
-                                                     SEXP x,
-                                                     SEXP y,
-                                                     bool na_equal,
-                                                     struct df_short_circuit_info* p_info) {
+static void df_compare_impl(int* p_out,
+                            SEXP x,
+                            SEXP y,
+                            bool na_equal,
+                            struct df_short_circuit_info* p_info) {
   int n_col = Rf_length(x);
 
   if (n_col == 0) {
@@ -273,15 +273,13 @@ static struct df_short_circuit_info* df_compare_impl(int* p_out,
     SEXP x_col = VECTOR_ELT(x, i);
     SEXP y_col = VECTOR_ELT(y, i);
 
-    p_info = vec_compare_col(p_out, x_col, y_col, na_equal, p_info);
+    vec_compare_col(p_out, x_col, y_col, na_equal, p_info);
 
     // If we know all comparison values, break
     if (p_info->remaining == 0) {
       break;
     }
   }
-
-  return p_info;
 }
 
 // -----------------------------------------------------------------------------
@@ -308,22 +306,20 @@ do {                                                                 \
       }                                                              \
     }                                                                \
   }                                                                  \
-                                                                     \
-  return p_info;                                                     \
 }                                                                    \
 while (0)
 
-static struct df_short_circuit_info* vec_compare_col(int* p_out,
-                                                     SEXP x,
-                                                     SEXP y,
-                                                     bool na_equal,
-                                                     struct df_short_circuit_info* p_info) {
+static void vec_compare_col(int* p_out,
+                            SEXP x,
+                            SEXP y,
+                            bool na_equal,
+                            struct df_short_circuit_info* p_info) {
   switch (vec_proxy_typeof(x)) {
-  case vctrs_type_logical:   COMPARE_COL(int, LOGICAL_RO, lgl_compare_scalar);
-  case vctrs_type_integer:   COMPARE_COL(int, INTEGER_RO, int_compare_scalar);
-  case vctrs_type_double:    COMPARE_COL(double, REAL_RO, dbl_compare_scalar);
-  case vctrs_type_character: COMPARE_COL(SEXP, STRING_PTR_RO, chr_compare_scalar);
-  case vctrs_type_dataframe: return df_compare_impl(p_out, x, y, na_equal, p_info);
+  case vctrs_type_logical:   COMPARE_COL(int, LOGICAL_RO, lgl_compare_scalar); break;
+  case vctrs_type_integer:   COMPARE_COL(int, INTEGER_RO, int_compare_scalar); break;
+  case vctrs_type_double:    COMPARE_COL(double, REAL_RO, dbl_compare_scalar); break;
+  case vctrs_type_character: COMPARE_COL(SEXP, STRING_PTR_RO, chr_compare_scalar); break;
+  case vctrs_type_dataframe: df_compare_impl(p_out, x, y, na_equal, p_info); break;
   case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
   case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
   default:                   Rf_error("Unimplemented type in `vctrs_compare()`");

--- a/src/compare.c
+++ b/src/compare.c
@@ -234,24 +234,6 @@ static struct vctrs_df_rowwise_info df_compare_impl(int* p_out,
                                                     bool na_equal,
                                                     struct vctrs_df_rowwise_info info);
 
-static struct vctrs_df_rowwise_info new_rowwise_compare_info(R_len_t size) {
-  SEXP row_known = PROTECT(Rf_allocVector(RAWSXP, size * sizeof(bool)));
-  bool* p_row_known = (bool*) RAW(row_known);
-
-  // To begin with, no rows have a known comparison value
-  memset(p_row_known, false, size * sizeof(bool));
-
-  struct vctrs_df_rowwise_info info = {
-    .row_known = row_known,
-    .p_row_known = p_row_known,
-    .remaining = size,
-    .size = size
-  };
-
-  UNPROTECT(1);
-  return info;
-}
-
 static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t size) {
   int nprot = 0;
 
@@ -262,7 +244,7 @@ static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t size) {
   // and only change if we learn that it differs
   memset(p_out, 0, size * sizeof(int));
 
-  struct vctrs_df_rowwise_info info = new_rowwise_compare_info(size);
+  struct vctrs_df_rowwise_info info = new_rowwise_info(size);
   PROTECT_DF_ROWWISE_INFO(&info, &nprot);
 
   df_compare_impl(p_out, x, y, na_equal, info);

--- a/src/equal.c
+++ b/src/equal.c
@@ -352,33 +352,6 @@ static struct df_short_circuit_info df_equal_impl(int* p_out,
                                                   SEXP x,
                                                   SEXP y,
                                                   bool na_equal,
-                                                  struct df_short_circuit_info info);
-
-static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t size) {
-  int nprot = 0;
-
-  SEXP out = PROTECT_N(Rf_allocVector(LGLSXP, size), &nprot);
-  int* p_out = LOGICAL(out);
-
-  // Initialize to "equality" value
-  // and only change if we learn that it differs
-  for (R_len_t i = 0; i < size; ++i) {
-    p_out[i] = 1;
-  }
-
-  struct df_short_circuit_info info = new_df_short_circuit_info(size);
-  PROTECT_DF_SHORT_CIRCUIT_INFO(&info, &nprot);
-
-  info = df_equal_impl(p_out, x, y, na_equal, info);
-
-  UNPROTECT(nprot);
-  return out;
-}
-
-static struct df_short_circuit_info df_equal_impl(int* p_out,
-                                                  SEXP x,
-                                                  SEXP y,
-                                                  bool na_equal,
                                                   struct df_short_circuit_info info) {
   int n_col = Rf_length(x);
 
@@ -399,6 +372,27 @@ static struct df_short_circuit_info df_equal_impl(int* p_out,
   }
 
   return info;
+}
+
+static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t size) {
+  int nprot = 0;
+
+  SEXP out = PROTECT_N(Rf_allocVector(LGLSXP, size), &nprot);
+  int* p_out = LOGICAL(out);
+
+  // Initialize to "equality" value
+  // and only change if we learn that it differs
+  for (R_len_t i = 0; i < size; ++i) {
+    p_out[i] = 1;
+  }
+
+  struct df_short_circuit_info info = new_df_short_circuit_info(size);
+  PROTECT_DF_SHORT_CIRCUIT_INFO(&info, &nprot);
+
+  info = df_equal_impl(p_out, x, y, na_equal, info);
+
+  UNPROTECT(nprot);
+  return out;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/equal.c
+++ b/src/equal.c
@@ -354,24 +354,6 @@ static struct vctrs_df_rowwise_info df_equal_impl(int* p_out,
                                                   bool na_equal,
                                                   struct vctrs_df_rowwise_info info);
 
-static struct vctrs_df_rowwise_info new_rowwise_equal_info(R_len_t size) {
-  SEXP row_known = PROTECT(Rf_allocVector(RAWSXP, size * sizeof(bool)));
-  bool* p_row_known = (bool*) RAW(row_known);
-
-  // To begin with, no rows have a known comparison value
-  memset(p_row_known, false, size * sizeof(bool));
-
-  struct vctrs_df_rowwise_info info = {
-    .row_known = row_known,
-    .p_row_known = p_row_known,
-    .remaining = size,
-    .size = size
-  };
-
-  UNPROTECT(1);
-  return info;
-}
-
 static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t size) {
   int nprot = 0;
 
@@ -384,7 +366,7 @@ static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t size) {
     p_out[i] = 1;
   }
 
-  struct vctrs_df_rowwise_info info = new_rowwise_equal_info(size);
+  struct vctrs_df_rowwise_info info = new_rowwise_info(size);
   PROTECT_DF_ROWWISE_INFO(&info, &nprot);
 
   info = df_equal_impl(p_out, x, y, na_equal, info);
@@ -669,8 +651,7 @@ static SEXP df_equal_na(SEXP x, R_len_t size) {
     p_out[i] = 1;
   }
 
-  // Same rowwise info as `df_equal()`
-  struct vctrs_df_rowwise_info info = new_rowwise_equal_info(size);
+  struct vctrs_df_rowwise_info info = new_rowwise_info(size);
   PROTECT_DF_ROWWISE_INFO(&info, &nprot);
 
   info = df_equal_na_impl(p_out, x, info);

--- a/src/equal.c
+++ b/src/equal.c
@@ -342,17 +342,17 @@ bool equal_names(SEXP x, SEXP y) {
 
 // -----------------------------------------------------------------------------
 
-static struct vctrs_df_rowwise_info vec_equal_col(int* p_out,
+static struct df_short_circuit_info vec_equal_col(int* p_out,
                                                   SEXP x,
                                                   SEXP y,
                                                   bool na_equal,
-                                                  struct vctrs_df_rowwise_info info);
+                                                  struct df_short_circuit_info info);
 
-static struct vctrs_df_rowwise_info df_equal_impl(int* p_out,
+static struct df_short_circuit_info df_equal_impl(int* p_out,
                                                   SEXP x,
                                                   SEXP y,
                                                   bool na_equal,
-                                                  struct vctrs_df_rowwise_info info);
+                                                  struct df_short_circuit_info info);
 
 static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t size) {
   int nprot = 0;
@@ -366,8 +366,8 @@ static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t size) {
     p_out[i] = 1;
   }
 
-  struct vctrs_df_rowwise_info info = new_rowwise_info(size);
-  PROTECT_DF_ROWWISE_INFO(&info, &nprot);
+  struct df_short_circuit_info info = new_df_short_circuit_info(size);
+  PROTECT_DF_SHORT_CIRCUIT_INFO(&info, &nprot);
 
   info = df_equal_impl(p_out, x, y, na_equal, info);
 
@@ -375,11 +375,11 @@ static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t size) {
   return out;
 }
 
-static struct vctrs_df_rowwise_info df_equal_impl(int* p_out,
+static struct df_short_circuit_info df_equal_impl(int* p_out,
                                                   SEXP x,
                                                   SEXP y,
                                                   bool na_equal,
-                                                  struct vctrs_df_rowwise_info info) {
+                                                  struct df_short_circuit_info info) {
   int n_col = Rf_length(x);
 
   if (n_col != Rf_length(y)) {
@@ -454,11 +454,11 @@ do {                                                   \
 }                                                      \
 while (0)
 
-static struct vctrs_df_rowwise_info vec_equal_col(int* p_out,
+static struct df_short_circuit_info vec_equal_col(int* p_out,
                                                   SEXP x,
                                                   SEXP y,
                                                   bool na_equal,
-                                                  struct vctrs_df_rowwise_info info) {
+                                                  struct df_short_circuit_info info) {
   switch (vec_proxy_typeof(x)) {
   case vctrs_type_logical:   EQUAL_COL(int, LOGICAL_RO, lgl_equal_scalar);
   case vctrs_type_integer:   EQUAL_COL(int, INTEGER_RO, int_equal_scalar);
@@ -616,13 +616,13 @@ static inline int df_equal_na_scalar(SEXP x, R_len_t i) {
 
 // -----------------------------------------------------------------------------
 
-static struct vctrs_df_rowwise_info vec_equal_na_col(int* p_out,
+static struct df_short_circuit_info vec_equal_na_col(int* p_out,
                                                      SEXP x,
-                                                     struct vctrs_df_rowwise_info info);
+                                                     struct df_short_circuit_info info);
 
-static struct vctrs_df_rowwise_info df_equal_na_impl(int* p_out,
+static struct df_short_circuit_info df_equal_na_impl(int* p_out,
                                                      SEXP x,
-                                                     struct vctrs_df_rowwise_info info) {
+                                                     struct df_short_circuit_info info) {
   int n_col = Rf_length(x);
 
   for (R_len_t i = 0; i < n_col; ++i) {
@@ -651,8 +651,8 @@ static SEXP df_equal_na(SEXP x, R_len_t size) {
     p_out[i] = 1;
   }
 
-  struct vctrs_df_rowwise_info info = new_rowwise_info(size);
-  PROTECT_DF_ROWWISE_INFO(&info, &nprot);
+  struct df_short_circuit_info info = new_df_short_circuit_info(size);
+  PROTECT_DF_SHORT_CIRCUIT_INFO(&info, &nprot);
 
   info = df_equal_na_impl(p_out, x, info);
 
@@ -708,9 +708,9 @@ do {                                          \
 }                                             \
 while (0)
 
-static struct vctrs_df_rowwise_info vec_equal_na_col(int* p_out,
+static struct df_short_circuit_info vec_equal_na_col(int* p_out,
                                                      SEXP x,
-                                                     struct vctrs_df_rowwise_info info) {
+                                                     struct df_short_circuit_info info) {
   switch (vec_proxy_typeof(x)) {
   case vctrs_type_logical:   EQUAL_NA_COL(int, LOGICAL_RO, lgl_equal_na_scalar);
   case vctrs_type_integer:   EQUAL_NA_COL(int, INTEGER_RO, int_equal_na_scalar);

--- a/src/equal.c
+++ b/src/equal.c
@@ -342,17 +342,17 @@ bool equal_names(SEXP x, SEXP y) {
 
 // -----------------------------------------------------------------------------
 
-static struct df_short_circuit_info vec_equal_col(int* p_out,
-                                                  SEXP x,
-                                                  SEXP y,
-                                                  bool na_equal,
-                                                  struct df_short_circuit_info info);
+static struct df_short_circuit_info* vec_equal_col(int* p_out,
+                                                   SEXP x,
+                                                   SEXP y,
+                                                   bool na_equal,
+                                                   struct df_short_circuit_info* p_info);
 
-static struct df_short_circuit_info df_equal_impl(int* p_out,
-                                                  SEXP x,
-                                                  SEXP y,
-                                                  bool na_equal,
-                                                  struct df_short_circuit_info info) {
+static struct df_short_circuit_info* df_equal_impl(int* p_out,
+                                                   SEXP x,
+                                                   SEXP y,
+                                                   bool na_equal,
+                                                   struct df_short_circuit_info* p_info) {
   int n_col = Rf_length(x);
 
   if (n_col != Rf_length(y)) {
@@ -363,15 +363,15 @@ static struct df_short_circuit_info df_equal_impl(int* p_out,
     SEXP x_col = VECTOR_ELT(x, i);
     SEXP y_col = VECTOR_ELT(y, i);
 
-    info = vec_equal_col(p_out, x_col, y_col, na_equal, info);
+    p_info = vec_equal_col(p_out, x_col, y_col, na_equal, p_info);
 
     // If we know all comparison values, break
-    if (info.remaining == 0) {
+    if (p_info->remaining == 0) {
       break;
     }
   }
 
-  return info;
+  return p_info;
 }
 
 static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t size) {
@@ -387,9 +387,10 @@ static SEXP df_equal(SEXP x, SEXP y, bool na_equal, R_len_t size) {
   }
 
   struct df_short_circuit_info info = new_df_short_circuit_info(size);
-  PROTECT_DF_SHORT_CIRCUIT_INFO(&info, &nprot);
+  struct df_short_circuit_info* p_info = &info;
+  PROTECT_DF_SHORT_CIRCUIT_INFO(p_info, &nprot);
 
-  info = df_equal_impl(p_out, x, y, na_equal, info);
+  p_info = df_equal_impl(p_out, x, y, na_equal, p_info);
 
   UNPROTECT(nprot);
   return out;
@@ -402,8 +403,8 @@ do {                                                                 \
   const CTYPE* p_x = CONST_DEREF(x);                                 \
   const CTYPE* p_y = CONST_DEREF(y);                                 \
                                                                      \
-  for (R_len_t i = 0; i < info.size; ++i, ++p_x, ++p_y) {            \
-    if (info.p_row_known[i]) {                                       \
+  for (R_len_t i = 0; i < p_info->size; ++i, ++p_x, ++p_y) {         \
+    if (p_info->p_row_known[i]) {                                    \
       continue;                                                      \
     }                                                                \
                                                                      \
@@ -411,23 +412,23 @@ do {                                                                 \
                                                                      \
     if (eq <= 0) {                                                   \
       p_out[i] = eq;                                                 \
-      info.p_row_known[i] = true;                                    \
-      --info.remaining;                                              \
+      p_info->p_row_known[i] = true;                                 \
+      --p_info->remaining;                                           \
                                                                      \
-      if (info.remaining == 0) {                                     \
+      if (p_info->remaining == 0) {                                  \
         break;                                                       \
       }                                                              \
     }                                                                \
   }                                                                  \
                                                                      \
-  return info;                                                       \
+  return p_info;                                                     \
 }                                                                    \
 while (0)
 
 #define EQUAL_COL_BARRIER(SCALAR_EQUAL)                \
 do {                                                   \
-  for (R_len_t i = 0; i < info.size; ++i) {            \
-    if (info.p_row_known[i]) {                         \
+  for (R_len_t i = 0; i < p_info->size; ++i) {         \
+    if (p_info->p_row_known[i]) {                      \
       continue;                                        \
     }                                                  \
                                                        \
@@ -435,24 +436,24 @@ do {                                                   \
                                                        \
     if (eq <= 0) {                                     \
       p_out[i] = eq;                                   \
-      info.p_row_known[i] = true;                      \
-      --info.remaining;                                \
+      p_info->p_row_known[i] = true;                   \
+      --p_info->remaining;                             \
                                                        \
-      if (info.remaining == 0) {                       \
+      if (p_info->remaining == 0) {                    \
         break;                                         \
       }                                                \
     }                                                  \
   }                                                    \
                                                        \
-  return info;                                         \
+  return p_info;                                       \
 }                                                      \
 while (0)
 
-static struct df_short_circuit_info vec_equal_col(int* p_out,
-                                                  SEXP x,
-                                                  SEXP y,
-                                                  bool na_equal,
-                                                  struct df_short_circuit_info info) {
+static struct df_short_circuit_info* vec_equal_col(int* p_out,
+                                                   SEXP x,
+                                                   SEXP y,
+                                                   bool na_equal,
+                                                   struct df_short_circuit_info* p_info) {
   switch (vec_proxy_typeof(x)) {
   case vctrs_type_logical:   EQUAL_COL(int, LOGICAL_RO, lgl_equal_scalar);
   case vctrs_type_integer:   EQUAL_COL(int, INTEGER_RO, int_equal_scalar);
@@ -461,7 +462,7 @@ static struct df_short_circuit_info vec_equal_col(int* p_out,
   case vctrs_type_complex:   EQUAL_COL(Rcomplex, COMPLEX_RO, cpl_equal_scalar);
   case vctrs_type_character: EQUAL_COL(SEXP, STRING_PTR_RO, chr_equal_scalar);
   case vctrs_type_list:      EQUAL_COL_BARRIER(list_equal_scalar);
-  case vctrs_type_dataframe: return df_equal_impl(p_out, x, y, na_equal, info);
+  case vctrs_type_dataframe: return df_equal_impl(p_out, x, y, na_equal, p_info);
   case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_equal()`");
   default:                   Rf_error("Unimplemented type in `vctrs_equal()`");
   }
@@ -610,27 +611,27 @@ static inline int df_equal_na_scalar(SEXP x, R_len_t i) {
 
 // -----------------------------------------------------------------------------
 
-static struct df_short_circuit_info vec_equal_na_col(int* p_out,
-                                                     SEXP x,
-                                                     struct df_short_circuit_info info);
+static struct df_short_circuit_info* vec_equal_na_col(int* p_out,
+                                                      SEXP x,
+                                                      struct df_short_circuit_info* p_info);
 
-static struct df_short_circuit_info df_equal_na_impl(int* p_out,
-                                                     SEXP x,
-                                                     struct df_short_circuit_info info) {
+static struct df_short_circuit_info* df_equal_na_impl(int* p_out,
+                                                      SEXP x,
+                                                      struct df_short_circuit_info* p_info) {
   int n_col = Rf_length(x);
 
   for (R_len_t i = 0; i < n_col; ++i) {
     SEXP col = VECTOR_ELT(x, i);
 
-    info = vec_equal_na_col(p_out, col, info);
+    p_info = vec_equal_na_col(p_out, col, p_info);
 
     // If all rows have at least one non-missing value, break
-    if (info.remaining == 0) {
+    if (p_info->remaining == 0) {
       break;
     }
   }
 
-  return info;
+  return p_info;
 }
 
 static SEXP df_equal_na(SEXP x, R_len_t size) {
@@ -646,9 +647,10 @@ static SEXP df_equal_na(SEXP x, R_len_t size) {
   }
 
   struct df_short_circuit_info info = new_df_short_circuit_info(size);
-  PROTECT_DF_SHORT_CIRCUIT_INFO(&info, &nprot);
+  struct df_short_circuit_info* p_info = &info;
+  PROTECT_DF_SHORT_CIRCUIT_INFO(p_info, &nprot);
 
-  info = df_equal_na_impl(p_out, x, info);
+  p_info = df_equal_na_impl(p_out, x, p_info);
 
   UNPROTECT(nprot);
   return out;
@@ -660,51 +662,51 @@ static SEXP df_equal_na(SEXP x, R_len_t size) {
 do {                                                      \
   const CTYPE* p_x = CONST_DEREF(x);                      \
                                                           \
-  for (R_len_t i = 0; i < info.size; ++i, ++p_x) {        \
-    if (info.p_row_known[i]) {                            \
+  for (R_len_t i = 0; i < p_info->size; ++i, ++p_x) {     \
+    if (p_info->p_row_known[i]) {                         \
       continue;                                           \
     }                                                     \
                                                           \
     if (!SCALAR_EQUAL_NA(p_x)) {                          \
       p_out[i] = 0;                                       \
-      info.p_row_known[i] = true;                         \
-      --info.remaining;                                   \
+      p_info->p_row_known[i] = true;                      \
+      --p_info->remaining;                                \
                                                           \
-      if (info.remaining == 0) {                          \
+      if (p_info->remaining == 0) {                       \
         break;                                            \
       }                                                   \
     }                                                     \
   }                                                       \
                                                           \
-  return info;                                            \
+  return p_info;                                          \
 }                                                         \
 while (0)
 
-#define EQUAL_NA_COL_BARRIER(SCALAR_EQUAL_NA) \
-do {                                          \
-  for (R_len_t i = 0; i < info.size; ++i) {   \
-    if (info.p_row_known[i]) {                \
-      continue;                               \
-    }                                         \
-                                              \
-    if (!SCALAR_EQUAL_NA(x, i)) {             \
-      p_out[i] = 0;                           \
-      info.p_row_known[i] = true;             \
-      --info.remaining;                       \
-                                              \
-      if (info.remaining == 0) {              \
-        break;                                \
-      }                                       \
-    }                                         \
-  }                                           \
-                                              \
-  return info;                                \
-}                                             \
+#define EQUAL_NA_COL_BARRIER(SCALAR_EQUAL_NA)  \
+do {                                           \
+  for (R_len_t i = 0; i < p_info->size; ++i) { \
+    if (p_info->p_row_known[i]) {              \
+      continue;                                \
+    }                                          \
+                                               \
+    if (!SCALAR_EQUAL_NA(x, i)) {              \
+      p_out[i] = 0;                            \
+      p_info->p_row_known[i] = true;           \
+      --p_info->remaining;                     \
+                                               \
+      if (p_info->remaining == 0) {            \
+        break;                                 \
+      }                                        \
+    }                                          \
+  }                                            \
+                                               \
+  return p_info;                               \
+}                                              \
 while (0)
 
-static struct df_short_circuit_info vec_equal_na_col(int* p_out,
-                                                     SEXP x,
-                                                     struct df_short_circuit_info info) {
+static struct df_short_circuit_info* vec_equal_na_col(int* p_out,
+                                                      SEXP x,
+                                                      struct df_short_circuit_info* p_info) {
   switch (vec_proxy_typeof(x)) {
   case vctrs_type_logical:   EQUAL_NA_COL(int, LOGICAL_RO, lgl_equal_na_scalar);
   case vctrs_type_integer:   EQUAL_NA_COL(int, INTEGER_RO, int_equal_na_scalar);
@@ -713,7 +715,7 @@ static struct df_short_circuit_info vec_equal_na_col(int* p_out,
   case vctrs_type_raw:       EQUAL_NA_COL(Rbyte, RAW_RO, raw_equal_na_scalar);
   case vctrs_type_character: EQUAL_NA_COL(SEXP, STRING_PTR_RO, chr_equal_na_scalar);
   case vctrs_type_list:      EQUAL_NA_COL_BARRIER(list_equal_na_scalar);
-  case vctrs_type_dataframe: return df_equal_na_impl(p_out, x, info);
+  case vctrs_type_dataframe: return df_equal_na_impl(p_out, x, p_info);
   case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vec_equal_na()`");
   default:                   Rf_error("Unimplemented type in `vec_equal_na()`");
   }

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -493,6 +493,7 @@ struct vctrs_df_rowwise_info {
   SEXP row_known;
   bool* p_row_known;
   R_len_t remaining;
+  R_len_t size;
 };
 
 #define PROTECT_DF_ROWWISE_INFO(info, n) do {  \

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -477,8 +477,6 @@ bool duplicated_any(SEXP names);
 // `vec_compare()`.
 
 /**
- * @member out A vector of size `n_row` containing the output of the
- *   row wise data frame operation.
  * @member row_known A boolean array of size `n_row`. Allocated on the R heap.
  *   Initially, all values are initialized to `false`. As we iterate along the
  *   columns, we flip the corresponding row's `row_known` value to `true` if we
@@ -492,16 +490,14 @@ bool duplicated_any(SEXP names);
  *   immediately because all `out` values are already known.
  */
 struct vctrs_df_rowwise_info {
-  SEXP out;
   SEXP row_known;
   bool* p_row_known;
   R_len_t remaining;
 };
 
 #define PROTECT_DF_ROWWISE_INFO(info, n) do {  \
-  PROTECT((info)->out);                        \
   PROTECT((info)->row_known);                  \
-  *n += 2;                                     \
+  *n += 1;                                     \
 } while (0)
 
 // Missing values -----------------------------------------------

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -488,6 +488,7 @@ bool duplicated_any(SEXP names);
  * @member remaining The number of `row_known` values that are still `false`.
  *   If this hits `0` before we traverse the entire data frame, we can exit
  *   immediately because all `out` values are already known.
+ * @member size The number of rows in the data frame.
  */
 struct df_short_circuit_info {
   SEXP row_known;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -470,10 +470,10 @@ void hash_fill(uint32_t* p, R_len_t n, SEXP x, bool na_equal);
 SEXP vec_unique(SEXP x);
 bool duplicated_any(SEXP names);
 
-// Rowwise operations -------------------------------------------
+// Data frame column iteration ----------------------------------
 
 // Used in functions that treat data frames as vectors of rows, but
-// iterate over them column wise. Examples are `vec_equal()` and
+// iterate over columns. Examples are `vec_equal()` and
 // `vec_compare()`.
 
 /**
@@ -489,26 +489,26 @@ bool duplicated_any(SEXP names);
  *   If this hits `0` before we traverse the entire data frame, we can exit
  *   immediately because all `out` values are already known.
  */
-struct vctrs_df_rowwise_info {
+struct df_short_circuit_info {
   SEXP row_known;
   bool* p_row_known;
   R_len_t remaining;
   R_len_t size;
 };
 
-#define PROTECT_DF_ROWWISE_INFO(info, n) do {  \
-  PROTECT((info)->row_known);                  \
-  *n += 1;                                     \
+#define PROTECT_DF_SHORT_CIRCUIT_INFO(info, n) do {  \
+  PROTECT((info)->row_known);                        \
+  *n += 1;                                           \
 } while (0)
 
-static inline struct vctrs_df_rowwise_info new_rowwise_info(R_len_t size) {
+static inline struct df_short_circuit_info new_df_short_circuit_info(R_len_t size) {
   SEXP row_known = PROTECT(Rf_allocVector(RAWSXP, size * sizeof(bool)));
   bool* p_row_known = (bool*) RAW(row_known);
 
   // To begin with, no rows have a known comparison value
   memset(p_row_known, false, size * sizeof(bool));
 
-  struct vctrs_df_rowwise_info info = {
+  struct df_short_circuit_info info = {
     .row_known = row_known,
     .p_row_known = p_row_known,
     .remaining = size,

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -501,6 +501,24 @@ struct vctrs_df_rowwise_info {
   *n += 1;                                     \
 } while (0)
 
+static inline struct vctrs_df_rowwise_info new_rowwise_info(R_len_t size) {
+  SEXP row_known = PROTECT(Rf_allocVector(RAWSXP, size * sizeof(bool)));
+  bool* p_row_known = (bool*) RAW(row_known);
+
+  // To begin with, no rows have a known comparison value
+  memset(p_row_known, false, size * sizeof(bool));
+
+  struct vctrs_df_rowwise_info info = {
+    .row_known = row_known,
+    .p_row_known = p_row_known,
+    .remaining = size,
+    .size = size
+  };
+
+  UNPROTECT(1);
+  return info;
+}
+
 // Missing values -----------------------------------------------
 
 // Annex F of C99 specifies that `double` should conform to the IEEE 754


### PR DESCRIPTION
This PR is a follow up of #897, and refactors the `struct vctrs_rowwise_info` into `struct df_short_circuit_info`.

- `SEXP out` has been removed from `df_short_circuit_info`. It didn't really belong, and this new name makes more sense without it.

- `R_len_t size` has been added to `df_short_circuit_info`. This makes it so we don't have to pass size through in all of the underlying functions that already take `info`.

- Now that we removed `out`, we can have a common `new_df_short_circuit_info()` constructor.

- General improvements in code quality, like using `size` rather than `n_row`.