### PR TITLE
Attempt to lookup S4 `c()` methods in `vec_c()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # vctrs (development version)
 
+* `vec_c()` and `vec_unchop()` now fall back to `base::c()` for S4 objects if
+  the object doesn't implement `vec_ptype2()` but sets an S4 `c()`
+  method (#919).
+
 * `vec_as_location2()` properly picks up `subscript_arg`
   (tidyverse/tibble#735).
 

--- a/src/c.c
+++ b/src/c.c
@@ -130,7 +130,7 @@ bool needs_vec_c_fallback(SEXP xs) {
 
   return
     !vec_implements_ptype2(x) &&
-    list_is_s3_homogeneous(xs);
+    list_is_homogeneously_classed(xs);
 }
 
 static inline bool vec_implements_base_c(SEXP x);

--- a/src/c.c
+++ b/src/c.c
@@ -161,9 +161,15 @@ SEXP vec_c_fallback(SEXP xs, SEXP ptype, SEXP name_spec) {
 }
 
 static inline bool vec_implements_base_c(SEXP x) {
-  return
-    OBJECT(x) &&
-    s3_find_method("c", x, base_method_table) != R_NilValue;
+  if (!OBJECT(x)) {
+    return false;
+  }
+
+  if (IS_S4_OBJECT(x)) {
+    return s4_find_method(x, s4_c_method_table) != R_NilValue;
+  } else {
+    return s3_find_method("c", x, base_method_table) != R_NilValue;
+  }
 }
 
 static inline int vec_c_fallback_validate_args(SEXP ptype, SEXP name_spec) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -10,6 +10,7 @@ SEXP (*rlang_env_dots_values)(SEXP) = NULL;
 SEXP (*rlang_env_dots_list)(SEXP) = NULL;
 SEXP vctrs_method_table = NULL;
 SEXP base_method_table = NULL;
+SEXP s4_c_method_table = NULL;
 
 SEXP strings_tbl = NULL;
 SEXP strings_tbl_df = NULL;
@@ -348,6 +349,46 @@ SEXP s3_find_method(const char* generic, SEXP x, SEXP table) {
 
   for (int i = 0; i < n_class; ++i, ++class_ptr) {
     SEXP method = s3_get_method(generic, CHAR(*class_ptr), table);
+    if (method != R_NilValue) {
+      UNPROTECT(1);
+      return method;
+    }
+  }
+
+  UNPROTECT(1);
+  return R_NilValue;
+}
+
+static SEXP s4_get_method(const char* class, SEXP table) {
+  SEXP sym = Rf_install(class);
+
+  SEXP method = r_env_get(table, sym);
+  if (r_is_function(method)) {
+    return method;
+  }
+
+  return R_NilValue;
+}
+
+// For S4 objects, the `table` is specific to the generic
+SEXP s4_find_method(SEXP x, SEXP table) {
+  if (!IS_S4_OBJECT(x)) {
+    return R_NilValue;
+  }
+
+  SEXP class = PROTECT(Rf_getAttrib(x, R_ClassSymbol));
+
+  // Avoid corrupt objects where `x` is an OBJECT(), but the class is NULL
+  if (class == R_NilValue) {
+    UNPROTECT(1);
+    return R_NilValue;
+  }
+
+  SEXP* p_class = STRING_PTR(class);
+  int n_class = Rf_length(class);
+
+  for (int i = 0; i < n_class; ++i) {
+    SEXP method = s4_get_method(CHAR(p_class[i]), table);
     if (method != R_NilValue) {
       UNPROTECT(1);
       return method;
@@ -1353,6 +1394,9 @@ void vctrs_init_utils(SEXP ns) {
   vctrs_method_table = r_env_get(ns, Rf_install(".__S3MethodsTable__."));
 
   base_method_table = r_env_get(R_BaseNamespace, Rf_install(".__S3MethodsTable__."));
+
+  s4_c_method_table = r_parse_eval("environment(methods::getGeneric('c'))$.MTable", R_GlobalEnv);
+  R_PreserveObject(s4_c_method_table);
 
   vctrs_shared_empty_str = Rf_mkString("");
   R_PreserveObject(vctrs_shared_empty_str);

--- a/src/utils.c
+++ b/src/utils.c
@@ -388,7 +388,7 @@ SEXP list_first_non_null(SEXP xs, R_len_t* non_null_i) {
 }
 
 // [[ include("utils.h") ]]
-bool list_is_s3_homogeneous(SEXP xs) {
+bool list_is_homogeneously_classed(SEXP xs) {
   R_len_t n = Rf_length(xs);
   if (n == 0 || n == 1) {
     return true;

--- a/src/utils.h
+++ b/src/utils.h
@@ -99,7 +99,7 @@ SEXP s3_find_method(const char* generic, SEXP x, SEXP table);
 bool vec_implements_ptype2(SEXP x);
 
 SEXP list_first_non_null(SEXP xs, R_len_t* non_null_i);
-bool list_is_s3_homogeneous(SEXP xs);
+bool list_is_homogeneously_classed(SEXP xs);
 
 // Destructive compacting
 SEXP node_compact_d(SEXP xs);

--- a/src/utils.h
+++ b/src/utils.h
@@ -93,9 +93,10 @@ bool is_record(SEXP x);
 SEXP vec_unique_names(SEXP x, bool quiet);
 SEXP vec_unique_colnames(SEXP x, bool quiet);
 
-// Returns S3 method for `generic` suitable for the class of `x`. The
+// Returns S3 / S4 method for `generic` suitable for the class of `x`. The
 // inheritance hierarchy is explored except for the default method.
 SEXP s3_find_method(const char* generic, SEXP x, SEXP table);
+SEXP s4_find_method(SEXP x, SEXP table);
 bool vec_implements_ptype2(SEXP x);
 
 SEXP list_first_non_null(SEXP xs, R_len_t* non_null_i);
@@ -439,6 +440,7 @@ extern SEXP fns_names;
 
 extern SEXP vctrs_method_table;
 extern SEXP base_method_table;
+extern SEXP s4_c_method_table;
 
 
 #endif

--- a/tests/testthat/error/test-c.txt
+++ b/tests/testthat/error/test-c.txt
@@ -1,11 +1,30 @@
 
-vec_c() falls back to c() for foreign classes
-=============================================
+vec_c() falls back to c() for foreign S3 classes
+================================================
 
 > vec_c(foobar(1), foobar(2))
 Error: Can't find vctrs or base methods for concatenation.
 vctrs methods must be implemented for class `vctrs_foobar`.
 See <https://vctrs.r-lib.org/articles/s3-vector.html>.
+
+
+vec_c() falls back to c() for S4 classes with a registered c() method
+=====================================================================
+
+> joe1 <- .Counts(c(1L, 2L), name = "Joe")
+> joe2 <- .Counts(3L, name = "Joe")
+> vec_c(joe1, joe2)
+Error: Can't find vctrs or base methods for concatenation.
+vctrs methods must be implemented for class `Counts`.
+See <https://vctrs.r-lib.org/articles/s3-vector.html>.
+
+> vec_c(NULL, joe1, joe2)
+Error: Can't find vctrs or base methods for concatenation.
+vctrs methods must be implemented for class `Counts`.
+See <https://vctrs.r-lib.org/articles/s3-vector.html>.
+
+> vec_c(joe1, 1, joe2)
+Error: No common type for `..1` <Counts> and `..2` <double>.
 
 
 vec_c() fallback doesn't support `name_spec` or `ptype`

--- a/tests/testthat/error/test-unchop.txt
+++ b/tests/testthat/error/test-unchop.txt
@@ -21,6 +21,20 @@ vctrs methods must be implemented for class `vctrs_foobar`.
 See <https://vctrs.r-lib.org/articles/s3-vector.html>.
 
 
+vec_unchop() falls back for S4 classes with a registered c() method
+===================================================================
+
+> joe1 <- .Counts(c(1L, 2L), name = "Joe")
+> joe2 <- .Counts(3L, name = "Joe")
+> vec_unchop(list(joe1, joe2), list(c(1, 3), 2))
+Error: Can't find vctrs or base methods for concatenation.
+vctrs methods must be implemented for class `Counts`.
+See <https://vctrs.r-lib.org/articles/s3-vector.html>.
+
+> vec_unchop(list(joe1, 1, joe2), list(c(1, 2), 3, 4))
+Error: No common type for `..1` <Counts> and `..2` <double>.
+
+
 vec_unchop() fallback doesn't support `name_spec` or `ptype`
 ============================================================
 

--- a/tests/testthat/helper-s4.R
+++ b/tests/testthat/helper-s4.R
@@ -11,3 +11,6 @@ setMethod("[", "rando", function(x, i, j, ..., drop = TRUE) {
   new_n <- length(vec_as_location(i, length(x@.Data), names(x@.Data)))
   rando(new_n)
 })
+
+
+.Counts <- methods::setClass("Counts", contains = "integer", slots = c(name = "character"))


### PR DESCRIPTION
Closes #919 
Closes tidyverse/dplyr#4986
Related to https://github.com/tidyverse/lubridate/issues/721

This PR adds a way to check for S4 `c()` methods to fall back to in `vec_c()`. The implementation is derived from looking at `methods:::.showMethodsTable()`. S4 generic functions have an environment attached to them, and that environment contains another environment, `.MTable`, which is the methods table for that specific generic. That can be used to check if a method exists or not.

``` r
library(vctrs)
library(lubridate, warn.conflicts = FALSE)

vec_c(days(1:2), 3)
#> Error: No common type for `..1` <Period> and `..2` <double>.

vec_c(days(1:2), days(3))
#> [1] "1d 0H 0M 0S" "2d 0H 0M 0S" "3d 0H 0M 0S"
```

It seems to also work even if you don't explicitly load lubridate, which is nice

```r
library(vctrs)

vec_c(lubridate::days(1:2), lubridate::days(3))
#> [1] "1d 0H 0M 0S" "2d 0H 0M 0S" "3d 0H 0M 0S"
```