### PR TITLE
Remove default args

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -119,14 +119,14 @@
 #'
 #' # Cast to common type
 #' vec_cast_common(factor("a"), factor(c("a", "b")))
-vec_cast <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
   return(.Call(vctrs_cast, x, to, x_arg, to_arg))
   UseMethod("vec_cast", to)
 }
-vec_cast_dispatch <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast_dispatch <- function(x, to, ..., x_arg = "", to_arg = "") {
   UseMethod("vec_cast", to)
 }
 
@@ -137,12 +137,12 @@ vec_cast_common <- function(..., .to = NULL) {
 }
 
 #' @export
-vec_cast.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
 # Cast `x` to `to` but only if they are coercible
-vec_coercible_cast <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_coercible_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
@@ -164,7 +164,7 @@ vec_coercible_cast <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 #'
 #' @inheritParams vec_cast
 #' @export
-vec_default_cast <- function(x, to, x_arg = "x", to_arg = "to") {
+vec_default_cast <- function(x, to, x_arg = "", to_arg = "") {
   if (is_asis(x)) {
     return(vec_cast_from_asis(x, to, x_arg = x_arg, to_arg = to_arg))
   }

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -420,7 +420,8 @@ stop_recycle_incompatible_size <- function(x_size, size, x_arg = "x") {
 
 #' @export
 cnd_header.vctrs_error_recycle_incompatible_size <- function(cnd, ...) {
-  glue::glue_data(cnd, "`{x_arg}` can't be recycled to size {size}.")
+  arg <- append_arg("Input", cnd$x_arg)
+  glue::glue("{arg} can't be recycled to size {cnd$size}.")
 }
 #' @export
 cnd_body.vctrs_error_recycle_incompatible_size <- function(cnd, ...) {

--- a/R/recycle.R
+++ b/R/recycle.R
@@ -45,7 +45,7 @@
 #' vec_recycle_common(data.frame(x = 1), 1:5)
 #' vec_recycle_common(array(1:2, c(1, 2)), 1:5)
 #' vec_recycle_common(array(1:3, c(1, 3, 1)), 1:5)
-vec_recycle <- function(x, size, ..., x_arg = "x") {
+vec_recycle <- function(x, size, ..., x_arg = "") {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }

--- a/R/slice.R
+++ b/R/slice.R
@@ -158,7 +158,7 @@ vec_slice_dispatch_integer64 <- function(x, i) {
 }
 #' @rdname vec_slice
 #' @export
-vec_assign <- function(x, i, value, ..., x_arg = "x", value_arg = "value") {
+vec_assign <- function(x, i, value, ..., x_arg = "", value_arg = "value") {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }

--- a/R/type-asis.R
+++ b/R/type-asis.R
@@ -45,20 +45,20 @@ vec_restore.AsIs <- function(x, to, ...) {
 #' @export vec_ptype2.AsIs
 #' @method vec_ptype2 AsIs
 #' @export
-vec_ptype2.AsIs <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.AsIs <- function(x, y, ..., x_arg = "", y_arg = "") {
   UseMethod("vec_ptype2.AsIs", y)
 }
 
 #' @method vec_ptype2.AsIs default
 #' @export
-vec_ptype2.AsIs.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.AsIs.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   x <- asis_strip(x)
   vec_ptype2_asis(x, y, ..., x_arg = x_arg, y_arg = y_arg)
 }
 
 #' @method vec_ptype2.AsIs AsIs
 #' @export
-vec_ptype2.AsIs.AsIs <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.AsIs.AsIs <- function(x, y, ..., x_arg = "", y_arg = "") {
   x <- asis_strip(x)
   y <- asis_strip(y)
   vec_ptype2_asis(x, y, ..., x_arg = x_arg, y_arg = y_arg)

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -6,7 +6,7 @@
 #' @export vec_ptype2.logical
 #' @method vec_ptype2 logical
 #' @export
-vec_ptype2.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.logical <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(x)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -17,7 +17,7 @@ vec_ptype2.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 #' @export vec_ptype2.integer
 #' @method vec_ptype2 integer
 #' @export
-vec_ptype2.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.integer <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(x)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -28,7 +28,7 @@ vec_ptype2.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 #' @export vec_ptype2.double
 #' @method vec_ptype2 double
 #' @export
-vec_ptype2.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.double <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(x)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -39,7 +39,7 @@ vec_ptype2.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 #' @export vec_ptype2.complex
 #' @method vec_ptype2 complex
 #' @export
-vec_ptype2.complex <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.complex <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(x)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -50,7 +50,7 @@ vec_ptype2.complex <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 #' @export vec_ptype2.character
 #' @method vec_ptype2 character
 #' @export
-vec_ptype2.character <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.character <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(x)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -61,7 +61,7 @@ vec_ptype2.character <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 #' @export vec_ptype2.raw
 #' @method vec_ptype2 raw
 #' @export
-vec_ptype2.raw <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.raw <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(x)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -72,7 +72,7 @@ vec_ptype2.raw <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 #' @export vec_ptype2.list
 #' @method vec_ptype2 list
 #' @export
-vec_ptype2.list <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.list <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(x)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -85,7 +85,7 @@ vec_ptype2.list <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 
 #' @method vec_ptype2.logical logical
 #' @export
-vec_ptype2.logical.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.logical.logical <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else if (is_unspecified(x) && is_unspecified(y)) {
@@ -99,7 +99,7 @@ vec_ptype2.logical.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 
 #' @export
 #' @method vec_ptype2.integer integer
-vec_ptype2.integer.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.integer.integer <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -108,7 +108,7 @@ vec_ptype2.integer.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 }
 #' @export
 #' @method vec_ptype2.logical integer
-vec_ptype2.logical.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.logical.integer <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -117,7 +117,7 @@ vec_ptype2.logical.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 }
 #' @export
 #' @method vec_ptype2.integer logical
-vec_ptype2.integer.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.integer.logical <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -127,7 +127,7 @@ vec_ptype2.integer.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 
 #' @export
 #' @method vec_ptype2.double double
-vec_ptype2.double.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.double.double <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -136,7 +136,7 @@ vec_ptype2.double.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 }
 #' @export
 #' @method vec_ptype2.logical double
-vec_ptype2.logical.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.logical.double <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -145,7 +145,7 @@ vec_ptype2.logical.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 }
 #' @export
 #' @method vec_ptype2.double logical
-vec_ptype2.double.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.double.logical <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -154,7 +154,7 @@ vec_ptype2.double.logical <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 }
 #' @export
 #' @method vec_ptype2.integer double
-vec_ptype2.integer.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.integer.double <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -163,7 +163,7 @@ vec_ptype2.integer.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 }
 #' @export
 #' @method vec_ptype2.double integer
-vec_ptype2.double.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.double.integer <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -173,7 +173,7 @@ vec_ptype2.double.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 
 #' @export
 #' @method vec_ptype2.complex complex
-vec_ptype2.complex.complex <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.complex.complex <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -182,7 +182,7 @@ vec_ptype2.complex.complex <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 }
 #' @export
 #' @method vec_ptype2.integer complex
-vec_ptype2.integer.complex <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.integer.complex <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -191,7 +191,7 @@ vec_ptype2.integer.complex <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 }
 #' @export
 #' @method vec_ptype2.complex integer
