### PR TITLE
More efficient `vec_group_loc()` vector access

### DIFF
--- a/src/group.c
+++ b/src/group.c
@@ -154,8 +154,8 @@ SEXP vec_group_loc(SEXP x) {
 
   // Identify groups, this is essentially `vec_group_id()`
   for (int i = 0; i < n; ++i) {
-    int32_t hash = dict_hash_scalar(d, i);
-    R_len_t key = d->key[hash];
+    const int32_t hash = dict_hash_scalar(d, i);
+    const R_len_t key = d->key[hash];
 
     if (key == DICT_EMPTY) {
       dict_put(d, hash, i);
@@ -166,7 +166,7 @@ SEXP vec_group_loc(SEXP x) {
     }
   }
 
-  int n_groups = d->used;
+  const int n_groups = d->used;
 
   // Location of first occurence of each group in `x`
   SEXP key_loc = PROTECT_N(Rf_allocVector(INTSXP, n_groups), &nprot);
@@ -179,14 +179,14 @@ SEXP vec_group_loc(SEXP x) {
   memset(p_counts, 0, n_groups * sizeof(int));
 
   for (int i = 0; i < n; ++i) {
-    int group = p_groups[i];
+    const int group = p_groups[i];
 
     if (group == key_loc_current) {
       p_key_loc[key_loc_current] = i + 1;
-      key_loc_current++;
+      ++key_loc_current;
     }
 
-    p_counts[group]++;
+    ++p_counts[group];
   }
 
   SEXP out_loc = PROTECT_N(Rf_allocVector(VECSXP, n_groups), &nprot);
@@ -209,10 +209,10 @@ SEXP vec_group_loc(SEXP x) {
 
   // Fill in the location values for each group
   for (int i = 0; i < n; ++i) {
-    int group = p_groups[i];
-    int location = p_locations[group];
+    const int group = p_groups[i];
+    const int location = p_locations[group];
     p_elt_loc[group][location] = i + 1;
-    p_locations[group]++;
+    ++p_locations[group];
   }
 
   SEXP out_key = PROTECT_N(vec_slice(x, key_loc), &nprot);

--- a/src/group.c
+++ b/src/group.c
@@ -191,10 +191,15 @@ SEXP vec_group_loc(SEXP x) {
 
   SEXP out_loc = PROTECT_N(Rf_allocVector(VECSXP, n_groups), &nprot);
 
+  // Direct pointer to the location vectors we store in `out_loc`
+  int** p_elt_loc = (int**) R_alloc(n_groups, sizeof(int*));
+
   // Initialize `out_loc` to a list of integers with sizes corresponding
   // to the number of elements in that group
   for (int i = 0; i < n_groups; ++i) {
-    SET_VECTOR_ELT(out_loc, i, Rf_allocVector(INTSXP, p_counts[i]));
+    SEXP elt_loc = Rf_allocVector(INTSXP, p_counts[i]);
+    p_elt_loc[i] = INTEGER(elt_loc);
+    SET_VECTOR_ELT(out_loc, i, elt_loc);
   }
 
   // The current location we are updating, each group has its own counter
@@ -206,7 +211,7 @@ SEXP vec_group_loc(SEXP x) {
   for (int i = 0; i < n; ++i) {
     int group = p_groups[i];
     int location = p_locations[group];
-    INTEGER(VECTOR_ELT(out_loc, group))[location] = i + 1;
+    p_elt_loc[group][location] = i + 1;
     p_locations[group]++;
   }
 


### PR DESCRIPTION
This PR further optimizes `vec_group_loc()`, which should directly result in performance improvements for `group_by()`.

In Instruments I noticed that the biggest killer in `vec_group_loc()` is the double deference in a tight loop of `INTEGER(VECTOR_ELT())`. That can be replaced with an array of integer pointers that index directly into those integer vectors. That really helped.

Side note: It is insane how fast this is if you order the data ahead of time. As pointed out by @brodieG

```r
library(dplyr, warn.conflicts = FALSE)
library(vctrs)

set.seed(42)

g <- sample(1e6, 1e7, replace = TRUE)
tbl <- tibble(g = g)

o <- order(g)
ordered_tbl <- tbl[o,]
```

```r
bench::mark(
  vec_group_loc(tbl),
  vec_group_loc(ordered_tbl),
  check = FALSE,
  iterations = 20
)

# Master
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_group_loc(tbl)            2.86s    2.99s     0.333     163MB    0.416
#> 2 vec_group_loc(ordered_tbl) 277.95ms 304.13ms     3.18      163MB    3.33

# This PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_group_loc(tbl)            1.63s    1.71s     0.578     171MB    0.722
#> 2 vec_group_loc(ordered_tbl) 258.03ms 276.63ms     3.46      171MB    3.63
```