### PR TITLE
Link to pkgdown site in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Description: Defines new notions of prototype and size that are
     and size-recycling, and are in turn connected to ideas of type- and
     size-stability useful for analysing function interfaces.
 License: GPL-3
-URL: https://vctrs.r-lib.org/, https://github.com/r-lib/vctrs
+URL: https://vctrs.r-lib.org/
 BugReports: https://github.com/r-lib/vctrs/issues
 Depends: 
     R (>= 3.2)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Description: Defines new notions of prototype and size that are
     and size-recycling, and are in turn connected to ideas of type- and
     size-stability useful for analysing function interfaces.
 License: GPL-3
-URL: https://github.com/r-lib/vctrs
+URL: https://vctrs.r-lib.org/, https://github.com/r-lib/vctrs
 BugReports: https://github.com/r-lib/vctrs/issues
 Depends: 
     R (>= 3.2)


### PR DESCRIPTION
Not sure if you want this or not, but I'd rather my pkgdown links to `vctrs::vec_cast()` go to your site rather than rdrr.io! Cheers!