### PR TITLE
Make locations available in stop_names()

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -442,10 +442,11 @@ stop_names <- function(class = NULL, ...) {
   )
 }
 
-stop_names_cannot_be_empty <- function(names) {
+stop_names_cannot_be_empty <- function(names, locations) {
   stop_names(
     class = "vctrs_error_names_cannot_be_empty",
-    names = names
+    names = names,
+    locations = locations
   )
 }
 
@@ -468,10 +469,11 @@ cnd_body.vctrs_error_names_cannot_be_empty <- function(cnd, ...) {
   format_error_bullets(bullet)
 }
 
-stop_names_cannot_be_dot_dot <- function(names) {
+stop_names_cannot_be_dot_dot <- function(names, locations) {
   stop_names(
     class = "vctrs_error_names_cannot_be_dot_dot",
-    names = names
+    names = names,
+    locations = locations
   )
 }
 

--- a/R/names.R
+++ b/R/names.R
@@ -169,12 +169,12 @@ validate_unique <- function(names, n = NULL) {
 
   empty_names <- detect_empty_names(names)
   if (has_length(empty_names)) {
-    stop_names_cannot_be_empty(names)
+    stop_names_cannot_be_empty(names, locations = empty_names)
   }
 
   dot_dot_name <- detect_dot_dot(names)
   if (has_length(dot_dot_name)) {
-    stop_names_cannot_be_dot_dot(names)
+    stop_names_cannot_be_dot_dot(names, locations = dot_dot_name)
   }
 
   if (anyDuplicated(names)) {

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -11,8 +11,8 @@ test_that("conditions inherit from `vctrs_error`", {
   expect_error(stop_unimplemented("", ""), class = "vctrs_error")
   expect_error(stop_scalar_type(NULL), class = "vctrs_error")
   expect_error(stop_names(), class = "vctrs_error")
-  expect_error(stop_names_cannot_be_empty(""), class = "vctrs_error")
-  expect_error(stop_names_cannot_be_dot_dot("..1"), class = "vctrs_error")
+  expect_error(stop_names_cannot_be_empty("", 1L), class = "vctrs_error")
+  expect_error(stop_names_cannot_be_dot_dot("..1", 1L), class = "vctrs_error")
   expect_error(stop_names_must_be_unique("x"), class = "vctrs_error")
 })
 

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -691,19 +691,23 @@ test_that("Name repair works with non-UTF-8 names", {
 
 test_that("names cannot be empty", {
   expect_error_cnd(
-    stop_names_cannot_be_empty(c("", "")),
+    stop_names_cannot_be_empty(c("", ""), 1:2),
     class = c("vctrs_error_names_cannot_be_empty", "vctrs_error_names", "vctrs_error"),
     message = "Names can't be empty.",
-    names = c("", "")
+    names = c("", ""),
+    # for tibble
+    locations = 1:2
   )
 })
 
 test_that("names cannot be dot dot", {
   expect_error_cnd(
-    stop_names_cannot_be_dot_dot(c("..1", "..2")),
+    stop_names_cannot_be_dot_dot(c("..1", "..2"), 1:2),
     class = c("vctrs_error_names_cannot_be_dot_dot", "vctrs_error_names", "vctrs_error"),
     message = "Names can't be of the form `...` or `..j`.",
-    names = c("..1", "..2")
+    names = c("..1", "..2"),
+    # for tibble
+    locations = 1:2
   )
 })
 


### PR DESCRIPTION
Follow-up to #898. The idea is to make the locations available in the `cnd` object when they are easy to compute.