### PR TITLE
Copy "extending" vignette from tibble, with tweaks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,13 +36,15 @@ Suggests:
     crayon,
     generics,
     knitr,
-    pillar (>= 1.4.1),
+    pillar (>= 1.4.3.9001),
     pkgdown,
     rmarkdown,
     testthat (>= 2.3.0),
     tibble,
     xml2,
     zeallot
+Remotes: 
+    r-lib/pillar
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/vignettes/pillar.Rmd
+++ b/vignettes/pillar.Rmd
@@ -1,0 +1,458 @@
+---
+title: "Printing vectors nicely in tibbles"
+author: "Kirill Müller, Hadley Wickham"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Printing vectors nicely in tibbles}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+options(crayon.enabled = TRUE)
+options(pillar.bold = TRUE)
+
+knitr::opts_chunk$set(collapse = TRUE, comment = pillar::style_subtle("#>"))
+
+colourise_chunk <- function(type) {
+  function(x, options) {
+    # lines <- strsplit(x, "\\n")[[1]]
+    lines <- x
+    if (type != "output") {
+      lines <- crayon::red(lines)
+    }
+    paste0(
+      '<div class="sourceCode"><pre class="sourceCode"><code class="sourceCode">',
+      paste0(
+        sgr_to_html(htmltools::htmlEscape(lines)),
+        collapse = "\n"
+      ),
+      "</code></pre></div>"
+    )
+  }
+}
+
+knitr::knit_hooks$set(
+  output = colourise_chunk("output"),
+  message = colourise_chunk("message"),
+  warning = colourise_chunk("warning"),
+  error = colourise_chunk("error")
+)
+
+# Fallback if fansi is missing
+sgr_to_html <- identity
+sgr_to_html <- fansi::sgr_to_html
+```
+
+To ensure that a vector prints nicely in a tibble, you need to understand how printing works.
+The presentation of a column in a tibble is powered by four S3 generics:
+
+* `type_sum()` determines what goes into the column header.
+* `pillar_shaft()` determines what goes into the body of the column.
+* `is_vector_s3()` and `obj_sum()` are used when rendering list columns.
+
+If you have created a vector class that can be used as a column, you can override these generics to make sure your data prints well in a tibble.
+To start, you must import the `pillar` package that powers the printing of tibbles.
+Either add `pillar` to the `Imports:` section of your `DESCRIPTION`, or call:
+
+```{r, eval = FALSE}
+usethis::use_package("pillar")
+```
+
+This short vignette assumes a package that implements a `"latlon"` vector and uses `roxygen2` to create documentation and the `NAMESPACE` file.
+To make the required methods available, we attach pillar.
+
+```{r attach}
+library(pillar)
+```
+
+
+
+## Prerequisites
+
+We define a class `"latlon"` that encodes geographic coordinates in a record.
+For simplicity, the values are printed as degrees and minutes only.
+
+```{r}
+library(vctrs)
+
+#' @export
+latlon <- function(lat, lon) {
+  new_rcrd(list(lat = lat, lon = lon), class = "latlon")
+}
+
+#' @export
+format.latlon <- function(x, ..., formatter = deg_min) {
+  x_valid <- which(!is.na(x))
+
+  lat <- field(x, "lat")[x_valid]
+  lon <- field(x, "lon")[x_valid]
+
+  ret <- rep("<NA>", vec_size(x))
+  ret[x_valid] <- paste(
+    formatter(lat, c("N", "S")),
+    formatter(lon, c("E", "W"))
+  )
+  format(ret, justify = "right")
+}
+
+deg_min <- function(x, pm) {
+  sign <- sign(x)
+  x <- abs(x)
+  deg <- trunc(x)
+  x <- x - deg
+  min <- round(x * 60)
+
+  ret <- sprintf("%d°%.2d'%s", deg, min, pm[ifelse(sign >= 0, 1, 2)])
+  format(ret, justify = "right")
+}
+
+latlon(32.7102978, -117.1704058)
+```
+
+By using `vctrs_rcrd()`, we already get the infrastructure to make this class fully compatible with data frames for free.
+
+
+## Using in a tibble
+
+Columns on this class can be used in a tibble right away, but the output will be less than ideal:
+
+```{r}
+library(tibble)
+data <- tibble(
+  venue = "rstudio::conf",
+  year  = 2017:2019,
+  loc   = latlon(
+    c(28.3411783, 32.7102978, NA),
+    c(-81.5480348, -117.1704058, NA)
+  ),
+  paths = list(
+    loc[1],
+    c(loc[1], loc[2]),
+    loc[2]
+  )
+)
+
+data
+```
+
+(The `paths` column is a list that contains arbitrary data, in our case `latlon` vectors.
+A list column is a powerful way to attach hierarchical or unstructured data to an observation in a data frame.)
+
+The output has three main problems:
+
+1. The column type of the `loc` column is displayed as `<latlon>`.  This default formatting works reasonably well for any kind of object, but the generated output may be too wide and waste precious space when displaying the tibble.
+1. The values in the `loc` column are formatted as complex numbers (the underlying storage), without using the `format()` method we have defined. This is by design.
+1. The cells in the `paths` column are also displayed as `<latlon>`.
+
+In the remainder I'll show how to fix these problems, and also how to implement rendering that adapts to the available width.
+
+
+## Fixing the data type
+
+To display `<geo>` as data type, we need to override the `type_sum()` method.
+This method should return a string that can be used in a column header.
+For your own classes, strive for an evocative abbreviation that's under 6 characters.
+
+
+```{r include=FALSE}
+import::from(pillar, type_sum)
+```
+
+```{r}
+#' @importFrom pillar type_sum
+#' @export
+type_sum.latlon <- function(x) {
+  "geo"
+}
+```
+
+Because the value shown there doesn't depend on the data, we just return a constant.
+(For date-times, the column info will eventually contain information about the timezone, see [#53](https://github.com/r-lib/pillar/pull/53).)
+
+```{r}
+data
+```
+
+
+## Rendering the value
+
+To use our format method for rendering, we implement the `pillar_shaft()` method for our class.
+(A [*pillar*](https://en.wikipedia.org/wiki/Column#Nomenclature) is mainly a *shaft* (decorated with an *ornament*), with a *capital* above and a *base* below.
+Multiple pillars form a *colonnade*, which can be stacked in multiple *tiers*.
+This is the motivation behind the names in our API.)
+
+```{r include=FALSE}
+import::from(pillar, pillar_shaft)
+```
+
+```{r}
+#' @importFrom pillar pillar_shaft
+#' @export
+pillar_shaft.latlon <- function(x, ...) {
+  out <- format(x)
+  out[is.na(x)] <- NA
+  pillar::new_pillar_shaft_simple(out, align = "right")
+}
+```
+
+The simplest variant calls our `format()` method, everything else is handled by pillar, in particular by the `new_pillar_shaft_simple()` helper.
+Note how the `align` argument affects the alignment of NA values and of the column name and type.
+
+```{r}
+data
+```
+
+We could also use left alignment and indent only the `NA` values:
+
+```{r}
+#' @importFrom pillar pillar_shaft
+#' @export
+pillar_shaft.latlon <- function(x, ...) {
+  out <- format(x)
+  out[is.na(x)] <- NA
+  pillar::new_pillar_shaft_simple(out, align = "left", na_indent = 5)
+}
+
+data
+```
+
+
+## Adaptive rendering
+
+If there is not enough space to render the values, the formatted values are truncated with an ellipsis.
+This doesn't currently apply to our class, because we haven't specified a minimum width for our values:
+
+```{r}
+print(data, width = 35)
+```
+
+If we specify a minimum width when constructing the shaft, the `loc` column will be truncated:
+
+```{r}
+#' @importFrom pillar pillar_shaft
+#' @export
+pillar_shaft.latlon <- function(x, ...) {
+  out <- format(x)
+  out[is.na(x)] <- NA
+  pillar::new_pillar_shaft_simple(out, align = "right", min_width = 10)
+}
+
+print(data, width = 35)
+```
+
+This may be useful for character data, but for lat-lon data we may prefer to show full degrees and remove the minutes if the available space is not enough to show accurate values.
+A more sophisticated implementation of the `pillar_shaft()` method is required to achieve this:
+
+```{r}
+#' @importFrom pillar pillar_shaft
+#' @export
+pillar_shaft.latlon <- function(x, ...) {
+  deg <- format(x, formatter = deg)
+  deg[is.na(x)] <- pillar::style_na("NA")
+  deg_min <- format(x)
+  deg_min[is.na(x)] <- pillar::style_na("NA")
+  pillar::new_pillar_shaft(
+    list(deg = deg, deg_min = deg_min),
+    width = pillar::get_max_extent(deg_min),
+    min_width = pillar::get_max_extent(deg),
+    class = "pillar_shaft_latlon"
+  )
+}
+```
+
+Here, `pillar_shaft()` returns an object of the `"pillar_shaft_latlon"` class created by the generic `new_pillar_shaft()` constructor.
+This object contains the necessary information to render the values, and also minimum and maximum width values.
+For simplicity, both formattings are pre-rendered, and the minimum and maximum widths are computed from there.
+Note that we also need to take care of `NA` values explicitly.
+(`get_max_extent()` is a helper that computes the maximum display width occupied by the values in a character vector.)
+
+For completeness, the code that implements the degree-only formatting looks like this:
+
+```{r}
+deg <- function(x, pm) {
+  sign <- sign(x)
+  x <- abs(x)
+  deg <- round(x)
+
+  ret <- sprintf("%d°%s", deg, pm[ifelse(sign >= 0, 1, 2)])
+  format(ret, justify = "right")
+}
+```
+
+All that's left to do is to implement a `format()` method for our new `"pillar_shaft_latlon"` class.
+This method will be called with a `width` argument, which then determines which of the formattings to choose:
+
+```{r}
+#' @export
+format.pillar_shaft_latlon <- function(x, width, ...) {
+  if (all(crayon::col_nchar(x$deg_min) <= width)) {
+    ornament <- x$deg_min
+  } else {
+    ornament <- x$deg
+  }
+
+  pillar::new_ornament(ornament)
+}
+
+data
+print(data, width = 35)
+```
+
+
+## Adding color
+
+Both `new_pillar_shaft_simple()` and `new_ornament()` accept ANSI escape codes for coloring, emphasis, or other ways of highlighting text on terminals that support it.
+Some formattings are predefined, e.g.
+`style_subtle()` displays text in a light gray.
+For default data types, this style is used for insignificant digits.
+We'll be formatting the degree and minute signs in a subtle style, because they serve only as separators.
+You can also use the [crayon](https://cran.r-project.org/package=crayon) package to add custom formattings to your output.
+
+```{r}
+#' @importFrom pillar pillar_shaft
+#' @export
+pillar_shaft.latlon <- function(x, ...) {
+  out <- format(x, formatter = deg_min_color)
+  out[is.na(x)] <- NA
+  pillar::new_pillar_shaft_simple(out, align = "left", na_indent = 5)
+}
+
+deg_min_color <- function(x, pm) {
+  sign <- sign(x)
+  x <- abs(x)
+  deg <- trunc(x)
+  x <- x - deg
+  rad <- round(x * 60)
+  ret <- sprintf(
+    "%d%s%.2d%s%s",
+    deg,
+    pillar::style_subtle("°"),
+    rad,
+    pillar::style_subtle("'"),
+    pm[ifelse(sign >= 0, 1, 2)]
+  )
+  ret[is.na(x)] <- ""
+  format(ret, justify = "right")
+}
+
+data
+```
+
+Currently, ANSI escapes are not rendered in vignettes, so the display here isn't much different from earlier examples.
+This may change in the future.
+
+## Testing
+
+If you want to test the output of your code, you can compare it with a known state recorded in a text file.
+For this, pillar offers the `expect_known_display()` expectation which requires and works best with the testthat package.
+Make sure that the output is generated only by your package to avoid inconsistencies when external code is updated.
+Here, this means that you test only the shaft portion of the pillar, and not the entire pillar or even a tibble that contains a column with your data type!
+
+The tests work best with the testthat package:
+
+```{r}
+library(testthat)
+```
+
+```{r include = FALSE}
+unlink("latlon.txt")
+unlink("latlon-bw.txt")
+```
+
+The code below will compare the output of `pillar_shaft(data$loc)` with known output stored in the `latlon.txt` file.
+The first run warns because the file doesn't exist yet.
+
+
+```{r error = TRUE, warning = TRUE}
+test_that("latlon pillar matches known output", {
+  pillar::expect_known_display(
+    pillar_shaft(data$loc),
+    file = "latlon.txt"
+  )
+})
+```
+
+From the second run on, the printing will be compared with the file:
+
+```{r}
+test_that("latlon pillar matches known output", {
+  pillar::expect_known_display(
+    pillar_shaft(data$loc),
+    file = "latlon.txt"
+  )
+})
+```
+
+However, if we look at the file we'll notice strange characters: The output contains ANSI escapes!
+
+```{r}
+readLines("latlon.txt")
+```
+
+We can turn them off by passing `crayon = FALSE` to the expectation, but we need to run twice again:
+
+```{r error = TRUE, warning = TRUE}
+library(testthat)
+test_that("latlon pillar matches known output", {
+  pillar::expect_known_display(
+    pillar_shaft(data$loc),
+    file = "latlon.txt",
+    crayon = FALSE
+  )
+})
+```
+
+```{r}
+test_that("latlon pillar matches known output", {
+  pillar::expect_known_display(
+    pillar_shaft(data$loc),
+    file = "latlon.txt",
+    crayon = FALSE
+  )
+})
+
+readLines("latlon.txt")
+```
+
+You may want to create a series of output files for different scenarios:
+
+- Colored vs. plain (to simplify viewing differences)
+- With or without special Unicode characters (if your output uses them)
+- Different widths
+
+For this it is helpful to create your own expectation function.
+Use the tidy evaluation framework to make sure that construction and printing happens at the right time:
+
+```{r}
+expect_known_latlon_display <- function(x, file_base) {
+  quo <- rlang::quo(pillar::pillar_shaft(x))
+  pillar::expect_known_display(
+    !! quo,
+    file = paste0(file_base, ".txt")
+  )
+  pillar::expect_known_display(
+    !! quo,
+    file = paste0(file_base, "-bw.txt"),
+    crayon = FALSE
+  )
+}
+```
+
+```{r error = TRUE, warning = TRUE}
+test_that("latlon pillar matches known output", {
+  expect_known_latlon_display(data$loc, file_base = "latlon")
+})
+```
+
+```{r}
+readLines("latlon.txt")
+readLines("latlon-bw.txt")
+```
+
+Learn more about the tidyeval framework in the [dplyr vignette](http://dplyr.tidyverse.org/articles/programming.html).
+
+```{r include = FALSE}
+unlink("latlon.txt")
+unlink("latlon-bw.txt")
+```

--- a/vignettes/pillar.Rmd
+++ b/vignettes/pillar.Rmd
@@ -8,67 +8,64 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r setup, include = FALSE}
+```{r, include = FALSE}
 knitr::opts_chunk$set(collapse = TRUE, comment = pillar::style_subtle("#>"))
 ```
 
-To ensure that a vector prints nicely in a tibble, you need to understand how printing works.
-The presentation of a column in a tibble is powered by four S3 generics:
+You can get basic control over how a vector is printed in a tibble by providing a `format()` method.
+But if you want greater control, you need to understand how printing works.
+The presentation of a column in a tibble is controlled by two S3 generics:
 
 * `vctrs::vec_ptype_abbr()` determines what goes into the column header.
-* `pillar::pillar_shaft()` determines what goes into the body of the column.
+* `pillar::pillar_shaft()` determines what goes into the body, or the shaft, of the column.
 
-If you have created a vector class that can be used as a column, you can override these generics to make sure your data prints well in a tibble.
-This short vignette assumes a package that implements a `"latlon"` vector and uses roxygen2 to create documentation and the `NAMESPACE` file.
-To make the required methods available in this vignette, we attach pillar and vctrs.
-You don't need to do this in your package.
+Technically a [*pillar*](https://en.wikipedia.org/wiki/Column#Nomenclature) is composed of a *shaft* (decorated with an *ornament*), with a *capital* above and a *base* below.
+Multiple pillars form a *colonnade*, which can be stacked in multiple *tiers*.
+This is the motivation behind the names in our API.
 
-```{r attach}
+This short vignette shows the basics of column styling using a `"latlon"` vector.
+The vignette imagines the code is in a package, so that you can see the roxygen2 commands you'll need to create documentation and the `NAMESPACE` file.
+In this vignette, we'll attach pillar and vctrs:
+
+```{r setup}
 library(vctrs)
 library(pillar)
 ```
 
