### PR TITLE
Improve user-friendliness of cast error messages

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -288,7 +288,7 @@ conditionMessage.vctrs_error_cast_lossy <- function(c) {
 cnd_header.vctrs_error_cast_lossy <- function(cnd, ...) {
   x_label <- format_arg_label(vec_ptype_full(cnd$x), cnd$x_arg)
   to_label <- format_arg_label(vec_ptype_full(cnd$to), cnd$to_arg)
-  glue::glue("Lossy cast from {x_label} to {to_label}.")
+  glue::glue("Can't convert from {x_label} to {to_label} because this loses precision.")
 }
 #' @export
 cnd_body.vctrs_error_cast_lossy <- function(cnd, ...) {

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -288,7 +288,7 @@ conditionMessage.vctrs_error_cast_lossy <- function(c) {
 cnd_header.vctrs_error_cast_lossy <- function(cnd, ...) {
   x_label <- format_arg_label(vec_ptype_full(cnd$x), cnd$x_arg)
   to_label <- format_arg_label(vec_ptype_full(cnd$to), cnd$to_arg)
-  glue::glue("Can't convert from {x_label} to {to_label} because this loses precision.")
+  glue::glue("Can't convert from {x_label} to {to_label} due to loss of precision.")
 }
 #' @export
 cnd_body.vctrs_error_cast_lossy <- function(cnd, ...) {

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -115,7 +115,7 @@ stop_incompatible_cast <- function(x,
     to_label <- format_arg_label(vec_ptype_full(y), to_arg)
 
     message <- glue_lines(
-      "Can't cast {x_label} to {to_label}.",
+      "Can't convert from {x_label} to {to_label}.",
       details
     )
   }

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -97,7 +97,7 @@ i It must be logical, numeric, or character.
 
 > vec_as_location(2.5, 3L)
 Error: Must subset elements with a valid subscript vector.
-x Can't convert from <double> to <integer> because this loses precision.
+x Can't convert from <double> to <integer> due to loss of precision.
 
 > vec_as_location(list(), 10L)
 Error: Must subset elements with a valid subscript vector.
@@ -127,7 +127,7 @@ i It must be logical, numeric, or character.
 
 > vec_as_location(2.5, 3L, arg = "foo")
 Error: Must subset elements with a valid subscript vector.
-x Can't convert from `foo` <double> to <integer> because this loses precision.
+x Can't convert from `foo` <double> to <integer> due to loss of precision.
 
 
 vec_as_location2() requires integer or character inputs
@@ -167,7 +167,7 @@ i It must be numeric or character.
 
 > vec_as_location2(2.5, 3L)
 Error: Must extract element with a single valid subscript.
-x Can't convert from <double> to <integer> because this loses precision.
+x Can't convert from <double> to <integer> due to loss of precision.
 
 > # Idem with custom `arg`
 > vec_as_location2(foobar(), 10L, arg = "foo")
@@ -177,7 +177,7 @@ i It must be numeric or character.
 
 > vec_as_location2(2.5, 3L, arg = "foo")
 Error: Must extract element with a single valid subscript.
-x Can't convert from `foo` <double> to <integer> because this loses precision.
+x Can't convert from `foo` <double> to <integer> due to loss of precision.
 
 > with_tibble_rows(vec_as_location2(TRUE))
 Error: Must remove row with a single valid subscript.

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -97,7 +97,7 @@ i It must be logical, numeric, or character.
 
 > vec_as_location(2.5, 3L)
 Error: Must subset elements with a valid subscript vector.
-x Lossy cast from <double> to <integer>.
+x Can't convert from <double> to <integer> because this loses precision.
 
 > vec_as_location(list(), 10L)
 Error: Must subset elements with a valid subscript vector.
@@ -127,7 +127,7 @@ i It must be logical, numeric, or character.
 
 > vec_as_location(2.5, 3L, arg = "foo")
 Error: Must subset elements with a valid subscript vector.
-x Lossy cast from `foo` <double> to <integer>.
+x Can't convert from `foo` <double> to <integer> because this loses precision.
 
 
 vec_as_location2() requires integer or character inputs
@@ -167,7 +167,7 @@ i It must be numeric or character.
 
 > vec_as_location2(2.5, 3L)
 Error: Must extract element with a single valid subscript.
-x Lossy cast from <double> to <integer>.
+x Can't convert from <double> to <integer> because this loses precision.
 
 > # Idem with custom `arg`
 > vec_as_location2(foobar(), 10L, arg = "foo")
@@ -177,7 +177,7 @@ i It must be numeric or character.
 
 > vec_as_location2(2.5, 3L, arg = "foo")
 Error: Must extract element with a single valid subscript.
-x Lossy cast from `foo` <double> to <integer>.
+x Can't convert from `foo` <double> to <integer> because this loses precision.
 
 > with_tibble_rows(vec_as_location2(TRUE))
 Error: Must remove row with a single valid subscript.

--- a/tests/testthat/error/test-type-asis.txt
+++ b/tests/testthat/error/test-type-asis.txt
@@ -10,5 +10,5 @@ AsIs objects throw cast errors with their underlying types
 ==========================================================
 
 > vec_cast(I(1), I(factor("x")))
-Error: Can't cast <double> to <factor<5a425>>.
+Error: Can't convert from <double> to <factor<5a425>>.
 

--- a/tests/testthat/test-cast-error-nested.txt
+++ b/tests/testthat/test-cast-error-nested.txt
@@ -1,7 +1,7 @@
 
 vec_cast("foo", 10):
 
-Lossy cast from <character> to <double>.
+Can't convert from <character> to <double> because this loses precision.
 * Locations: 1 
 
 
@@ -12,7 +12,7 @@ Can't cast <factor<bd40e>> to <double>.
 
 vec_cast(x, y):
 
-Lossy cast from `a$b` <character> to `a$b` <double>.
+Can't convert from `a$b` <character> to `a$b` <double> because this loses precision.
 * Locations: 1 
 
 

--- a/tests/testthat/test-cast-error-nested.txt
+++ b/tests/testthat/test-cast-error-nested.txt
@@ -1,7 +1,7 @@
 
 vec_cast("foo", 10):
 
-Can't convert from <character> to <double> because this loses precision.
+Can't convert from <character> to <double> due to loss of precision.
 * Locations: 1 
 
 
@@ -12,7 +12,7 @@ Can't convert from <factor<bd40e>> to <double>.
 
 vec_cast(x, y):
 
-Can't convert from `a$b` <character> to `a$b` <double> because this loses precision.
+Can't convert from `a$b` <character> to `a$b` <double> due to loss of precision.
 * Locations: 1 
 
 

--- a/tests/testthat/test-cast-error-nested.txt
+++ b/tests/testthat/test-cast-error-nested.txt
@@ -7,7 +7,7 @@ Can't convert from <character> to <double> because this loses precision.
 
 vec_cast(factor("foo"), 10):
 
-Can't cast <factor<bd40e>> to <double>. 
+Can't convert from <factor<bd40e>> to <double>. 
 
 
 vec_cast(x, y):
@@ -18,7 +18,7 @@ Can't convert from `a$b` <character> to `a$b` <double> because this loses precis
 
 vec_cast(x, y):
 
-Can't cast `a$b` <factor<bd40e>> to `a$b` <double>. 
+Can't convert from `a$b` <factor<bd40e>> to `a$b` <double>. 
 
 
 vec_cast_common(x, y):


### PR DESCRIPTION
Part of #922.

* Cast errors mention "convert" instead of "cast".
* Lossy cast errors explain that the conversion loses precision.