### PR TITLE
Fix `vec_unchop()` fallback with repeated assignment

### DIFF
--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -490,6 +490,17 @@ test_that("vec_unchop() falls back to c() for foreign classes", {
     class = "vctrs_error_subscript_oob"
   )
 
+  # Unassigned locations results in missing values.
+  # Repeated assignment uses the last assigned value.
+  expect_identical(
+    vec_unchop(list(foobar(c(1, 2)), foobar(3)), list(c(1, 3), 1)),
+    foobar(c(3, NA, 2))
+  )
+  expect_identical(
+    vec_unchop(list(foobar(c(1, 2)), foobar(3)), list(c(2, NA), NA)),
+    foobar(c(NA, 1, NA))
+  )
+
   # Names are kept
   expect_identical(
     vec_unchop(list(foobar(c(x = 1, y = 2)), foobar(c(x = 1))), list(c(2, 1), 3)),
@@ -571,6 +582,17 @@ test_that("vec_unchop() falls back for S4 classes with a registered c() method",
   expect_identical(
     vec_unchop(list(NULL, joe1, joe2), list(integer(), c(1, 3), 2)),
     .Counts(c(1L, 3L, 2L), name = "Joe")
+  )
+
+  # Unassigned locations results in missing values.
+  # Repeated assignment uses the last assigned value.
+  expect_identical(
+    vec_unchop(list(joe1, joe2), list(c(1, 3), 1)),
+    .Counts(c(3L, NA, 2L), name = "Joe")
+  )
+  expect_identical(
+    vec_unchop(list(joe1, joe2), list(c(2, NA), NA)),
+    .Counts(c(NA, 1L, NA), name = "Joe")
   )
 })
 


### PR DESCRIPTION
The rare case of `vec_unchop()` having to fall back + having repeated assignment in the `indices` was broken. This fixes that. It uses the flattened `indices` vector to build a `locations` vector that will be used to slice the result of the `vec_c_fallback()`. It builds the `locations` vector in such a way that:

- Locations that are never touched are sliced with `NA_integer_`

- Indices that are repeated use the value of the last one

(This is identical to what the non-fallback does)

``` r
library(vctrs)

x <- c("a", "b")
y <- "c"

x_foo <- structure(x, class = "vctrs_foobar")
y_foo <- structure(y, class = "vctrs_foobar")

c.vctrs_foobar <- function(...) {
  dots <- list(...)
  dots <- lapply(dots, unclass)
  out <- do.call(c, dots)
  structure(out, class = "vctrs_foobar")
}
```

```r
# Master

vec_unchop(list(x, y), list(c(1, 2), 1))
#> [1] "c" "b" NA

vec_unchop(list(x_foo, y_foo), list(c(1, 2), 1))
#> [1] "a" "c" "b"
#> attr(,"class")
#> [1] "vctrs_foobar"
```

```r
# This PR

vec_unchop(list(x, y), list(c(1, 2), 1))
#> [1] "c" "b" NA

vec_unchop(list(x_foo, y_foo), list(c(1, 2), 1))
#> [1] "c" "b" NA 
#> attr(,"class")
#> [1] "vctrs_foobar"
```