-In a package, you must import the pillar package that powers the printing of tibbles.
-Add `pillar` to the `Imports:` section of your `DESCRIPTION`.
+You don't need to do this in a package.
+Instead, you'll need to _import_ the packages by then to the `Imports:` section of your `DESCRIPTION`.
 The following helper does this for you:
 
 ```{r, eval = FALSE}
+usethis::use_package("vctrs")
 usethis::use_package("pillar")
 ```
 
-
-
 ## Prerequisites
 
-We define a class `"latlon"` that encodes geographic coordinates in a record.
+To illustrate the basic ideas we're going to create a `"latlon"` class that encodes geographic coordinates in a record.
+We'll pretend that this code lives in a package called earth.
 For simplicity, the values are printed as degrees and minutes only.
+By using `vctrs_rcrd()`, we already get the infrastructure to make this class fully compatible with data frames for free.
+See `vignette("s3-vector", package = "vctrs")` for details on the record data type.
 
 ```{r}
-library(vctrs)
-
 #' @export
 latlon <- function(lat, lon) {
-  new_rcrd(list(lat = lat, lon = lon), class = "latlon")
+  new_rcrd(list(lat = lat, lon = lon), class = "earth_latlon")
 }
 
-format_latlon <- function(x, formatter = deg_min) {
+#' @export
+format.earth_latlon <- function(x, ..., formatter = deg_min) {
   x_valid <- which(!is.na(x))
 
   lat <- field(x, "lat")[x_valid]
   lon <- field(x, "lon")[x_valid]
 
   ret <- rep(NA_character_, vec_size(x))
-  ret[x_valid] <- paste(
-    formatter(lat, "lat"),
-    formatter(lon, "lon")
-  )
+  ret[x_valid] <- paste0(formatter(lat, "lat"), " ", formatter(lon, "lon"))
   # It's important to keep NA in the vector!
-  format(ret, justify = "right", na.encode = FALSE)
-}
-
-#' @export
-print.latlon <- function(x, ...) {
-  cat(format_latlon(x), sep = "\n")
+  ret
 }
 
 deg_min <- function(x, direction) {
@@ -80,20 +77,17 @@ deg_min <- function(x, direction) {
   x <- x - deg
   min <- round(x * 60)
 
-  ret <- sprintf("%d°%.2d'%s", deg, min, pm[ifelse(sign >= 0, 1, 2)])
+  # Ensure the columns are always the same width so they line up nicely
+  ret <- sprintf("%d°%.2d'%s", deg, min, ifelse(sign >= 0, pm[[1]], pm[[2]]))
   format(ret, justify = "right")
 }
 
-latlon(32.7102978, -117.1704058)
+latlon(c(32.71, 2.95), c(-117.17, 1.67))
 ```
