### PR TITLE
Unclass `as.data.frame2()` input to avoid dispatch on `as.data.frame()`

### DIFF
--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -305,8 +305,13 @@ as.POSIXlt.vctrs_vctr <- function(x, tz = "", ...) {
   vec_cast(x, to)
 }
 
-# Work around inconsistencies in as.data.frame() for 1D arrays
+# Work around inconsistencies in as.data.frame()
 as.data.frame2 <- function(x) {
+  # Unclass to avoid dispatching on `as.data.frame()` methods that break size
+  # invariants, like `as.data.frame.table()` (#913). This also prevents infinite
+  # recursion with shaped vctrs in `as.data.frame.vctrs_vctr()`.
+  x <- unclass(x)
+
   out <- as.data.frame(x)
 
   if (vec_dim_n(x) == 1) {
@@ -329,7 +334,7 @@ as.data.frame.vctrs_vctr <- function(x,
   force(nm)
 
   if (has_dim(x)) {
-    return(as.data.frame2(vec_data(x)))
+    return(as.data.frame2(x))
   }
 
   cols <- list(x)

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -142,6 +142,21 @@ test_that("can rbind POSIXlt objects into POSIXct objects", {
   expect_named(vec_rbind(datetime_named, datetime_named), "col")
 })
 
+test_that("can rbind table objects (#913)", {
+  x <- new_table(1:4, c(2L, 2L))
+  y <- x
+
+  colnames <- c("c1", "c2")
+  rownames <- c("r1", "r2", "r3", "r4")
+
+  dimnames(x) <- list(rownames[1:2], colnames)
+  dimnames(y) <- list(rownames[3:4], colnames)
+
+  expect <- data.frame(c1 = c(1:2, 1:2), c2 = c(3:4, 3:4), row.names = rownames)
+
+  expect_identical(vec_rbind(x, y), expect)
+})
+
 test_that("can rbind missing vectors", {
   expect_identical(vec_rbind(na_int), data_frame(...1 = na_int))
   expect_identical(vec_rbind(na_int, na_int), data_frame(...1 = int(na_int, na_int)))

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -107,6 +107,21 @@ test_that("as.data.frame creates data frame", {
   expect_named(df, "x")
 })
 
+test_that("as.data.frame on shaped vctrs doesn't bring along extra attributes", {
+  x <- new_vctr(1:3, foo = "bar", dim = c(3L, 1L))
+  df <- as.data.frame(x)
+  expect_null(attr(df, "foo", exact = TRUE))
+})
+
+test_that("as.data.frame2() unclasses input to avoid dispatch on as.data.frame()", {
+  x <- structure(1:2, dim = c(1L, 2L), dimnames = list("r1", c("c1", "c2")), class = "foo")
+  expect <- data.frame(c1 = 1L, c2 = 2L, row.names = "r1")
+
+  local_methods(as.data.frame.foo = function(x, ...) "dispatched!")
+
+  expect_identical(as.data.frame2(x), expect)
+})
+
 test_that("as.list() chops vectors", {
   expect_identical(
     as.list(new_vctr(1:3)),


### PR DESCRIPTION
Closes #913 

We now unclass input in `as.data.frame2()` to avoid dispatching on `as.data.frame()` methods that might not respect size invariants (or that generally don't do what we expect)