### PR TITLE
Don't implicitly rely on `nan` -> `NA_INTEGER` cast

### DIFF
--- a/src/subscript.c
+++ b/src/subscript.c
@@ -135,6 +135,9 @@ static SEXP dbl_cast_subscript(SEXP subscript,
   for (R_len_t i = 0; i < n; ++i) {
     double elt = p[i];
 
+    // Generally `(int) nan` results in the correct `NA_INTEGER` value,
+    // but this is not guaranteed, so we have to explicitly check for it.
+    // https://stackoverflow.com/questions/10366485/problems-casting-nan-floats-to-int
     if (isnan(elt)) {
       out_p[i] = NA_INTEGER;
       continue;

--- a/src/subscript.c
+++ b/src/subscript.c
@@ -134,6 +134,12 @@ static SEXP dbl_cast_subscript(SEXP subscript,
 
   for (R_len_t i = 0; i < n; ++i) {
     double elt = p[i];
+
+    if (isnan(elt)) {
+      out_p[i] = NA_INTEGER;
+      continue;
+    }
+
     int out_elt = (int) elt;
 
     // Detect out-of-bounds and fractional numbers


### PR DESCRIPTION
Closes #902 

Apparently it works as is because `nan` is cast to `-2147483648` in many cases, no matter what the underlying value of `nan` is (i.e. it could be `NA_REAL` or `NaN` and still work). But we shouldn't rely on that!
https://stackoverflow.com/questions/10366485/problems-casting-nan-floats-to-int