### PR TITLE
Preserve names when row-binding data frames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # vctrs (development version)
 
+* The internal version of `vec_assign()` now has support for assigning
+  names and inner names. For data frames, the names are assigned
+  recursively.
+
 * `vec_restore()` no longer restores row names if the target is not a
   data frame. This fixes an issue where `POSIXlt` objects would carry
   a `row.names` attribute after a proxy/restore roundtrip.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # vctrs (development version)
 
+* `vec_rbind()` and `vec_c()` with data frame inputs now consistently
+  preserve the names of list-columns, df-columns, and matrix-columns
+  (#689).
+
 * The internal version of `vec_assign()` now has support for assigning
   names and inner names. For data frames, the names are assigned
   recursively.

--- a/R/slice.R
+++ b/R/slice.R
@@ -176,6 +176,10 @@ vec_assign_fallback <- function(x, i, value) {
   x
 }
 
+vec_assign_params <- function(x, i, value, assign_names = FALSE) {
+  .Call(vctrs_assign_params, x, i, value, assign_names)
+}
+
 vec_remove <- function(x, i) {
   vec_slice(x, -vec_as_location(i, length(x), names(x)))
 }

--- a/src/bind.c
+++ b/src/bind.c
@@ -1,4 +1,5 @@
 #include "vctrs.h"
+#include "slice-assign.h"
 #include "type-data-frame.h"
 #include "utils.h"
 
@@ -145,6 +146,9 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
   // Compact sequences use 0-based counters
   R_len_t counter = 0;
 
+  const struct vec_assign_opts bind_assign_opts =
+    new_vec_assign_opts(true, args_empty, args_empty);
+
   for (R_len_t i = 0; i < n; ++i) {
     R_len_t size = ns[i];
     if (!size) {
@@ -154,7 +158,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
 
     SEXP tbl = PROTECT(vec_cast(x, ptype, args_empty, args_empty));
     init_compact_seq(idx_ptr, counter, size, true);
-    out = df_assign(out, idx, tbl);
+    out = df_assign(out, idx, tbl, &bind_assign_opts);
     REPROTECT(out, out_pi);
 
     if (has_rownames) {

--- a/src/c.c
+++ b/src/c.c
@@ -1,4 +1,5 @@
 #include "vctrs.h"
+#include "slice-assign.h"
 #include "utils.h"
 
 // From type.c
@@ -74,6 +75,9 @@ SEXP vec_c(SEXP xs,
   // Compact sequences use 0-based counters
   R_len_t counter = 0;
 
+  const struct vec_assign_opts c_assign_opts =
+    new_vec_assign_opts(true, args_empty, args_empty);
+
   for (R_len_t i = 0; i < n; ++i) {
     R_len_t size = ns[i];
     if (!size) {
@@ -86,17 +90,19 @@ SEXP vec_c(SEXP xs,
 
     init_compact_seq(idx_ptr, counter, size, true);
 
-    out = vec_proxy_assign(out, idx, elt);
+    out = vec_proxy_assign_opts(out, idx, elt, &c_assign_opts);
     REPROTECT(out, out_pi);
 
     if (has_names) {
       SEXP outer = xs_names == R_NilValue ? R_NilValue : STRING_ELT(xs_names, i);
       SEXP inner = PROTECT(vec_names(x));
       SEXP x_nms = PROTECT(apply_name_spec(name_spec, outer, inner, size));
+
       if (x_nms != R_NilValue) {
         out_names = chr_assign(out_names, idx, x_nms);
         REPROTECT(out_names, out_names_pi);
       }
+
       UNPROTECT(2);
     }
 

--- a/src/init.c
+++ b/src/init.c
@@ -102,7 +102,7 @@ extern SEXP vctrs_equal_scalar(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_linked_version();
 extern SEXP vctrs_tib_ptype2(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_);
 extern SEXP vctrs_tib_cast(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_);
-
+extern SEXP vctrs_assign_params(SEXP, SEXP, SEXP, SEXP);
 
 
 // Maturing
@@ -226,6 +226,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_linked_version",             (DL_FUNC) &vctrs_linked_version, 0},
   {"vctrs_tib_ptype2",                 (DL_FUNC) &vctrs_tib_ptype2, 4},
   {"vctrs_tib_cast",                   (DL_FUNC) &vctrs_tib_cast, 4},
+  {"vctrs_assign_params",              (DL_FUNC) &vctrs_assign_params, 4},
   {NULL, NULL, 0}
 };
 

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -141,22 +141,22 @@ SEXP vec_proxy_assign(SEXP proxy, SEXP index, SEXP value) {
 }
 SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
                            const struct vec_assign_opts* opts) {
-  struct vctrs_proxy_info info = vec_proxy_info(value);
+  struct vctrs_proxy_info value_info = vec_proxy_info(value);
 
   // If a fallback is required, the `proxy` is identical to the output container
   // because no proxy method was called
   SEXP out = R_NilValue;
 
-  if (vec_requires_fallback(value, info) || has_dim(proxy)) {
+  if (vec_requires_fallback(value, value_info) || has_dim(proxy)) {
     index = PROTECT(compact_materialize(index));
     out = PROTECT(vec_assign_fallback(proxy, index, value));
   } else {
     PROTECT(index);
-    out = PROTECT(vec_assign_switch(proxy, index, info.proxy, opts));
+    out = PROTECT(vec_assign_switch(proxy, index, value_info.proxy, opts));
   }
 
   if (opts->assign_names) {
-    out = vec_proxy_assign_names(out, index, value);
+    out = vec_proxy_assign_names(out, index, value_info.proxy);
   }
 
   UNPROTECT(2);

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -115,7 +115,7 @@ SEXP vec_proxy_assign_names(SEXP proxy, SEXP index, SEXP value) {
   proxy_nms = PROTECT(chr_assign(proxy_nms, index, value_nms));
 
   proxy = PROTECT(r_maybe_duplicate(proxy));
-  vec_set_names(proxy, proxy_nms);
+  proxy = vec_set_names(proxy, proxy_nms);
 
   UNPROTECT(4);
   return proxy;

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -316,12 +316,13 @@ SEXP df_assign(SEXP x, SEXP index, SEXP value,
     // restore are not recursive so need to be done for each element
     // we recurse into. `vec_proxy_assign()` will proxy the `value_elt`.
     SEXP proxy_elt = PROTECT(vec_proxy(out_elt));
+    proxy_elt = PROTECT(Rf_shallow_duplicate(proxy_elt));
 
     SEXP assigned = PROTECT(vec_proxy_assign_opts(proxy_elt, index, value_elt, opts));
     assigned = vec_restore(assigned, out_elt, R_NilValue);
 
     SET_VECTOR_ELT(out, i, assigned);
-    UNPROTECT(2);
+    UNPROTECT(3);
   }
 
   UNPROTECT(1);

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -32,12 +32,9 @@ SEXP vctrs_assign(SEXP x, SEXP index, SEXP value, SEXP x_arg_, SEXP value_arg_) 
   struct vctrs_arg x_arg = new_wrapper_arg(NULL, r_chr_get_c_string(x_arg_, 0));
   struct vctrs_arg value_arg = new_wrapper_arg(NULL, r_chr_get_c_string(value_arg_, 0));
 
-  const struct vec_assign_opts opts = {
-    .assign_names = false,
-    .x_arg = &x_arg,
-    .value_arg = &value_arg
-  };
-
+  const struct vec_assign_opts opts = new_vec_assign_opts(false,
+                                                          &x_arg,
+                                                          &value_arg);
   return vec_assign_opts(x, index, value, &opts);
 }
 
@@ -77,11 +74,9 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
 // [[ register() ]]
 SEXP vctrs_assign_params(SEXP x, SEXP index, SEXP value,
                          SEXP assign_names) {
-  struct vec_assign_opts opts = {
-    .assign_names = r_bool_as_int(assign_names),
-    .x_arg = args_empty,
-    .value_arg = args_empty
-  };
+  const struct vec_assign_opts opts = new_vec_assign_opts(r_bool_as_int(assign_names),
+                                                          args_empty,
+                                                          args_empty);
   return vec_assign_opts(x, index, value, &opts);
 }
 

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -23,6 +23,8 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
 SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
                            const struct vec_assign_opts* opts);
 
+SEXP chr_assign(SEXP out, SEXP index, SEXP value);
+SEXP list_assign(SEXP out, SEXP index, SEXP value);
 SEXP df_assign(SEXP x, SEXP index, SEXP value,
                const struct vec_assign_opts* opts);
 

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -1,0 +1,29 @@
+#ifndef VCTRS_SLICE_ASSIGN_H
+#define VCTRS_SLICE_ASSIGN_H
+
+struct vec_assign_opts {
+  bool assign_names;
+  struct vctrs_arg* x_arg;
+  struct vctrs_arg* value_arg;
+};
+
+static inline struct vec_assign_opts new_vec_assign_opts(bool assign_names,
+                                                         struct vctrs_arg* x_arg,
+                                                         struct vctrs_arg* value_arg) {
+  return (struct vec_assign_opts) {
+    .assign_names = assign_names,
+    .x_arg = x_arg,
+    .value_arg = value_arg
+  };
+}
+
+SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
+                     const struct vec_assign_opts* opts);
+
+SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
+                           const struct vec_assign_opts* opts);
+
+SEXP df_assign(SEXP x, SEXP index, SEXP value,
+               const struct vec_assign_opts* opts);
+
+#endif

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -1,5 +1,6 @@
 #include "vctrs.h"
 #include "slice.h"
+#include "slice-assign.h"
 #include "subscript-loc.h"
 #include "type-data-frame.h"
 #include "utils.h"

--- a/src/utils.c
+++ b/src/utils.c
@@ -1373,7 +1373,6 @@ SEXP fns_names = NULL;
 SEXP result_attrib = NULL;
 
 struct vctrs_arg args_empty_;
-struct vctrs_arg* args_empty = NULL;
 
 
 SEXP r_new_shared_vector(SEXPTYPE type, R_len_t n) {
@@ -1611,7 +1610,6 @@ void vctrs_init_utils(SEXP ns) {
   R_PreserveObject(rlang_formula_formals);
 
   args_empty_ = new_wrapper_arg(NULL, "");
-  args_empty = &args_empty_;
 
   rlang_is_splice_box = (bool (*)(SEXP)) R_GetCCallable("rlang", "rlang_is_splice_box");
   rlang_unbox = (SEXP (*)(SEXP)) R_GetCCallable("rlang", "rlang_unbox");

--- a/src/utils.h
+++ b/src/utils.h
@@ -105,7 +105,8 @@ bool list_is_homogeneously_classed(SEXP xs);
 // Destructive compacting
 SEXP node_compact_d(SEXP xs);
 
-extern struct vctrs_arg* args_empty;
+extern struct vctrs_arg args_empty_;
+static struct vctrs_arg* const args_empty = &args_empty_;
 SEXP arg_validate(SEXP arg, const char* arg_nm);
 
 void never_reached(const char* fn) __attribute__((noreturn));

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -428,9 +428,6 @@ R_len_t df_raw_size_from_list(SEXP x);
 SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n);
 SEXP vec_df_restore(SEXP x, SEXP to, SEXP n);
 
-SEXP chr_assign(SEXP out, SEXP index, SEXP value);
-SEXP list_assign(SEXP out, SEXP index, SEXP value);
-
 // equal_object() never propagates missingness, so
 // it can return a `bool`
 bool equal_object(SEXP x, SEXP y);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -371,7 +371,7 @@ SEXP vec_slice(SEXP x, SEXP subscript);
 SEXP vec_slice_impl(SEXP x, SEXP subscript);
 SEXP vec_chop(SEXP x, SEXP indices);
 SEXP vec_slice_shaped(enum vctrs_type type, SEXP x, SEXP index);
-SEXP vec_assign(SEXP x, SEXP index, SEXP value, struct vctrs_arg* x_arg, struct vctrs_arg* value_arg);
+SEXP vec_assign(SEXP x, SEXP index, SEXP value);
 SEXP vec_proxy_assign(SEXP proxy, SEXP index, SEXP value);
 bool vec_requires_fallback(SEXP x, struct vctrs_proxy_info info);
 SEXP vec_init(SEXP x, R_len_t n);
@@ -430,7 +430,6 @@ SEXP vec_df_restore(SEXP x, SEXP to, SEXP n);
 
 SEXP chr_assign(SEXP out, SEXP index, SEXP value);
 SEXP list_assign(SEXP out, SEXP index, SEXP value);
-SEXP df_assign(SEXP out, SEXP index, SEXP value);
 
 // equal_object() never propagates missingness, so
 // it can return a `bool`

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -579,3 +579,27 @@ test_that("vec_cbind() and vec_rbind() have informative error messages", {
     vec_rbind(set_names(joe, "x"), set_names(jane, "x"))
   })
 })
+
+test_that("rbind supports names and inner names (#689)", {
+  out <- vec_rbind(
+    data_frame(x = list(a = 1, b = 2)),
+    data_frame(x = list(3)),
+    data_frame(x = list(d = 4))
+  )
+  expect_identical(out$x, list(a = 1, b = 2, 3, d = 4))
+
+  vec_x <- set_names(1:3, letters[1:3])
+  vec_y <- c(FOO = 4L)
+  df_x <- new_data_frame(list(x = 1:3), row.names = letters[1:3])
+  df_y <- new_data_frame(list(x = 4L), row.names = "d")
+  mat_x <- matrix(1:3, 3, dimnames = list(letters[1:3]))
+  mat_y <- matrix(4L, 1, dimnames = list("d"))
+  nested_x <- new_data_frame(list(df = df_x, mat = mat_x, vec = vec_x), row.names = c("foo", "bar", "baz"))
+  nested_y <- new_data_frame(list(df = df_y, mat = mat_y, vec = vec_y), row.names = c("quux"))
+
+  nested_out <- vec_rbind(nested_x, nested_y)
+  expect_identical(row.names(nested_out), c("foo", "bar", "baz", "quux"))
+  expect_identical(row.names(nested_out$df), c("a", "b", "c", "d"))
+  expect_identical(row.names(nested_out$mat), c("a", "b", "c", "d"))
+  expect_identical(names(nested_out$vec), c("a", "b", "c", "FOO"))
+})

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -590,16 +590,25 @@ test_that("rbind supports names and inner names (#689)", {
 
   vec_x <- set_names(1:3, letters[1:3])
   vec_y <- c(FOO = 4L)
+  oo_x <- set_names(as.POSIXlt(c("2020-01-01", "2020-01-02", "2020-01-03")), letters[1:3])
+  oo_y <- c(FOO = as.POSIXlt(c("2020-01-04")))
   df_x <- new_data_frame(list(x = 1:3), row.names = letters[1:3])
   df_y <- new_data_frame(list(x = 4L), row.names = "d")
   mat_x <- matrix(1:3, 3, dimnames = list(letters[1:3]))
   mat_y <- matrix(4L, 1, dimnames = list("d"))
-  nested_x <- new_data_frame(list(df = df_x, mat = mat_x, vec = vec_x), row.names = c("foo", "bar", "baz"))
-  nested_y <- new_data_frame(list(df = df_y, mat = mat_y, vec = vec_y), row.names = c("quux"))
+  nested_x <- new_data_frame(
+    list(df = df_x, mat = mat_x, vec = vec_x, oo = oo_x),
+    row.names = c("foo", "bar", "baz")
+  )
+  nested_y <- new_data_frame(
+    list(df = df_y, mat = mat_y, vec = vec_y, oo = oo_y),
+    row.names = c("quux")
+  )
 
   nested_out <- vec_rbind(nested_x, nested_y)
   expect_identical(row.names(nested_out), c("foo", "bar", "baz", "quux"))
   expect_identical(row.names(nested_out$df), c("a", "b", "c", "d"))
   expect_identical(row.names(nested_out$mat), c("a", "b", "c", "d"))
   expect_identical(names(nested_out$vec), c("a", "b", "c", "FOO"))
+  expect_identical(names(nested_out$oo), c("a", "b", "c", "FOO"))
 })

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -125,18 +125,27 @@ test_that("vec_c() preserves row names and inner names", {
 
   vec_x <- set_names(1:3, letters[1:3])
   vec_y <- c(FOO = 4L)
+  oo_x <- set_names(as.POSIXlt(c("2020-01-01", "2020-01-02", "2020-01-03")), letters[1:3])
+  oo_y <- as.POSIXlt(c(FOO = "2020-01-04"))
   df_x <- new_data_frame(list(x = 1:3), row.names = letters[1:3])
   df_y <- new_data_frame(list(x = 4L), row.names = "d")
   mat_x <- matrix(1:3, 3, dimnames = list(letters[1:3]))
   mat_y <- matrix(4L, 1, dimnames = list("d"))
-  nested_x <- new_data_frame(list(df = df_x, mat = mat_x, vec = vec_x), row.names = c("foo", "bar", "baz"))
-  nested_y <- new_data_frame(list(df = df_y, mat = mat_y, vec = vec_y), row.names = c("quux"))
+  nested_x <- new_data_frame(
+    list(df = df_x, mat = mat_x, vec = vec_x, oo = oo_x),
+    row.names = c("foo", "bar", "baz")
+  )
+  nested_y <- new_data_frame(
+    list(df = df_y, mat = mat_y, vec = vec_y, oo = oo_y),
+    row.names = c("quux")
+  )
 
   nested_out <- vec_c(nested_x, nested_y)
   expect_identical(row.names(nested_out), c("foo", "bar", "baz", "quux"))
   expect_identical(row.names(nested_out$df), c("a", "b", "c", "d"))
   expect_identical(row.names(nested_out$mat), c("a", "b", "c", "d"))
   expect_identical(names(nested_out$vec), c("a", "b", "c", "FOO"))
+  expect_identical(names(nested_out$oo), c("a", "b", "c", "FOO"))
 })
 
 test_that("vec_c() outer names work with proxied objects", {

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -461,3 +461,77 @@ test_that("slice and assign have informative errors", {
     vec_assign(1:2, 1L, 1:2, value_arg = "bar")
   })
 })
+
+test_that("names are not assigned by default", {
+  vec_x <- set_names(1:3, letters[1:3])
+  vec_y <- c(FOO = 4L)
+  vec_out <- c(a = 1L, b = 4L, c = 3L)
+  expect_identical(
+    vec_assign(vec_x, 2, vec_y),
+    vec_out
+  )
+
+  df_x <- new_data_frame(list(x = 1:3), row.names = letters[1:3])
+  df_y <- new_data_frame(list(x = 4L), row.names = "FOO")
+  df_out <- new_data_frame(list(x = c(1L, 4L, 3L)), row.names = letters[1:3])
+  expect_identical(
+    vec_assign(df_x, 2, df_y),
+    df_out
+  )
+
+  mat_x <- matrix(1:3, 3, dimnames = list(letters[1:3]))
+  mat_y <- matrix(4L, 1, dimnames = list("FOO"))
+  mat_out <- matrix(c(1L, 4L, 3L), dimnames = list(letters[1:3]))
+  expect_identical(
+    vec_assign(mat_x, 2, mat_y),
+    mat_out
+  )
+
+  nested_x <- data_frame(df = df_x, mat = mat_x)
+  nested_y <- data_frame(df = df_y, mat = mat_y)
+  nested_out <- data_frame(
+    df = df_out,
+    mat = mat_out
+  )
+  expect_identical(
+    vec_assign(nested_x, 2, nested_y),
+    nested_out
+  )
+})
+
+test_that("can optionally assign names", {
+  vec_x <- set_names(1:3, letters[1:3])
+  vec_y <- c(FOO = 4L)
+  vec_out <- c(a = 1L, FOO = 4L, c = 3L)
+  expect_identical(
+    vec_assign_params(vec_x, 2, vec_y, assign_names = TRUE),
+    vec_out
+  )
+
+  df_x <- new_data_frame(list(x = 1:3), row.names = letters[1:3])
+  df_y <- new_data_frame(list(x = 4L), row.names = "FOO")
+  df_out <- new_data_frame(list(x = c(1L, 4L, 3L)), row.names = c("a", "FOO", "c"))
+  expect_identical(
+    vec_assign_params(df_x, 2, df_y, assign_names = TRUE),
+    df_out
+  )
+
+  mat_x <- matrix(1:3, 3, dimnames = list(letters[1:3]))
+  mat_y <- matrix(4L, 1, dimnames = list("FOO"))
+  mat_out <- matrix(c(1L, 4L, 3L), dimnames = list(c("a", "FOO", "c")))
+  expect_identical(
+    vec_assign_params(mat_x, 2, mat_y, assign_names = TRUE),
+    mat_out
+  )
+
+  nested_x <- data_frame(df = df_x, mat = mat_x)
+  nested_y <- data_frame(df = df_y, mat = mat_y)
+  nested_out <- data_frame(
+    df = df_out,
+    mat = mat_out
+  )
+  expect_identical(
+    vec_assign_params(nested_x, 2, nested_y, assign_names = TRUE),
+    nested_out
+  )
+})

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -505,6 +505,14 @@ test_that("can optionally assign names", {
     vec_out
   )
 
+  oo_x <- set_names(as.POSIXlt(c("2020-01-01", "2020-01-02", "2020-01-03")), letters[1:3])
+  oo_y <- as.POSIXlt(c(FOO = "2020-01-04"))
+  oo_out <- as.POSIXlt(c(a = "2020-01-01", FOO = "2020-01-04", c = "2020-01-03"))
+  expect_identical(
+    vec_assign_params(oo_x, 2, oo_y, assign_names = TRUE),
+    oo_out
+  )
+
   df_x <- new_data_frame(list(x = 1:3), row.names = letters[1:3])
   df_y <- new_data_frame(list(x = 4L), row.names = "FOO")
   df_out <- new_data_frame(list(x = c(1L, 4L, 3L)), row.names = c("a", "FOO", "c"))
@@ -521,9 +529,9 @@ test_that("can optionally assign names", {
     mat_out
   )
 
-  nested_x <- new_data_frame(list(df = df_x, mat = mat_x, vec = vec_x), row.names = c("foo", "bar", "baz"))
-  nested_y <- new_data_frame(list(df = df_y, mat = mat_y, vec = vec_y), row.names = c("quux"))
-  nested_out <- new_data_frame(list(df = df_out, mat = mat_out, vec = vec_out), row.names = c("foo", "quux", "baz"))
+  nested_x <- new_data_frame(list(df = df_x, mat = mat_x, vec = vec_x, oo = oo_x), row.names = c("foo", "bar", "baz"))
+  nested_y <- new_data_frame(list(df = df_y, mat = mat_y, vec = vec_y, oo = oo_y), row.names = c("quux"))
+  nested_out <- new_data_frame(list(df = df_out, mat = mat_out, vec = vec_out, oo = oo_out), row.names = c("foo", "quux", "baz"))
 
   expect_identical(
     vec_assign_params(nested_x, 2, nested_y, assign_names = TRUE),

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -487,12 +487,9 @@ test_that("names are not assigned by default", {
     mat_out
   )
 
-  nested_x <- data_frame(df = df_x, mat = mat_x)
-  nested_y <- data_frame(df = df_y, mat = mat_y)
-  nested_out <- data_frame(
-    df = df_out,
-    mat = mat_out
-  )
+  nested_x <- new_data_frame(list(df = df_x, mat = mat_x, vec = vec_x), row.names = c("foo", "bar", "baz"))
+  nested_y <- new_data_frame(list(df = df_y, mat = mat_y, vec = vec_y), row.names = c("quux"))
+  nested_out <- new_data_frame(list(df = df_out, mat = mat_out, vec = vec_out), row.names = c("foo", "bar", "baz"))
   expect_identical(
     vec_assign(nested_x, 2, nested_y),
     nested_out
@@ -524,12 +521,10 @@ test_that("can optionally assign names", {
     mat_out
   )
 
-  nested_x <- data_frame(df = df_x, mat = mat_x)
-  nested_y <- data_frame(df = df_y, mat = mat_y)
-  nested_out <- data_frame(
-    df = df_out,
-    mat = mat_out
-  )
+  nested_x <- new_data_frame(list(df = df_x, mat = mat_x, vec = vec_x), row.names = c("foo", "bar", "baz"))
+  nested_y <- new_data_frame(list(df = df_y, mat = mat_y, vec = vec_y), row.names = c("quux"))
+  nested_out <- new_data_frame(list(df = df_out, mat = mat_out, vec = vec_out), row.names = c("foo", "quux", "baz"))
+
   expect_identical(
     vec_assign_params(nested_x, 2, nested_y, assign_names = TRUE),
     nested_out


### PR DESCRIPTION
Branched from #923.
Closes #689.

* The internal `vec_assign()` function gains an `assign_names` parameter. When `true`, names are assigned row-recursively.

* `vec_c()` and `vec_rbind()` set `assign_names` to `true` so that they preserve row names and inner names.