### PR TITLE
Remove `vec_coercible_cast()`

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -136,14 +136,6 @@ vec_cast_common <- function(..., .to = NULL) {
   .External2(vctrs_cast_common, .to)
 }
 
-# Cast `x` to `to` but only if they are coercible
-vec_coercible_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
-  if (!missing(...)) {
-    ellipsis::check_dots_empty()
-  }
-  .Call(vctrs_coercible_cast, x, to, x_arg, to_arg)
-}
-
 #' Default cast method
 #'
 #' @description

--- a/R/type-list-of.R
+++ b/R/type-list-of.R
@@ -173,7 +173,7 @@ as.character.vctrs_list_of <- function(x, ...) {
 
 #' @export
 `$<-.vctrs_list_of` <- function(x, i, value) {
-  value <- vec_coercible_cast(value, attr(x, "ptype"), x_arg = "", to_arg = "")
+  value <- vec_cast(value, attr(x, "ptype"))
   NextMethod()
 }
 

--- a/R/type-list-of.R
+++ b/R/type-list-of.R
@@ -167,7 +167,7 @@ as.character.vctrs_list_of <- function(x, ...) {
     return(x)
   }
 
-  value <- vec_coercible_cast(value, attr(x, "ptype"), x_arg = "", to_arg = "")
+  value <- vec_cast(value, attr(x, "ptype"))
   NextMethod()
 }
 

