### PR TITLE
Only set names if they exist to avoid a potential needless copy

### DIFF
--- a/src/subscript.c
+++ b/src/subscript.c
@@ -84,10 +84,12 @@ SEXP vec_as_subscript_opts(SEXP subscript,
     return R_NilValue;
   }
 
-  // FIXME: Handle names in cast methods
-  subscript = r_maybe_duplicate(subscript);
-  REPROTECT(subscript, subscript_pi);
-  r_poke_names(subscript, orig_names);
+  if (orig_names != R_NilValue) {
+    // FIXME: Handle names in cast methods
+    subscript = r_maybe_duplicate(subscript);
+    REPROTECT(subscript, subscript_pi);
+    r_poke_names(subscript, orig_names);
+  }
 
   UNPROTECT(2);
   return subscript;


### PR DESCRIPTION
The most common case by far is that we won't have names on the subscript, so this was duplicating the index more than was required.

Master:

```r
library(vctrs)

n <- 5000000
idx <- 1:4000000 + 0L

profmem::profmem(vec_as_location(idx, n))
#> Rprofmem memory profiling of:
#> vec_as_location(idx, n)
#> 
#> Memory allocations:
#>        what    bytes             calls
#> 1     alloc 16000048 vec_as_location()
#> total       16000048

bench::mark(vec_as_location(idx, n))
#> # A tibble: 1 x 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_as_location(idx, n)   6.56ms   7.28ms      132.    15.3MB     136.
```

This PR

```r
library(vctrs)

n <- 5000000
idx <- 1:4000000 + 0L

profmem::profmem(vec_as_location(idx, n))
#> Rprofmem memory profiling of:
#> vec_as_location(idx, n)
#> 
#> Memory allocations:
#>       what bytes calls
#> total          0

bench::mark(vec_as_location(idx, n))
#> # A tibble: 1 x 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_as_location(idx, n)   3.82ms    4.3ms      225.        0B        0
```