### PR TITLE
Very very WIP: Support for S4SXP vectors

### DIFF
--- a/src/type-info.c
+++ b/src/type-info.c
@@ -82,13 +82,17 @@ static enum vctrs_type vec_base_typeof(SEXP x, bool proxied) {
   case CPLXSXP: return vctrs_type_complex;
   case STRSXP: return vctrs_type_character;
   case RAWSXP: return vctrs_type_raw;
+  case S4SXP:
+    // S4 objects are only vectors if they are proxied
+    if (proxied) return vctrs_type_list;
+    return vctrs_type_scalar;
   case VECSXP:
     // Bare lists and data frames are vectors
     if (!OBJECT(x)) return vctrs_type_list;
     if (is_data_frame(x)) return vctrs_type_dataframe;
     // S3 lists are only vectors if they are proxied
     if (proxied || Rf_inherits(x, "list")) return vctrs_type_list;
-    // fallthrough
+    return vctrs_type_scalar;
   default: return vctrs_type_scalar;
   }
 }

--- a/tests/testthat/helper-s4-obj.R
+++ b/tests/testthat/helper-s4-obj.R
@@ -1,0 +1,19 @@
+.zando <- setClass("zando", slots = list(x = "numeric"))
+zando <- function(n = 0) {
+  .zando(x = as.numeric(seq_len(n)))
+}
+
+as_zando <- function(x) {
+  zando(length(x))
+}
+
+setMethod("[", "zando", function(x, i, j, ..., drop = TRUE) {
+  new_n <- length(vec_as_location(i, length(x@n), names(x@n)))
+  zando(new_n)
+})
+
+vec_proxy.zando <- function(x, ...) {
+  x
+}
+
+s3_register("vctrs::vec_proxy", "zando")

--- a/tests/testthat/test-s4-obj.R
+++ b/tests/testthat/test-s4-obj.R
@@ -1,0 +1,5 @@
+test_that("basics", {
+  x <- zando(10)
+
+  expect_true(vec_is(x))
+})


### PR DESCRIPTION
Has a class, a tweak, and one successful tests. Can copy over "rando" tests from `test-s4.R` and rename rando -> zando once the infrastructure is available.

Addresses #332, eventually.