### PR TITLE
Improve support of foreign classes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,22 @@
   that it only supports lists. Atomic vectors and data frames result in an
   error.
 
+* Improved support for foreign classes in the combining operations
+  `vec_c()`, `vec_rbind()`, and `vec_unchop()`. A foreign class is a
+  class that doesn't implement `vec_ptype2()`. When all the objects to
+  combine have the same foreign class, one of these fallbacks is invoked:
+
+  -  If the class implements a `base::c()` method, the method is used
+    for the combination. (FIXME: `vec_rbind()` currently doesn't use
+    this fallback.)
+
+  - Otherwise if the objects have identical attributes and the same
+    base type, we consider them to be compatible. The vectors are
+    concatenated and the attributes are restored (#776).
+
+  These fallbacks do not make your class completely compatible with
+  vctrs-powered packages, but they should help in many simple cases.
+
 * `vec_c()` and `vec_unchop()` now fall back to `base::c()` for S4 objects if
   the object doesn't implement `vec_ptype2()` but sets an S4 `c()`
   method (#919).

--- a/R/cast.R
+++ b/R/cast.R
@@ -138,10 +138,7 @@ vec_cast_common <- function(..., .to = NULL) {
 
 #' @export
 vec_cast.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
-  if (has_same_type(x, to)) {
-    return(x)
-  }
-  stop_incompatible_cast(x, to, x_arg = x_arg, to_arg = to_arg)
+  vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 # Cast `x` to `to` but only if they are coercible

--- a/R/cast.R
+++ b/R/cast.R
@@ -169,10 +169,13 @@ vec_coercible_cast <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 #' @export
 vec_default_cast <- function(x, to, x_arg = "x", to_arg = "to") {
   if (is_unspecified(x)) {
-    vec_init(to, length(x))
-  } else if (is_asis(x)) {
-    vec_cast_from_asis(x, to, x_arg = x_arg, to_arg = to_arg)
-  } else {
-    stop_incompatible_cast(x, to, x_arg = x_arg, to_arg = to_arg)
+    return(vec_init(to, length(x)))
   }
+  if (is_asis(x)) {
+    return(vec_cast_from_asis(x, to, x_arg = x_arg, to_arg = to_arg))
+  }
+  if (is_same_type(x, to)) {
+    return(x)
+  }
+  stop_incompatible_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }

--- a/tests/testthat/error/test-bind.txt
+++ b/tests/testthat/error/test-bind.txt
@@ -1,0 +1,18 @@
+
+vec_rbind() fails with complex foreign S3 classes
+=================================================
+
+> x <- structure(foobar(1), attr_foo = "foo")
+> y <- structure(foobar(2), attr_bar = "bar")
+> vec_rbind(set_names(x, "x"), set_names(y, "x"))
+Error: No common type for `..1$x` <vctrs_foobar> and `..2$x` <vctrs_foobar>.
+
+
+vec_rbind() fails with complex foreign S4 classes
+=================================================
+
+> joe <- .Counts(1L, name = "Joe")
+> jane <- .Counts(2L, name = "Jane")
+> vec_rbind(set_names(joe, "x"), set_names(jane, "x"))
+Error: No common type for `..1$x` <vctrs_Counts> and `..2$x` <vctrs_Counts>.
+

--- a/tests/testthat/error/test-c.txt
+++ b/tests/testthat/error/test-c.txt
@@ -1,41 +1,31 @@
 
-vec_c() falls back to c() for foreign S3 classes
-================================================
+vec_c() fails with complex foreign S3 classes
+=============================================
 
-> vec_c(foobar(1), foobar(2))
-Error: Can't find vctrs or base methods for concatenation.
-vctrs methods must be implemented for class `vctrs_foobar`.
-See <https://vctrs.r-lib.org/articles/s3-vector.html>.
+> x <- structure(foobar(1), attr_foo = "foo")
+> y <- structure(foobar(2), attr_bar = "bar")
+> vec_c(x, y)
+Error: No common type for `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
 
 
-vec_c() falls back to c() for S4 classes with a registered c() method
-=====================================================================
+vec_c() fails with complex foreign S4 classes
+=============================================
 
-> joe1 <- .Counts(c(1L, 2L), name = "Joe")
-> joe2 <- .Counts(3L, name = "Joe")
-> vec_c(joe1, joe2)
-Error: Can't find vctrs or base methods for concatenation.
-vctrs methods must be implemented for class `vctrs_Counts`.
-See <https://vctrs.r-lib.org/articles/s3-vector.html>.
-
-> vec_c(NULL, joe1, joe2)
-Error: Can't find vctrs or base methods for concatenation.
-vctrs methods must be implemented for class `vctrs_Counts`.
-See <https://vctrs.r-lib.org/articles/s3-vector.html>.
-
-> vec_c(joe1, 1, joe2)
-Error: No common type for `..1` <vctrs_Counts> and `..2` <double>.
+> joe <- .Counts(c(1L, 2L), name = "Joe")
+> jane <- .Counts(3L, name = "Jane")
+> vec_c(joe, jane)
+Error: No common type for `..1` <vctrs_Counts> and `..2` <vctrs_Counts>.
 
 
 vec_c() fallback doesn't support `name_spec` or `ptype`
 =======================================================
 
-> vec_c(foobar(1), foobar(2), .name_spec = "{outer}_{inner}")
+> with_c_foobar(vec_c(foobar(1), foobar(2), .name_spec = "{outer}_{inner}"))
 Error: Can't use a name specification with non-vctrs types.
 vctrs methods must be implemented for class `vctrs_foobar`.
 See <https://vctrs.r-lib.org/articles/s3-vector.html>.
 
-> vec_c(foobar(1), foobar(2), .ptype = "")
+> with_c_foobar(vec_c(foobar(1), foobar(2), .ptype = ""))
 Error: Can't specify a prototype with non-vctrs types.
 vctrs methods must be implemented for class `vctrs_foobar`.
 See <https://vctrs.r-lib.org/articles/s3-vector.html>.

--- a/tests/testthat/error/test-unchop.txt
+++ b/tests/testthat/error/test-unchop.txt
@@ -12,13 +12,22 @@ Error: Must subset elements with a valid subscript vector.
 x The subscript can't contain negative locations.
 
 
-vec_unchop() falls back to c() for foreign classes
+vec_unchop() fails with complex foreign S3 classes
 ==================================================
 
-> vec_unchop(list(foobar(1), foobar(2)))
-Error: Can't find vctrs or base methods for concatenation.
-vctrs methods must be implemented for class `vctrs_foobar`.
-See <https://vctrs.r-lib.org/articles/s3-vector.html>.
+> x <- structure(foobar(1), attr_foo = "foo")
+> y <- structure(foobar(2), attr_bar = "bar")
+> vec_unchop(list(x, y))
+Error: No common type for `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
+
+
+vec_unchop() fails with complex foreign S4 classes
+==================================================
+
+> joe <- .Counts(c(1L, 2L), name = "Joe")
+> jane <- .Counts(3L, name = "Jane")
+> vec_unchop(list(joe, jane))
+Error: No common type for `..1` <vctrs_Counts> and `..2` <vctrs_Counts>.
 
 
 vec_unchop() falls back for S4 classes with a registered c() method
@@ -26,11 +35,6 @@ vec_unchop() falls back for S4 classes with a registered c() method
 
 > joe1 <- .Counts(c(1L, 2L), name = "Joe")
 > joe2 <- .Counts(3L, name = "Joe")
-> vec_unchop(list(joe1, joe2), list(c(1, 3), 2))
-Error: Can't find vctrs or base methods for concatenation.
-vctrs methods must be implemented for class `vctrs_Counts`.
-See <https://vctrs.r-lib.org/articles/s3-vector.html>.
-
 > vec_unchop(list(joe1, 1, joe2), list(c(1, 2), 3, 4))
 Error: No common type for `..1` <vctrs_Counts> and `..2` <double>.
 
@@ -38,12 +42,14 @@ Error: No common type for `..1` <vctrs_Counts> and `..2` <double>.
 vec_unchop() fallback doesn't support `name_spec` or `ptype`
 ============================================================
 
-> vec_unchop(list(foobar(1)), name_spec = "{outer}_{inner}")
+> foo <- structure(foobar(1), foo = "foo")
+> bar <- structure(foobar(2), bar = "bar")
+> with_c_foobar(vec_unchop(list(foo, bar), name_spec = "{outer}_{inner}"))
 Error: Can't use a name specification with non-vctrs types.
 vctrs methods must be implemented for class `vctrs_foobar`.
 See <https://vctrs.r-lib.org/articles/s3-vector.html>.
 
-> vec_unchop(list(foobar(1)), ptype = "")
+> with_c_foobar(vec_unchop(list(foobar(1)), ptype = ""))
 Error: Can't specify a prototype with non-vctrs types.
 vctrs methods must be implemented for class `vctrs_foobar`.
 See <https://vctrs.r-lib.org/articles/s3-vector.html>.

--- a/tests/testthat/helper-s3.R
+++ b/tests/testthat/helper-s3.R
@@ -33,7 +33,9 @@ proxy_deref <- function(x) {
 local_env_proxy <- function(frame = caller_env()) {
   local_methods(.frame = frame,
     vec_proxy.vctrs_proxy = proxy_deref,
-    vec_restore.vctrs_proxy = function(x, ...) new_proxy(x)
+    vec_restore.vctrs_proxy = function(x, ...) new_proxy(x),
+    vec_cast.vctrs_proxy = function(x, to, ...) UseMethod("vec_cast.vctrs_proxy"),
+    vec_cast.vctrs_proxy.vctrs_proxy = function(x, to, ...) x
   )
 }
 

--- a/tests/testthat/helper-s3.R
+++ b/tests/testthat/helper-s3.R
@@ -1,6 +1,13 @@
 
 foobar <- function(x = list()) structure(x, class = "vctrs_foobar")
 
+with_c_foobar <- function(expr) {
+  with_methods(
+    expr,
+    c.vctrs_foobar = function(...) foobar(NextMethod())
+  )
+}
+
 unrownames <- function(x) {
   row.names(x) <- NULL
   x
@@ -9,6 +16,11 @@ unrownames <- function(x) {
 local_methods <- function(..., .frame = caller_env()) {
   local_bindings(..., .env = global_env(), .frame = .frame)
 }
+with_methods <- function(.expr, ...) {
+  local_methods(...)
+  .expr
+}
+
 local_proxy <- function(frame = caller_env()) {
   local_methods(.frame = frame,
     vec_proxy.vctrs_proxy = function(x, ...) proxy_deref(x),
@@ -22,7 +34,6 @@ local_proxy <- function(frame = caller_env()) {
     vec_cast.vctrs_proxy.vctrs_proxy = function(x, to, ...) x
   )
 }
-
 
 new_proxy <- function(x) {
   structure(list(env(x = x)), class = "vctrs_proxy")

--- a/tests/testthat/helper-s4.R
+++ b/tests/testthat/helper-s4.R
@@ -23,6 +23,25 @@ setMethod("[", "vctrs_rando", function(x, i, j, ..., drop = TRUE) {
   slots = c(name = "character")
 )
 
+local_c_counts <- function(frame = caller_env()) {
+  c_counts <- function(x, ...) {
+    xs <- list(x, ...)
+
+    xs_data <- lapply(xs, function(x) x@.Data)
+    new_data <- do.call(c, xs_data)
+
+    .Counts(new_data, name = "Dispatched")
+  }
+
+  local_s4_method(
+    frame = frame,
+    "c",
+    methods::signature(x = "vctrs_Counts"),
+    c_counts
+  )
+}
+
+
 local_s4_method <- function(generic, signature, method, frame = caller_env()) {
   methods::setMethod(generic, signature, method)
   exit_expr <- call2(methods::removeMethod, generic, signature, where = topenv(frame))

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -517,3 +517,60 @@ test_that("rbind repairs names of data frames (#704)", {
     class = "vctrs_error_names_must_be_unique"
   )
 })
+
+test_that("vec_rbind() works with simple homogeneous foreign S3 classes", {
+  expect_identical(
+    vec_rbind(set_names(foobar(1), "x"), set_names(foobar(2), "x")),
+    data_frame(x = foobar(c(1, 2)))
+  )
+})
+
+test_that("vec_rbind() works with simple homogeneous foreign S4 classes", {
+  joe1 <- .Counts(1L, name = "Joe")
+  joe2 <- .Counts(2L, name = "Joe")
+  expect_identical(
+    vec_rbind(set_names(joe1, "x"), set_names(joe2, "x")),
+    data_frame(x = .Counts(1:2, name = "Joe"))
+  )
+})
+
+test_that("vec_rbind() fails with complex foreign S3 classes", {
+  verify_errors({
+    x <- structure(foobar(1), attr_foo = "foo")
+    y <- structure(foobar(2), attr_bar = "bar")
+    expect_error(
+      vec_rbind(set_names(x, "x"), set_names(y, "x")),
+      class = "vctrs_error_incompatible_type"
+    )
+  })
+})
+
+test_that("vec_rbind() fails with complex foreign S4 classes", {
+  verify_errors({
+    joe <- .Counts(1L, name = "Joe")
+    jane <- .Counts(2L, name = "Jane")
+    expect_error(vec_rbind(joe, jane), class = "vctrs_error_incompatible_type")
+  })
+})
+
+test_that("vec_rbind() falls back to c() if S3 method is available", {
+  skip("TODO")
+})
+
+test_that("vec_rbind() falls back to c() if S4 method is available", {
+  skip("TODO")
+})
+
+test_that("vec_cbind() and vec_rbind() have informative error messages", {
+  verify_output(test_path("error", "test-bind.txt"), {
+    "# vec_rbind() fails with complex foreign S3 classes"
+    x <- structure(foobar(1), attr_foo = "foo")
+    y <- structure(foobar(2), attr_bar = "bar")
+    vec_rbind(set_names(x, "x"), set_names(y, "x"))
+
+    "# vec_rbind() fails with complex foreign S4 classes"
+    joe <- .Counts(1L, name = "Joe")
+    jane <- .Counts(2L, name = "Jane")
+    vec_rbind(set_names(joe, "x"), set_names(jane, "x"))
+  })
+})

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -21,6 +21,10 @@ test_that("cast base methods are not inherited", {
   }
 })
 
+test_that("default cast allows objects with the same type", {
+  x <- structure(1, class = c("foo", "double"))
+  expect_equal(vec_cast(x, x), x)
+})
 
 # shape_match -------------------------------------------------------------
 


### PR DESCRIPTION
In combining operations `vec_c()`, `vec_rbind()`, `vec_unchop()`, for homogeneously classed inputs. Closes #776.

* Like before, `c()` is used as fallback. However we check in advance for a `c()` implementation. If not found, we use the second fallback.

* Like `vec_ptype2()`, `vec_cast()` now uses `is_same_type()`. If the types are the same (their prototypes all have the same attributes), we no-op. Combining operations restore the attributes after concatenation.

I don't remember why I didn't implement this fallback immediately, I think it had to do with issues caused by method inheritance and `vctrs_vctr` inheriting from the base type, which we have since disabled.

Currently `vec_rbind()` doesn't fall back to `c()`, I'll implement this separately. Also still need to provide hints about implementing vctrs methods for incompatible homogeneously classed inputs (see #922).