### PR TITLE
Improve subscript errors of unexpected dimensionality

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* Improved error messages in `vec_as_location()` when subscript is a
+  matrix or array (#936).
+
 * New `list_sizes()` for computing the size of every element in a list.
   `list_sizes()` is to `vec_size()` as `lengths()` is to `length()`, except
   that it only supports lists. Atomic vectors and data frames result in an

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -250,6 +250,32 @@ new_error_subscript2_type <- function(i,
   )
 }
 
+stop_subscript_dim <- function(i, ...) {
+  cnd_signal(new_error_subscript_type(
+    i,
+    body = cnd_body_subcript_dim,
+    ...
+  ))
+}
+
+cnd_body_subcript_dim <- function(cnd, ...) {
+  arg <- append_arg("The subscript", cnd$subscript_arg)
+
+  dim <- length(dim(cnd$i))
+  if (dim < 2) {
+    abort("Internal error: Unexpected dimensionality in `cnd_body_subcript_dim()`.")
+  }
+  if (dim == 2) {
+    shape <- "a matrix"
+  } else {
+    shape <- "an array"
+  }
+
+  format_error_bullets(c(
+    x = glue::glue("{arg} must be a simple vector, not {shape}.")
+  ))
+}
+
 cnd_subscript_element <- function(cnd) {
   elt <- cnd$subscript_elt %||% "element"
 

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -318,7 +318,7 @@ SEXP vec_as_location_opts(SEXP subscript, R_len_t n, SEXP names,
   case REALSXP: out = dbl_as_location(subscript, n, location_opts); break;
   case LGLSXP: out = lgl_as_location(subscript, n, location_opts); break;
   case STRSXP: out = chr_as_location(subscript, names, location_opts); break;
-  default: Rf_errorcall(R_NilValue, "`i` must be an integer, character, or logical vector, not a %s.",
+  default: Rf_errorcall(R_NilValue, "Internal error: Wrong subscript type `%s` in `vec_as_location_opts()`.",
                         Rf_type2char(TYPEOF(subscript)));
   }
 

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -26,6 +26,9 @@ static void stop_location_negative_positive(SEXP i,
                                             const struct vec_as_location_opts* opts);
 static void stop_location_oob_non_consecutive(SEXP i, R_len_t size,
                                               const struct vec_as_location_opts* opts);
+static void stop_subscript_dim(SEXP i,
+                               const struct vec_as_location_opts* opts);
+
 
 
 static SEXP int_as_location(SEXP subscript, R_len_t n,
@@ -289,7 +292,7 @@ SEXP vec_as_location_opts(SEXP subscript, R_len_t n, SEXP names,
                           const struct vec_as_subscript_opts* subscript_opts) {
 
   if (vec_dim_n(subscript) != 1) {
-    Rf_errorcall(R_NilValue, "`i` must be a one-dimensional vector but has %d dimensions.", vec_dim_n(subscript));
+    stop_subscript_dim(subscript, location_opts);
   }
 
   ERR err = NULL;
@@ -534,6 +537,18 @@ static void stop_location_oob_non_consecutive(SEXP i, R_len_t size,
   never_reached("stop_location_oob_non_consecutive");
 }
 
+static void stop_subscript_dim(SEXP i,
+                               const struct vec_as_location_opts* opts) {
+  SEXP arg = PROTECT(vctrs_arg(opts->subscript_arg));
+  vctrs_eval_mask3(Rf_install("stop_subscript_dim"),
+                   syms_i, i,
+                   syms_subscript_action, get_opts_action(opts),
+                   syms_subscript_arg, arg,
+                   vctrs_ns_env);
+
+  UNPROTECT(1);
+  never_reached("stop_subscript_dim");
+}
 
 struct vec_as_location_opts vec_as_location_default_opts_obj;
 struct vec_as_location_opts vec_as_location_default_assign_opts_obj;

--- a/tests/testthat/error/test-slice.txt
+++ b/tests/testthat/error/test-slice.txt
@@ -70,5 +70,6 @@ x The subscript has the wrong type `date`.
 i It must be logical, numeric, or character.
 
 > vec_slice(1:3, matrix(TRUE, ncol = 1))
-Error: `i` must be a one-dimensional vector but has 2 dimensions.
+Error: Must subset elements with a valid subscript vector.
+x The subscript must be a simple vector, not a matrix.
 

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -501,5 +501,14 @@ vec_as_location() checks dimensionality
 =======================================
 
 > vec_as_location(matrix(TRUE, nrow = 1), 3L)
-Error: `i` must be a one-dimensional vector but has 2 dimensions.
+Error: Must subset elements with a valid subscript vector.
+x The subscript must be a simple vector, not a matrix.
+
+> vec_as_location(array(TRUE, dim = c(1, 1, 1)), 3L)
+Error: Must subset elements with a valid subscript vector.
+x The subscript must be a simple vector, not an array.
+
+> with_tibble_rows(vec_as_location(matrix(TRUE, nrow = 1), 3L))
+Error: Must remove rows with a valid subscript vector.
+x The subscript `foo(bar)` must be a simple vector, not a matrix.
 

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -6,7 +6,7 @@ test_that("vec_slice throws error with non-vector inputs", {
 test_that("vec_slice throws error with non-vector subscripts", {
   verify_errors({
     expect_error(vec_slice(1:3, Sys.Date()), class = "vctrs_error_subscript_type")
-    expect_error(vec_slice(1:3, matrix(TRUE, nrow = 1)), "must be a one-dimensional")
+    expect_error(vec_slice(1:3, matrix(TRUE, nrow = 1)), class = "vctrs_error_subscript_type")
   })
 })
 

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -430,8 +430,14 @@ test_that("num_as_location() requires non-S3 inputs", {
 
 test_that("vec_as_location() checks dimensionality", {
   verify_errors({
-    expect_error(vec_as_location(matrix(TRUE, nrow = 1), 3L), "must be a one-dimensional")
+    expect_error(vec_as_location(matrix(TRUE, nrow = 1), 3L), class = "vctrs_error_subscript_type")
+    expect_error(vec_as_location(array(TRUE, dim = c(1, 1, 1)), 3L), class = "vctrs_error_subscript_type")
+    expect_error(with_tibble_rows(vec_as_location(matrix(TRUE, nrow = 1), 3L)), class = "vctrs_error_subscript_type")
   })
+})
+
+test_that("vec_as_location() works with vectors of dimensionality 1", {
+  expect_identical(vec_as_location(array(TRUE, dim = 1), 3L), 1:3)
 })
 
 test_that("conversion to locations has informative error messages", {
@@ -565,5 +571,7 @@ test_that("conversion to locations has informative error messages", {
 
     "# vec_as_location() checks dimensionality"
     vec_as_location(matrix(TRUE, nrow = 1), 3L)
+    vec_as_location(array(TRUE, dim = c(1, 1, 1)), 3L)
+    with_tibble_rows(vec_as_location(matrix(TRUE, nrow = 1), 3L))
   })
 })


### PR DESCRIPTION
Closes #936.

```
> vec_as_location(array(TRUE, dim = c(1, 1, 1)), 3L)
Error: Must subset elements with a valid subscript vector.
x The subscript must be a simple vector, not an array.

> with_tibble_rows(vec_as_location(matrix(TRUE, nrow = 1), 3L))
Error: Must remove rows with a valid subscript vector.
x The subscript `foo(bar)` must be a simple vector, not a matrix.
```