-
-By using `vctrs_rcrd()`, we already get the infrastructure to make this class fully compatible with data frames for free.
-See `vignette("s3-vector", package = "vctrs")` for details on the record data type.
-
 
 ## Using in a tibble
 
-Columns on this class can be used in a tibble right away, because `vctrs::vec_is()` is `TRUE` for latlon objects:
+Columns on this class can be used in a tibble right away because we've made a class using the vctrs infrastructure and have provided a format method:
 
 ```{r}
 library(tibble)
@@ -102,109 +96,49 @@ loc <- latlon(
   c(28.3411783, 32.7102978, 30.2622356, 37.7859102, 28.5, NA),
   c(-81.5480348, -117.1704058, -97.7403327, -122.4131357, -81.4, NA)
 )
-vctrs::vec_is(loc)
 
 data <- tibble(venue = "rstudio::conf", year = 2017:2022, loc = loc)
 
-data$loc
-```
-
-The tibble can't be printed yet because we haven't implemented a `format()` method for our class:
-
-```{r error = TRUE}
 data
 ```
 
-The easiest solution is to implement a `format()` method.
-This method should return a character vector with one element per item, with `NA` in locations where the input vector is `NA`.
-See `vignette("s3-vector", package = "vctrs")` for details.
-(This also allows us to take advantage of the `print()` method implemented for the rcrd class.)
+This output is ok, but we could improve it by:
 
-```{r}
-#' @importFrom pillar pillar_shaft
-#' @export
-format.latlon <- function(x, ...) {
-  format_latlon(x)
-}
+1. Using a more description type abbreviation than `<erth_ltl>`.
 
-rm(print.latlon)
-data$loc
-```
+1. Using a dash of colour to highlight the most important parts of the value.
 
-The new `format()` method is used to render the column:
+1. Providing a narrower view when horizontal space is at a premium.
 
-```{r}
-data
-```
-
-The output has two main problems:
-
-1. The column type of the `loc` column is displayed as `<latlon>`.  This default formatting works reasonably well for any kind of object, but may be too wide or too technical.
-1. Likewise, the values in the `loc` column consume a lot of precious horizontal space, which might take away space from other columns.
-
-In the remainder I'll show how to fix these problems.
-
+The following sections show how to fix these problems.
 
 ## Fixing the data type
 
-To display `<geo>` as data type, we need to override the `vec_ptype_abbr()` method.
-This method should return a string that can be used in a column header.
+Instead of `<erth_ltl>` we'd prefer to use `<latlon>`.
+We can do that by implementing the `vec_ptype_abbr()` method, which should return a string that can be used in a column header.
 For your own classes, strive for an evocative abbreviation that's under 6 characters.
 
 ```{r}
-#' @importFrom vctrs vec_ptype_abbr
 #' @export
-vec_ptype_abbr.latlon <- function(x) {
-  "geo"
+vec_ptype_abbr.earth_latlon <- function(x) {
+  "latlon"
 }
-```
 
-The `x` argument is used only for method dispatch, the return value is a constant that doesn't depend on the data.
-
-```{r}
 data
 ```
 
 
 ## Custom rendering
 
