### PR TITLE
Fix indirections in child errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* `vec_as_location2()` properly picks up `subscript_arg`
+  (tidyverse/tibble#735).
+
 * `vec_cast()` to and from data frames preserves the row names of
   inputs.
 

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -172,8 +172,8 @@ vec_as_location2_result <- function(i,
     return(result(err = new_error_location2_type(
       i = i,
       subscript_arg = arg,
-      # FIXME: Should body fields in parents be automatically inherited?
-      body = function(...) cnd_body(parent),
+      # Should body fields in parents be automatically inherited?
+      body = parent$body,
       parent = parent
     )))
   }

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -87,7 +87,8 @@ vec_as_subscript2_result <- function(i,
     character = character
   )
 
-  # Return a subclass of subscript error
+  # Return a child of subscript error. The child error messages refer
+  # to single subscripts instead of subscript vectors.
   if (!is_null(result$err)) {
     parent <- result$err$parent
     if (inherits(parent, "vctrs_error_cast_lossy")) {

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -92,7 +92,7 @@ vec_as_subscript2_result <- function(i,
   if (!is_null(result$err)) {
     parent <- result$err$parent
     if (inherits(parent, "vctrs_error_cast_lossy")) {
-      bullets <- cnd_bullets_subscript_lossy_cast
+      bullets <- new_cnd_bullets_subscript_lossy_cast(parent)
     } else {
       bullets <- cnd_body.vctrs_error_subscript_type
     }
@@ -201,8 +201,10 @@ cnd_body.vctrs_error_subscript_type <- function(cnd) {
     i = glue::glue("It must be {expected_types}.")
   ))
 }
-cnd_bullets_subscript_lossy_cast <- function(cnd, ...) {
-  format_error_bullets(c(x = cnd_header(cnd$parent)))
+new_cnd_bullets_subscript_lossy_cast <- function(lossy_err) {
+  function(cnd, ...) {
+    format_error_bullets(c(x = cnd_header(lossy_err)))
+  }
 }
 
 collapse_subscript_type <- function(cnd) {

--- a/src/subscript.c
+++ b/src/subscript.c
@@ -123,7 +123,8 @@ static SEXP obj_cast_subscript(SEXP subscript,
 static SEXP dbl_cast_subscript_fallback(SEXP subscript,
                                         const struct vec_as_subscript_opts* opts,
                                         ERR* err);
-static SEXP dbl_cast_subscript_body = NULL;
+static SEXP syms_new_dbl_cast_subscript_body = NULL;
+static SEXP syms_lossy_err = NULL;
 
 static SEXP dbl_cast_subscript(SEXP subscript,
                                const struct vec_as_subscript_opts* opts,
@@ -173,11 +174,16 @@ static SEXP dbl_cast_subscript_fallback(SEXP subscript,
                                           err));
   if (*err) {
     SEXP err_obj = PROTECT(*err);
+
+    SEXP body = PROTECT(vctrs_eval_mask1(syms_new_dbl_cast_subscript_body,
+                                         syms_lossy_err, err_obj,
+                                         vctrs_ns_env));
+
     *err = new_error_subscript_type(subscript,
                                     opts,
-                                    dbl_cast_subscript_body,
+                                    body,
                                     err_obj);
-    UNPROTECT(2);
+    UNPROTECT(3);
     return R_NilValue;
   }
 
@@ -302,5 +308,6 @@ static SEXP new_error_subscript_type(SEXP subscript,
 
 void vctrs_init_subscript(SEXP ns) {
   syms_new_error_subscript_type = Rf_install("new_error_subscript_type");
-  dbl_cast_subscript_body = r_env_get(ns, Rf_install("cnd_bullets_subscript_lossy_cast"));
+  syms_new_dbl_cast_subscript_body = Rf_install("new_cnd_bullets_subscript_lossy_cast");
+  syms_lossy_err = Rf_install("lossy_err");
 }

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -174,6 +174,11 @@ i It must be numeric or character.
 Error: Must extract element with a single valid subscript.
 x Lossy cast from `foo` <double> to <integer>.
 
+> with_tibble_rows(vec_as_location2(TRUE))
+Error: Must remove row with a single valid subscript.
+x The subscript `foo(bar)` has the wrong type `logical`.
+i It must be numeric or character.
+
 
 vec_as_location2() requires length 1 inputs
 ===========================================

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -15,6 +15,7 @@ test_that("vec_as_location2() requires integer or character inputs", {
     "Idem with custom `arg`"
     expect_error(vec_as_location2(foobar(), 10L, arg = "foo"), class = "vctrs_error_subscript_type")
     expect_error(vec_as_location2(2.5, 3L, arg = "foo"), class = "vctrs_error_subscript_type")
+    expect_error(with_tibble_rows(vec_as_location2(TRUE)), class = "vctrs_error_subscript_type")
   })
 })
 
@@ -470,6 +471,7 @@ test_that("conversion to locations has informative error messages", {
     "Idem with custom `arg`"
     vec_as_location2(foobar(), 10L, arg = "foo")
     vec_as_location2(2.5, 3L, arg = "foo")
+    with_tibble_rows(vec_as_location2(TRUE))
 
     "# vec_as_location2() requires length 1 inputs"
     vec_as_location2(1:2, 2L)


### PR DESCRIPTION
Closes tidyverse/tibble#735.

@krlmlr This had to do with closure-inlined `cnd_body()` methods and child errors. The fix was rather tricky, but I think these rules might offer a general solution:

```
* Close over the parent when a child error is created outside of a
  given error class. For instance lossy cast errors need to consistently
  refer to their actual error object.

* Conversely, don't close over the parent when a child error is
  created within a given class. This allows subscript errors to pick up
  updated `subscript_arg` fields.
```