### PR TITLE
Return row names from `vec_names()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # vctrs (development version)
 
+* The internal function `vec_names()` now returns row names if the
+  input is a data frame. This is part of a general effort at
+  making row names the vector names of data frames in vctrs.
+
 * `vec_assign()` gains `x_arg` and `value_arg` parameters (#918).
 
 * `vec_group_loc()`, which powers `dplyr::group_by()`, now has more

--- a/src/names.c
+++ b/src/names.c
@@ -1,9 +1,7 @@
 #include <ctype.h>
-
 #include "vctrs.h"
+#include "type-data-frame.h"
 #include "utils.h"
-
-#include <ctype.h>
 
 static void describe_repair(SEXP old_names, SEXP new_names);
 
@@ -99,7 +97,14 @@ SEXP vec_as_custom_names(SEXP names, const struct name_repair_opts* opts) {
 // [[ register(); include("vctrs.h") ]]
 SEXP vec_names(SEXP x) {
   if (OBJECT(x) && Rf_inherits(x, "data.frame")) {
-    return R_NilValue;
+    // Only return row names if they are character. Data frames with
+    // automatic row names are treated as unnamed.
+    SEXP rn = df_rownames(x);
+    if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
+      return rn;
+    } else {
+      return R_NilValue;
+    }
   }
 
   if (vec_dim_n(x) == 1) {

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -5,8 +5,12 @@ context("test-names")
 test_that("vec_names() retrieves names", {
   expect_null(vec_names(letters))
   expect_identical(vec_names(set_names(letters)), letters)
-  expect_null(vec_names(mtcars))
+
+  expect_identical(vec_names(mtcars), row.names(mtcars))
+  expect_null(vec_names(unrownames(mtcars)))
+
   expect_identical(vec_names(Titanic), dimnames(Titanic)[[1]])
+
   x <- matrix(1L, dimnames = list("row", "col"))
   expect_identical(vec_names(x), dimnames(x)[[1]])
 })
@@ -45,8 +49,13 @@ test_that("vec_names2() repairs names", {
 })
 
 test_that("vec_names2() treats data frames and arrays as vectors", {
-  expect_identical(vec_names2(mtcars), rep_len("", nrow(mtcars)))
+  expect_identical(vec_names2(mtcars), row.names(mtcars))
   expect_identical(vec_names2(as.matrix(mtcars)), row.names(mtcars))
+
+  df <- unrownames(mtcars)
+  exp <- rep_len("", nrow(mtcars))
+  expect_identical(vec_names2(df), exp)
+  expect_identical(vec_names2(as.matrix(df)), exp)
 })
 
 test_that("vec_names2() accepts and checks repair function", {
@@ -272,8 +281,13 @@ test_that("as_minimal_names() is idempotent", {
 })
 
 test_that("minimal_names() treats data frames and arrays as vectors", {
-  expect_identical(minimal_names(mtcars), rep_len("", nrow(mtcars)))
+  expect_identical(minimal_names(mtcars), row.names(mtcars))
   expect_identical(minimal_names(as.matrix(mtcars)), row.names(mtcars))
+
+  df <- unrownames(mtcars)
+  exp <- rep_len("", nrow(mtcars))
+  expect_identical(minimal_names(df), exp)
+  expect_identical(minimal_names(as.matrix(df)), exp)
 })
 
 test_that("as_minimal_names() copies on write", {


### PR DESCRIPTION
Step towards #689, and general support of row names.

`vec_names()` returns row names, but only if they are of type character. Numeric row names are not treated as identifiers.