-vec_ptype2.complex.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.complex.integer <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -200,7 +200,7 @@ vec_ptype2.complex.integer <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 }
 #' @export
 #' @method vec_ptype2.double complex
-vec_ptype2.double.complex <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.double.complex <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -209,7 +209,7 @@ vec_ptype2.double.complex <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 }
 #' @export
 #' @method vec_ptype2.complex double
-vec_ptype2.complex.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.complex.double <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -223,7 +223,7 @@ vec_ptype2.complex.double <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 
 #' @method vec_ptype2.character character
 #' @export
-vec_ptype2.character.character <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.character.character <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -236,7 +236,7 @@ vec_ptype2.character.character <- function(x, y, ..., x_arg = "x", y_arg = "y") 
 
 #' @export
 #' @method vec_ptype2.raw raw
-vec_ptype2.raw.raw <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.raw.raw <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -249,7 +249,7 @@ vec_ptype2.raw.raw <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 
 #' @method vec_ptype2.list list
 #' @export
-vec_ptype2.list.list <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.list.list <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is.object(y)) {
     vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
   } else {
@@ -262,7 +262,7 @@ vec_ptype2.list.list <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 
 #' @method vec_ptype2.logical default
 #' @export
-vec_ptype2.logical.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.logical.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is_unspecified(x)) {
     vec_ptype(y)
   } else {
@@ -271,32 +271,32 @@ vec_ptype2.logical.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 }
 #' @method vec_ptype2.integer default
 #' @export
-vec_ptype2.integer.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.integer.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.double default
 #' @export
-vec_ptype2.double.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.double.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.complex default
 #' @export
-vec_ptype2.complex.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.complex.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.character default
 #' @export
-vec_ptype2.character.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.character.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.raw default
 #' @export
-vec_ptype2.raw.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.raw.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.list default
 #' @export
-vec_ptype2.list.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.list.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 
@@ -315,7 +315,7 @@ vec_cast.logical <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.logical logical
-vec_cast.logical.logical <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.logical.logical <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -323,7 +323,7 @@ vec_cast.logical.logical <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.logical integer
-vec_cast.logical.integer <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.logical.integer <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -334,7 +334,7 @@ vec_cast.logical.integer <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.logical double
-vec_cast.logical.double <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.logical.double <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -345,7 +345,7 @@ vec_cast.logical.double <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.logical character
-vec_cast.logical.character <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.logical.character <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -356,7 +356,7 @@ vec_cast.logical.character <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.logical list
-vec_cast.logical.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.logical.list <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -364,7 +364,7 @@ vec_cast.logical.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.logical default
-vec_cast.logical.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.logical.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -377,7 +377,7 @@ vec_cast.integer <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.integer logical
-vec_cast.integer.logical <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.integer.logical <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -386,7 +386,7 @@ vec_cast.integer.logical <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.integer integer
-vec_cast.integer.integer <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.integer.integer <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -394,7 +394,7 @@ vec_cast.integer.integer <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.integer double
-vec_cast.integer.double <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.integer.double <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -409,7 +409,7 @@ vec_cast.integer.double <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 vec_cast.integer.character <- vec_cast.integer.double
 #' @export
 #' @method vec_cast.integer list
