### PR TITLE
Don't restore row names if target is not a data frame

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,4 +51,4 @@ Encoding: UTF-8
 Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # vctrs (development version)
 
+* `vec_restore()` no longer restores row names if the target is not a
+  data frame. This fixes an issue where `POSIXlt` objects would carry
+  a `row.names` attribute after a proxy/restore roundtrip.
+
 * `vec_as_subscript()` now fails when the subscript is a matrix or an
   array, consistently with `vec_as_location()`.
 

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -73,7 +73,11 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
     SET_ATTRIB(x, attrib);
 
     Rf_setAttrib(x, R_NamesSymbol, nms);
-    Rf_setAttrib(x, R_RowNamesSymbol, rownms);
+
+    // Don't restore row names if `to` isn't a data frame
+    if (rownms != R_NilValue && is_data_frame(to)) {
+      Rf_setAttrib(x, R_RowNamesSymbol, rownms);
+    }
     UNPROTECT(2);
   } else {
     SEXP dimnames = PROTECT(Rf_getAttrib(x, R_DimNamesSymbol));

--- a/tests/testthat/test-proxy-restore.R
+++ b/tests/testthat/test-proxy-restore.R
@@ -94,3 +94,10 @@ test_that("restoring to non-bare data frames calls `vec_bare_df_restore()` befor
 
   expect_error(vec_restore(x, to), class = "error_df_restore_was_called")
 })
+
+test_that("row names are not restored if target is not a data frame", {
+  proxy <- data.frame(x = 1)
+  out <- vec_restore(proxy, to = foobar(""))
+  exp <- list(names = "x", class = "vctrs_foobar")
+  expect_identical(attributes(out), exp)
+})

--- a/tests/testthat/test-type-date-time.R
+++ b/tests/testthat/test-type-date-time.R
@@ -47,6 +47,13 @@ test_that("vec_proxy() returns a double for Dates with int representation", {
   expect_true(is.double(vec_proxy(x)))
 })
 
+test_that("POSIXlt roundtrips through proxy and restore", {
+  x <- as.POSIXlt("2020-01-03")
+  out <- vec_restore(vec_proxy(x), x)
+  expect_identical(out, x)
+})
+
+
 # coerce ------------------------------------------------------------------
 
 test_that("datetime coercions are symmetric and unchanging", {


### PR DESCRIPTION
Fixes proxy/restore roundtrip for POSIXlt objects. Before the patch, they'd gain a `row.names` attribute.