### PR TITLE
Return immediately if restoring to the same reference

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -107,7 +107,6 @@ extern SEXP vctrs_assign_params(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_has_dim(SEXP);
 extern SEXP vctrs_rep(SEXP, SEXP);
 extern SEXP vctrs_rep_each(SEXP, SEXP);
-extern SEXP vctrs_maybe_referenced(SEXP);
 extern SEXP vctrs_maybe_referenced_col(SEXP, SEXP);
 extern SEXP vctrs_new_df_unreferenced_col();
 
@@ -237,7 +236,6 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_has_dim",                    (DL_FUNC) &vctrs_has_dim, 1},
   {"vctrs_rep",                        (DL_FUNC) &vctrs_rep, 2},
   {"vctrs_rep_each",                   (DL_FUNC) &vctrs_rep_each, 2},
-  {"vctrs_maybe_referenced",           (DL_FUNC) &vctrs_maybe_referenced, 1},
   {"vctrs_maybe_referenced_col",       (DL_FUNC) &vctrs_maybe_referenced_col, 2},
   {"vctrs_new_df_unreferenced_col",    (DL_FUNC) &vctrs_new_df_unreferenced_col, 0},
   {NULL, NULL, 0}

--- a/src/init.c
+++ b/src/init.c
@@ -107,6 +107,9 @@ extern SEXP vctrs_assign_params(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_has_dim(SEXP);
 extern SEXP vctrs_rep(SEXP, SEXP);
 extern SEXP vctrs_rep_each(SEXP, SEXP);
+extern SEXP vctrs_maybe_referenced(SEXP);
+extern SEXP vctrs_maybe_referenced_col(SEXP, SEXP);
+extern SEXP vctrs_new_df_unreferenced_col();
 
 // Maturing
 // In the public header
@@ -234,6 +237,9 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_has_dim",                    (DL_FUNC) &vctrs_has_dim, 1},
   {"vctrs_rep",                        (DL_FUNC) &vctrs_rep, 2},
   {"vctrs_rep_each",                   (DL_FUNC) &vctrs_rep_each, 2},
+  {"vctrs_maybe_referenced",           (DL_FUNC) &vctrs_maybe_referenced, 1},
+  {"vctrs_maybe_referenced_col",       (DL_FUNC) &vctrs_maybe_referenced_col, 2},
+  {"vctrs_new_df_unreferenced_col",    (DL_FUNC) &vctrs_new_df_unreferenced_col, 0},
   {NULL, NULL, 0}
 };
 

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -9,10 +9,6 @@ static SEXP fns_vec_restore_dispatch = NULL;
 
 // Copy attributes except names and dim. This duplicates `x` if needed.
 SEXP vec_restore_default(SEXP x, SEXP to) {
-  if (x == to) {
-    return x;
-  }
-
   SEXP attrib = ATTRIB(to);
 
   const bool is_s4 = IS_S4_OBJECT(to);
@@ -74,14 +70,18 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
 
   if (dim == R_NilValue) {
     SEXP nms = PROTECT(Rf_getAttrib(x, R_NamesSymbol));
+
+    // Check if `to` is a data frame early. If `x` and `to` point
+    // to the same reference, then `SET_ATTRIB()` would alter `to`.
     SEXP rownms = PROTECT(df_rownames(x));
+    const bool restore_rownms = rownms != R_NilValue && is_data_frame(to);
 
     SET_ATTRIB(x, attrib);
 
     Rf_setAttrib(x, R_NamesSymbol, nms);
 
     // Don't restore row names if `to` isn't a data frame
-    if (rownms != R_NilValue && is_data_frame(to)) {
+    if (restore_rownms) {
       Rf_setAttrib(x, R_RowNamesSymbol, rownms);
     }
     UNPROTECT(2);

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -9,6 +9,10 @@ static SEXP fns_vec_restore_dispatch = NULL;
 
 // Copy attributes except names and dim. This duplicates `x` if needed.
 SEXP vec_restore_default(SEXP x, SEXP to) {
+  if (x == to) {
+    return x;
+  }
+
   SEXP attrib = ATTRIB(to);
 
   const bool is_s4 = IS_S4_OBJECT(to);

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -338,13 +338,12 @@ SEXP df_assign(SEXP x, SEXP index, SEXP value,
     // restore are not recursive so need to be done for each element
     // we recurse into. `vec_proxy_assign()` will proxy the `value_elt`.
     SEXP proxy_elt = PROTECT(vec_proxy(out_elt));
-    proxy_elt = PROTECT(Rf_shallow_duplicate(proxy_elt));
 
     SEXP assigned = PROTECT(vec_proxy_assign_opts(proxy_elt, index, value_elt, opts));
     assigned = vec_restore(assigned, out_elt, R_NilValue);
 
     SET_VECTOR_ELT(out, i, assigned);
-    UNPROTECT(3);
+    UNPROTECT(2);
   }
 
   UNPROTECT(1);

--- a/src/utils.c
+++ b/src/utils.c
@@ -180,16 +180,11 @@ static SEXP vctrs_eval_mask_n_impl(SEXP fn, SEXP* syms, SEXP* args, SEXP mask) {
 }
 
 // [[ register() ]]
-SEXP vctrs_maybe_referenced(SEXP x) {
-  bool out = MAYBE_REFERENCED(x);
-  return Rf_ScalarLogical(out);
-}
-
-// [[ register() ]]
 SEXP vctrs_maybe_referenced_col(SEXP x, SEXP i) {
   int i_ = r_int_get(i, 0) - 1;
   SEXP col = VECTOR_ELT(x, i_);
-  return vctrs_maybe_referenced(col);
+  bool out = MAYBE_REFERENCED(col);
+  return Rf_ScalarLogical(out);
 }
 
 // [[ register() ]]

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,5 +1,6 @@
 #include "vctrs.h"
 #include "utils.h"
+#include "type-data-frame.h"
 
 #include <R_ext/Rdynload.h>
 
@@ -175,6 +176,38 @@ static SEXP vctrs_eval_mask_n_impl(SEXP fn, SEXP* syms, SEXP* args, SEXP mask) {
   SEXP out = Rf_eval(call, mask);
 
   UNPROTECT(1);
+  return out;
+}
+
+// [[ register() ]]
+SEXP vctrs_maybe_referenced(SEXP x) {
+  bool out = MAYBE_REFERENCED(x);
+  return Rf_ScalarLogical(out);
+}
+
+// [[ register() ]]
+SEXP vctrs_maybe_referenced_col(SEXP x, SEXP i) {
+  int i_ = r_int_get(i, 0) - 1;
+  SEXP col = VECTOR_ELT(x, i_);
+  return vctrs_maybe_referenced(col);
+}
+
+// [[ register() ]]
+SEXP vctrs_new_df_unreferenced_col() {
+  SEXP col = PROTECT(Rf_allocVector(INTSXP, 1));
+  INTEGER(col)[0] = 1;
+
+  SEXP out = PROTECT(Rf_allocVector(VECSXP, 1));
+  SET_VECTOR_ELT(out, 0, col);
+
+  SEXP names = PROTECT(Rf_allocVector(STRSXP, 1));
+  SET_STRING_ELT(names, 0, Rf_mkChar("x"));
+
+  Rf_setAttrib(out, R_NamesSymbol, names);
+
+  init_data_frame(out, 1);
+
+  UNPROTECT(3);
   return out;
 }
 

--- a/tests/testthat/helper-memory.R
+++ b/tests/testthat/helper-memory.R
@@ -1,0 +1,11 @@
+maybe_referenced <- function(x) {
+  .Call(vctrs_maybe_referenced, x)
+}
+
+maybe_referenced_col <- function(x, i) {
+  .Call(vctrs_maybe_referenced_col, x, i)
+}
+
+new_df_unreferenced_col <- function() {
+  .Call(vctrs_new_df_unreferenced_col)
+}

--- a/tests/testthat/helper-memory.R
+++ b/tests/testthat/helper-memory.R
@@ -1,7 +1,3 @@
-maybe_referenced <- function(x) {
-  .Call(vctrs_maybe_referenced, x)
-}
-
 maybe_referenced_col <- function(x, i) {
   .Call(vctrs_maybe_referenced_col, x, i)
 }

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -595,12 +595,10 @@ test_that("assignment to a data frame with unreferenced columns doesn't overwrit
   value <- new_data_frame(list(x = 2))
   expect <- new_data_frame(list(x = 1L))
 
-  expect_true(maybe_referenced(x))
   expect_false(maybe_referenced_col(x, 1L))
 
   new <- vec_assign(x, 1, value)
 
-  expect_true(maybe_referenced(x))
   expect_true(maybe_referenced_col(x, 1L))
 
   # Expect no changes to `x`!

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -590,6 +590,23 @@ test_that("can optionally assign names", {
   )
 })
 
+test_that("assignment to a data frame with unreferenced columns doesn't overwrite (#986)", {
+  x <- new_df_unreferenced_col()
+  value <- new_data_frame(list(x = 2))
+  expect <- new_data_frame(list(x = 1L))
+
+  expect_true(maybe_referenced(x))
+  expect_false(maybe_referenced_col(x, 1L))
+
+  new <- vec_assign(x, 1, value)
+
+  expect_true(maybe_referenced(x))
+  expect_true(maybe_referenced_col(x, 1L))
+
+  # Expect no changes to `x`!
+  expect_identical(x, expect)
+})
+
 # vec_assign + compact_seq -------------------------------------------------
 
 # `start` is 0-based


### PR DESCRIPTION
Fixes #984 

This problem was really difficult to track down.

Right now, `vec_c()` and `vec_rbind()` do the right thing with row names because of this forced shallow duplication in `df_assign()`.

https://github.com/r-lib/vctrs/blob/fd249275c79ccd01910c947f63296ea9c5e6aa99/src/slice-assign.c#L341

The problem is that this is very slow, and should be unnecessary since `out` is a completely new object that we are assigning to, so we shouldn't have to duplicate the columns.

However, naively replacing that line with `r_maybe_duplicate()` or removing it entirely results in this problem where we lose row names:

```r
library(vctrs)
library(tibble)

df_x <- new_data_frame(list(x = 1:3), row.names = letters[1:3])
df_y <- new_data_frame(list(x = 4L), row.names = "d")

x <- tibble(dfcol = df_x)
y <- tibble(dfcol = df_y)

vec_rbind(x, y)$dfcol
#> New names:
#> * `` -> ...4
#> New names:
#> * `` -> ...1
#> * `` -> ...2
#> * `` -> ...3
#>   x
#> 1 1
#> 2 2
#> 3 3
#> 4 4
```

We lose them at the `vec_restore()` step here
https://github.com/r-lib/vctrs/blob/fd249275c79ccd01910c947f63296ea9c5e6aa99/src/slice-assign.c#L344

Note that in the call to `vec_restore()`, `assigned` and `out_elt` _are the same object_. This eventually passes through to `vec_restore_default()`. So when we get to this part of `vec_restore_default()` posted below we clear the attributes on `x` (`assigned`) by replacing them with `attrib`, which are the attributes of `to` (`out_elt`) but without a few of the core attributes, like the class. But because `x` and `to` are the same object, _this reset `to` as well_. So when we do the `is_data_frame(to)` check later on to decide if we should add row names on, it fails because `to` no longer has a class.

https://github.com/r-lib/vctrs/blob/fd249275c79ccd01910c947f63296ea9c5e6aa99/src/proxy-restore.c#L72-L82

I've fixed this for now by returning early from `vec_restore_default()` if we encounter identical objects. @lionel- does this seem like a reasonable fix?