### PR TITLE
Add `x_arg` and `value_arg` to `vec_assign()`

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -12,6 +12,10 @@
 #' @param value Replacement values. `value` is cast to the type of
 #'   `x`, but only if they have a common type. See below for examples
 #'   of this rule.
+#' @param x_arg,value_arg Argument names for `x` and `value`. These are used
+#'   in error messages to inform the user about the locations of
+#'   incompatible types and sizes (see [stop_incompatible_type()] and
+#'   [stop_incompatible_size()]).
 #' @return A vector of the same type as `x`.
 #'
 #' @section Genericity:
@@ -149,12 +153,12 @@ vec_slice_dispatch_integer64 <- function(x, i) {
 #' @rdname vec_slice
 #' @export
 `vec_slice<-` <- function(x, i, value) {
-  .Call(vctrs_assign, x, i, value)
+  .Call(vctrs_assign, x, i, value, "x", "value")
 }
 #' @rdname vec_slice
 #' @export
-vec_assign <- function(x, i, value) {
-  .Call(vctrs_assign, x, i, value)
+vec_assign <- function(x, i, value, x_arg = "x", value_arg = "value") {
+  .Call(vctrs_assign, x, i, value, x_arg, value_arg)
 }
 vec_assign_fallback <- function(x, i, value) {
   # Work around bug in base `[<-`

--- a/R/slice.R
+++ b/R/slice.R
@@ -16,6 +16,7 @@
 #'   in error messages to inform the user about the locations of
 #'   incompatible types and sizes (see [stop_incompatible_type()] and
 #'   [stop_incompatible_size()]).
+#' @param ... These dots are for future extensions and must be empty.
 #' @return A vector of the same type as `x`.
 #'
 #' @section Genericity:
@@ -157,7 +158,10 @@ vec_slice_dispatch_integer64 <- function(x, i) {
 }
 #' @rdname vec_slice
 #' @export
-vec_assign <- function(x, i, value, x_arg = "x", value_arg = "value") {
+vec_assign <- function(x, i, value, ..., x_arg = "x", value_arg = "value") {
+  if (!missing(...)) {
+    ellipsis::check_dots_empty()
+  }
   .Call(vctrs_assign, x, i, value, x_arg, value_arg)
 }
 vec_assign_fallback <- function(x, i, value) {

--- a/man/vec_as_location.Rd
+++ b/man/vec_as_location.Rd
@@ -59,6 +59,8 @@ vector that \code{i} will be matched against to construct the index. Otherwise,
 not used. The default value of \code{NULL} will result in an error
 if \code{i} is a character vector.}
 
+\item{...}{These dots are for future extensions and must be empty.}
+
 \item{missing}{Whether to throw an \code{"error"} when \code{i} is a missing
 value, or \code{"propagate"} it (return it as is). By default, vector
 subscripts can contain missing values and scalar subscripts can't.}

--- a/man/vec_as_subscript.Rd
+++ b/man/vec_as_subscript.Rd
@@ -29,6 +29,8 @@ locations or names of the observations to get/set. Specify
 \code{TRUE} to index all elements (as in \code{x[]}), or \code{NULL}, \code{FALSE} or
 \code{integer()} to index none (as in \code{x[NULL]}).}
 
+\item{...}{These dots are for future extensions and must be empty.}
+
 \item{logical, location, character}{How to handle logical, numeric,
 and character subscripts.
 

--- a/man/vec_slice.Rd
+++ b/man/vec_slice.Rd
@@ -10,7 +10,7 @@ vec_slice(x, i)
 
 vec_slice(x, i) <- value
 
-vec_assign(x, i, value, x_arg = "x", value_arg = "value")
+vec_assign(x, i, value, ..., x_arg = "x", value_arg = "value")
 }
 \arguments{
 \item{x}{A vector}
@@ -23,6 +23,8 @@ locations or names of the observations to get/set. Specify
 \item{value}{Replacement values. \code{value} is cast to the type of
 \code{x}, but only if they have a common type. See below for examples
 of this rule.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{x_arg, value_arg}{Argument names for \code{x} and \code{value}. These are used
 in error messages to inform the user about the locations of

--- a/man/vec_slice.Rd
+++ b/man/vec_slice.Rd
@@ -10,7 +10,7 @@ vec_slice(x, i)
 
 vec_slice(x, i) <- value
 
-vec_assign(x, i, value)
+vec_assign(x, i, value, x_arg = "x", value_arg = "value")
 }
 \arguments{
 \item{x}{A vector}
@@ -23,6 +23,11 @@ locations or names of the observations to get/set. Specify
 \item{value}{Replacement values. \code{value} is cast to the type of
 \code{x}, but only if they have a common type. See below for examples
 of this rule.}
+
+\item{x_arg, value_arg}{Argument names for \code{x} and \code{value}. These are used
+in error messages to inform the user about the locations of
+incompatible types and sizes (see \code{\link[=stop_incompatible_type]{stop_incompatible_type()}} and
+\code{\link[=stop_incompatible_size]{stop_incompatible_size()}}).}
 }
 \value{
 A vector of the same type as \code{x}.

--- a/src/init.c
+++ b/src/init.c
@@ -75,7 +75,7 @@ extern SEXP vctrs_class_type(SEXP);
 extern SEXP vec_bare_df_restore(SEXP, SEXP, SEXP);
 extern SEXP vctrs_recycle(SEXP, SEXP, SEXP);
 extern SEXP vctrs_coercible_cast(SEXP, SEXP, SEXP, SEXP);
-extern SEXP vec_assign(SEXP, SEXP, SEXP);
+extern SEXP vctrs_assign(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_set_attributes(SEXP, SEXP);
 extern SEXP vctrs_as_df_row(SEXP, SEXP);
 extern SEXP vctrs_outer_names(SEXP, SEXP, SEXP);
@@ -195,7 +195,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_bare_df_restore",            (DL_FUNC) &vec_bare_df_restore, 3},
   {"vctrs_recycle",                    (DL_FUNC) &vctrs_recycle, 3},
   {"vctrs_coercible_cast",             (DL_FUNC) &vctrs_coercible_cast, 4},
-  {"vctrs_assign",                     (DL_FUNC) &vec_assign, 3},
+  {"vctrs_assign",                     (DL_FUNC) &vctrs_assign, 5},
   {"vctrs_set_attributes",             (DL_FUNC) &vctrs_set_attributes, 2},
   {"vctrs_as_df_row",                  (DL_FUNC) &vctrs_as_df_row, 2},
   {"vctrs_outer_names",                (DL_FUNC) &vctrs_outer_names, 3},

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -371,7 +371,7 @@ SEXP vec_slice(SEXP x, SEXP subscript);
 SEXP vec_slice_impl(SEXP x, SEXP subscript);
 SEXP vec_chop(SEXP x, SEXP indices);
 SEXP vec_slice_shaped(enum vctrs_type type, SEXP x, SEXP index);
-SEXP vec_assign(SEXP x, SEXP index, SEXP value);
+SEXP vec_assign(SEXP x, SEXP index, SEXP value, struct vctrs_arg* x_arg, struct vctrs_arg* value_arg);
 SEXP vec_proxy_assign(SEXP proxy, SEXP index, SEXP value);
 bool vec_requires_fallback(SEXP x, struct vctrs_proxy_info info);
 SEXP vec_init(SEXP x, R_len_t n);

--- a/tests/testthat/error/test-slice-assign.txt
+++ b/tests/testthat/error/test-slice-assign.txt
@@ -55,3 +55,14 @@ Error: Must assign to elements with a valid subscript vector.
 x Negative locations can't have missing values.
 i The subscript has a missing value at location 2.
 
+
+`vec_assign()` error args can be overridden
+===========================================
+
+> vec_assign(1:2, 1L, "x", x_arg = "foo", value_arg = "bar")
+Error: No common type for `bar` <character> and `foo` <integer>.
+
+> vec_assign(1:2, 1L, 1:2, value_arg = "bar")
+Error: `bar` can't be recycled to size 1.
+x It must be size 1, not 2.
+

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -360,6 +360,18 @@ test_that("can slice-assign unspecified vectors with default type2 method", {
   expect_identical(x, rational(c(NA, 2L), c(NA, 3L)))
 })
 
+test_that("`vec_assign()` validates `x_arg`", {
+  expect_error(vec_assign(1, 1, 1, x_arg = 1), "`x_arg` must be a string")
+  expect_error(vec_assign(1, 1, 1, x_arg = c("x", "y")), "`x_arg` must be a string")
+  expect_error(vec_assign(1, 1, 1, x_arg = NA_character_), "`x_arg` must be a string")
+})
+
+test_that("`vec_assign()` validates `value_arg`", {
+  expect_error(vec_assign(1, 1, 1, value_arg = 1), "`value_arg` must be a string")
+  expect_error(vec_assign(1, 1, 1, value_arg = c("x", "y")), "`value_arg` must be a string")
+  expect_error(vec_assign(1, 1, 1, value_arg = NA_character_), "`value_arg` must be a string")
+})
+
 test_that("`vec_assign()` requires recyclable value", {
   verify_errors({
     expect_error(
@@ -412,6 +424,19 @@ test_that("must assign with proper negative locations", {
   })
 })
 
+test_that("`vec_assign()` error args can be overridden", {
+  verify_errors({
+    expect_error(
+      vec_assign(1:2, 1L, "x", x_arg = "foo", value_arg = "bar"),
+      class = "vctrs_error_incompatible_type"
+    )
+    expect_error(
+      vec_assign(1:2, 1L, 1:2, value_arg = "bar"),
+      class = "vctrs_error_recycle_incompatible_size"
+    )
+  })
+})
+
 test_that("slice and assign have informative errors", {
   verify_output(test_path("error", "test-slice-assign.txt"), {
     "# `vec_assign()` requires recyclable value"
@@ -430,5 +455,9 @@ test_that("slice and assign have informative errors", {
     "# must assign with proper negative locations"
     vec_assign(1:3, c(-1, 1), 1:2)
     vec_assign(1:3, c(-1, NA), 1:2)
+
+    "# `vec_assign()` error args can be overridden"
+    vec_assign(1:2, 1L, "x", x_arg = "foo", value_arg = "bar")
+    vec_assign(1:2, 1L, 1:2, value_arg = "bar")
   })
 })

--- a/tests/testthat/test-vctrs.R
+++ b/tests/testthat/test-vctrs.R
@@ -11,4 +11,5 @@ test_that("generics are extensible", {
   expect_error(vec_ptype_full(NA, NA), class = "rlib_error_dots_nonempty")
   expect_error(vec_arith(NA, NA, NA, NA), class = "rlib_error_dots_nonempty")
   expect_error(vec_ptype_finalise(NA, NA), class = "rlib_error_dots_nonempty")
+  expect_error(vec_assign(NA, NA, NA, NA), class = "rlib_error_dots_nonempty")
 })


### PR DESCRIPTION
Closes #917 

CC @krlmlr 

Oh @lionel- I just had a thought. Should we add `...` to the signature before `x_arg` and `value_arg` and check that they are empty? (I'm going to guess yes)