### PR TITLE
Fix `vec_match()` args

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # vctrs (development version)
 
+* `vec_match()` and `vec_in()` gain parameters for argument tags (#944).
+
 * The `is.na<-()` method for `vctrs_vctr` now supports numeric and
   character subscripts to indicate where to insert missing values (#947). 
 

--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -215,6 +215,8 @@ vec_unique_count <- function(x) {
 #'   matched to missing values in `haystack`. If `FALSE`, they
 #'   propagate, missing values in `needles` are represented as `NA` in
 #'   the return value.
+#' @param needles_arg,haystack_arg Argument tags for `needles` and
+#'   `haystack` used in error messages.
 #' @return A vector the same length as `needles`. `vec_in()` returns a
 #'   logical vector; `vec_match()` returns an integer vector.
 #' @export
@@ -228,14 +230,24 @@ vec_unique_count <- function(x) {
 #'
 #' # Only the first index of duplicates is returned
 #' vec_match(c("a", "b"), c("a", "b", "a", "b"))
-vec_match <- function(needles, haystack, ..., na_equal = TRUE) {
+vec_match <- function(needles,
+                      haystack,
+                      ...,
+                      na_equal = TRUE,
+                      needles_arg = "needles",
+                      haystack_arg = "haystack") {
   if (!missing(...)) ellipsis::check_dots_empty()
-  .Call(vctrs_match, needles, haystack, na_equal)
+  .Call(vctrs_match, needles, haystack, na_equal, needles_arg, haystack_arg)
 }
 
 #' @export
 #' @rdname vec_match
-vec_in <- function(needles, haystack, ..., na_equal = TRUE) {
+vec_in <- function(needles,
+                   haystack,
+                   ...,
+                   na_equal = TRUE,
+                   needles_arg = "needles",
+                   haystack_arg = "haystack") {
   if (!missing(...)) ellipsis::check_dots_empty()
-  .Call(vctrs_in, needles, haystack, na_equal)
+  .Call(vctrs_in, needles, haystack, na_equal, needles_arg, haystack_arg)
 }

--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -234,8 +234,8 @@ vec_match <- function(needles,
                       haystack,
                       ...,
                       na_equal = TRUE,
-                      needles_arg = "needles",
-                      haystack_arg = "haystack") {
+                      needles_arg = "",
+                      haystack_arg = "") {
   if (!missing(...)) ellipsis::check_dots_empty()
   .Call(vctrs_match, needles, haystack, na_equal, needles_arg, haystack_arg)
 }
@@ -246,8 +246,8 @@ vec_in <- function(needles,
                    haystack,
                    ...,
                    na_equal = TRUE,
-                   needles_arg = "needles",
-                   haystack_arg = "haystack") {
+                   needles_arg = "",
+                   haystack_arg = "") {
   if (!missing(...)) ellipsis::check_dots_empty()
   .Call(vctrs_in, needles, haystack, na_equal, needles_arg, haystack_arg)
 }

--- a/man/vec_match.Rd
+++ b/man/vec_match.Rd
@@ -10,8 +10,8 @@ vec_match(
   haystack,
   ...,
   na_equal = TRUE,
-  needles_arg = "needles",
-  haystack_arg = "haystack"
+  needles_arg = "",
+  haystack_arg = ""
 )
 
 vec_in(
@@ -19,8 +19,8 @@ vec_in(
   haystack,
   ...,
   na_equal = TRUE,
-  needles_arg = "needles",
-  haystack_arg = "haystack"
+  needles_arg = "",
+  haystack_arg = ""
 )
 }
 \arguments{

--- a/man/vec_match.Rd
+++ b/man/vec_match.Rd
@@ -5,9 +5,23 @@
 \alias{vec_in}
 \title{Find matching observations across vectors}
 \usage{
-vec_match(needles, haystack, ..., na_equal = TRUE)
+vec_match(
+  needles,
+  haystack,
+  ...,
+  na_equal = TRUE,
+  needles_arg = "needles",
+  haystack_arg = "haystack"
+)
 
-vec_in(needles, haystack, ..., na_equal = TRUE)
+vec_in(
+  needles,
+  haystack,
+  ...,
+  na_equal = TRUE,
+  needles_arg = "needles",
+  haystack_arg = "haystack"
+)
 }
 \arguments{
 \item{needles, haystack}{Vector of \code{needles} to search for in vector haystack.
@@ -23,6 +37,9 @@ comparison.}
 matched to missing values in \code{haystack}. If \code{FALSE}, they
 propagate, missing values in \code{needles} are represented as \code{NA} in
 the return value.}
+
+\item{needles_arg, haystack_arg}{Argument tags for \code{needles} and
+\code{haystack} used in error messages.}
 }
 \value{
 A vector the same length as \code{needles}. \code{vec_in()} returns a

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -484,8 +484,16 @@ SEXP vctrs_id(SEXP x) {
 }
 
 // [[ register() ]]
-SEXP vctrs_match(SEXP needles, SEXP haystack, SEXP na_equal) {
-  return vec_match_params(needles, haystack, r_bool_as_int(na_equal));
+SEXP vctrs_match(SEXP needles, SEXP haystack, SEXP na_equal,
+                 SEXP needles_arg_, SEXP haystack_arg_) {
+  struct vctrs_arg needles_arg = vec_as_arg(needles_arg_);
+  struct vctrs_arg haystack_arg = vec_as_arg(haystack_arg_);
+
+  return vec_match_params(needles,
+                          haystack,
+                          r_bool_as_int(na_equal),
+                          &needles_arg,
+                          &haystack_arg);
 }
 
 static inline void vec_match_loop(int* p_out,
@@ -497,13 +505,17 @@ static inline void vec_match_loop_propagate(int* p_out,
                                             struct dictionary* d_needles,
                                             R_len_t n_needle);
 
-SEXP vec_match_params(SEXP needles, SEXP haystack, bool na_equal) {
+SEXP vec_match_params(SEXP needles,
+                      SEXP haystack,
+                      bool na_equal,
+                      struct vctrs_arg* needles_arg,
+                      struct vctrs_arg* haystack_arg) {
   int nprot = 0;
   int _;
-  SEXP type = PROTECT_N(vec_ptype2(needles, haystack, &args_needles, &args_haystack, &_), &nprot);
+  SEXP type = PROTECT_N(vec_ptype2(needles, haystack, needles_arg, haystack_arg, &_), &nprot);
 
-  needles = PROTECT_N(vec_cast(needles, type, args_empty, args_empty), &nprot);
-  haystack = PROTECT_N(vec_cast(haystack, type, args_empty, args_empty), &nprot);
+  needles = PROTECT_N(vec_cast(needles, type, needles_arg, args_empty), &nprot);
+  haystack = PROTECT_N(vec_cast(haystack, type, haystack_arg, args_empty), &nprot);
 
   needles = PROTECT_N(vec_proxy_equal(needles), &nprot);
   haystack = PROTECT_N(vec_proxy_equal(haystack), &nprot);
@@ -581,12 +593,15 @@ static inline void vec_match_loop_propagate(int* p_out,
 }
 
 // [[ register() ]]
-SEXP vctrs_in(SEXP needles, SEXP haystack, SEXP na_equal_) {
+SEXP vctrs_in(SEXP needles, SEXP haystack, SEXP na_equal_,
+              SEXP needles_arg_, SEXP haystack_arg_) {
   int nprot = 0;
   bool na_equal = r_bool_as_int(na_equal_);
 
   int _;
-  SEXP type = PROTECT_N(vec_ptype2(needles, haystack, &args_needles, &args_haystack, &_), &nprot);
+  struct vctrs_arg needles_arg = vec_as_arg(needles_arg_);
+  struct vctrs_arg haystack_arg = vec_as_arg(haystack_arg_);
+  SEXP type = PROTECT_N(vec_ptype2(needles, haystack, &needles_arg, &haystack_arg, &_), &nprot);
 
   needles = PROTECT_N(vec_cast(needles, type, args_empty, args_empty), &nprot);
   haystack = PROTECT_N(vec_cast(haystack, type, args_empty, args_empty), &nprot);

--- a/src/init.c
+++ b/src/init.c
@@ -20,7 +20,6 @@ extern SEXP vctrs_n_fields(SEXP);
 extern SEXP vctrs_hash(SEXP);
 extern SEXP vctrs_hash_object(SEXP);
 extern SEXP vctrs_equal_object(SEXP, SEXP);
-extern SEXP vctrs_in(SEXP, SEXP, SEXP);
 extern SEXP vctrs_duplicated(SEXP);
 extern SEXP vctrs_unique_loc(SEXP);
 extern SEXP vctrs_count(SEXP);
@@ -33,7 +32,8 @@ extern SEXP vec_group_loc(SEXP);
 extern SEXP vctrs_equal(SEXP, SEXP, SEXP);
 extern SEXP vctrs_equal_na(SEXP);
 extern SEXP vctrs_compare(SEXP, SEXP, SEXP);
-extern SEXP vctrs_match(SEXP, SEXP, SEXP);
+extern SEXP vctrs_match(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_in(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_duplicated_any(SEXP);
 extern SEXP vctrs_size(SEXP);
 extern SEXP vctrs_list_sizes(SEXP);
@@ -142,7 +142,6 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_hash",                       (DL_FUNC) &vctrs_hash, 1},
   {"vctrs_hash_object",                (DL_FUNC) &vctrs_hash_object, 1},
   {"vctrs_equal_object",               (DL_FUNC) &vctrs_equal_object, 2},
-  {"vctrs_in",                         (DL_FUNC) &vctrs_in, 3},
   {"vctrs_unique_loc",                 (DL_FUNC) &vctrs_unique_loc, 1},
   {"vctrs_duplicated",                 (DL_FUNC) &vctrs_duplicated, 1},
   {"vctrs_duplicated_any",             (DL_FUNC) &vctrs_duplicated_any, 1},
@@ -161,7 +160,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_equal",                      (DL_FUNC) &vctrs_equal, 3},
   {"vctrs_equal_na",                   (DL_FUNC) &vctrs_equal_na, 1},
   {"vctrs_compare",                    (DL_FUNC) &vctrs_compare, 3},
-  {"vctrs_match",                      (DL_FUNC) &vctrs_match, 3},
+  {"vctrs_match",                      (DL_FUNC) &vctrs_match, 5},
+  {"vctrs_in",                         (DL_FUNC) &vctrs_in, 5},
   {"vctrs_typeof",                     (DL_FUNC) &vctrs_typeof, 2},
   {"vctrs_init_library",               (DL_FUNC) &vctrs_init_library, 1},
   {"vctrs_is_vector",                  (DL_FUNC) &vctrs_is_vector, 1},

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -383,10 +383,11 @@ SEXP vec_recycle_fallback(SEXP x, R_len_t size, struct vctrs_arg* x_arg);
 SEXP vec_recycle_common(SEXP xs, R_len_t size);
 SEXP vec_names(SEXP x);
 SEXP vec_group_loc(SEXP x);
-SEXP vec_match_params(SEXP needles, SEXP haystack, bool na_equal);
+SEXP vec_match_params(SEXP needles, SEXP haystack, bool na_equal,
+                      struct vctrs_arg* needles_arg, struct vctrs_arg* haystack_arg);
 
 static inline SEXP vec_match(SEXP needles, SEXP haystack) {
-  return vec_match_params(needles, haystack, true);
+  return vec_match_params(needles, haystack, true, NULL, NULL);
 }
 
 

--- a/tests/testthat/error/test-dictionary.txt
+++ b/tests/testthat/error/test-dictionary.txt
@@ -7,6 +7,12 @@ vec_match() and vec_in() check types
 > vec_match(df1, df2)
 Error: No common type for `needles$x$foo` <double> and `haystack$x$foo` <character>.
 
+> vec_match(df1, df2, needles_arg = "n", haystack_arg = "h")
+Error: No common type for `n$x$foo` <double> and `h$x$foo` <character>.
+
 > vec_in(df1, df2)
 Error: No common type for `needles$x$foo` <double> and `haystack$x$foo` <character>.
+
+> vec_in(df1, df2, needles_arg = "n", haystack_arg = "h")
+Error: No common type for `n$x$foo` <double> and `h$x$foo` <character>.
 

--- a/tests/testthat/error/test-dictionary.txt
+++ b/tests/testthat/error/test-dictionary.txt
@@ -5,13 +5,13 @@ vec_match() and vec_in() check types
 > df1 <- data_frame(x = data_frame(foo = 1))
 > df2 <- data_frame(x = data_frame(foo = ""))
 > vec_match(df1, df2)
-Error: No common type for `needles$x$foo` <double> and `haystack$x$foo` <character>.
+Error: No common type for `x$foo` <double> and `x$foo` <character>.
 
 > vec_match(df1, df2, needles_arg = "n", haystack_arg = "h")
 Error: No common type for `n$x$foo` <double> and `h$x$foo` <character>.
 
 > vec_in(df1, df2)
-Error: No common type for `needles$x$foo` <double> and `haystack$x$foo` <character>.
+Error: No common type for `x$foo` <double> and `x$foo` <character>.
 
 > vec_in(df1, df2, needles_arg = "n", haystack_arg = "h")
 Error: No common type for `n$x$foo` <double> and `h$x$foo` <character>.

--- a/tests/testthat/error/test-dictionary.txt
+++ b/tests/testthat/error/test-dictionary.txt
@@ -1,0 +1,12 @@
+
+vec_match() and vec_in() check types
+====================================
+
+> df1 <- data_frame(x = data_frame(foo = 1))
+> df2 <- data_frame(x = data_frame(foo = ""))
+> vec_match(df1, df2)
+Error: No common type for `needles$x$foo` <double> and `haystack$x$foo` <character>.
+
+> vec_in(df1, df2)
+Error: No common type for `needles$x$foo` <double> and `haystack$x$foo` <character>.
+

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -212,6 +212,15 @@ test_that("vec_match() matches match()", {
   expect_equal(vec_match("x", "x"), match("x", "x"))
 })
 
+test_that("vec_match() and vec_in() check types", {
+  verify_errors({
+    df1 <- data_frame(x = data_frame(foo = 1))
+    df2 <- data_frame(x = data_frame(foo = ""))
+    expect_error(vec_match(df1, df2), class = "vctrs_error_incompatible_type")
+    expect_error(vec_in(df1, df2), class = "vctrs_error_incompatible_type")
+  })
+})
+
 test_that("vec_in() matches %in%", {
   n <- c(1:3, NA)
   h <- c(4, 2, 1, NA)
@@ -301,4 +310,14 @@ test_that("missing values are propagated across columns", {
 
 test_that("can't supply NA as `na_equal`", {
   expect_error(vec_match(NA, NA, na_equal = NA), "single `TRUE` or `FALSE`")
+})
+
+test_that("dictionary tools have informative errors", {
+  verify_output(test_path("error", "test-dictionary.txt"), {
+    "# vec_match() and vec_in() check types"
+    df1 <- data_frame(x = data_frame(foo = 1))
+    df2 <- data_frame(x = data_frame(foo = ""))
+    vec_match(df1, df2)
+    vec_in(df1, df2)
+  })
 })

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -217,7 +217,9 @@ test_that("vec_match() and vec_in() check types", {
     df1 <- data_frame(x = data_frame(foo = 1))
     df2 <- data_frame(x = data_frame(foo = ""))
     expect_error(vec_match(df1, df2), class = "vctrs_error_incompatible_type")
+    expect_error(vec_match(df1, df2, needles_arg = "n", haystack_arg = "h"), class = "vctrs_error_incompatible_type")
     expect_error(vec_in(df1, df2), class = "vctrs_error_incompatible_type")
+    expect_error(vec_in(df1, df2, needles_arg = "n", haystack_arg = "h"), class = "vctrs_error_incompatible_type")
   })
 })
 
@@ -318,6 +320,8 @@ test_that("dictionary tools have informative errors", {
     df1 <- data_frame(x = data_frame(foo = 1))
     df2 <- data_frame(x = data_frame(foo = ""))
     vec_match(df1, df2)
+    vec_match(df1, df2, needles_arg = "n", haystack_arg = "h")
     vec_in(df1, df2)
+    vec_in(df1, df2, needles_arg = "n", haystack_arg = "h")
   })
 })


### PR DESCRIPTION
* Add `needles_arg` and `haystack_arg` to `vec_match()` and `vec_in()`. Closes #944.

* Removes arg defaults, as in #957.