--- a/R/type-list-of.R
+++ b/R/type-list-of.R
@@ -154,7 +154,7 @@ as.character.vctrs_list_of <- function(x, ...) {
 #' @export
 `[<-.vctrs_list_of` <- function(x, i, value) {
   wrapped_type <- attr(x, "ptype")
-  value <- map(value, vec_coercible_cast, to = wrapped_type, x_arg = "", to_arg = "")
+  value <- map(value, vec_cast, to = wrapped_type)
   value <- new_list_of(value, ptype = attr(x, "ptype"))
   NextMethod()
 }

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -225,7 +225,7 @@ diff.vctrs_vctr <- function(x, lag = 1L, differences = 1L, ...) {
 #' @export
 `[[<-.vctrs_vctr` <- function(x, ..., value) {
   if (!is.list(x)) {
-    value <- vec_coercible_cast(value, x, x_arg = "", to_arg = "")
+    value <- vec_cast(value, x)
   }
   NextMethod()
 }

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -242,7 +242,7 @@ diff.vctrs_vctr <- function(x, lag = 1L, differences = 1L, ...) {
 
 #' @export
 `[<-.vctrs_vctr` <- function(x, i, value) {
-  value <- vec_coercible_cast(value, x, x_arg = "", to_arg = "")
+  value <- vec_cast(value, x)
   NextMethod()
 }
 

--- a/R/vctrs-deprecated.R
+++ b/R/vctrs-deprecated.R
@@ -68,7 +68,7 @@ vec_as_index <- function(i, n, names = NULL) {
     "`vec_as_index()` is deprecated as of vctrs 0.2.2.",
     "Please use `vec_as_location() instead.`"
   ))
-  n <- vec_coercible_cast(n, integer())
+  n <- vec_cast(n, integer())
   vec_assert(n, integer(), 1L)
   i <- vec_as_subscript(i)
 

--- a/src/cast.c
+++ b/src/cast.c
@@ -286,14 +286,6 @@ SEXP vec_coercible_cast_e(SEXP x,
   return data.out;
 }
 
-// [[ register() ]]
-SEXP vctrs_coercible_cast(SEXP x, SEXP to, SEXP x_arg_, SEXP to_arg_) {
-  struct vctrs_arg x_arg = vec_as_arg(x_arg_);
-  struct vctrs_arg to_arg = vec_as_arg(to_arg_);
-
-  return vec_coercible_cast(x, to, &x_arg, &to_arg);
-}
-
 
 SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype);
 

--- a/src/cast.c
+++ b/src/cast.c
@@ -236,31 +236,26 @@ SEXP vctrs_is_coercible(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_) {
   return r_lgl(vec_is_coercible(x, y, &x_arg, &y_arg, &dir));
 }
 
-struct vec_coercible_cast_e_data {
+struct vec_cast_e_data {
   SEXP x;
   SEXP to;
   struct vctrs_arg* x_arg;
   struct vctrs_arg* to_arg;
   SEXP out;
 };
-static void vec_coercible_cast_e_cb(void* data_) {
-  struct vec_coercible_cast_e_data* data = (struct vec_coercible_cast_e_data*) data_;
+
+static void vec_cast_e_cb(void* data_) {
+  struct vec_cast_e_data* data = (struct vec_cast_e_data*) data_;
   data->out = vec_cast(data->x, data->to, data->x_arg, data->to_arg);
 }
 
 // [[ include("vctrs.h") ]]
-SEXP vec_coercible_cast_e(SEXP x,
-                          SEXP to,
-                          struct vctrs_arg* x_arg,
-                          struct vctrs_arg* to_arg,
-                          ERR* err) {
-  int dir;
-  vec_is_coercible_e(x, to, x_arg, to_arg, &dir, err);
-  if (*err) {
-    return R_NilValue;
-  }
-
-  struct vec_coercible_cast_e_data data = {
+SEXP vec_cast_e(SEXP x,
+                SEXP to,
+                struct vctrs_arg* x_arg,
+                struct vctrs_arg* to_arg,
+                ERR* err) {
+  struct vec_cast_e_data data = {
     .x = x,
     .to = to,
     .x_arg = x_arg,
@@ -268,7 +263,7 @@ SEXP vec_coercible_cast_e(SEXP x,
     .out = R_NilValue
   };
 
-  *err = r_try_catch(&vec_coercible_cast_e_cb,
+  *err = r_try_catch(&vec_cast_e_cb,
                      &data,
                      syms_vctrs_error_cast_lossy,
                      NULL,

--- a/src/cast.c
+++ b/src/cast.c
@@ -236,16 +236,6 @@ SEXP vctrs_is_coercible(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_) {
   return r_lgl(vec_is_coercible(x, y, &x_arg, &y_arg, &dir));
 }
 
-// [[ include("vctrs.h") ]]
-SEXP vec_coercible_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg) {
-  // Called for the side effect of generating an error if there is no
-  // common type
-  int _left;
-  vec_ptype2(x, to, x_arg, to_arg, &_left);
-
-  return vec_cast(x, to, x_arg, to_arg);
-}
-
 struct vec_coercible_cast_e_data {
   SEXP x;
   SEXP to;

--- a/src/init.c
+++ b/src/init.c
@@ -75,7 +75,6 @@ extern SEXP vctrs_proxy_info(SEXP);
 extern SEXP vctrs_class_type(SEXP);
 extern SEXP vec_bare_df_restore(SEXP, SEXP, SEXP);
 extern SEXP vctrs_recycle(SEXP, SEXP, SEXP);
-extern SEXP vctrs_coercible_cast(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_assign(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_assign_seq(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_set_attributes(SEXP, SEXP);
@@ -203,7 +202,6 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_class_type",                 (DL_FUNC) &vctrs_class_type, 1},
   {"vctrs_bare_df_restore",            (DL_FUNC) &vec_bare_df_restore, 3},
   {"vctrs_recycle",                    (DL_FUNC) &vctrs_recycle, 3},
-  {"vctrs_coercible_cast",             (DL_FUNC) &vctrs_coercible_cast, 4},
   {"vctrs_assign",                     (DL_FUNC) &vctrs_assign, 5},
   {"vctrs_assign_seq",                 (DL_FUNC) &vctrs_assign_seq, 5},
   {"vctrs_set_attributes",             (DL_FUNC) &vctrs_set_attributes, 2},

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -48,7 +48,7 @@ SEXP vctrs_assign_seq(SEXP x, SEXP value, SEXP start, SEXP size, SEXP increasing
   const struct vec_assign_opts* opts = &vec_assign_default_opts;
 
   // Cast and recycle `value`
-  value = PROTECT(vec_coercible_cast(value, x, opts->value_arg, opts->x_arg));
+  value = PROTECT(vec_cast(value, x, opts->value_arg, opts->x_arg));
   value = PROTECT(vec_recycle(value, vec_subscript_size(index), opts->value_arg));
 
   SEXP proxy = PROTECT(vec_proxy(x));
@@ -76,7 +76,7 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
                                        location_default_assign_opts));
 
   // Cast and recycle `value`
-  value = PROTECT(vec_coercible_cast(value, x, opts->value_arg, opts->x_arg));
+  value = PROTECT(vec_cast(value, x, opts->value_arg, opts->x_arg));
   value = PROTECT(vec_recycle(value, vec_size(index), opts->value_arg));
 
   SEXP proxy = PROTECT(vec_proxy(x));

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -390,7 +390,7 @@ SEXP vctrs_as_location(SEXP subscript, SEXP n_, SEXP names,
     n = Rf_length(subscript);
   } else {
     if (OBJECT(n_) || TYPEOF(n_) != INTSXP) {
-      n_ = vec_coercible_cast(n_, vctrs_shared_empty_int, args_empty, args_empty);
+      n_ = vec_cast(n_, vctrs_shared_empty_int, args_empty, args_empty);
     }
     PROTECT(n_);
 

--- a/src/subscript.c
+++ b/src/subscript.c
@@ -174,11 +174,11 @@ static SEXP dbl_cast_subscript_fallback(SEXP subscript,
                                         const struct subscript_opts* opts,
                                         ERR* err) {
 
-  SEXP out = PROTECT(vec_coercible_cast_e(subscript,
-                                          vctrs_shared_empty_int,
-                                          opts->subscript_arg,
-                                          NULL,
-                                          err));
+  SEXP out = PROTECT(vec_cast_e(subscript,
+                                vctrs_shared_empty_int,
+                                opts->subscript_arg,
+                                NULL,
+                                err));
   if (*err) {
     SEXP err_obj = PROTECT(*err);
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -364,7 +364,6 @@ SEXP vec_bare_dim(SEXP x);
 R_len_t vec_bare_dim_n(SEXP x);
 SEXP vec_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_cast_common(SEXP xs, SEXP to);
-SEXP vec_coercible_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_coercible_cast_e(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg, ERR* err);
 bool vec_is_coercible(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg, int* dir);
 SEXP vec_slice(SEXP x, SEXP subscript);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -364,7 +364,7 @@ SEXP vec_bare_dim(SEXP x);
 R_len_t vec_bare_dim_n(SEXP x);
 SEXP vec_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_cast_common(SEXP xs, SEXP to);
-SEXP vec_coercible_cast_e(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg, ERR* err);
+SEXP vec_cast_e(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg, ERR* err);
 bool vec_is_coercible(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg, int* dir);
 SEXP vec_slice(SEXP x, SEXP subscript);
 SEXP vec_slice_impl(SEXP x, SEXP subscript);

--- a/tests/testthat/error/test-slice-assign.txt
+++ b/tests/testthat/error/test-slice-assign.txt
@@ -60,7 +60,7 @@ i Subscript has a missing value at location 2.
 ===========================================
 
 > vec_assign(1:2, 1L, "x", x_arg = "foo", value_arg = "bar")
-Error: Can't combine `bar` <character> and `foo` <integer>.
+Error: Can't convert `bar` <character> to `foo` <integer>.
 
 > vec_assign(1:2, 1L, 1:2, value_arg = "bar")
 Error: Input `bar` can't be recycled to size 1.

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -40,12 +40,6 @@ test_that("empty input to vec_cast_common() returns list()", {
 
 test_that("identical structures can be cast to each other", {
   expect_identical(vec_cast(foobar("foo"), foobar("bar")), foobar("foo"))
-  expect_identical(vec_coercible_cast(foobar("foo"), foobar("bar")), foobar("foo"))
-})
-
-test_that("inputs to vec_coercible_cast() are checked", {
-  expect_error(vec_coercible_cast("", "", x_arg = 1), "must be a string")
-  expect_error(vec_coercible_cast("", "", to_arg = chr()), "must be a string")
 })
 
 test_that("cast common preserves names", {


### PR DESCRIPTION
Closes #969 

Replaces all usage of `vec_coercible_cast()` with `vec_cast()` and removes `vec_coercible_cast()`.

The C level `vec_coercible_cast_e()` has been replaced with `vec_cast_e()`