### PR TITLE
Zap input names by default in `vec_rbind()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* `vec_rbind()` gains option to treat input names as row names. This
+  is disabled by default (#966).
+
 * `vec_ptype()` gained an `x_arg` argument.
 
 * `stop_incompatible_cast()` now throws an error of class

--- a/R/bind.R
+++ b/R/bind.R
@@ -40,10 +40,15 @@
 #'
 #'   `NULL` inputs are silently ignored. Empty (e.g. zero row) inputs
 #'   will not appear in the output, but will affect the derived `.ptype`.
-#' @param .names_to Optionally, the name of a column where the names
-#'   of `...` arguments are copied. These names are useful to identify
-#'   which row comes from which input. If supplied and `...` is not named,
-#'   an integer column is used to identify the rows.
+#' @param .names_to
+#'   * By default, input names are [zapped][rlang::zap].
+#'
+#'   * If a string, specifies a column where the input names will be
+#'     copied. These names are often useful to identify rows with
+#'     their original input. If a column name is supplied and `...` is
+#'     not named, an integer column is used instead.
+#'
+#'   * If `NULL`, the input names are used as row names.
 #' @param .name_repair One of `"unique"`, `"universal"`, or
 #'   `"check_unique"`. See [vec_as_names()] for the meaning of these
 #'   options.
@@ -140,7 +145,7 @@ NULL
 #' @rdname vec_bind
 vec_rbind <- function(...,
                       .ptype = NULL,
-                      .names_to = NULL,
+                      .names_to = rlang::zap(),
                       .name_repair = c("unique", "universal", "check_unique")) {
   .External2(vctrs_rbind, .ptype, .names_to, .name_repair)
 }

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -9,7 +9,7 @@
 vec_rbind(
   ...,
   .ptype = NULL,
-  .names_to = NULL,
+  .names_to = rlang::zap(),
   .name_repair = c("unique", "universal", "check_unique")
 )
 
@@ -42,10 +42,16 @@ Alternatively, you can supply \code{.ptype} to give the output known type.
 If \code{getOption("vctrs.no_guessing")} is \code{TRUE} you must supply this value:
 this is a convenient way to make production code demand fixed types.}
 
-\item{.names_to}{Optionally, the name of a column where the names
-of \code{...} arguments are copied. These names are useful to identify
-which row comes from which input. If supplied and \code{...} is not named,
-an integer column is used to identify the rows.}
+\item{.names_to}{\itemize{
+\item By default, input names are \link[rlang:zap]{zapped}.
+\itemize{
+\item If a string, specifies a column where the input names will be
+copied. These names are often useful to identify rows with
+their original input. If a column name is supplied and \code{...} is
+not named, an integer column is used instead.
+\item If \code{NULL}, the input names are used as row names.
+}
+}}
 
 \item{.name_repair}{One of \code{"unique"}, \code{"universal"}, or
 \code{"check_unique"}. See \code{\link[=vec_as_names]{vec_as_names()}} for the meaning of these

--- a/src/bind.c
+++ b/src/bind.c
@@ -22,10 +22,14 @@ SEXP vctrs_rbind(SEXP call, SEXP op, SEXP args, SEXP env) {
   SEXP name_repair = PROTECT(Rf_eval(CAR(args), env));
 
   if (names_to != R_NilValue) {
-    if (!r_is_string(names_to)) {
-      Rf_errorcall(R_NilValue, "`.names_to` must be `NULL` or a string.");
+    if (Rf_inherits(names_to, "rlang_zap")) {
+      r_poke_names(xs, R_NilValue);
+      names_to = R_NilValue;
+    } else if (r_is_string(names_to)) {
+      names_to = r_chr_get(names_to, 0);
+    } else {
+      Rf_errorcall(R_NilValue, "`.names_to` must be `NULL`, a string, or an `rlang::zap()` object.");
     }
-    names_to = r_chr_get(names_to, 0);
   }
 
   struct name_repair_opts name_repair_opts = validate_bind_name_repair(name_repair, false);

--- a/tests/testthat/output/bind-name-repair.txt
+++ b/tests/testthat/output/bind-name-repair.txt
@@ -2,7 +2,6 @@
 vec_rbind()
 ===========
 
-> # Suboptimal
 > vec_rbind(1, 2)
 Message: New names:
 * `` -> ...1
@@ -14,8 +13,33 @@ Message: New names:
 1    1
 2    2
 
-> # Suboptimal
+> vec_rbind(1, 2, .names_to = NULL)
+Message: New names:
+* `` -> ...1
+
+Message: New names:
+* `` -> ...1
+
+  ...1
+1    1
+2    2
+
 > vec_rbind(1, 2, ...10 = 3)
+Message: New names:
+* `` -> ...1
+
+Message: New names:
+* `` -> ...1
+
+Message: New names:
+* `` -> ...1
+
+  ...1
+1    1
+2    2
+3    3
+
+> vec_rbind(1, 2, ...10 = 3, .names_to = NULL)
 Message: New names:
 * `` -> ...1
 
@@ -43,10 +67,26 @@ Message: New names:
 * `` -> ...1
 
   ...1
+1    1
+2    2
+
+> vec_rbind(a = 1, b = 2, .names_to = NULL)
+Message: New names:
+* `` -> ...1
+
+Message: New names:
+* `` -> ...1
+
+  ...1
 a    1
 b    2
 
 > vec_rbind(c(a = 1), c(b = 2))
+   a  b
+1  1 NA
+2 NA  2
+
+> vec_rbind(c(a = 1), c(b = 2), .names_to = NULL)
    a  b
 1  1 NA
 2 NA  2

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -220,7 +220,11 @@ test_that("can assign row names in vec_rbind()", {
   df2 <- mtcars[4:5, ]
 
   # Combination
-  out <- vec_rbind(foo = df1, df2)
+  out <- vec_rbind(
+    foo = df1,
+    df2,
+    .names_to = NULL
+  )
   exp <- mtcars[1:5, ]
   row.names(exp) <- c(paste0("foo...", row.names(df1)), row.names(df2))
   expect_identical(out, exp)
@@ -231,12 +235,22 @@ test_that("can assign row names in vec_rbind()", {
   expect_identical(out, exp)
 
   # Sequence
-  out <- vec_rbind(foo = unrownames(df1), df2, bar = unrownames(mtcars[6, ]))
+  out <- vec_rbind(
+    foo = unrownames(df1),
+    df2,
+    bar = unrownames(mtcars[6, ]),
+    .names_to = NULL
+  )
   exp <- mtcars[1:6, ]
   row.names(exp) <- c(paste0("foo", 1:3), row.names(df2), "bar")
   expect_identical(out, exp)
 
-  out <- vec_rbind(foo = unrownames(df1), df2, bar = unrownames(mtcars[6, ]), .names_to = "id")
+  out <- vec_rbind(
+    foo = unrownames(df1),
+    df2,
+    bar = unrownames(mtcars[6, ]),
+    .names_to = "id"
+  )
   exp <- mtcars[1:6, ]
   exp <- vec_cbind(id = c(rep("foo", 3), rep("", 2), "bar"), exp)
   row.names(exp) <- c(paste0("...", 1:3), row.names(df2), "...6")
@@ -432,21 +446,32 @@ test_that("vec_cbind() fails with arrays of dimensionality > 3", {
 test_that("vec_rbind() consistently handles unnamed outputs", {
   # Name repair of columns is a little weird but unclear we can do better
   expect_identical(
-    vec_rbind(1, 2),
+    vec_rbind(1, 2, .names_to = NULL),
     data.frame(...1 = c(1, 2))
   )
   expect_identical(
-    vec_rbind(1, 2, ...10 = 3),
+    vec_rbind(1, 2, ...10 = 3, .names_to = NULL),
     data.frame(...1 = c(1, 2, 3), row.names = c("...1", "...2", "...3"))
   )
 
   expect_identical(
-    vec_rbind(a = 1, b = 2),
+    vec_rbind(a = 1, b = 2, .names_to = NULL),
     data.frame(...1 = c(1, 2), row.names = c("a", "b"))
   )
   expect_identical(
-    vec_rbind(c(a = 1), c(b = 2)),
+    vec_rbind(c(a = 1), c(b = 2), .names_to = NULL),
     data.frame(a = c(1, NA), b = c(NA, 2))
+  )
+})
+
+test_that("vec_rbind() ignores named inputs by default (#966)", {
+  expect_identical(
+    vec_rbind(foo = c(a = 1)),
+    data.frame(a = 1)
+  )
+  expect_identical(
+    vec_rbind(foo = c(a = 1), .names_to = NULL),
+    data.frame(a = 1, row.names = "foo")
   )
 })
 
@@ -472,15 +497,17 @@ test_that("vec_cbind() consistently handles unnamed outputs", {
 test_that("rbind() and cbind() have informative outputs when repairing names", {
   verify_output(test_path("output", "bind-name-repair.txt"), {
     "# vec_rbind()"
-
-    "Suboptimal"
     vec_rbind(1, 2)
+    vec_rbind(1, 2, .names_to = NULL)
 
-    "Suboptimal"
     vec_rbind(1, 2, ...10 = 3)
+    vec_rbind(1, 2, ...10 = 3, .names_to = NULL)
 
     vec_rbind(a = 1, b = 2)
+    vec_rbind(a = 1, b = 2, .names_to = NULL)
+
     vec_rbind(c(a = 1), c(b = 2))
+    vec_rbind(c(a = 1), c(b = 2), .names_to = NULL)
 
     "# vec_cbind()"
     vec_cbind(1, 2)


### PR DESCRIPTION
Part of #966

`.names_to` is set to `rlang::zap()` by default. This is a sentinel for ignoring the input names.