-vec_cast.integer.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.integer.list <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -417,7 +417,7 @@ vec_cast.integer.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.integer default
-vec_cast.integer.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.integer.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -430,7 +430,7 @@ vec_cast.double <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.double logical
-vec_cast.double.logical <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.double.logical <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -442,7 +442,7 @@ vec_cast.double.logical <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 vec_cast.double.integer <- vec_cast.double.logical
 #' @export
 #' @method vec_cast.double character
-vec_cast.double.character <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.double.character <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -454,7 +454,7 @@ vec_cast.double.character <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.double double
-vec_cast.double.double <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.double.double <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -462,7 +462,7 @@ vec_cast.double.double <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.double list
-vec_cast.double.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.double.list <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -470,7 +470,7 @@ vec_cast.double.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.double default
-vec_cast.double.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.double.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -483,7 +483,7 @@ vec_cast.complex <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.complex logical
-vec_cast.complex.logical <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.complex.logical <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -498,7 +498,7 @@ vec_cast.complex.integer <- vec_cast.complex.logical
 vec_cast.complex.double <- vec_cast.complex.logical
 #' @export
 #' @method vec_cast.complex complex
-vec_cast.complex.complex <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.complex.complex <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -506,7 +506,7 @@ vec_cast.complex.complex <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.complex list
-vec_cast.complex.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.complex.list <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -514,7 +514,7 @@ vec_cast.complex.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.complex default
-vec_cast.complex.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.complex.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -527,7 +527,7 @@ vec_cast.raw <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.raw raw
-vec_cast.raw.raw <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.raw.raw <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -535,7 +535,7 @@ vec_cast.raw.raw <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.raw list
-vec_cast.raw.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.raw.list <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -543,7 +543,7 @@ vec_cast.raw.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.raw default
-vec_cast.raw.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.raw.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -556,7 +556,7 @@ vec_cast.character <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.character logical
-vec_cast.character.logical <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.character.logical <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -571,7 +571,7 @@ vec_cast.character.integer <- vec_cast.character.logical
 vec_cast.character.double <- vec_cast.character.logical
 #' @export
 #' @method vec_cast.character character
-vec_cast.character.character <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.character.character <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -579,7 +579,7 @@ vec_cast.character.character <- function(x, to, ..., x_arg = "x", to_arg = "to")
 }
 #' @export
 #' @method vec_cast.character difftime
-vec_cast.character.difftime <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.character.difftime <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (!inherits_only(x, "difftime")) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -588,7 +588,7 @@ vec_cast.character.difftime <- function(x, to, ..., x_arg = "x", to_arg = "to") 
 }
 #' @export
 #' @method vec_cast.character list
-vec_cast.character.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.character.list <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -596,7 +596,7 @@ vec_cast.character.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.character default
-vec_cast.character.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.character.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -609,7 +609,7 @@ vec_cast.list <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.list list
-vec_cast.list.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.list.list <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -617,7 +617,7 @@ vec_cast.list.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 }
 #' @export
 #' @method vec_cast.list default
-vec_cast.list.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.list.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is.object(x)) {
     return(vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg))
   }
