### PR TITLE
Check for dimensionality in `vec_as_subscript()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* `vec_as_subscript()` now fails when the subscript is a matrix or an
+  array, consistently with `vec_as_location()`.
+
 * Improved error messages in `vec_as_location()` when subscript is a
   matrix or array (#936).
 

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -250,15 +250,7 @@ new_error_subscript2_type <- function(i,
   )
 }
 
-stop_subscript_dim <- function(i, ...) {
-  cnd_signal(new_error_subscript_type(
-    i,
-    body = cnd_body_subcript_dim,
-    ...
-  ))
-}
-
-cnd_body_subcript_dim <- function(cnd, ...) {
+cnd_body_subscript_dim <- function(cnd, ...) {
   arg <- append_arg("The subscript", cnd$subscript_arg)
 
   dim <- length(dim(cnd$i))

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -48,8 +48,7 @@ SEXP vec_assign(SEXP x, SEXP index, SEXP value,
   index = PROTECT(vec_as_location_opts(index,
                                        vec_size(x),
                                        PROTECT(vec_names(x)),
-                                       vec_as_location_default_assign_opts,
-                                       NULL));
+                                       vec_as_location_default_assign_opts));
 
   // Cast and recycle `value`
   value = PROTECT(vec_coercible_cast(value, x, value_arg, x_arg));

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -614,26 +614,26 @@ static SEXP vec_as_indices(SEXP indices, R_len_t n, SEXP names) {
 
   R_len_t size = vec_size(indices);
 
-  // Restrict index values to positive integer locations
-  const struct vec_as_location_opts opts = {
-    .action = SUBSCRIPT_ACTION_DEFAULT,
-    .missing = SUBSCRIPT_MISSING_PROPAGATE,
-    .loc_negative = LOC_NEGATIVE_ERROR,
-    .loc_oob = LOC_OOB_ERROR,
-    .loc_zero = LOC_ZERO_ERROR,
-    .subscript_arg = NULL
-  };
-
   const struct vec_as_subscript_opts subscript_opts = {
+    .action = SUBSCRIPT_ACTION_DEFAULT,
     .logical = SUBSCRIPT_TYPE_ACTION_ERROR,
     .numeric = SUBSCRIPT_TYPE_ACTION_CAST,
     .character = SUBSCRIPT_TYPE_ACTION_ERROR,
     .subscript_arg = NULL
   };
 
+  // Restrict index values to positive integer locations
+  const struct vec_as_location_opts opts = {
+    .subscript_opts = &subscript_opts,
+    .missing = SUBSCRIPT_MISSING_PROPAGATE,
+    .loc_negative = LOC_NEGATIVE_ERROR,
+    .loc_oob = LOC_OOB_ERROR,
+    .loc_zero = LOC_ZERO_ERROR
+  };
+
   for (int i = 0; i < size; ++i) {
     SEXP index = VECTOR_ELT(indices, i);
-    index = vec_as_location_opts(index, n, names, &opts, &subscript_opts);
+    index = vec_as_location_opts(index, n, names, &opts);
     SET_VECTOR_ELT(indices, i, index);
   }
 

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -118,7 +118,9 @@ static SEXP int_invert_location(SEXP subscript, R_len_t n,
     j = -j;
     if (j > n) {
       struct vec_as_location_opts updated_opts = *opts;
-      updated_opts.action = SUBSCRIPT_ACTION_NEGATE;
+      struct vec_as_subscript_opts updated_subscript_opts = *updated_opts.subscript_opts;
+      updated_subscript_opts.action = SUBSCRIPT_ACTION_NEGATE;
+      updated_opts.subscript_opts = &updated_subscript_opts;
       stop_subscript_oob_location(subscript, n, &updated_opts);
     }
 
@@ -283,30 +285,18 @@ SEXP vec_as_location(SEXP subscript, R_len_t n, SEXP names) {
   return vec_as_location_opts(subscript,
                               n,
                               names,
-                              vec_as_location_default_opts,
-                              NULL);
+                              vec_as_location_default_opts);
 }
 
 SEXP vec_as_location_opts(SEXP subscript, R_len_t n, SEXP names,
-                          const struct vec_as_location_opts* location_opts,
-                          const struct vec_as_subscript_opts* subscript_opts) {
+                          const struct vec_as_location_opts* opts) {
 
   if (vec_dim_n(subscript) != 1) {
-    stop_subscript_dim(subscript, location_opts);
+    stop_subscript_dim(subscript, opts);
   }
 
   ERR err = NULL;
-  if (subscript_opts) {
-    subscript = vec_as_subscript_opts(subscript, subscript_opts, &err);
-  } else {
-    struct vec_as_subscript_opts default_subscript_opts = {
-      .logical = SUBSCRIPT_TYPE_ACTION_CAST,
-      .numeric = SUBSCRIPT_TYPE_ACTION_CAST,
-      .character = SUBSCRIPT_TYPE_ACTION_CAST,
-      .subscript_arg = location_opts->subscript_arg
-    };
-    subscript = vec_as_subscript_opts(subscript, &default_subscript_opts, &err);
-  }
+  subscript = vec_as_subscript_opts(subscript, opts->subscript_opts, &err);
   PROTECT2(subscript, err);
 
   if (err) {
@@ -317,10 +307,10 @@ SEXP vec_as_location_opts(SEXP subscript, R_len_t n, SEXP names,
   SEXP out = R_NilValue;
   switch (TYPEOF(subscript)) {
   case NILSXP: out = vctrs_shared_empty_int; break;
-  case INTSXP: out = int_as_location(subscript, n, location_opts); break;
-  case REALSXP: out = dbl_as_location(subscript, n, location_opts); break;
-  case LGLSXP: out = lgl_as_location(subscript, n, location_opts); break;
-  case STRSXP: out = chr_as_location(subscript, names, location_opts); break;
+  case INTSXP: out = int_as_location(subscript, n, opts); break;
+  case REALSXP: out = dbl_as_location(subscript, n, opts); break;
+  case LGLSXP: out = lgl_as_location(subscript, n, opts); break;
+  case STRSXP: out = chr_as_location(subscript, names, opts); break;
   default: Rf_errorcall(R_NilValue, "Internal error: Wrong subscript type `%s` in `vec_as_location_opts()`.",
                         Rf_type2char(TYPEOF(subscript)));
   }
@@ -420,16 +410,19 @@ SEXP vctrs_as_location(SEXP subscript, SEXP n_, SEXP names,
   }
 
   struct vctrs_arg arg = vec_as_arg(arg_);
+
+  struct vec_as_subscript_opts subscript_opts = {
+    .subscript_arg  = &arg
+  };
   struct vec_as_location_opts opts = {
-    .action = SUBSCRIPT_ACTION_DEFAULT,
-    .missing = parse_subscript_arg_missing(missing),
-    .loc_negative = parse_loc_negative(loc_negative),
-    .loc_oob = parse_loc_oob(loc_oob),
-    .loc_zero = parse_loc_zero(loc_zero),
-    .subscript_arg = &arg
+    .subscript_opts = &subscript_opts,
+    .missing        = parse_subscript_arg_missing(missing),
+    .loc_negative   = parse_loc_negative(loc_negative),
+    .loc_oob        = parse_loc_oob(loc_oob),
+    .loc_zero       = parse_loc_zero(loc_zero)
   };
 
-  return vec_as_location_opts(subscript, n, names, &opts, NULL);
+  return vec_as_location_opts(subscript, n, names, &opts);
 }
 
 static void stop_subscript_missing(SEXP i) {
@@ -441,21 +434,21 @@ static void stop_subscript_missing(SEXP i) {
 
 static void stop_location_negative_missing(SEXP i,
                                            const struct vec_as_location_opts* opts) {
-  SEXP arg = PROTECT(vctrs_arg(opts->subscript_arg));
+  SEXP arg = PROTECT(vctrs_arg(opts->subscript_opts->subscript_arg));
   vctrs_eval_mask3(Rf_install("stop_location_negative_missing"),
                    syms_i, i,
                    syms_subscript_arg, arg,
-                   syms_subscript_action, get_opts_action(opts),
+                   syms_subscript_action, get_opts_action(opts->subscript_opts),
                    vctrs_ns_env);
   never_reached("stop_location_negative_missing");
 }
 static void stop_location_negative_positive(SEXP i,
                                             const struct vec_as_location_opts* opts) {
-  SEXP arg = PROTECT(vctrs_arg(opts->subscript_arg));
+  SEXP arg = PROTECT(vctrs_arg(opts->subscript_opts->subscript_arg));
   vctrs_eval_mask3(Rf_install("stop_location_negative_positive"),
                    syms_i, i,
                    syms_subscript_arg, arg,
-                   syms_subscript_action, get_opts_action(opts),
+                   syms_subscript_action, get_opts_action(opts->subscript_opts),
                    vctrs_ns_env);
   never_reached("stop_location_negative_positive");
 }
@@ -463,12 +456,12 @@ static void stop_location_negative_positive(SEXP i,
 static void stop_subscript_oob_location(SEXP i, R_len_t size,
                                         const struct vec_as_location_opts* opts) {
   SEXP size_obj = PROTECT(r_int(size));
-  SEXP arg = PROTECT(vctrs_arg(opts->subscript_arg));
+  SEXP arg = PROTECT(vctrs_arg(opts->subscript_opts->subscript_arg));
   vctrs_eval_mask5(Rf_install("stop_subscript_oob"),
                    syms_i, i,
                    syms_subscript_type, chrs_numeric,
                    syms_size, size_obj,
-                   syms_subscript_action, get_opts_action(opts),
+                   syms_subscript_action, get_opts_action(opts->subscript_opts),
                    syms_subscript_arg, arg,
                    vctrs_ns_env);
 
@@ -477,12 +470,12 @@ static void stop_subscript_oob_location(SEXP i, R_len_t size,
 }
 static void stop_subscript_oob_name(SEXP i, SEXP names,
                                     const struct vec_as_location_opts* opts) {
-  SEXP arg = PROTECT(vctrs_arg(opts->subscript_arg));
+  SEXP arg = PROTECT(vctrs_arg(opts->subscript_opts->subscript_arg));
   vctrs_eval_mask5(Rf_install("stop_subscript_oob"),
                    syms_i, i,
                    syms_subscript_type, chrs_character,
                    syms_names, names,
-                   syms_subscript_action, get_opts_action(opts),
+                   syms_subscript_action, get_opts_action(opts->subscript_opts),
                    syms_subscript_arg, arg,
                    vctrs_ns_env);
   never_reached("stop_subscript_oob_name");
@@ -490,10 +483,10 @@ static void stop_subscript_oob_name(SEXP i, SEXP names,
 
 static void stop_location_negative(SEXP i,
                                    const struct vec_as_location_opts* opts) {
-  SEXP arg = PROTECT(vctrs_arg(opts->subscript_arg));
+  SEXP arg = PROTECT(vctrs_arg(opts->subscript_opts->subscript_arg));
   vctrs_eval_mask3(Rf_install("stop_location_negative"),
                    syms_i, i,
-                   syms_subscript_action, get_opts_action(opts),
+                   syms_subscript_action, get_opts_action(opts->subscript_opts),
                    syms_subscript_arg, arg,
                    vctrs_ns_env);
   never_reached("stop_location_negative");
@@ -501,10 +494,10 @@ static void stop_location_negative(SEXP i,
 
 static void stop_location_zero(SEXP i,
                                const struct vec_as_location_opts* opts) {
-  SEXP arg = PROTECT(vctrs_arg(opts->subscript_arg));
+  SEXP arg = PROTECT(vctrs_arg(opts->subscript_opts->subscript_arg));
   vctrs_eval_mask3(Rf_install("stop_location_zero"),
                    syms_i, i,
-                   syms_subscript_action, get_opts_action(opts),
+                   syms_subscript_action, get_opts_action(opts->subscript_opts),
                    syms_subscript_arg, arg,
                    vctrs_ns_env);
   never_reached("stop_location_zero");
@@ -512,11 +505,11 @@ static void stop_location_zero(SEXP i,
 
 static void stop_indicator_size(SEXP i, SEXP n,
                                 const struct vec_as_location_opts* opts) {
-  SEXP arg = PROTECT(vctrs_arg(opts->subscript_arg));
+  SEXP arg = PROTECT(vctrs_arg(opts->subscript_opts->subscript_arg));
   vctrs_eval_mask4(Rf_install("stop_indicator_size"),
                    syms_i, i,
                    syms_n, n,
-                   syms_subscript_action, get_opts_action(opts),
+                   syms_subscript_action, get_opts_action(opts->subscript_opts),
                    syms_subscript_arg, arg,
                    vctrs_ns_env);
   never_reached("stop_indicator_size");
@@ -525,11 +518,11 @@ static void stop_indicator_size(SEXP i, SEXP n,
 static void stop_location_oob_non_consecutive(SEXP i, R_len_t size,
                                               const struct vec_as_location_opts* opts) {
   SEXP size_obj = PROTECT(r_int(size));
-  SEXP arg = PROTECT(vctrs_arg(opts->subscript_arg));
+  SEXP arg = PROTECT(vctrs_arg(opts->subscript_opts->subscript_arg));
   vctrs_eval_mask4(Rf_install("stop_location_oob_non_consecutive"),
                    syms_i, i,
                    syms_size, size_obj,
-                   syms_subscript_action, get_opts_action(opts),
+                   syms_subscript_action, get_opts_action(opts->subscript_opts),
                    syms_subscript_arg, arg,
                    vctrs_ns_env);
 
@@ -539,10 +532,10 @@ static void stop_location_oob_non_consecutive(SEXP i, R_len_t size,
 
 static void stop_subscript_dim(SEXP i,
                                const struct vec_as_location_opts* opts) {
-  SEXP arg = PROTECT(vctrs_arg(opts->subscript_arg));
+  SEXP arg = PROTECT(vctrs_arg(opts->subscript_opts->subscript_arg));
   vctrs_eval_mask3(Rf_install("stop_subscript_dim"),
                    syms_i, i,
-                   syms_subscript_action, get_opts_action(opts),
+                   syms_subscript_action, get_opts_action(opts->subscript_opts),
                    syms_subscript_arg, arg,
                    vctrs_ns_env);
 
@@ -554,17 +547,12 @@ struct vec_as_location_opts vec_as_location_default_opts_obj;
 struct vec_as_location_opts vec_as_location_default_assign_opts_obj;
 
 void vctrs_init_subscript_loc(SEXP ns) {
-  vec_as_location_default_opts_obj.action = SUBSCRIPT_ACTION_DEFAULT;
+  vec_as_location_default_opts_obj.subscript_opts = &vec_as_subscript_default_opts;
   vec_as_location_default_opts_obj.loc_negative = LOC_NEGATIVE_INVERT;
   vec_as_location_default_opts_obj.loc_oob = LOC_OOB_ERROR;
   vec_as_location_default_opts_obj.loc_zero = LOC_ZERO_REMOVE;
-  vec_as_location_default_opts_obj.subscript_arg = NULL;
   vec_as_location_default_opts_obj.missing = SUBSCRIPT_MISSING_PROPAGATE;
 
-  vec_as_location_default_assign_opts_obj.action = SUBSCRIPT_ACTION_ASSIGN;
-  vec_as_location_default_assign_opts_obj.loc_negative = LOC_NEGATIVE_INVERT;
-  vec_as_location_default_assign_opts_obj.loc_oob = LOC_OOB_ERROR;
-  vec_as_location_default_assign_opts_obj.loc_zero = LOC_ZERO_REMOVE;
-  vec_as_location_default_assign_opts_obj.subscript_arg = NULL;
-  vec_as_location_default_assign_opts_obj.missing = SUBSCRIPT_MISSING_PROPAGATE;
+  vec_as_location_default_assign_opts_obj = vec_as_location_default_opts_obj;
+  vec_as_location_default_assign_opts_obj.subscript_opts = &vec_as_subscript_default_assign_opts;
 }

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -26,9 +26,6 @@ static void stop_location_negative_positive(SEXP i,
                                             const struct vec_as_location_opts* opts);
 static void stop_location_oob_non_consecutive(SEXP i, R_len_t size,
                                               const struct vec_as_location_opts* opts);
-static void stop_subscript_dim(SEXP i,
-                               const struct vec_as_location_opts* opts);
-
 
 
 static SEXP int_as_location(SEXP subscript, R_len_t n,
@@ -291,10 +288,6 @@ SEXP vec_as_location(SEXP subscript, R_len_t n, SEXP names) {
 SEXP vec_as_location_opts(SEXP subscript, R_len_t n, SEXP names,
                           const struct vec_as_location_opts* opts) {
 
-  if (vec_dim_n(subscript) != 1) {
-    stop_subscript_dim(subscript, opts);
-  }
-
   ERR err = NULL;
   subscript = vec_as_subscript_opts(subscript, opts->subscript_opts, &err);
   PROTECT2(subscript, err);
@@ -528,19 +521,6 @@ static void stop_location_oob_non_consecutive(SEXP i, R_len_t size,
 
   UNPROTECT(1);
   never_reached("stop_location_oob_non_consecutive");
-}
-
-static void stop_subscript_dim(SEXP i,
-                               const struct vec_as_location_opts* opts) {
-  SEXP arg = PROTECT(vctrs_arg(opts->subscript_opts->subscript_arg));
-  vctrs_eval_mask3(Rf_install("stop_subscript_dim"),
-                   syms_i, i,
-                   syms_subscript_action, get_opts_action(opts->subscript_opts),
-                   syms_subscript_arg, arg,
-                   vctrs_ns_env);
-
-  UNPROTECT(1);
-  never_reached("stop_subscript_dim");
 }
 
 struct vec_as_location_opts vec_as_location_default_opts_obj;

--- a/src/subscript-loc.h
+++ b/src/subscript-loc.h
@@ -5,15 +5,6 @@
 #include "subscript.h"
 
 
-enum subscript_action {
-  SUBSCRIPT_ACTION_DEFAULT,
-  SUBSCRIPT_ACTION_SUBSET,
-  SUBSCRIPT_ACTION_EXTRACT,
-  SUBSCRIPT_ACTION_ASSIGN,
-  SUBSCRIPT_ACTION_RENAME,
-  SUBSCRIPT_ACTION_REMOVE,
-  SUBSCRIPT_ACTION_NEGATE
-};
 enum subscript_missing {
   SUBSCRIPT_MISSING_PROPAGATE,
   SUBSCRIPT_MISSING_ERROR
@@ -34,12 +25,11 @@ enum num_as_location_loc_zero {
 };
 
 struct vec_as_location_opts {
-  enum subscript_action action;
+  const struct vec_as_subscript_opts* subscript_opts;
   enum num_as_location_loc_negative loc_negative;
   enum num_as_location_loc_oob loc_oob;
   enum num_as_location_loc_zero loc_zero;
   enum subscript_missing missing;
-  struct vctrs_arg* subscript_arg;
 };
 
 extern struct vec_as_location_opts vec_as_location_default_opts_obj;
@@ -51,21 +41,7 @@ static const struct vec_as_location_opts* const vec_as_location_default_assign_o
 
 SEXP vec_as_location(SEXP i, R_len_t n, SEXP names);
 SEXP vec_as_location_opts(SEXP subscript, R_len_t n, SEXP names,
-                          const struct vec_as_location_opts* location_opts,
-                          const struct vec_as_subscript_opts* subscript_opts);
-
-static inline SEXP get_opts_action(const struct vec_as_location_opts* opts) {
-  switch (opts->action) {
-  case SUBSCRIPT_ACTION_DEFAULT: return R_NilValue;
-  case SUBSCRIPT_ACTION_SUBSET: return chrs_subset;
-  case SUBSCRIPT_ACTION_EXTRACT: return chrs_extract;
-  case SUBSCRIPT_ACTION_ASSIGN: return chrs_assign;
-  case SUBSCRIPT_ACTION_RENAME: return chrs_rename;
-  case SUBSCRIPT_ACTION_REMOVE: return chrs_remove;
-  case SUBSCRIPT_ACTION_NEGATE: return chrs_negate;
-  }
-  never_reached("get_opts_action");
-}
+                          const struct vec_as_location_opts* location_opts);
 
 
 #endif

--- a/src/subscript.c
+++ b/src/subscript.c
@@ -2,6 +2,8 @@
 #include "subscript.h"
 #include "utils.h"
 
+static SEXP fns_cnd_body_subscript_dim = NULL;
+
 static SEXP new_error_subscript_type(SEXP subscript,
                                      const struct vec_as_subscript_opts* opts,
                                      SEXP body,
@@ -19,6 +21,11 @@ static SEXP dbl_cast_subscript(SEXP subscript,
 SEXP vec_as_subscript_opts(SEXP subscript,
                            const struct vec_as_subscript_opts* opts,
                            ERR* err) {
+  if (vec_dim_n(subscript) != 1) {
+    *err = new_error_subscript_type(subscript, opts, fns_cnd_body_subscript_dim, R_NilValue);
+    return R_NilValue;
+  }
+
   PROTECT_INDEX subscript_pi;
   PROTECT_WITH_INDEX(subscript, &subscript_pi);
 
@@ -312,4 +319,6 @@ void vctrs_init_subscript(SEXP ns) {
   syms_new_error_subscript_type = Rf_install("new_error_subscript_type");
   syms_new_dbl_cast_subscript_body = Rf_install("new_cnd_bullets_subscript_lossy_cast");
   syms_lossy_err = Rf_install("lossy_err");
+
+  fns_cnd_body_subscript_dim = Rf_eval(Rf_install("cnd_body_subscript_dim"), ns);
 }

--- a/src/subscript.c
+++ b/src/subscript.c
@@ -277,9 +277,10 @@ static SEXP new_error_subscript_type(SEXP subscript,
   subscript = PROTECT(expr_protect(subscript));
   SEXP subscript_arg = PROTECT(vctrs_arg(opts->subscript_arg));
 
-  SEXP syms[8] = {
+  SEXP syms[9] = {
     syms_i,
     syms_subscript_arg,
+    syms_subscript_action,
     syms_logical,
     syms_numeric,
     syms_character,
@@ -287,9 +288,10 @@ static SEXP new_error_subscript_type(SEXP subscript,
     syms_parent,
     NULL
   };
-  SEXP args[8] = {
+  SEXP args[9] = {
     subscript,
     subscript_arg,
+    get_opts_action(opts),
     logical,
     numeric,
     character,

--- a/src/subscript.h
+++ b/src/subscript.h
@@ -4,16 +4,41 @@
 #include "utils.h"
 
 
+enum subscript_action {
+  SUBSCRIPT_ACTION_DEFAULT = 0,
+  SUBSCRIPT_ACTION_SUBSET,
+  SUBSCRIPT_ACTION_EXTRACT,
+  SUBSCRIPT_ACTION_ASSIGN,
+  SUBSCRIPT_ACTION_RENAME,
+  SUBSCRIPT_ACTION_REMOVE,
+  SUBSCRIPT_ACTION_NEGATE
+};
 enum subscript_type_action {
-  SUBSCRIPT_TYPE_ACTION_CAST,
+  SUBSCRIPT_TYPE_ACTION_CAST = 0,
   SUBSCRIPT_TYPE_ACTION_ERROR
 };
 
 struct vec_as_subscript_opts {
+  enum subscript_action action;
   enum subscript_type_action logical;
   enum subscript_type_action numeric;
   enum subscript_type_action character;
   struct vctrs_arg* subscript_arg;
+};
+
+static const struct vec_as_subscript_opts vec_as_subscript_default_opts = {
+  .action = SUBSCRIPT_ACTION_DEFAULT,
+  .logical = SUBSCRIPT_TYPE_ACTION_CAST,
+  .numeric = SUBSCRIPT_TYPE_ACTION_CAST,
+  .character = SUBSCRIPT_TYPE_ACTION_CAST,
+  .subscript_arg = NULL
+};
+static const struct vec_as_subscript_opts vec_as_subscript_default_assign_opts = {
+  .action = SUBSCRIPT_ACTION_ASSIGN,
+  .logical = SUBSCRIPT_TYPE_ACTION_CAST,
+  .numeric = SUBSCRIPT_TYPE_ACTION_CAST,
+  .character = SUBSCRIPT_TYPE_ACTION_CAST,
+  .subscript_arg = NULL
 };
 
 SEXP vec_as_subscript_opts(SEXP subscript,
@@ -27,5 +52,19 @@ static inline SEXP subscript_type_action_chr(enum subscript_type_action action) 
   }
   never_reached("subscript_type_action_chr");
 }
+
+static inline SEXP get_opts_action(const struct vec_as_subscript_opts* opts) {
+  switch (opts->action) {
+  case SUBSCRIPT_ACTION_DEFAULT: return R_NilValue;
+  case SUBSCRIPT_ACTION_SUBSET: return chrs_subset;
+  case SUBSCRIPT_ACTION_EXTRACT: return chrs_extract;
+  case SUBSCRIPT_ACTION_ASSIGN: return chrs_assign;
+  case SUBSCRIPT_ACTION_RENAME: return chrs_rename;
+  case SUBSCRIPT_ACTION_REMOVE: return chrs_remove;
+  case SUBSCRIPT_ACTION_NEGATE: return chrs_negate;
+  }
+  never_reached("get_opts_action");
+}
+
 
 #endif

--- a/tests/testthat/error/test-subscript.txt
+++ b/tests/testthat/error/test-subscript.txt
@@ -60,3 +60,19 @@ Error: Must rename columns with a valid subscript vector.
 x The subscript `foo(bar)` has the wrong type `environment`.
 i It must be logical, numeric, or character.
 
+
+vec_as_subscript() checks dimensionality
+========================================
+
+> vec_as_subscript(matrix(TRUE, nrow = 1))
+Error: Must subset elements with a valid subscript vector.
+x The subscript must be a simple vector, not a matrix.
+
+> vec_as_subscript(array(TRUE, dim = c(1, 1, 1)))
+Error: Must subset elements with a valid subscript vector.
+x The subscript must be a simple vector, not an array.
+
+> with_tibble_rows(vec_as_subscript(matrix(TRUE, nrow = 1)))
+Error: Must remove rows with a valid subscript vector.
+x The subscript `foo(bar)` must be a simple vector, not a matrix.
+

--- a/tests/testthat/test-subscript.R
+++ b/tests/testthat/test-subscript.R
@@ -51,6 +51,19 @@ test_that("can customise subscript errors", {
   })
 })
 
+test_that("vec_as_subscript() checks dimensionality", {
+  verify_errors({
+    expect_error(vec_as_subscript(matrix(TRUE, nrow = 1)), class = "vctrs_error_subscript_type")
+    expect_error(vec_as_subscript(array(TRUE, dim = c(1, 1, 1))), class = "vctrs_error_subscript_type")
+    expect_error(with_tibble_rows(vec_as_subscript(matrix(TRUE, nrow = 1))), class = "vctrs_error_subscript_type")
+  })
+})
+
+test_that("vec_as_subscript() works with vectors of dimensionality 1", {
+  arr <- array(TRUE, dim = 1)
+  expect_identical(vec_as_subscript(arr), arr)
+})
+
 test_that("subscript functions have informative error messages", {
   verify_output(test_path("error", "test-subscript.txt"), {
     "# vec_as_subscript() forbids subscript types"
@@ -68,5 +81,10 @@ test_that("subscript functions have informative error messages", {
 
     "# can customise subscript errors"
     with_tibble_cols(vec_as_subscript(env()))
+
+    "# vec_as_subscript() checks dimensionality"
+    vec_as_subscript(matrix(TRUE, nrow = 1))
+    vec_as_subscript(array(TRUE, dim = c(1, 1, 1)))
+    with_tibble_rows(vec_as_subscript(matrix(TRUE, nrow = 1)))
   })
 })


### PR DESCRIPTION
Branched from #939.

Some internal reorganisation:

* Include `subscript_action` in subscript struct.
* Include subscript struct in location struct.
* Remove `subscript_arg` from location struct and use the one from the subscript struct instead.

This allows moving the dimensionality check in `vec_as_subscript()`, which now consistently checks for matrices and arrays in the same way as `vec_as_location()`.