-The `format()` method us used by default for rendering.
-For custom formatting we implement the `pillar_shaft()` method for our class.[^pillar-shaft]
-Our custom implementation uses left alignment and indents only the `NA` values so that they align with the latitude values:
+The `format()` method is used by default for rendering.
+For custom formatting you need to implement the `pillar_shaft()` method.
+This function should always return a pillar shaft object, created `new_pillar_shaft_simple()` or similar.
+`new_pillar_shaft_simple()` accepts ANSI escape codes for colouring, and includes some built in styles like `style_subtle()`.
+We can use subtle style for the degree and minute separators to make the data more obvious.
 
-[^pillar-shaft]: A [*pillar*](https://en.wikipedia.org/wiki/Column#Nomenclature) is mainly a *shaft* (decorated with an *ornament*), with a *capital* above and a *base* below.
-Multiple pillars form a *colonnade*, which can be stacked in multiple *tiers*.
-This is the motivation behind the names in our API.
-
-```{r}
-#' @importFrom pillar pillar_shaft
-#' @export
-pillar_shaft.latlon <- function(x, ...) {
-  out <- format_latlon(x)
-  pillar::new_pillar_shaft_simple(out, align = "left", na_indent = 5)
-}
-
-data
-```
-
-
-
-## Adding color
-
-`new_pillar_shaft_simple()` accepts ANSI escape codes for coloring, emphasis, or other ways of highlighting text on terminals that support it.
-Some formattings are predefined, e.g. `style_subtle()` displays text in a light gray.
-For default data types, this style is used for insignificant digits.
-We'll be formatting the degree and minute signs in a subtle style, because they serve only as separators.
-You can also use the [crayon](https://cran.r-project.org/package=crayon) package to add custom formattings to your output.
+First we define a degree formatter that makes use of `style_subtle()`:
 
 ```{r}
-#' @importFrom pillar pillar_shaft
-#' @export
-pillar_shaft.latlon <- function(x, ...) {
-  out <- format_latlon(x, formatter = deg_min_color)
-  pillar::new_pillar_shaft_simple(out, align = "left", na_indent = 5)
-}
-
 deg_min_color <- function(x, direction) {
   pm <- if (direction == "lat") c("N", "S") else c("E", "W")
 
@@ -223,65 +157,52 @@ deg_min_color <- function(x, direction) {
   )
   format(ret, justify = "right")
 }
+```
 
+And then we pass that to our format method:
+
+```{r}
+#' @importFrom pillar pillar_shaft
+#' @export
+pillar_shaft.earth_latlon <- function(x, ...) {
+  out <- format(x, formatter = deg_min_color)
+  pillar::new_pillar_shaft_simple(out, align = "right")
+}
+```
+
+Currently, ANSI escapes are not rendered in vignettes, so this result doesn't look any different, but if you run the code yourself you'll see an improved display.
+
+```{r}
 data
 ```
 
-Currently, ANSI escapes are not rendered in vignettes, so the display here isn't much different from earlier examples.
-This may change in the future.
-
-
+As well as the functions in pillar, the [cli](http://cli.r-lib.org/) package provides a variety of tools for styling text.
 
 ## Truncation
 
-If there is not enough space to render the values, the formatted values are truncated with an ellipsis.
-This doesn't currently apply to our class, because we haven't specified a minimum width for our values:
+Tibbles can automatically compacts columns when there's no enough horizontal space to display everything:
 
 ```{r}
 print(data, width = 30)
 ```
 
-If we specify a minimum width when constructing the shaft, the `loc` column will be truncated:
+Currently the latlon class isn't ever compacted because we haven't specified a minimum width when constructing the shaft.
+Let's fix that and re-print the data:
 
 ```{r}
 #' @importFrom pillar pillar_shaft
 #' @export
-pillar_shaft.latlon <- function(x, ...) {
-  out <- format_latlon(x)
+pillar_shaft.earth_latlon <- function(x, ...) {
+  out <- format(x)
   pillar::new_pillar_shaft_simple(out, align = "right", min_width = 10)
 }
 
 print(data, width = 30)
 ```
-
-
 ## Adaptive rendering
 
-Truncation may be useful for character data, but for lat-lon data we may prefer to show full degrees and remove the minutes if the available space is not enough to show accurate values.
-A more sophisticated implementation of the `pillar_shaft()` method is required to achieve this:
-
-```{r}
-#' @importFrom pillar pillar_shaft
-#' @export
-pillar_shaft.latlon <- function(x, ...) {
-  deg <- format_latlon(x, formatter = deg)
-  deg_min <- format_latlon(x)
-
-  pillar::new_pillar_shaft(
-    list(deg = deg, deg_min = deg_min),
-    width = pillar::get_max_extent(deg_min),
-    min_width = pillar::get_max_extent(deg),
-    class = "pillar_shaft_latlon"
-  )
-}
-```
-
-Here, `pillar_shaft()` returns an object of the `"pillar_shaft_latlon"` class created by the generic `new_pillar_shaft()` constructor.
-This object contains the necessary information to render the values, and also minimum and maximum width values.
-For simplicity, both formattings are pre-rendered, and the minimum and maximum widths are computed from there.
-(`get_max_extent()` is a helper that computes the maximum display width occupied by the values in a character vector.)
-
-For completeness, the code that implements the degree-only formatting looks like this:
+Truncation may be useful for character data, but for lat-lon data it'd be nicer to show full degrees and remove the minutes.
+We'll first write a function that does this:
 
 ```{r}
 deg <- function(x, direction) {
@@ -296,8 +217,31 @@ deg <- function(x, direction) {
 }
 ```
 
+Then use it as part of more sophisticated implementation of the `pillar_shaft()` method:
+
+```{r}
+#' @importFrom pillar pillar_shaft
+#' @export
+pillar_shaft.earth_latlon <- function(x, ...) {
+  deg <- format(x, formatter = deg)
+  deg_min <- format(x)
+
+  pillar::new_pillar_shaft(
+    list(deg = deg, deg_min = deg_min),
+    width = pillar::get_max_extent(deg_min),
+    min_width = pillar::get_max_extent(deg),
+    class = "pillar_shaft_latlon"
+  )
+}
+```
+
+Now the `pillar_shaft()` method returns an object of class `"pillar_shaft_latlon"` created by `new_pillar_shaft()`.
+This object contains the necessary information to render the values, and also minimum and maximum width values.
+For simplicity, both format are pre-rendered, and the minimum and maximum widths are computed from there.
+(`get_max_extent()` is a helper that computes the maximum display width occupied by the values in a character vector.)
+
 All that's left to do is to implement a `format()` method for our new `"pillar_shaft_latlon"` class.
-This method will be called with a `width` argument, which then determines which of the formattings to choose.
+This method will be called with a `width` argument, which then determines which of the formats to choose.
 The formatting of our choice is passed to the `new_ornament()` function:
 
 ```{r}
@@ -315,9 +259,6 @@ format.pillar_shaft_latlon <- function(x, width, ...) {
 data
 print(data, width = 30)
 ```
-
-`new_ornament()` also accepts ANSI escapes for highlighted output.
-
 
 ## Testing
 
@@ -341,7 +282,6 @@ The code below will compare the output of `pillar_shaft(data$loc)` with known ou
 There is no need to put it in a `test_that()` block.
 
 The first run warns because the file doesn't exist yet.
-
 
 ```{r error = TRUE, warning = TRUE}
 verify_output("latlon.txt", {

--- a/vignettes/pillar.Rmd
+++ b/vignettes/pillar.Rmd
@@ -57,7 +57,7 @@ format.latlon <- function(x, ..., formatter = deg_min) {
   lat <- field(x, "lat")[x_valid]
   lon <- field(x, "lon")[x_valid]
 
-  ret <- rep("<NA>", vec_size(x))
+  ret <- rep(NA_character_, vec_size(x))
   ret[x_valid] <- paste(
     formatter(lat, c("N", "S")),
     formatter(lon, c("E", "W"))
@@ -88,17 +88,23 @@ Columns on this class can be used in a tibble right away, but the output will be
 
 ```{r}
 library(tibble)
+
+loc <- latlon(
+  c(28.3411783, 32.7102978, 30.2622356, 37.7859102, 28.5, NA),
+  c(-81.5480348, -117.1704058, -97.7403327, -122.4131357, -81.4, NA)
+)
+
 data <- tibble(
   venue = "rstudio::conf",
-  year  = 2017:2019,
-  loc   = latlon(
-    c(28.3411783, 32.7102978, NA),
-    c(-81.5480348, -117.1704058, NA)
-  ),
+  year  = 2017:2022,
+  loc   = loc,
   paths = list(
     loc[1],
     c(loc[1], loc[2]),
-    loc[2]
+    c(loc[2], loc[3]),
+    c(loc[3], loc[4]),
+    c(loc[4], loc[5]),
+    loc[4]
   )
 )
 

--- a/vignettes/pillar.Rmd
+++ b/vignettes/pillar.Rmd
@@ -9,39 +9,7 @@ vignette: >
 ---
 
 ```{r setup, include = FALSE}
-options(crayon.enabled = TRUE)
-options(pillar.bold = TRUE)
-
 knitr::opts_chunk$set(collapse = TRUE, comment = pillar::style_subtle("#>"))
-
-colourise_chunk <- function(type) {
-  function(x, options) {
-    # lines <- strsplit(x, "\\n")[[1]]
-    lines <- x
-    if (type != "output") {
-      lines <- crayon::red(lines)
-    }
-    paste0(
-      '<div class="sourceCode"><pre class="sourceCode"><code class="sourceCode">',
-      paste0(
-        sgr_to_html(htmltools::htmlEscape(lines)),
-        collapse = "\n"
-      ),
-      "</code></pre></div>"
-    )
-  }
-}
-
-knitr::knit_hooks$set(
-  output = colourise_chunk("output"),
-  message = colourise_chunk("message"),
-  warning = colourise_chunk("warning"),
-  error = colourise_chunk("error")
-)
-
-# Fallback if fansi is missing
-sgr_to_html <- identity
-sgr_to_html <- fansi::sgr_to_html
 ```
 
 To ensure that a vector prints nicely in a tibble, you need to understand how printing works.
@@ -52,19 +20,19 @@ The presentation of a column in a tibble is powered by four S3 generics:
 * `is_vector_s3()` and `obj_sum()` are used when rendering list columns.
 
 If you have created a vector class that can be used as a column, you can override these generics to make sure your data prints well in a tibble.
-To start, you must import the `pillar` package that powers the printing of tibbles.
-Either add `pillar` to the `Imports:` section of your `DESCRIPTION`, or call:
-
-```{r, eval = FALSE}
-usethis::use_package("pillar")
-```
-
 This short vignette assumes a package that implements a `"latlon"` vector and uses `roxygen2` to create documentation and the `NAMESPACE` file.
 To make the required methods available in this vignette, we attach pillar. 
 You don't need to do this in your package.
 
 ```{r attach}
 library(pillar)
+```
+
+In a package, you must import the pillar package that powers the printing of tibbles.
+Either add `pillar` to the `Imports:` section of your `DESCRIPTION`, or call:
+
+```{r, eval = FALSE}
+usethis::use_package("pillar")
 ```
 
 
@@ -156,10 +124,6 @@ This method should return a string that can be used in a column header.
 For your own classes, strive for an evocative abbreviation that's under 6 characters.
 
 
-```{r include=FALSE}
-import::from(pillar, type_sum)
-```
-
 ```{r}
 #' @importFrom pillar type_sum
 #' @export
@@ -169,7 +133,6 @@ type_sum.latlon <- function(x) {
 ```
 
 Because the value shown there doesn't depend on the data, we just return a constant.
-(For date-times, the column info will eventually contain information about the timezone, see [#53](https://github.com/r-lib/pillar/pull/53).)
 
 ```{r}
 data
@@ -346,9 +309,10 @@ This may change in the future.
 ## Testing
 
 If you want to test the output of your code, you can compare it with a known state recorded in a text file.
-For this, pillar offers the `expect_known_display()` expectation which requires and works best with the testthat package.
-Make sure that the output is generated only by your package to avoid inconsistencies when external code is updated.
-Here, this means that you test only the shaft portion of the pillar, and not the entire pillar or even a tibble that contains a column with your data type!
+The `testthat::verify_output()` function offers an easy way to test output-generating functions.
+It takes care about details such as Unicode, ANSI escapes, and output width.
+Furthermore it won't make the tests fail on CRAN.
+This is important because your output may rely on details out of your control, which should be fixed eventually but should not lead to your package being removed from CRAN.
 
 The tests work best with the testthat package:
 
@@ -362,98 +326,28 @@ unlink("latlon-bw.txt")
 ```
 
 The code below will compare the output of `pillar_shaft(data$loc)` with known output stored in the `latlon.txt` file.
+There is no need to put it in a `test_that()` block.
+
 The first run warns because the file doesn't exist yet.
 
 
 ```{r error = TRUE, warning = TRUE}
-test_that("latlon pillar matches known output", {
-  pillar::expect_known_display(
-    pillar_shaft(data$loc),
-    file = "latlon.txt"
-  )
+verify_output("latlon.txt", {
+  pillar_shaft(data$loc)
 })
 ```
 
 From the second run on, the printing will be compared with the file:
 
 ```{r}
-test_that("latlon pillar matches known output", {
-  pillar::expect_known_display(
-    pillar_shaft(data$loc),
-    file = "latlon.txt"
-  )
+verify_output("latlon.txt", {
+  pillar_shaft(data$loc)
 })
 ```
 
-However, if we look at the file we'll notice strange characters: The output contains ANSI escapes!
+By default, the file does not contain ANSI escapes.
+See `?verify_output` for more options.
 
 ```{r}
-readLines("latlon.txt")
-```
-
-We can turn them off by passing `crayon = FALSE` to the expectation, but we need to run twice again:
-
-```{r error = TRUE, warning = TRUE}
-library(testthat)
-test_that("latlon pillar matches known output", {
-  pillar::expect_known_display(
-    pillar_shaft(data$loc),
-    file = "latlon.txt",
-    crayon = FALSE
-  )
-})
-```
-
-```{r}
-test_that("latlon pillar matches known output", {
-  pillar::expect_known_display(
-    pillar_shaft(data$loc),
-    file = "latlon.txt",
-    crayon = FALSE
-  )
-})
-
-readLines("latlon.txt")
-```
-
-You may want to create a series of output files for different scenarios:
-
-- Colored vs. plain (to simplify viewing differences)
-- With or without special Unicode characters (if your output uses them)
-- Different widths
-
-For this it is helpful to create your own expectation function.
-Use the tidy evaluation framework to make sure that construction and printing happens at the right time:
-
-```{r}
-expect_known_latlon_display <- function(x, file_base) {
-  quo <- rlang::quo(pillar::pillar_shaft(x))
-  pillar::expect_known_display(
-    !! quo,
-    file = paste0(file_base, ".txt")
-  )
-  pillar::expect_known_display(
-    !! quo,
-    file = paste0(file_base, "-bw.txt"),
-    crayon = FALSE
-  )
-}
-```
-
-```{r error = TRUE, warning = TRUE}
-test_that("latlon pillar matches known output", {
-  expect_known_latlon_display(data$loc, file_base = "latlon")
-})
-```
-
-```{r}
-readLines("latlon.txt")
-readLines("latlon-bw.txt")
-```
-
-Learn more about the tidyeval framework in the [dplyr vignette](http://dplyr.tidyverse.org/articles/programming.html).
-
-```{r include = FALSE}
-unlink("latlon.txt")
-unlink("latlon-bw.txt")
+cat(readLines("latlon.txt"), sep = "\n")
 ```

--- a/vignettes/pillar.Rmd
+++ b/vignettes/pillar.Rmd
@@ -88,6 +88,7 @@ latlon(32.7102978, -117.1704058)
 ```
 
 By using `vctrs_rcrd()`, we already get the infrastructure to make this class fully compatible with data frames for free.
+See `vignette("s3-vector", package = "vctrs")` for details on the record data type.
 
 
 ## Using in a tibble

--- a/vignettes/pillar.Rmd
+++ b/vignettes/pillar.Rmd
@@ -15,21 +15,22 @@ knitr::opts_chunk$set(collapse = TRUE, comment = pillar::style_subtle("#>"))
 To ensure that a vector prints nicely in a tibble, you need to understand how printing works.
 The presentation of a column in a tibble is powered by four S3 generics:
 
-* `type_sum()` determines what goes into the column header.
-* `pillar_shaft()` determines what goes into the body of the column.
-* `is_vector_s3()` and `obj_sum()` are used when rendering list columns.
+* `vctrs::vec_ptype_abbr()` determines what goes into the column header.
+* `pillar::pillar_shaft()` determines what goes into the body of the column.
 
 If you have created a vector class that can be used as a column, you can override these generics to make sure your data prints well in a tibble.
-This short vignette assumes a package that implements a `"latlon"` vector and uses `roxygen2` to create documentation and the `NAMESPACE` file.
-To make the required methods available in this vignette, we attach pillar. 
+This short vignette assumes a package that implements a `"latlon"` vector and uses roxygen2 to create documentation and the `NAMESPACE` file.
+To make the required methods available in this vignette, we attach pillar and vctrs.
 You don't need to do this in your package.
 
 ```{r attach}
+library(vctrs)
 library(pillar)
 ```
 
 In a package, you must import the pillar package that powers the printing of tibbles.
-Either add `pillar` to the `Imports:` section of your `DESCRIPTION`, or call:
+Add `pillar` to the `Imports:` section of your `DESCRIPTION`.
+The following helper does this for you:
 
 ```{r, eval = FALSE}
 usethis::use_package("pillar")
@@ -50,8 +51,7 @@ latlon <- function(lat, lon) {
   new_rcrd(list(lat = lat, lon = lon), class = "latlon")
 }
 
-#' @export
-format.latlon <- function(x, ..., formatter = deg_min) {
+format_latlon <- function(x, formatter = deg_min) {
   x_valid <- which(!is.na(x))
 
   lat <- field(x, "lat")[x_valid]
@@ -59,13 +59,21 @@ format.latlon <- function(x, ..., formatter = deg_min) {
 
   ret <- rep(NA_character_, vec_size(x))
   ret[x_valid] <- paste(
-    formatter(lat, c("N", "S")),
-    formatter(lon, c("E", "W"))
+    formatter(lat, "lat"),
+    formatter(lon, "lon")
   )
-  format(ret, justify = "right")
+  # It's important to keep NA in the vector!
+  format(ret, justify = "right", na.encode = FALSE)
 }
 
-deg_min <- function(x, pm) {
+#' @export
+print.latlon <- function(x, ...) {
+  cat(format_latlon(x), sep = "\n")
+}
+
+deg_min <- function(x, direction) {
+  pm <- if (direction == "lat") c("N", "S") else c("E", "W")
+
   sign <- sign(x)
   x <- abs(x)
   deg <- trunc(x)
@@ -84,7 +92,7 @@ By using `vctrs_rcrd()`, we already get the infrastructure to make this class fu
 
 ## Using in a tibble
 
-Columns on this class can be used in a tibble right away, but the output will be less than ideal:
+Columns on this class can be used in a tibble right away, because `vctrs::vec_is()` is `TRUE` for latlon objects:
 
 ```{r}
 library(tibble)
@@ -93,94 +101,85 @@ loc <- latlon(
   c(28.3411783, 32.7102978, 30.2622356, 37.7859102, 28.5, NA),
   c(-81.5480348, -117.1704058, -97.7403327, -122.4131357, -81.4, NA)
 )
+vctrs::vec_is(loc)
 
-data <- tibble(
-  venue = "rstudio::conf",
-  year  = 2017:2022,
-  loc   = loc,
-  paths = list(
-    loc[1],
-    c(loc[1], loc[2]),
-    c(loc[2], loc[3]),
-    c(loc[3], loc[4]),
-    c(loc[4], loc[5]),
-    loc[4]
-  )
-)
+data <- tibble(venue = "rstudio::conf", year = 2017:2022, loc = loc)
 
+data$loc
+```
+
+The tibble can't be printed yet because we haven't implemented a `format()` method for our class:
+
+```{r error = TRUE}
 data
 ```
 
-(The `paths` column is a list that contains arbitrary data, in our case `latlon` vectors.
-A list column is a powerful way to attach hierarchical or unstructured data to an observation in a data frame.)
+The easiest solution is to implement a `format()` method.
+This method should return a character vector with one element per item, with `NA` in locations where the input vector is `NA`.
+See `vignette("s3-vector", package = "vctrs")` for details.
+(This also allows us to take advantage of the `print()` method implemented for the rcrd class.)
 
-The output has three main problems:
+```{r}
+#' @importFrom pillar pillar_shaft
+#' @export
+format.latlon <- function(x, ...) {
+  format_latlon(x)
+}
 
-1. The column type of the `loc` column is displayed as `<latlon>`.  This default formatting works reasonably well for any kind of object, but the generated output may be too wide and waste precious space when displaying the tibble.
-1. The values in the `loc` column are formatted as complex numbers (the underlying storage), without using the `format()` method we have defined. This is by design.
-1. The cells in the `paths` column are also displayed as `<latlon>`.
+rm(print.latlon)
+data$loc
+```
 
-In the remainder I'll show how to fix these problems, and also how to implement rendering that adapts to the available width.
+The new `format()` method is used to render the column:
+
+```{r}
+data
+```
+
+The output has two main problems:
+
+1. The column type of the `loc` column is displayed as `<latlon>`.  This default formatting works reasonably well for any kind of object, but may be too wide or too technical.
+1. Likewise, the values in the `loc` column consume a lot of precious horizontal space, which might take away space from other columns.
+
+In the remainder I'll show how to fix these problems.
 
 
 ## Fixing the data type
 
-To display `<geo>` as data type, we need to override the `type_sum()` method.
+To display `<geo>` as data type, we need to override the `vec_ptype_abbr()` method.
 This method should return a string that can be used in a column header.
 For your own classes, strive for an evocative abbreviation that's under 6 characters.
 
-
 ```{r}
-#' @importFrom pillar type_sum
+#' @importFrom vctrs vec_ptype_abbr
 #' @export
-type_sum.latlon <- function(x) {
+vec_ptype_abbr.latlon <- function(x) {
   "geo"
 }
 ```
 
-Because the value shown there doesn't depend on the data, we just return a constant.
+The `x` argument is used only for method dispatch, the return value is a constant that doesn't depend on the data.
 
 ```{r}
 data
 ```
 
 
-## Rendering the value
+## Custom rendering
 
-To use our format method for rendering, we implement the `pillar_shaft()` method for our class.
-(A [*pillar*](https://en.wikipedia.org/wiki/Column#Nomenclature) is mainly a *shaft* (decorated with an *ornament*), with a *capital* above and a *base* below.
+The `format()` method us used by default for rendering.
+For custom formatting we implement the `pillar_shaft()` method for our class.[^pillar-shaft]
+Our custom implementation uses left alignment and indents only the `NA` values so that they align with the latitude values:
+
+[^pillar-shaft]: A [*pillar*](https://en.wikipedia.org/wiki/Column#Nomenclature) is mainly a *shaft* (decorated with an *ornament*), with a *capital* above and a *base* below.
 Multiple pillars form a *colonnade*, which can be stacked in multiple *tiers*.
-This is the motivation behind the names in our API.)
-
-```{r include=FALSE}
-import::from(pillar, pillar_shaft)
-```
+This is the motivation behind the names in our API.
 
 ```{r}
 #' @importFrom pillar pillar_shaft
 #' @export
 pillar_shaft.latlon <- function(x, ...) {
-  out <- format(x)
-  out[is.na(x)] <- NA
-  pillar::new_pillar_shaft_simple(out, align = "right")
-}
-```
-
-The simplest variant calls our `format()` method, everything else is handled by pillar, in particular by the `new_pillar_shaft_simple()` helper.
-Note how the `align` argument affects the alignment of NA values and of the column name and type.
-
-```{r}
-data
-```
-
-We could also use left alignment and indent only the `NA` values:
-
-```{r}
-#' @importFrom pillar pillar_shaft
-#' @export
-pillar_shaft.latlon <- function(x, ...) {
-  out <- format(x)
-  out[is.na(x)] <- NA
+  out <- format_latlon(x)
   pillar::new_pillar_shaft_simple(out, align = "left", na_indent = 5)
 }
 
@@ -188,93 +187,11 @@ data
 ```
 
 
-## Adaptive rendering
-
-If there is not enough space to render the values, the formatted values are truncated with an ellipsis.
-This doesn't currently apply to our class, because we haven't specified a minimum width for our values:
-
-```{r}
-print(data, width = 35)
-```
-
-If we specify a minimum width when constructing the shaft, the `loc` column will be truncated:
-
-```{r}
-#' @importFrom pillar pillar_shaft
-#' @export
-pillar_shaft.latlon <- function(x, ...) {
-  out <- format(x)
-  out[is.na(x)] <- NA
-  pillar::new_pillar_shaft_simple(out, align = "right", min_width = 10)
-}
-
-print(data, width = 35)
-```
-
-This may be useful for character data, but for lat-lon data we may prefer to show full degrees and remove the minutes if the available space is not enough to show accurate values.
-A more sophisticated implementation of the `pillar_shaft()` method is required to achieve this:
-
-```{r}
-#' @importFrom pillar pillar_shaft
-#' @export
-pillar_shaft.latlon <- function(x, ...) {
-  deg <- format(x, formatter = deg)
-  deg[is.na(x)] <- pillar::style_na("NA")
-  deg_min <- format(x)
-  deg_min[is.na(x)] <- pillar::style_na("NA")
-  pillar::new_pillar_shaft(
-    list(deg = deg, deg_min = deg_min),
-    width = pillar::get_max_extent(deg_min),
-    min_width = pillar::get_max_extent(deg),
-    class = "pillar_shaft_latlon"
-  )
-}
-```
-
-Here, `pillar_shaft()` returns an object of the `"pillar_shaft_latlon"` class created by the generic `new_pillar_shaft()` constructor.
-This object contains the necessary information to render the values, and also minimum and maximum width values.
-For simplicity, both formattings are pre-rendered, and the minimum and maximum widths are computed from there.
-Note that we also need to take care of `NA` values explicitly.
-(`get_max_extent()` is a helper that computes the maximum display width occupied by the values in a character vector.)
-
-For completeness, the code that implements the degree-only formatting looks like this:
-
-```{r}
-deg <- function(x, pm) {
-  sign <- sign(x)
-  x <- abs(x)
-  deg <- round(x)
-
-  ret <- sprintf("%d°%s", deg, pm[ifelse(sign >= 0, 1, 2)])
-  format(ret, justify = "right")
-}
-```
-
-All that's left to do is to implement a `format()` method for our new `"pillar_shaft_latlon"` class.
-This method will be called with a `width` argument, which then determines which of the formattings to choose:
-
-```{r}
-#' @export
-format.pillar_shaft_latlon <- function(x, width, ...) {
-  if (all(crayon::col_nchar(x$deg_min) <= width)) {
-    ornament <- x$deg_min
-  } else {
-    ornament <- x$deg
-  }
-
-  pillar::new_ornament(ornament)
-}
-
-data
-print(data, width = 35)
-```
-
 
 ## Adding color
 
-Both `new_pillar_shaft_simple()` and `new_ornament()` accept ANSI escape codes for coloring, emphasis, or other ways of highlighting text on terminals that support it.
-Some formattings are predefined, e.g.
-`style_subtle()` displays text in a light gray.
+`new_pillar_shaft_simple()` accepts ANSI escape codes for coloring, emphasis, or other ways of highlighting text on terminals that support it.
+Some formattings are predefined, e.g. `style_subtle()` displays text in a light gray.
 For default data types, this style is used for insignificant digits.
 We'll be formatting the degree and minute signs in a subtle style, because they serve only as separators.
 You can also use the [crayon](https://cran.r-project.org/package=crayon) package to add custom formattings to your output.
@@ -283,12 +200,13 @@ You can also use the [crayon](https://cran.r-project.org/package=crayon) package
 #' @importFrom pillar pillar_shaft
 #' @export
 pillar_shaft.latlon <- function(x, ...) {
-  out <- format(x, formatter = deg_min_color)
-  out[is.na(x)] <- NA
+  out <- format_latlon(x, formatter = deg_min_color)
   pillar::new_pillar_shaft_simple(out, align = "left", na_indent = 5)
 }
 
-deg_min_color <- function(x, pm) {
+deg_min_color <- function(x, direction) {
+  pm <- if (direction == "lat") c("N", "S") else c("E", "W")
+
   sign <- sign(x)
   x <- abs(x)
   deg <- trunc(x)
@@ -302,7 +220,6 @@ deg_min_color <- function(x, pm) {
     pillar::style_subtle("'"),
     pm[ifelse(sign >= 0, 1, 2)]
   )
-  ret[is.na(x)] <- ""
   format(ret, justify = "right")
 }
 
@@ -311,6 +228,95 @@ data
 
 Currently, ANSI escapes are not rendered in vignettes, so the display here isn't much different from earlier examples.
 This may change in the future.
+
+
+
+## Truncation
+
+If there is not enough space to render the values, the formatted values are truncated with an ellipsis.
+This doesn't currently apply to our class, because we haven't specified a minimum width for our values:
+
+```{r}
+print(data, width = 30)
+```
+
+If we specify a minimum width when constructing the shaft, the `loc` column will be truncated:
+
+```{r}
+#' @importFrom pillar pillar_shaft
+#' @export
+pillar_shaft.latlon <- function(x, ...) {
+  out <- format_latlon(x)
+  pillar::new_pillar_shaft_simple(out, align = "right", min_width = 10)
+}
+
+print(data, width = 30)
+```
+
+
+## Adaptive rendering
+
+Truncation may be useful for character data, but for lat-lon data we may prefer to show full degrees and remove the minutes if the available space is not enough to show accurate values.
+A more sophisticated implementation of the `pillar_shaft()` method is required to achieve this:
+
+```{r}
+#' @importFrom pillar pillar_shaft
+#' @export
+pillar_shaft.latlon <- function(x, ...) {
+  deg <- format_latlon(x, formatter = deg)
+  deg_min <- format_latlon(x)
+
+  pillar::new_pillar_shaft(
+    list(deg = deg, deg_min = deg_min),
+    width = pillar::get_max_extent(deg_min),
+    min_width = pillar::get_max_extent(deg),
+    class = "pillar_shaft_latlon"
+  )
+}
+```
+
+Here, `pillar_shaft()` returns an object of the `"pillar_shaft_latlon"` class created by the generic `new_pillar_shaft()` constructor.
+This object contains the necessary information to render the values, and also minimum and maximum width values.
+For simplicity, both formattings are pre-rendered, and the minimum and maximum widths are computed from there.
+(`get_max_extent()` is a helper that computes the maximum display width occupied by the values in a character vector.)
+
+For completeness, the code that implements the degree-only formatting looks like this:
+
+```{r}
+deg <- function(x, direction) {
+  pm <- if (direction == "lat") c("N", "S") else c("E", "W")
+
+  sign <- sign(x)
+  x <- abs(x)
+  deg <- round(x)
+
+  ret <- sprintf("%d°%s", deg, pm[ifelse(sign >= 0, 1, 2)])
+  format(ret, justify = "right")
+}
+```
+
+All that's left to do is to implement a `format()` method for our new `"pillar_shaft_latlon"` class.
+This method will be called with a `width` argument, which then determines which of the formattings to choose.
+The formatting of our choice is passed to the `new_ornament()` function:
+
+```{r}
+#' @export
+format.pillar_shaft_latlon <- function(x, width, ...) {
+  if (get_max_extent(x$deg_min) <= width) {
+    ornament <- x$deg_min
+  } else {
+    ornament <- x$deg
+  }
+
+  pillar::new_ornament(ornament, align = "left")
+}
+
+data
+print(data, width = 30)
+```
+
+`new_ornament()` also accepts ANSI escapes for highlighted output.
+
 
 ## Testing
 
@@ -328,7 +334,6 @@ library(testthat)
 
 ```{r include = FALSE}
 unlink("latlon.txt")
-unlink("latlon-bw.txt")
 ```
 
 The code below will compare the output of `pillar_shaft(data$loc)` with known output stored in the `latlon.txt` file.
@@ -356,4 +361,31 @@ See `?verify_output` for more options.
 
 ```{r}
 cat(readLines("latlon.txt"), sep = "\n")
+```
+
+Changing the code or the format method will give an error on the next run and update the reference file.
+Inspect the changes carefully before committing the new test and the updated reference file to version control.
+
+```{r error = TRUE}
+verify_output("latlon.txt", {
+  pillar_shaft(data$loc)
+  print(pillar_shaft(data$loc), width = 12)
+})
+```
+
+```{r}
+cat(readLines("latlon.txt"), sep = "\n")
+```
+
+From the second run on, no errors are shown again.
+
+```{r error = TRUE}
+verify_output("latlon.txt", {
+  pillar_shaft(data$loc)
+  print(pillar_shaft(data$loc), width = 12)
+})
+```
+
+```{r include = FALSE}
+unlink("latlon.txt")
 ```

--- a/vignettes/pillar.Rmd
+++ b/vignettes/pillar.Rmd
@@ -60,7 +60,8 @@ usethis::use_package("pillar")
 ```
 
 This short vignette assumes a package that implements a `"latlon"` vector and uses `roxygen2` to create documentation and the `NAMESPACE` file.
-To make the required methods available, we attach pillar.
+To make the required methods available in this vignette, we attach pillar. 
+You don't need to do this in your package.
 
 ```{r attach}
 library(pillar)

--- a/vignettes/pillar.Rmd
+++ b/vignettes/pillar.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(collapse = TRUE, comment = pillar::style_subtle("#>"))
 ```
 
 You can get basic control over how a vector is printed in a tibble by providing a `format()` method.
-But if you want greater control, you need to understand how printing works.
+If you want greater control, you need to understand how printing works.
 The presentation of a column in a tibble is controlled by two S3 generics:
 
 * `vctrs::vec_ptype_abbr()` determines what goes into the column header.
@@ -87,7 +87,7 @@ latlon(c(32.71, 2.95), c(-117.17, 1.67))
 
 ## Using in a tibble
 
-Columns on this class can be used in a tibble right away because we've made a class using the vctrs infrastructure and have provided a format method:
+Columns of this class can be used in a tibble right away because we've made a class using the vctrs infrastructure and have provided a `format()` method:
 
 ```{r}
 library(tibble)
@@ -110,7 +110,7 @@ This output is ok, but we could improve it by:
 
 1. Providing a narrower view when horizontal space is at a premium.
 
-The following sections show how to fix these problems.
+The following sections show how to enhance the rendering.
 
 ## Fixing the data type
 
@@ -132,8 +132,8 @@ data
 
 The `format()` method is used by default for rendering.
 For custom formatting you need to implement the `pillar_shaft()` method.
-This function should always return a pillar shaft object, created `new_pillar_shaft_simple()` or similar.
-`new_pillar_shaft_simple()` accepts ANSI escape codes for colouring, and includes some built in styles like `style_subtle()`.
+This function should always return a pillar shaft object, created by `new_pillar_shaft_simple()` or similar.
+`new_pillar_shaft_simple()` accepts ANSI escape codes for colouring, and pillar includes some built in styles like `style_subtle()`.
 We can use subtle style for the degree and minute separators to make the data more obvious.
 
 First we define a degree formatter that makes use of `style_subtle()`:
@@ -159,7 +159,7 @@ deg_min_color <- function(x, direction) {
 }
 ```
 
-And then we pass that to our format method:
+And then we pass that to our `format()` method:
 
 ```{r}
 #' @importFrom pillar pillar_shaft
@@ -237,7 +237,7 @@ pillar_shaft.earth_latlon <- function(x, ...) {
 
 Now the `pillar_shaft()` method returns an object of class `"pillar_shaft_latlon"` created by `new_pillar_shaft()`.
 This object contains the necessary information to render the values, and also minimum and maximum width values.
-For simplicity, both format are pre-rendered, and the minimum and maximum widths are computed from there.
+For simplicity, both formats are pre-rendered, and the minimum and maximum widths are computed from there.
 (`get_max_extent()` is a helper that computes the maximum display width occupied by the values in a character vector.)
 
 All that's left to do is to implement a `format()` method for our new `"pillar_shaft_latlon"` class.
@@ -253,7 +253,7 @@ format.pillar_shaft_latlon <- function(x, width, ...) {
     ornament <- x$deg
   }
 
-  pillar::new_ornament(ornament, align = "left")
+  pillar::new_ornament(ornament, align = "right")
 }
 
 data

--- a/vignettes/s3-vector.Rmd
+++ b/vignettes/s3-vector.Rmd
@@ -167,7 +167,7 @@ tibble::tibble(x)
 str(x)
 ```
 
-If you need more control over printing in tibbles, implement a method for  `pillar::pillar_shaft()`. See <https://tibble.tidyverse.org/articles/extending.html> for details.
+If you need more control over printing in tibbles, implement a method for  `pillar::pillar_shaft()`. See `vignette("pillar", package = "vctrs")` for details.
 
 ## Casting and coercion
 


### PR DESCRIPTION
More work to do:

- Default rendering is already good as soon as a `format()` method is defined. Maybe start with only a print method?
- Use more intense coloring
- Rethink `is_vector_s3()` (https://github.com/r-lib/pillar/issues/181)
- Mention `verify_output()`