### PR TITLE
Add fast path for identically named data frames in `df_ptype2()`

### DIFF
--- a/src/equal.c
+++ b/src/equal.c
@@ -160,7 +160,7 @@ SEXP vctrs_equal(SEXP x, SEXP y, SEXP na_equal_) {
     const CTYPE* p_y = CONST_DEREF(y);                    \
                                                           \
     for (R_len_t i = 0; i < n; ++i, ++p_x, ++p_y) {       \
-      if (!SCALAR_EQUAL(p_x, p_y, true)) {                \
+      if (!SCALAR_EQUAL(p_x, p_y)) {                      \
         return false;                                     \
       }                                                   \
     }                                                     \
@@ -171,7 +171,7 @@ SEXP vctrs_equal(SEXP x, SEXP y, SEXP na_equal_) {
 #define EQUAL_ALL_BARRIER(SCALAR_EQUAL)                   \
   do {                                                    \
     for (R_len_t i = 0; i < n; ++i) {                     \
-      if (!SCALAR_EQUAL(x, i, y, i, true)) {              \
+      if (!SCALAR_EQUAL(x, i, y, i)) {                    \
         return false;                                     \
       }                                                   \
     }                                                     \
@@ -279,14 +279,14 @@ bool equal_object(SEXP x, SEXP y) {
   }
 
   switch (type) {
-  case LGLSXP:  EQUAL_ALL(int, LOGICAL_RO, lgl_equal_scalar);
-  case INTSXP:  EQUAL_ALL(int, INTEGER_RO, int_equal_scalar);
-  case REALSXP: EQUAL_ALL(double, REAL_RO, dbl_equal_scalar);
-  case STRSXP:  EQUAL_ALL(SEXP, STRING_PTR_RO, chr_equal_scalar);
-  case RAWSXP:  EQUAL_ALL(Rbyte, RAW_RO, raw_equal_scalar);
-  case CPLXSXP: EQUAL_ALL(Rcomplex, COMPLEX_RO, cpl_equal_scalar);
+  case LGLSXP:  EQUAL_ALL(int, LOGICAL_RO, lgl_equal_scalar_na_equal);
+  case INTSXP:  EQUAL_ALL(int, INTEGER_RO, int_equal_scalar_na_equal);
+  case REALSXP: EQUAL_ALL(double, REAL_RO, dbl_equal_scalar_na_equal);
+  case STRSXP:  EQUAL_ALL(SEXP, STRING_PTR_RO, chr_equal_scalar_na_equal);
+  case RAWSXP:  EQUAL_ALL(Rbyte, RAW_RO, raw_equal_scalar_na_equal);
+  case CPLXSXP: EQUAL_ALL(Rcomplex, COMPLEX_RO, cpl_equal_scalar_na_equal);
   case EXPRSXP:
-  case VECSXP:  EQUAL_ALL_BARRIER(list_equal_scalar);
+  case VECSXP:  EQUAL_ALL_BARRIER(list_equal_scalar_na_equal);
   default:      Rf_errorcall(R_NilValue, "Internal error: Unexpected type in `equal_object()`");
   }
 }

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -287,46 +287,39 @@ SEXP vctrs_df_ptype2(SEXP x, SEXP y, SEXP x_arg, SEXP y_arg) {
   return df_ptype2(x, y, &x_arg_, &y_arg_);
 }
 
-static SEXP df_ptype2_impl(SEXP x, SEXP y,
-                           SEXP x_names, SEXP y_names,
-                           R_len_t x_len, R_len_t y_len,
+static SEXP df_ptype2_impl(SEXP x, SEXP y, SEXP x_names, SEXP y_names,
                            struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
 
-static SEXP df_ptype2_sequential(SEXP x, SEXP y,
-                                 SEXP names, R_len_t len,
+static SEXP df_ptype2_sequential(SEXP x, SEXP y, SEXP names,
                                  struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
-
-static bool identical_names(SEXP x_names, SEXP y_names, R_len_t x_len, R_len_t y_len);
 
 // [[ include("vctrs.h") ]]
 SEXP df_ptype2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) {
   SEXP x_names = PROTECT(r_names(x));
   SEXP y_names = PROTECT(r_names(y));
 
-  R_len_t x_len = Rf_length(x_names);
-  R_len_t y_len = Rf_length(y_names);
-
   SEXP out;
 
-  if (identical_names(x_names, y_names, x_len, y_len)) {
-    out = df_ptype2_sequential(x, y, x_names, x_len, x_arg, y_arg);
+  if (equal_object(x_names, y_names)) {
+    out = df_ptype2_sequential(x, y, x_names, x_arg, y_arg);
   } else {
-    out = df_ptype2_impl(x, y, x_names, y_names, x_len, y_len, x_arg, y_arg);
+    out = df_ptype2_impl(x, y, x_names, y_names, x_arg, y_arg);
   }
 
   UNPROTECT(2);
   return out;
 }
 
-SEXP df_ptype2_impl(SEXP x, SEXP y,
-                    SEXP x_names, SEXP y_names,
-                    R_len_t x_len, R_len_t y_len,
+SEXP df_ptype2_impl(SEXP x, SEXP y, SEXP x_names, SEXP y_names,
                     struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) {
   SEXP x_dups_pos = PROTECT(vec_match(x_names, y_names));
   SEXP y_dups_pos = PROTECT(vec_match(y_names, x_names));
 
   int* x_dups_pos_data = INTEGER(x_dups_pos);
   int* y_dups_pos_data = INTEGER(y_dups_pos);
+
+  R_len_t x_len = Rf_length(x_names);
+  R_len_t y_len = Rf_length(y_names);
 
   // Count columns that are only in `y`
   R_len_t rest_len = 0;
@@ -384,9 +377,10 @@ SEXP df_ptype2_impl(SEXP x, SEXP y,
   return out;
 }
 
-SEXP df_ptype2_sequential(SEXP x, SEXP y,
-                          SEXP names, R_len_t len,
+SEXP df_ptype2_sequential(SEXP x, SEXP y, SEXP names,
                           struct vctrs_arg* x_arg, struct vctrs_arg* y_arg) {
+  R_len_t len = Rf_length(names);
+
   SEXP out = PROTECT(Rf_allocVector(VECSXP, len));
   Rf_setAttrib(out, R_NamesSymbol, names);
 
@@ -413,30 +407,6 @@ SEXP df_ptype2_sequential(SEXP x, SEXP y,
 
   UNPROTECT(1);
   return out;
-}
-
-static bool identical_names(SEXP x_names, SEXP y_names, R_len_t x_len, R_len_t y_len) {
-  if (x_names == y_names) {
-    return true;
-  }
-
-  if (x_len != y_len) {
-    return false;
-  }
-
-  const SEXP* p_x_names = STRING_PTR_RO(x_names);
-  const SEXP* p_y_names = STRING_PTR_RO(y_names);
-
-  for (R_len_t i = 0; i < x_len; ++i) {
-    const SEXP x_name = p_x_names[i];
-    const SEXP y_name = p_y_names[i];
-
-    if (x_name != y_name) {
-      return false;
-    }
-  }
-
-  return true;
 }
 
 // [[ register() ]]


### PR DESCRIPTION
Closes #979 

This PR adds early exits for `df_ptype2()` when the names of the two data frames are either the exact same reference or have identical names. 

``` r
library(vctrs)
library(tibble)
library(rlang)
```

Empty tibble

```r
x <- tibble()

# Master
bench::mark(vec_ptype2(x, x), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(x, x)   2.22µs   2.97µs   319680.        0B     16.0

# This PR
bench::mark(vec_ptype2(x, x), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(x, x)   1.15µs   1.31µs   684663.        0B     20.5
```

1 row, 100 cols, identical names

```r
y <- as_tibble_row(set_names(as.list(1:100), paste0("a", 1:100)))

# Master
bench::mark(vec_ptype2(y, y), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(y, y)     11µs   13.9µs    66197.    6.42KB     7.94

# This PR
bench::mark(vec_ptype2(y, y), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(y, y)   5.11µs   5.58µs   162741.      848B     4.88
```

Same as before, but different objects with the same names so we have to loop through the names to check that they are identical.

```r
z1 <- as_tibble_row(set_names(as.list(1:100), paste0("a", 1:100)))
z2 <- as_tibble_row(set_names(as.list(1:100), paste0("a", 1:100)))

# Master
bench::mark(vec_ptype2(z1, z2))
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(z1, z2)   11.2µs   13.4µs    71764.    6.42KB     7.18

# This PR
bench::mark(vec_ptype2(z1, z2))
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(z1, z2)   6.91µs   7.74µs   120376.      848B     12.0
```

The last name is different here, everything else is the same. This is the worst case since we have to iterate through all the names and then fall back to matching.

```r
w1 <- as_tibble_row(set_names(as.list(1:100), paste0("a", 1:100)))
w2 <- as_tibble_row(set_names(as.list(1:100), c(paste0("a", 1:99), "a101")))

# Master
bench::mark(vec_ptype2(w1, w2))
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(w1, w2)   11.4µs   13.3µs    73539.    6.44KB     7.35

# This PR
bench::mark(vec_ptype2(w1, w2))
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype2(w1, w2)   11.6µs   16.5µs    58799.    6.44KB     5.88
```

Computing the common type of many data frames with identical names (like from `vec_chop()`)

```r
df <- tibble(x = 1:10000, y = 1:10000)
dfs <- vec_chop(df)

ptype_common <- function(x) {
  vec_ptype_common(!!!x)
}

# Master
bench::mark(ptype_common(dfs))
#> # A tibble: 1 x 6
#>   expression             min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 ptype_common(dfs)   19.9ms   23.4ms      42.6    6.92KB     47.3

# This PR
bench::mark(ptype_common(dfs))
#> # A tibble: 1 x 6
#>   expression             min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 ptype_common(dfs)   4.12ms   5.66ms      174.    6.92KB     16.2
```