### PR TITLE
Fix data frame methods for `vec_cast()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # vctrs (development version)
 
+* `vec_cast()` with data frames no longer uses inheritance (#710).
+
 * The internal function `vec_names()` now returns row names if the
   input is a data frame. This is part of a general effort at
   making row names the vector names of data frames in vctrs.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* `vec_cast()` to and from data frames preserves the row names of
+  inputs.
+
 * `vec_cast()` with data frames no longer uses inheritance (#710).
 
 * The internal function `vec_names()` now returns row names if the

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -103,7 +103,7 @@ vec_cast.data.frame <- function(x, to, ...) {
 #' @export
 #' @method vec_cast.data.frame data.frame
 vec_cast.data.frame.data.frame <- function(x, to, ..., x_arg = "x", to_arg = "to") {
-  .Call(vctrs_df_cast, x, to, x_arg, to_arg)
+  df_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.data.frame list
@@ -114,6 +114,9 @@ vec_cast.data.frame.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 #' @method vec_cast.data.frame default
 vec_cast.data.frame.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
+}
+df_cast <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  .Call(vctrs_df_cast, x, to, x_arg, to_arg)
 }
 
 #' @export

--- a/R/type-tibble.R
+++ b/R/type-tibble.R
@@ -32,3 +32,32 @@ vec_ptype2.data.frame.tbl_df <- function(x, y, ..., x_arg = "x", y_arg = "y") {
     y_arg = y_arg
   )
 }
+
+
+# Conditionally registered in .onLoad()
+vec_cast.tbl_df <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  UseMethod("vec_cast.tbl_df")
+}
+vec_cast.tbl_df.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
+}
+vec_cast.tbl_df.tbl_df <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  tib_cast(x, to, x_arg = x_arg, to_arg = to_arg)
+}
+
+vec_cast.data.frame.tbl_df <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  tib_cast(x, to, x_arg = x_arg, to_arg = to_arg)
+}
+vec_cast.tbl_df.data.frame <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  df_cast(x, to, x_arg = x_arg, to_arg = to_arg)
+}
+
+tib_cast <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+  .Call(
+    vctrs_tib_cast,
+    x = x,
+    to = to,
+    x_arg = x_arg,
+    to_arg = to_arg
+  )
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -16,13 +16,20 @@ on_package_load <- function(pkg, expr) {
   s3_register("generics::as.ordered", "vctrs_vctr")
   s3_register("generics::as.difftime", "vctrs_vctr")
 
+  # Remove once tibble has implemented the methods
   on_package_load("tibble", {
-    # Remove once tibble has implemented the methods
     if (!env_has(ns_env("tibble"), "vec_ptype2.tbl_df")) {
       s3_register("vctrs::vec_ptype2", "tbl_df")
       s3_register("vctrs::vec_ptype2.tbl_df", "default")
       s3_register("vctrs::vec_ptype2.tbl_df", "data.frame")
       s3_register("vctrs::vec_ptype2.data.frame", "tbl_df")
+    }
+
+    if (!env_has(ns_env("tibble"), "vec_cast.tbl_df")) {
+      s3_register("vctrs::vec_cast", "tbl_df")
+      s3_register("vctrs::vec_cast.tbl_df", "default")
+      s3_register("vctrs::vec_cast.tbl_df", "data.frame")
+      s3_register("vctrs::vec_cast.data.frame", "tbl_df")
     }
   })
 

--- a/src/cast-dispatch.c
+++ b/src/cast-dispatch.c
@@ -36,8 +36,7 @@ SEXP vec_cast_dispatch(SEXP x,
 
   case vctrs_type2_s3_dataframe_bare_tibble:
     if (dir == 0) {
-      // FIXME: Should have own method
-      return df_cast(x, to, x_arg, to_arg);
+      return tib_cast(x, to, x_arg, to_arg);
     } else {
       return df_cast(x, to, x_arg, to_arg);
     }

--- a/src/init.c
+++ b/src/init.c
@@ -100,6 +100,7 @@ extern SEXP df_flatten(SEXP);
 extern SEXP vctrs_equal_scalar(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_linked_version();
 extern SEXP vctrs_tib_ptype2(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_);
+extern SEXP vctrs_tib_cast(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_);
 
 
 
@@ -222,6 +223,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_equal_scalar",               (DL_FUNC) &vctrs_equal_scalar, 5},
   {"vctrs_linked_version",             (DL_FUNC) &vctrs_linked_version, 0},
   {"vctrs_tib_ptype2",                 (DL_FUNC) &vctrs_tib_ptype2, 4},
+  {"vctrs_tib_cast",                   (DL_FUNC) &vctrs_tib_cast, 4},
   {NULL, NULL, 0}
 };
 

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -437,6 +437,7 @@ SEXP df_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg)
   // Restore data frame size before calling `vec_restore()`. `x` and
   // `to` might not have any columns to compute the original size.
   init_data_frame(out, size);
+  Rf_setAttrib(out, R_RowNamesSymbol, df_rownames(x));
 
   R_len_t extra_len = Rf_length(x) - common_len;
   if (extra_len) {

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -438,8 +438,6 @@ SEXP df_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg)
   // `to` might not have any columns to compute the original size.
   init_data_frame(out, size);
 
-  out = PROTECT(vec_restore(out, to, R_NilValue));
-
   R_len_t extra_len = Rf_length(x) - common_len;
   if (extra_len) {
     out = vctrs_dispatch3(syms_df_lossy_cast, fns_df_lossy_cast,
@@ -448,7 +446,7 @@ SEXP df_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg)
                           syms_to, to);
   }
 
-  UNPROTECT(5);
+  UNPROTECT(4);
   return out;
 }
 

--- a/src/type-tibble.c
+++ b/src/type-tibble.c
@@ -17,3 +17,20 @@ SEXP vctrs_tib_ptype2(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_) {
   struct vctrs_arg y_arg = new_wrapper_arg(NULL, r_chr_get_c_string(y_arg_, 0));
   return tib_ptype2(x, y, &x_arg, &y_arg);
 }
+
+// [[ include("vctrs.h") ]]
+SEXP tib_cast(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) {
+  SEXP out = PROTECT(df_cast(x, y, x_arg, y_arg));
+
+  Rf_setAttrib(out, R_ClassSymbol, classes_tibble);
+
+  UNPROTECT(1);
+  return out;
+}
+
+// [[ register() ]]
+SEXP vctrs_tib_cast(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_) {
+  struct vctrs_arg x_arg = new_wrapper_arg(NULL, r_chr_get_c_string(x_arg_, 0));
+  struct vctrs_arg y_arg = new_wrapper_arg(NULL, r_chr_get_c_string(y_arg_, 0));
+  return tib_cast(x, y, &x_arg, &y_arg);
+}

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -575,11 +575,12 @@ SEXP ord_as_ordered(SEXP x, SEXP to, bool* lossy, struct vctrs_arg* x_arg, struc
 SEXP date_datetime_ptype2(SEXP x, SEXP y);
 SEXP datetime_datetime_ptype2(SEXP x, SEXP y);
 
-// Tibble methods ----------------------------------------------
+// Tibble methods ----------------------------------------------------
 
 SEXP tib_ptype2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
+SEXP tib_cast(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
 
-// Character translation ----------------------------------------
+// Character translation ---------------------------------------------
 
 SEXP obj_maybe_translate_encoding(SEXP x, R_len_t size);
 SEXP obj_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -155,6 +155,15 @@ test_that("df_cast() checks for names", {
   expect_error(vec_cast_common(x, y), "must have names")
 })
 
+test_that("casting to and from data frame preserves row names", {
+  out <- vec_cast(mtcars, unrownames(mtcars))
+  expect_identical(row.names(out), row.names(mtcars))
+
+  out <- vec_cast(out, unrownames(mtcars))
+  expect_identical(row.names(out), row.names(mtcars))
+})
+
+
 # new_data_frame ----------------------------------------------------------
 
 test_that("can construct an empty data frame", {

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -97,14 +97,6 @@ test_that("column order matches type", {
   expect_named(df3, c("x", "y", "z"))
 })
 
-test_that("casts preserve outer class", {
-  df <- data.frame(x = 1)
-  dt <- tibble::tibble(x = 1)
-
-  expect_s3_class(vec_cast(df, dt), "tbl_df")
-  expect_s3_class(vec_cast(dt, df), "data.frame")
-})
-
 test_that("restore generates correct row/col names", {
   df1 <- data.frame(x = NA, y = 1:4, z = 1:4)
   df1$x <- data.frame(a = 1:4, b = 1:4)

--- a/tests/testthat/test-type-tibble.R
+++ b/tests/testthat/test-type-tibble.R
@@ -25,6 +25,14 @@ test_that("can't cast vector to tibble", {
   expect_error(vec_cast(v, dt), class = "vctrs_error_incompatible_cast")
 })
 
+test_that("casting to and from tibble preserves row names", {
+  out <- vec_cast(mtcars, tibble::as_tibble(mtcars))
+  expect_identical(row.names(out), row.names(mtcars))
+
+  out <- vec_cast(out, unrownames(mtcars))
+  expect_identical(row.names(out), row.names(mtcars))
+})
+
 test_that("no common type between list and tibble", {
   dt <- tibble::tibble()
   l <- list()

--- a/tests/testthat/test-type-tibble.R
+++ b/tests/testthat/test-type-tibble.R
@@ -12,8 +12,8 @@ test_that("can cast tibble to df and vice versa", {
   df <- new_data_frame()
   dt <- tibble::tibble()
 
-  expect_equal(vec_cast(df, dt), dt)
-  expect_equal(vec_cast(dt, df), df)
+  expect_identical(vec_cast(df, dt), dt)
+  expect_identical(vec_cast(dt, df), df)
 })
 
 test_that("can't cast vector to tibble", {
@@ -31,16 +31,6 @@ test_that("no common type between list and tibble", {
 
   expect_error(vec_ptype2(l, dt), class = "vctrs_error_incompatible_type")
   expect_error(vec_ptype2(dt, l), class = "vctrs_error_incompatible_type")
-})
-
-test_that("can cast a list of 1 or 0 row tibbles to a tibble", {
-  dt1 <- tibble::tibble(x = numeric())
-  dt2 <- tibble::tibble(x = 1)
-  lst <- list(dt1, dt2)
-
-  expect <- tibble::tibble(x = c(NA, 1))
-
-  expect_equal(vec_cast(lst, dt1), expect)
 })
 
 test_that("vec_restore restores tibbles", {


### PR DESCRIPTION
Branched from #920.
Step towards #689 and #710.

* Simplify `vec_cast_dispatch()` to use `vec_typeof2_s3_impl()`. We can use the direction parameter instead of asymetric nested switches.

* Implement separate cast methods for tibbles instead of using inheritance. We previously relied on restoration of attributes in the data frame cast method, which I now think is incorrect.

* Preserve row names in the data frame cast method.