@@ -667,7 +667,7 @@ vec_proxy_compare.raw <- function(x, ...) {
 
 # Helpers -----------------------------------------------------------------
 
-lossy_floor <- function(x, to, x_arg = "x", to_arg = "to") {
+lossy_floor <- function(x, to, x_arg = "", to_arg = "") {
   x_floor <- floor(x)
   lossy <- x != x_floor
   maybe_lossy_cast(x_floor, x, to, lossy, x_arg = x_arg, to_arg = to_arg)

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -81,12 +81,12 @@ vec_ptype2.data.frame <- function(x, y, ...) {
 }
 #' @method vec_ptype2.data.frame data.frame
 #' @export
-vec_ptype2.data.frame.data.frame <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.data.frame.data.frame <- function(x, y, ..., x_arg = "", y_arg = "") {
   .Call(vctrs_df_ptype2, x, y, x_arg, y_arg)
 }
 #' @method vec_ptype2.data.frame default
 #' @export
-vec_ptype2.data.frame.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.data.frame.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 
@@ -102,20 +102,20 @@ vec_cast.data.frame <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.data.frame data.frame
-vec_cast.data.frame.data.frame <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.data.frame.data.frame <- function(x, to, ..., x_arg = "", to_arg = "") {
   df_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.data.frame list
-vec_cast.data.frame.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.data.frame.list <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.data.frame default
-vec_cast.data.frame.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.data.frame.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
-df_cast <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+df_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
   .Call(vctrs_df_cast, x, to, x_arg, to_arg)
 }
 

--- a/R/type-date-time.R
+++ b/R/type-date-time.R
@@ -137,7 +137,7 @@ vec_ptype_abbr.difftime <- function(x, ...) {
 vec_ptype2.Date <- function(x, y, ...) UseMethod("vec_ptype2.Date", y)
 #' @method vec_ptype2.Date default
 #' @export
-vec_ptype2.Date.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.Date.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.Date Date
@@ -151,7 +151,7 @@ vec_ptype2.Date.Date <- function(x, y, ...) new_date()
 vec_ptype2.POSIXt <- function(x, y, ...) UseMethod("vec_ptype2.POSIXt", y)
 #' @method vec_ptype2.POSIXt default
 #' @export
-vec_ptype2.POSIXt.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.POSIXt.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.POSIXt Date
@@ -171,7 +171,7 @@ vec_ptype2.POSIXt.POSIXt <- function(x, y, ...) new_datetime(tzone = tzone_union
 vec_ptype2.difftime <- function(x, y, ...) UseMethod("vec_ptype2.difftime", y)
 #' @method vec_ptype2.difftime default
 #' @export
-vec_ptype2.difftime.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.difftime.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.difftime difftime
@@ -204,19 +204,19 @@ vec_cast.Date.Date <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.Date POSIXt
-vec_cast.Date.POSIXt <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.Date.POSIXt <- function(x, to, ..., x_arg = "", to_arg = "") {
   out <- as.Date(x)
   lossy <- abs(x - as.POSIXct(out)) > 1e-9
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.Date list
-vec_cast.Date.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.Date.list <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.Date default
-vec_cast.Date.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.Date.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -254,12 +254,12 @@ vec_cast.POSIXct.POSIXct <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.POSIXct list
-vec_cast.POSIXct.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.POSIXct.list <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.POSIXct default
-vec_cast.POSIXct.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.POSIXct.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -297,12 +297,12 @@ vec_cast.POSIXlt.POSIXct <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.POSIXlt list
-vec_cast.POSIXlt.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.POSIXlt.list <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.POSIXlt default
-vec_cast.POSIXlt.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.POSIXlt.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -332,12 +332,12 @@ vec_cast.difftime.difftime <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.difftime list
-vec_cast.difftime.list <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.difftime.list <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_list_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 #' @export
 #' @method vec_cast.difftime default
-vec_cast.difftime.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.difftime.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 

--- a/R/type-factor.R
+++ b/R/type-factor.R
@@ -85,7 +85,7 @@ vec_ptype_abbr.ordered <- function(x, ...) {
 vec_ptype2.factor <- function(x, y, ...) UseMethod("vec_ptype2.factor", y)
 #' @method vec_ptype2.factor default
 #' @export
-vec_ptype2.factor.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.factor.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.character factor
@@ -105,7 +105,7 @@ vec_ptype2.factor.factor <- function(x, y, ...) new_factor(levels = levels_union
 vec_ptype2.ordered <- function(x, y, ...) UseMethod("vec_ptype2.ordered", y)
 #' @method vec_ptype2.ordered default
 #' @export
-vec_ptype2.ordered.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.ordered.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.ordered character
@@ -116,12 +116,12 @@ vec_ptype2.ordered.character <- function(x, y, ...) character()
 vec_ptype2.character.ordered <- function(x, y, ...) character()
 #' @method vec_ptype2.ordered factor
 #' @export
-vec_ptype2.ordered.factor <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.ordered.factor <- function(x, y, ..., x_arg = "", y_arg = "") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.factor ordered
 #' @export
-vec_ptype2.factor.ordered <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.factor.ordered <- function(x, y, ..., x_arg = "", y_arg = "") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.ordered ordered

--- a/R/type-integer64.R
+++ b/R/type-integer64.R
@@ -39,7 +39,7 @@ vec_ptype2.integer64 <- function(x, y, ...) {
 }
 #' @method vec_ptype2.integer64 default
 #' @export
-vec_ptype2.integer64.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.integer64.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 
@@ -76,7 +76,7 @@ vec_cast.integer64 <- function(x, to, ...) UseMethod("vec_cast.integer64")
 
 #' @export
 #' @method vec_cast.integer64 default
-vec_cast.integer64.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.integer64.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   # Don't use `vec_default_cast()` because integer64 is not compatible
   # with `vec_init()`
   if (is_unspecified(x)) {

--- a/R/type-list-of.R
+++ b/R/type-list-of.R
@@ -184,7 +184,7 @@ as.character.vctrs_list_of <- function(x, ...) {
 #' @export vec_ptype2.vctrs_list_of
 #' @method vec_ptype2 vctrs_list_of
 #' @export
-vec_ptype2.vctrs_list_of <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.vctrs_list_of <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (inherits_only(x, c("vctrs_list_of", "vctrs_vctr"))) {
     UseMethod("vec_ptype2.vctrs_list_of", y)
   } else {
@@ -199,17 +199,17 @@ vec_ptype2.vctrs_list_of.vctrs_list_of <- function(x, y, ...) {
 }
 #' @method vec_ptype2.vctrs_list_of list
 #' @export
-vec_ptype2.vctrs_list_of.list <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.vctrs_list_of.list <- function(x, y, ..., x_arg = "", y_arg = "") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.list vctrs_list_of
 #' @export
-vec_ptype2.list.vctrs_list_of <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.list.vctrs_list_of <- function(x, y, ..., x_arg = "", y_arg = "") {
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.vctrs_list_of default
 #' @export
-vec_ptype2.vctrs_list_of.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.vctrs_list_of.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 

--- a/R/type-table.R
+++ b/R/type-table.R
@@ -27,7 +27,7 @@ vec_ptype_abbr.table <- function(x, ...) {
 #' @export vec_ptype2.table
 #' @method vec_ptype2 table
 #' @export
-vec_ptype2.table <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.table <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is_bare_table(x)) {
     UseMethod("vec_ptype2.table", y)
   } else {
@@ -37,13 +37,13 @@ vec_ptype2.table <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 
 #' @method vec_ptype2.table default
 #' @export
-vec_ptype2.table.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.table.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 
 #' @method vec_ptype2.table table
 #' @export
-vec_ptype2.table.table <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.table.table <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is_bare_table(y)) {
     # TODO can shape_match() be relaxed now that the object checks are
     # in the ptype2 methods? This could be `shape_match(new_table(), x, y)`.
@@ -61,7 +61,7 @@ vec_ptype2.table.table <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 #' @export vec_cast.table
 #' @method vec_cast table
 #' @export
-vec_cast.table <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.table <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is_bare_table(to)) {
     UseMethod("vec_cast.table")
   } else {
@@ -71,13 +71,13 @@ vec_cast.table <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 
 #' @method vec_cast.table default
 #' @export
-vec_cast.table.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.table.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, ..., x_arg = x_arg, to_arg = to_arg)
 }
 
 #' @method vec_cast.table table
 #' @export
-vec_cast.table.table <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.table.table <- function(x, to, ..., x_arg = "", to_arg = "") {
   if (is_bare_table(x)) {
     shape_broadcast(x, to)
   } else {

--- a/R/type-tibble.R
+++ b/R/type-tibble.R
@@ -14,7 +14,7 @@ vec_ptype2.tbl_df.default <- function(x, y, ...) {
   vec_ptype2.data.frame(x, y, ...)
 }
 
-vec_ptype2.tbl_df.data.frame <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.tbl_df.data.frame <- function(x, y, ..., x_arg = "", y_arg = "") {
   .Call(
     vctrs_tib_ptype2,
     x = x,
@@ -23,7 +23,7 @@ vec_ptype2.tbl_df.data.frame <- function(x, y, ..., x_arg = "x", y_arg = "y") {
     y_arg = y_arg
   )
 }
-vec_ptype2.data.frame.tbl_df <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.data.frame.tbl_df <- function(x, y, ..., x_arg = "", y_arg = "") {
   .Call(
     vctrs_tib_ptype2,
     x = x,
@@ -35,24 +35,24 @@ vec_ptype2.data.frame.tbl_df <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 
 
 # Conditionally registered in .onLoad()
-vec_cast.tbl_df <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.tbl_df <- function(x, to, ..., x_arg = "", to_arg = "") {
   UseMethod("vec_cast.tbl_df")
 }
-vec_cast.tbl_df.default <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.tbl_df.default <- function(x, to, ..., x_arg = "", to_arg = "") {
   vec_default_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
-vec_cast.tbl_df.tbl_df <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.tbl_df.tbl_df <- function(x, to, ..., x_arg = "", to_arg = "") {
   tib_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
-vec_cast.data.frame.tbl_df <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.data.frame.tbl_df <- function(x, to, ..., x_arg = "", to_arg = "") {
   tib_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
-vec_cast.tbl_df.data.frame <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+vec_cast.tbl_df.data.frame <- function(x, to, ..., x_arg = "", to_arg = "") {
   df_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }
 
-tib_cast <- function(x, to, ..., x_arg = "x", to_arg = "to") {
+tib_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
   .Call(
     vctrs_tib_cast,
     x = x,

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -107,7 +107,7 @@ vec_restore.vctrs_vctr <- function(x, to, ..., i = NULL) {
 
 #' @method vec_ptype2 vctrs_vctr
 #' @export
-vec_ptype2.vctrs_vctr <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.vctrs_vctr <- function(x, y, ..., x_arg = "", y_arg = "") {
   # This method is redundant with `vec_ptype2.default()` but it
   # instructs `vec_c()` that it isn't a foreign type. This avoids
   # infinite recursion through `c.vctrs_vctr()`.
@@ -236,7 +236,7 @@ diff.vctrs_vctr <- function(x, lag = 1L, differences = 1L, ...) {
 #' @export
 `[[<-.vctrs_vctr` <- function(x, ..., value) {
   if (!is.list(x)) {
-    value <- vec_coercible_cast(value, x, x_arg = "x", to_arg = "value")
+    value <- vec_coercible_cast(value, x, x_arg = "", to_arg = "value")
   }
   NextMethod()
 }
@@ -253,7 +253,7 @@ diff.vctrs_vctr <- function(x, lag = 1L, differences = 1L, ...) {
 
 #' @export
 `[<-.vctrs_vctr` <- function(x, i, value) {
-  value <- vec_coercible_cast(value, x, x_arg = "x", to_arg = "value")
+  value <- vec_coercible_cast(value, x, x_arg = "", to_arg = "value")
   NextMethod()
 }
 

--- a/R/type2.R
+++ b/R/type2.R
@@ -35,14 +35,14 @@
 #'   in error messages to inform the user about the locations of
 #'   incompatible types (see [stop_incompatible_type()]).
 #' @export
-vec_ptype2 <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
   return(.Call(vctrs_ptype2, x, y, x_arg, y_arg))
   UseMethod("vec_ptype2")
 }
-vec_ptype2_dispatch_s3 <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2_dispatch_s3 <- function(x, y, ..., x_arg = "", y_arg = "") {
   UseMethod("vec_ptype2")
 }
 #' @export
@@ -51,7 +51,7 @@ vec_ptype2.default <- function(x, y, ...) {
 }
 #' @rdname vec_ptype2
 #' @export
-vec_default_ptype2 <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_default_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (is_unspecified(y)) {
     return(vec_ptype(x))
   }
@@ -74,14 +74,14 @@ vec_typeof2_s3 <- function(x, y) {
 }
 
 # https://github.com/r-lib/vctrs/issues/571
-vec_is_coercible <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_is_coercible <- function(x, y, ..., x_arg = "", y_arg = "") {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
   .Call(vctrs_is_coercible, x, y, x_arg, y_arg)
 }
 
-vec_is_subtype <- function(x, super, ..., x_arg = "x", super_arg = "super") {
+vec_is_subtype <- function(x, super, ..., x_arg = "", super_arg = "super") {
   tryCatch(
     vctrs_error_incompatible_type = function(...) FALSE,
     {

--- a/man/as-is.Rd
+++ b/man/as-is.Rd
@@ -6,7 +6,7 @@
 \alias{vec_cast.AsIs}
 \title{AsIs S3 class}
 \usage{
-\method{vec_ptype2}{AsIs}(x, y, ..., x_arg = "x", y_arg = "y")
+\method{vec_ptype2}{AsIs}(x, y, ..., x_arg = "", y_arg = "")
 
 \method{vec_cast}{AsIs}(x, to, ...)
 }

--- a/man/list_of.Rd
+++ b/man/list_of.Rd
@@ -17,7 +17,7 @@ validate_list_of(x)
 
 is_list_of(x)
 
-\method{vec_ptype2}{vctrs_list_of}(x, y, ..., x_arg = "x", y_arg = "y")
+\method{vec_ptype2}{vctrs_list_of}(x, y, ..., x_arg = "", y_arg = "")
 
 \method{vec_cast}{vctrs_list_of}(x, to, ...)
 }

--- a/man/table.Rd
+++ b/man/table.Rd
@@ -6,9 +6,9 @@
 \alias{vec_cast.table}
 \title{Table S3 class}
 \usage{
-\method{vec_ptype2}{table}(x, y, ..., x_arg = "x", y_arg = "y")
+\method{vec_ptype2}{table}(x, y, ..., x_arg = "", y_arg = "")
 
-\method{vec_cast}{table}(x, to, ..., x_arg = "x", to_arg = "to")
+\method{vec_cast}{table}(x, to, ..., x_arg = "", to_arg = "")
 }
 \description{
 These functions help the base table class fit into the vctrs type system

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -13,7 +13,7 @@
 \alias{vec_cast.list}
 \title{Cast a vector to specified type}
 \usage{
-vec_cast(x, to, ..., x_arg = "x", to_arg = "to")
+vec_cast(x, to, ..., x_arg = "", to_arg = "")
 
 vec_cast_common(..., .to = NULL)
 

--- a/man/vec_default_cast.Rd
+++ b/man/vec_default_cast.Rd
@@ -4,7 +4,7 @@
 \alias{vec_default_cast}
 \title{Default cast method}
 \usage{
-vec_default_cast(x, to, x_arg = "x", to_arg = "to")
+vec_default_cast(x, to, x_arg = "", to_arg = "")
 }
 \arguments{
 \item{x}{Vectors to cast.}

--- a/man/vec_ptype2.Rd
+++ b/man/vec_ptype2.Rd
@@ -12,23 +12,23 @@
 \alias{vec_default_ptype2}
 \title{Find the common type for a pair of vector types}
 \usage{
-\method{vec_ptype2}{logical}(x, y, ..., x_arg = "x", y_arg = "y")
+\method{vec_ptype2}{logical}(x, y, ..., x_arg = "", y_arg = "")
 
-\method{vec_ptype2}{integer}(x, y, ..., x_arg = "x", y_arg = "y")
+\method{vec_ptype2}{integer}(x, y, ..., x_arg = "", y_arg = "")
 
-\method{vec_ptype2}{double}(x, y, ..., x_arg = "x", y_arg = "y")
+\method{vec_ptype2}{double}(x, y, ..., x_arg = "", y_arg = "")
 
-\method{vec_ptype2}{complex}(x, y, ..., x_arg = "x", y_arg = "y")
+\method{vec_ptype2}{complex}(x, y, ..., x_arg = "", y_arg = "")
 
-\method{vec_ptype2}{character}(x, y, ..., x_arg = "x", y_arg = "y")
+\method{vec_ptype2}{character}(x, y, ..., x_arg = "", y_arg = "")
 
-\method{vec_ptype2}{raw}(x, y, ..., x_arg = "x", y_arg = "y")
+\method{vec_ptype2}{raw}(x, y, ..., x_arg = "", y_arg = "")
 
-\method{vec_ptype2}{list}(x, y, ..., x_arg = "x", y_arg = "y")
+\method{vec_ptype2}{list}(x, y, ..., x_arg = "", y_arg = "")
 
-vec_ptype2(x, y, ..., x_arg = "x", y_arg = "y")
+vec_ptype2(x, y, ..., x_arg = "", y_arg = "")
 
-vec_default_ptype2(x, y, ..., x_arg = "x", y_arg = "y")
+vec_default_ptype2(x, y, ..., x_arg = "", y_arg = "")
 }
 \arguments{
 \item{x, y}{Vector types.}

--- a/man/vec_recycle.Rd
+++ b/man/vec_recycle.Rd
@@ -5,7 +5,7 @@
 \alias{vec_recycle_common}
 \title{Vector recycling}
 \usage{
-vec_recycle(x, size, ..., x_arg = "x")
+vec_recycle(x, size, ..., x_arg = "")
 
 vec_recycle_common(..., .size = NULL)
 }

--- a/man/vec_slice.Rd
+++ b/man/vec_slice.Rd
@@ -10,7 +10,7 @@ vec_slice(x, i)
 
 vec_slice(x, i) <- value
 
-vec_assign(x, i, value, ..., x_arg = "x", value_arg = "value")
+vec_assign(x, i, value, ..., x_arg = "", value_arg = "value")
 }
 \arguments{
 \item{x}{A vector}

--- a/tests/testthat/error/test-recycle.txt
+++ b/tests/testthat/error/test-recycle.txt
@@ -3,7 +3,7 @@ incompatible recycling size has informative error
 =================================================
 
 > vec_recycle(1:2, 4)
-Error: `x` can't be recycled to size 4.
+Error: `` can't be recycled to size 4.
 x It must be size 4 or 1, not 2.
 
 > vec_recycle(1:2, 4, x_arg = "foo")
@@ -15,6 +15,6 @@ recycling to size 1 has informative error
 =========================================
 
 > vec_recycle(1:2, 1)
-Error: `x` can't be recycled to size 1.
+Error: `` can't be recycled to size 1.
 x It must be size 1, not 2.
 

--- a/tests/testthat/error/test-recycle.txt
+++ b/tests/testthat/error/test-recycle.txt
@@ -3,11 +3,11 @@ incompatible recycling size has informative error
 =================================================
 
 > vec_recycle(1:2, 4)
-Error: `` can't be recycled to size 4.
+Error: Input can't be recycled to size 4.
 x It must be size 4 or 1, not 2.
 
 > vec_recycle(1:2, 4, x_arg = "foo")
-Error: `foo` can't be recycled to size 4.
+Error: Input `foo` can't be recycled to size 4.
 x It must be size 4 or 1, not 2.
 
 
@@ -15,6 +15,6 @@ recycling to size 1 has informative error
 =========================================
 
 > vec_recycle(1:2, 1)
-Error: `` can't be recycled to size 1.
+Error: Input can't be recycled to size 1.
 x It must be size 1, not 2.
 

--- a/tests/testthat/error/test-slice-assign.txt
+++ b/tests/testthat/error/test-slice-assign.txt
@@ -3,7 +3,7 @@
 ========================================
 
 > vec_assign(1:3, 1:3, 1:2)
-Error: `value` can't be recycled to size 3.
+Error: Input `value` can't be recycled to size 3.
 x It must be size 3 or 1, not 2.
 
 
@@ -63,6 +63,6 @@ i The subscript has a missing value at location 2.
 Error: No common type for `bar` <character> and `foo` <integer>.
 
 > vec_assign(1:2, 1L, 1:2, value_arg = "bar")
-Error: `bar` can't be recycled to size 1.
+Error: Input `bar` can't be recycled to size 1.
 x It must be size 1, not 2.
 

--- a/tests/testthat/error/test-type-asis.txt
+++ b/tests/testthat/error/test-type-asis.txt
@@ -3,12 +3,12 @@ AsIs objects throw ptype2 errors with their underlying types
 ============================================================
 
 > vec_ptype2(I(1), I("x"))
-Error: No common type for `x` <double> and `y` <character>.
+Error: No common type for <double> and <character>.
 
 
 AsIs objects throw cast errors with their underlying types
 ==========================================================
 
 > vec_cast(I(1), I(factor("x")))
-Error: Can't cast `x` <double> to `to` <factor<5a425>>.
+Error: Can't cast <double> to <factor<5a425>>.
 

--- a/tests/testthat/helper-types.R
+++ b/tests/testthat/helper-types.R
@@ -60,7 +60,7 @@ tuple_methods <- list(
   vec_ptype2.tuple = function(x, y, ...)  UseMethod("vec_ptype2.tuple", y),
   vec_ptype2.tuple.vctrs_unspecified = function(x, y, ...) tuple(),
   vec_ptype2.tuple.tuple = function(x, y, ...) tuple(),
-  vec_ptype2.tuple.default = function(x, y, ..., x_arg = "x", y_arg = "y") {
+  vec_ptype2.tuple.default = function(x, y, ..., x_arg = "", y_arg = "") {
     stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
   },
 

--- a/tests/testthat/test-cast-error-nested.txt
+++ b/tests/testthat/test-cast-error-nested.txt
@@ -1,24 +1,24 @@
 
 vec_cast("foo", 10):
 
-Lossy cast from `x` <character> to `to` <double>.
+Lossy cast from <character> to <double>.
 * Locations: 1 
 
 
 vec_cast(factor("foo"), 10):
 
-Can't cast `x` <factor<bd40e>> to `to` <double>. 
+Can't cast <factor<bd40e>> to <double>. 
 
 
 vec_cast(x, y):
 
-Lossy cast from `x$a$b` <character> to `to$a$b` <double>.
+Lossy cast from `a$b` <character> to `a$b` <double>.
 * Locations: 1 
 
 
 vec_cast(x, y):
 
-Can't cast `x$a$b` <factor<bd40e>> to `to$a$b` <double>. 
+Can't cast `a$b` <factor<bd40e>> to `a$b` <double>. 
 
 
 vec_cast_common(x, y):

--- a/tests/testthat/test-type2-error-messages.txt
+++ b/tests/testthat/test-type2-error-messages.txt
@@ -2,11 +2,11 @@ Bare objects:
 
 vec_ptype2("foo", 10):
 
-No common type for `x` <character> and `y` <double>. 
+No common type for <character> and <double>. 
 
 Nested dataframes:
 
 vec_ptype2(df1, df2):
 
-No common type for `x$x$y$z` <double> and `y$x$y$z` <character>. 
+No common type for `x$y$z` <double> and `x$y$z` <character>. 
 

--- a/vignettes/s3-vector.Rmd
+++ b/vignettes/s3-vector.Rmd
@@ -192,7 +192,7 @@ Both generics use __[double dispatch](https://en.wikipedia.org/wiki/Double_dispa
 
 ```{r}
 vec_ptype2.MYCLASS <- function(x, y, ...) UseMethod("vec_ptype2.MYCLASS", y)
-vec_ptype2.MYCLASS.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.MYCLASS.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 
@@ -208,7 +208,7 @@ We'll make our percent class coercible back and forth with double vectors. I'll 
 
 ```{r}
 vec_ptype2.vctrs_percent <- function(x, y, ...) UseMethod("vec_ptype2.vctrs_percent", y)
-vec_ptype2.vctrs_percent.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.vctrs_percent.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 ```
@@ -370,7 +370,7 @@ Now consider `vec_cast()` and `vec_ptype2()`. I start with the standard recipes:
 
 ```{r}
 vec_ptype2.vctrs_decimal <- function(x, y, ...) UseMethod("vec_ptype2.vctrs_decimal", y)
-vec_ptype2.vctrs_decimal.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.vctrs_decimal.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 
@@ -565,7 +565,7 @@ For `rational`, `vec_ptype2()` and `vec_cast()` follow the same pattern as  `per
 
 ```{r}
 vec_ptype2.vctrs_rational <- function(x, y, ...) UseMethod("vec_ptype2.vctrs_rational", y)
-vec_ptype2.vctrs_rational.default <- function(x, y, ..., x_arg = "x", y_arg = "y") {
+vec_ptype2.vctrs_rational.default <- function(x, y, ..., x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 vec_ptype2.vctrs_rational.vctrs_rational <- function(x, y, ...) new_rational()
@@ -1103,7 +1103,7 @@ Now we finish the work around `vec_ptype2()` by providing all needed methods. Ea
 #' @export                                 
 vec_ptype2.vctrs_percent.default <- function(x, y,
                                              ...,
-                                             x_arg = "x", y_arg = "y") {
+                                             x_arg = "", y_arg = "") {
   vec_default_ptype2(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 #' @method vec_ptype2.vctrs_percent vctrs_percent


### PR DESCRIPTION
I think the default `arg` values end up to be misleading for end users because they refer to internal details of internal functions.

This brings up the issue of how to refer to arguments in error messages. `vec_recycle()` now uses the same approach as in subscript errors and uses a general noun "Input".

Before:

```r
#> Error: `x` can't be recycled to size 4.
```

After:

```r
#> Error: Input can't be recycled to size 4.
```

If `arg = "foo"` is supplied, this is:

```r
#> Error: Input `foo` can't be recycled to size 4.
```

We should standardise on a user-friendly noun for referring to arguments. I thought "Input" is shorter and less jargony than "Argument".

cc @batpigandme @krlmlr 