### PR TITLE
Add support for numeric and character subscripts in `is.na<-.vctrs_vctr()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* The `is.na<-()` method for `vctrs_vctr` now supports numeric and
+  character subscripts to indicate where to insert missing values (#947). 
+
 * `vec_rbind()` and `vec_c()` with data frame inputs now consistently
   preserve the names of list-columns, df-columns, and matrix-columns
   (#689).

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -639,12 +639,7 @@ levels.vctrs_vctr <- function(x) {
 
 #' @export
 `is.na<-.vctrs_vctr` <- function(x, value) {
-  # No support for other arguments than logical for now,
-  # even if base R is more lenient here.
-  vec_assert(value, logical())
-
-  vec_slice(x, value) <- vec_init(x)
-  x
+  vec_assign(x, value, vec_init(x))
 }
 
 # Helpers -----------------------------------------------------------------

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -125,12 +125,25 @@ test_that("equality functions remapped", {
 
 test_that("is.na<-() supported", {
   x <- new_vctr(1:4)
-
   is.na(x) <- c(FALSE, FALSE, TRUE, NA)
   expect_identical(x, new_vctr(c(1:2, NA, 4L)))
 
+  x <- new_vctr(1:4)
   is.na(x) <- TRUE
   expect_identical(x, new_vctr(rep(NA_integer_, 4)))
+
+  x <- new_vctr(1:4)
+  is.na(x) <- c(2, 3)
+  expect_identical(x, new_vctr(c(1L, NA, NA, 4L)))
+
+  names <- c("a", "b", "c", "d")
+  x <- set_names(new_vctr(1:4), names)
+  is.na(x) <- c("d", "b", "b")
+  expect_identical(x, set_names(new_vctr(c(1L, NA, 3L, NA)), names))
+
+  x <- new_vctr(1:4)
+  expect_error(is.na(x) <- "x", "character names to index an unnamed vector")
+  expect_error(is.na(x) <- 5, class = "vctrs_error_subscript_oob")
 })
 
 test_that("comparison functions remapped", {


### PR DESCRIPTION
Closes #947 

`vec_assign()` automatically calls `vec_as_location()` internally, so the implementation is pretty trivial now.

Note that we had explicitly forbidden this, but I think with `vec_as_location()` being well-defined now, this makes sense

```r
`is.na<-.vctrs_vctr` <- function(x, value) {
  # No support for other arguments than logical for now,
  # even if base R is more lenient here.
  vec_assert(value, logical())

  vec_slice(x, value) <- vec_init(x)
  x
}
```