### PR TITLE
Add `x_arg` to `vec_ptype()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # vctrs (development version)
 
+* `vec_ptype()` gained an `x_arg` argument.
+
 * `stop_incompatible_cast()` now throws an error of class
   `vctrs_error_incompatible_type` rather than `vctrs_error_incompatible_cast`.
   This means that `vec_cast()` also throws errors of this class, which better

--- a/R/type.R
+++ b/R/type.R
@@ -5,7 +5,13 @@
 #' `vec_ptype_show()` nicely prints the common type of any number of
 #' inputs, and is designed for interactive exploration.
 #'
-#' @param ...,x Vectors inputs
+#' @param x A vector
+#' @param ... For `vec_ptype()`, these dots are for future extensions and must
+#'   be empty.
+#'
+#'   For `vec_ptype_common()` and `vec_ptype_show()`, vector inputs.
+#' @param x_arg Argument name for `x`. This is used in error messages to inform
+#'   the user about the locations of incompatible types.
 #' @param .ptype If `NULL`, the default, the output type is determined by
 #'   computing the common type across all elements of `...`.
 #'
@@ -77,8 +83,11 @@
 #'   data.frame(y = 2),
 #'   data.frame(z = "a")
 #' )
-vec_ptype <- function(x) {
-  .Call(vctrs_ptype, x)
+vec_ptype <- function(x, ..., x_arg = "") {
+  if (!missing(...)) {
+    ellipsis::check_dots_empty()
+  }
+  .Call(vctrs_ptype, x, x_arg)
 }
 
 #' @export

--- a/R/type.R
+++ b/R/type.R
@@ -78,7 +78,7 @@
 #'   data.frame(z = "a")
 #' )
 vec_ptype <- function(x) {
-  .Call(vctrs_type, x)
+  .Call(vctrs_ptype, x)
 }
 
 #' @export

--- a/R/type2.R
+++ b/R/type2.R
@@ -76,7 +76,7 @@ vec_default_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
   }
 
   if (is_same_type(x, y)) {
-    return(vec_ptype(x))
+    return(vec_ptype(x, x_arg = x_arg))
   }
 
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)

--- a/man/vec_ptype.Rd
+++ b/man/vec_ptype.Rd
@@ -6,14 +6,22 @@
 \alias{vec_ptype_show}
 \title{Find the prototype of a set of vectors}
 \usage{
-vec_ptype(x)
+vec_ptype(x, ..., x_arg = "")
 
 vec_ptype_common(..., .ptype = NULL)
 
 vec_ptype_show(...)
 }
 \arguments{
-\item{..., x}{Vectors inputs}
+\item{x}{A vector}
+
+\item{...}{For \code{vec_ptype()}, these dots are for future extensions and must
+be empty.
+
+For \code{vec_ptype_common()} and \code{vec_ptype_show()}, vector inputs.}
+
+\item{x_arg}{Argument name for \code{x}. This is used in error messages to inform
+the user about the locations of incompatible types.}
 
 \item{.ptype}{If \code{NULL}, the default, the output type is determined by
 computing the common type across all elements of \code{...}.

--- a/src/init.c
+++ b/src/init.c
@@ -59,7 +59,7 @@ extern SEXP vec_restore_default(SEXP, SEXP);
 extern SEXP vec_proxy(SEXP);
 extern SEXP vec_proxy_equal(SEXP);
 extern SEXP vctrs_unspecified(SEXP);
-extern SEXP vec_type(SEXP);
+extern SEXP vec_ptype(SEXP);
 extern SEXP vec_ptype_finalise(SEXP);
 extern SEXP vctrs_minimal_names(SEXP);
 extern SEXP vctrs_unique_names(SEXP, SEXP);
@@ -187,7 +187,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_proxy",                      (DL_FUNC) &vec_proxy, 1},
   {"vctrs_proxy_equal",                (DL_FUNC) &vec_proxy_equal, 1},
   {"vctrs_unspecified",                (DL_FUNC) &vctrs_unspecified, 1},
-  {"vctrs_type",                       (DL_FUNC) &vec_type, 1},
+  {"vctrs_ptype",                      (DL_FUNC) &vec_ptype, 1},
   {"vctrs_ptype_finalise",             (DL_FUNC) &vec_ptype_finalise, 1},
   {"vctrs_minimal_names",              (DL_FUNC) &vctrs_minimal_names, 1},
   {"vctrs_unique_names",               (DL_FUNC) &vctrs_unique_names, 2},

--- a/src/init.c
+++ b/src/init.c
@@ -59,7 +59,7 @@ extern SEXP vec_restore_default(SEXP, SEXP);
 extern SEXP vec_proxy(SEXP);
 extern SEXP vec_proxy_equal(SEXP);
 extern SEXP vctrs_unspecified(SEXP);
-extern SEXP vec_ptype(SEXP);
+extern SEXP vctrs_ptype(SEXP, SEXP);
 extern SEXP vec_ptype_finalise(SEXP);
 extern SEXP vctrs_minimal_names(SEXP);
 extern SEXP vctrs_unique_names(SEXP, SEXP);
@@ -187,7 +187,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_proxy",                      (DL_FUNC) &vec_proxy, 1},
   {"vctrs_proxy_equal",                (DL_FUNC) &vec_proxy_equal, 1},
   {"vctrs_unspecified",                (DL_FUNC) &vctrs_unspecified, 1},
-  {"vctrs_ptype",                      (DL_FUNC) &vec_ptype, 1},
+  {"vctrs_ptype",                      (DL_FUNC) &vctrs_ptype, 2},
   {"vctrs_ptype_finalise",             (DL_FUNC) &vec_ptype_finalise, 1},
   {"vctrs_minimal_names",              (DL_FUNC) &vctrs_minimal_names, 1},
   {"vctrs_unique_names",               (DL_FUNC) &vctrs_unique_names, 2},

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -342,7 +342,7 @@ SEXP df_ptype2_impl(SEXP x, SEXP y, SEXP x_names, SEXP y_names,
 
     SEXP type;
     if (dup == NA_INTEGER) {
-      type = vec_type(VECTOR_ELT(x, i));
+      type = vec_ptype(VECTOR_ELT(x, i));
     } else {
       --dup; // 1-based index
       struct arg_data_index x_arg_data = new_index_arg_data(r_chr_get_c_string(x_names, i), x_arg);
@@ -365,7 +365,7 @@ SEXP df_ptype2_impl(SEXP x, SEXP y, SEXP x_names, SEXP y_names,
   for (R_len_t j = 0; i < out_len; ++j) {
     R_len_t dup = y_dups_pos_data[j];
     if (dup == NA_INTEGER) {
-      SET_VECTOR_ELT(out, i, vec_type(VECTOR_ELT(y, j)));
+      SET_VECTOR_ELT(out, i, vec_ptype(VECTOR_ELT(y, j)));
       SET_STRING_ELT(nms, i, STRING_ELT(y_names, j));
       ++i;
     }

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -340,16 +340,20 @@ SEXP df_ptype2_impl(SEXP x, SEXP y, SEXP x_names, SEXP y_names,
   for (; i < x_len; ++i) {
     R_len_t dup = x_dups_pos_data[i];
 
+    struct arg_data_index x_arg_data = new_index_arg_data(r_chr_get_c_string(x_names, i), x_arg);
+    struct vctrs_arg named_x_arg = new_index_arg(x_arg, &x_arg_data);
+
     SEXP type;
     if (dup == NA_INTEGER) {
-      type = vec_ptype(VECTOR_ELT(x, i));
+      type = vec_ptype(VECTOR_ELT(x, i), &named_x_arg);
     } else {
       --dup; // 1-based index
-      struct arg_data_index x_arg_data = new_index_arg_data(r_chr_get_c_string(x_names, i), x_arg);
+
       struct arg_data_index y_arg_data = new_index_arg_data(r_chr_get_c_string(y_names, dup), y_arg);
-      struct vctrs_arg named_x_arg = new_index_arg(x_arg, &x_arg_data);
       struct vctrs_arg named_y_arg = new_index_arg(y_arg, &y_arg_data);
+
       int _left;
+
       type = vec_ptype2(VECTOR_ELT(x, i),
                         VECTOR_ELT(y, dup),
                         &named_x_arg,
@@ -365,7 +369,10 @@ SEXP df_ptype2_impl(SEXP x, SEXP y, SEXP x_names, SEXP y_names,
   for (R_len_t j = 0; i < out_len; ++j) {
     R_len_t dup = y_dups_pos_data[j];
     if (dup == NA_INTEGER) {
-      SET_VECTOR_ELT(out, i, vec_ptype(VECTOR_ELT(y, j)));
+      struct arg_data_index y_arg_data = new_index_arg_data(r_chr_get_c_string(y_names, j), y_arg);
+      struct vctrs_arg named_y_arg = new_index_arg(y_arg, &y_arg_data);
+
+      SET_VECTOR_ELT(out, i, vec_ptype(VECTOR_ELT(y, j), &named_y_arg));
       SET_STRING_ELT(nms, i, STRING_ELT(y_names, j));
       ++i;
     }

--- a/src/type.c
+++ b/src/type.c
@@ -11,7 +11,7 @@ static SEXP vec_type_slice(SEXP x, SEXP empty);
 static SEXP s3_type(SEXP x);
 
 // [[ include("vctrs.h"); register() ]]
-SEXP vec_type(SEXP x) {
+SEXP vec_ptype(SEXP x) {
   switch (vec_typeof(x)) {
   case vctrs_type_null:        return R_NilValue;
   case vctrs_type_unspecified: return vctrs_shared_empty_uns;
@@ -22,7 +22,7 @@ SEXP vec_type(SEXP x) {
   case vctrs_type_character:   return vec_type_slice(x, vctrs_shared_empty_chr);
   case vctrs_type_raw:         return vec_type_slice(x, vctrs_shared_empty_raw);
   case vctrs_type_list:        return vec_type_slice(x, vctrs_shared_empty_list);
-  case vctrs_type_dataframe:   return bare_df_map(x, &vec_type);
+  case vctrs_type_dataframe:   return bare_df_map(x, &vec_ptype);
   case vctrs_type_s3:          return s3_type(x);
   case vctrs_type_scalar:      stop_scalar_type(x, args_empty);
   }
@@ -40,16 +40,16 @@ static SEXP vec_type_slice(SEXP x, SEXP empty) {
 static SEXP s3_type(SEXP x) {
   switch (class_type(x)) {
   case vctrs_class_bare_tibble:
-    return bare_df_map(x, &vec_type);
+    return bare_df_map(x, &vec_ptype);
 
   case vctrs_class_data_frame:
-    return df_map(x, &vec_type);
+    return df_map(x, &vec_ptype);
 
   case vctrs_class_bare_data_frame:
-    Rf_errorcall(R_NilValue, "Internal error: Bare data frames should be handled by `vec_type()`");
+    Rf_errorcall(R_NilValue, "Internal error: Bare data frames should be handled by `vec_ptype()`");
 
   case vctrs_class_none:
-    Rf_errorcall(R_NilValue, "Internal error: Non-S3 classes should be handled by `vec_type()`");
+    Rf_errorcall(R_NilValue, "Internal error: Non-S3 classes should be handled by `vec_ptype()`");
 
   default:
     break;
@@ -143,7 +143,7 @@ SEXP vctrs_type_common(SEXP call, SEXP op, SEXP args, SEXP env) {
 
 SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype) {
   if (!vec_is_partial(ptype)) {
-    return vec_type(ptype);
+    return vec_ptype(ptype);
   }
 
   if (r_is_true(r_peek_option("vctrs.no_guessing"))) {

--- a/src/type2.c
+++ b/src/type2.c
@@ -20,24 +20,24 @@ SEXP vec_ptype2(SEXP x, SEXP y,
       vec_assert(y, y_arg);
     }
     *left = y == R_NilValue;
-    return vec_type(y);
+    return vec_ptype(y);
   }
   if (y == R_NilValue) {
     if (!vec_is_partial(x)) {
       vec_assert(x, x_arg);
     }
     *left = x == R_NilValue;
-    return vec_type(x);
+    return vec_ptype(x);
   }
 
   enum vctrs_type type_x = vec_typeof(x);
   enum vctrs_type type_y = vec_typeof(y);
 
   if (type_x == vctrs_type_unspecified) {
-    return vec_type(y);
+    return vec_ptype(y);
   }
   if (type_y == vctrs_type_unspecified) {
-    return vec_type(x);
+    return vec_ptype(x);
   }
 
   if (has_dim(x) || has_dim(y)) {

--- a/src/type2.c
+++ b/src/type2.c
@@ -16,28 +16,22 @@ SEXP vec_ptype2(SEXP x, SEXP y,
                struct vctrs_arg* y_arg,
                int* left) {
   if (x == R_NilValue) {
-    if (!vec_is_partial(y)) {
-      vec_assert(y, y_arg);
-    }
     *left = y == R_NilValue;
-    return vec_ptype(y);
+    return vec_ptype(y, y_arg);
   }
   if (y == R_NilValue) {
-    if (!vec_is_partial(x)) {
-      vec_assert(x, x_arg);
-    }
     *left = x == R_NilValue;
-    return vec_ptype(x);
+    return vec_ptype(x, x_arg);
   }
 
   enum vctrs_type type_x = vec_typeof(x);
   enum vctrs_type type_y = vec_typeof(y);
 
   if (type_x == vctrs_type_unspecified) {
-    return vec_ptype(y);
+    return vec_ptype(y, y_arg);
   }
   if (type_y == vctrs_type_unspecified) {
-    return vec_ptype(x);
+    return vec_ptype(x, x_arg);
   }
 
   if (has_dim(x) || has_dim(y)) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -1454,6 +1454,7 @@ SEXP fns_names = NULL;
 SEXP result_attrib = NULL;
 
 struct vctrs_arg args_empty_;
+struct vctrs_arg args_dot_ptype_;
 
 
 SEXP r_new_shared_vector(SEXPTYPE type, R_len_t n) {
@@ -1700,6 +1701,7 @@ void vctrs_init_utils(SEXP ns) {
   R_PreserveObject(rlang_formula_formals);
 
   args_empty_ = new_wrapper_arg(NULL, "");
+  args_dot_ptype_ = new_wrapper_arg(NULL, ".ptype");
 
   rlang_is_splice_box = (bool (*)(SEXP)) R_GetCCallable("rlang", "rlang_is_splice_box");
   rlang_unbox = (SEXP (*)(SEXP)) R_GetCCallable("rlang", "rlang_unbox");

--- a/src/utils.h
+++ b/src/utils.h
@@ -124,6 +124,9 @@ SEXP node_compact_d(SEXP xs);
 extern struct vctrs_arg args_empty_;
 static struct vctrs_arg* const args_empty = &args_empty_;
 
+extern struct vctrs_arg args_dot_ptype_;
+static struct vctrs_arg* const args_dot_ptype = &args_dot_ptype_;
+
 void never_reached(const char* fn) __attribute__((noreturn));
 
 enum vctrs_type2 vec_typeof2_impl(enum vctrs_type type_x, enum vctrs_type type_y, int* left);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -376,7 +376,7 @@ SEXP vec_proxy_assign(SEXP proxy, SEXP index, SEXP value);
 SEXP vec_assign_shaped(SEXP proxy, SEXP index, SEXP value);
 bool vec_requires_fallback(SEXP x, struct vctrs_proxy_info info);
 SEXP vec_init(SEXP x, R_len_t n);
-SEXP vec_ptype(SEXP x);
+SEXP vec_ptype(SEXP x, struct vctrs_arg* x_arg);
 SEXP vec_ptype_finalise(SEXP x);
 bool vec_is_unspecified(SEXP x);
 SEXP vec_recycle(SEXP x, R_len_t size, struct vctrs_arg* x_arg);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -376,7 +376,7 @@ SEXP vec_proxy_assign(SEXP proxy, SEXP index, SEXP value);
 SEXP vec_assign_shaped(SEXP proxy, SEXP index, SEXP value);
 bool vec_requires_fallback(SEXP x, struct vctrs_proxy_info info);
 SEXP vec_init(SEXP x, R_len_t n);
-SEXP vec_type(SEXP x);
+SEXP vec_ptype(SEXP x);
 SEXP vec_ptype_finalise(SEXP x);
 bool vec_is_unspecified(SEXP x);
 SEXP vec_recycle(SEXP x, R_len_t size, struct vctrs_arg* x_arg);

--- a/tests/testthat/error/test-type2.txt
+++ b/tests/testthat/error/test-type2.txt
@@ -1,0 +1,20 @@
+
+can override scalar vector error message for base scalar types
+==============================================================
+
+> vec_ptype2(NULL, quote(x), y_arg = "foo")
+Error: `foo` must be a vector, not a symbol.
+
+> vec_ptype2(quote(x), NULL, x_arg = "foo")
+Error: `foo` must be a vector, not a symbol.
+
+
+can override scalar vector error message for S3 types
+=====================================================
+
+> vec_ptype2(NULL, foobar(), y_arg = "foo")
+Error: `foo` must be a vector, not a `vctrs_foobar` object.
+
+> vec_ptype2(foobar(), NULL, x_arg = "foo")
+Error: `foo` must be a vector, not a `vctrs_foobar` object.
+

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -191,3 +191,26 @@ test_that("vec_is_subtype() determines subtyping relationship", {
   expect_true(vec_is_subtype(foobar(TRUE), lgl()))
   expect_false(vec_is_subtype(lgl(), foobar(TRUE)))
 })
+
+test_that("can override scalar vector error message for base scalar types", {
+  expect_error(vec_ptype2(NULL, quote(x), y_arg = "foo"), class = "vctrs_error_scalar_type")
+  expect_error(vec_ptype2(quote(x), NULL, x_arg = "foo"), class = "vctrs_error_scalar_type")
+})
+
+test_that("can override scalar vector error message for S3 types", {
+  expect_error(vec_ptype2(NULL, foobar(), y_arg = "foo"), class = "vctrs_error_scalar_type")
+  expect_error(vec_ptype2(foobar(), NULL, x_arg = "foo"), class = "vctrs_error_scalar_type")
+})
+
+test_that("vec_ptype2() errors have informative output", {
+  verify_output(test_path("error", "test-type2.txt"), {
+    "# can override scalar vector error message for base scalar types"
+    vec_ptype2(NULL, quote(x), y_arg = "foo")
+    vec_ptype2(quote(x), NULL, x_arg = "foo")
+
+    "# can override scalar vector error message for S3 types"
+    vec_ptype2(NULL, foobar(), y_arg = "foo")
+    vec_ptype2(foobar(), NULL, x_arg = "foo")
+  })
+})
+

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -193,13 +193,17 @@ test_that("vec_is_subtype() determines subtyping relationship", {
 })
 
 test_that("can override scalar vector error message for base scalar types", {
-  expect_error(vec_ptype2(NULL, quote(x), y_arg = "foo"), class = "vctrs_error_scalar_type")
-  expect_error(vec_ptype2(quote(x), NULL, x_arg = "foo"), class = "vctrs_error_scalar_type")
+  verify_errors({
+    expect_error(vec_ptype2(NULL, quote(x), y_arg = "foo"), class = "vctrs_error_scalar_type")
+    expect_error(vec_ptype2(quote(x), NULL, x_arg = "foo"), class = "vctrs_error_scalar_type")
+  })
 })
 
 test_that("can override scalar vector error message for S3 types", {
-  expect_error(vec_ptype2(NULL, foobar(), y_arg = "foo"), class = "vctrs_error_scalar_type")
-  expect_error(vec_ptype2(foobar(), NULL, x_arg = "foo"), class = "vctrs_error_scalar_type")
+  verify_errors({
+    expect_error(vec_ptype2(NULL, foobar(), y_arg = "foo"), class = "vctrs_error_scalar_type")
+    expect_error(vec_ptype2(foobar(), NULL, x_arg = "foo"), class = "vctrs_error_scalar_type")
+  })
 })
 
 test_that("vec_ptype2() errors have informative output", {


### PR DESCRIPTION
This PR follows up on the notes in #823 and gives `vec_ptype()` an `x_arg` argument.

I also took the chance to finally switch `vec_type()` to `vec_ptype()` internally.

The nicest thing about this is a small simplification to `vec_ptype2()`, where we no longer have to do a `vec_assert()` that is guarded by a `!vec_is_partial()` before calling `vec_ptype()`. Because of #823, `vec_ptype()` handles partial types, base R scalars (like `quote(x)`), and classed scalars (like `foobar()`) correctly. Now that we can pass the `x_arg` through to `vec_ptype()`, we don't need this check anymore.