### PR TITLE
Add fallback for foreign data frame classes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,12 @@
     in `vec_assign()`), two double dispatch were needed. Now it can be
     done with one double dispatch by calling `vec_cast()` directly.
 
+* `vec_ptype2()` is now more permissive with subclasses of data frames
+  and falls back to a bare data frame when the classes do not have a
+  common type (#981). This is for convenience, users should normalise
+  their inputs to a common data frame class manually to avoid the
+  warning (if applicable, the classes could also implement a common type).
+
 * `vec_cbind()` now calls `vec_restore()` on inputs emptied of their
   columns before computing the common type. This has
   consequences for data frame classes with special columns that

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -202,7 +202,14 @@ cnd_type_separator <- function(action) {
   }
 }
 
-cnd_type_message <- function(x, y, x_arg, y_arg, details, action, message) {
+cnd_type_message <- function(x,
+                             y,
+                             x_arg,
+                             y_arg,
+                             details,
+                             action,
+                             message,
+                             types = NULL) {
   if (!is_null(message)) {
     return(message)
   }
@@ -222,8 +229,17 @@ cnd_type_message <- function(x, y, x_arg, y_arg, details, action, message) {
   action <- cnd_type_action(action)
   separator <- cnd_type_separator(action)
 
+  if (is_null(types)) {
+    x_type <- vec_ptype_full(x)
+    y_type <- vec_ptype_full(y)
+  } else {
+    stopifnot(is_character(types, n = 2))
+    x_type <- types[[1]]
+    y_type <- types[[2]]
+  }
+
   glue_lines(
-    "Can't {action}{x_name}<{vec_ptype_full(x)}> {separator}{y_name}<{vec_ptype_full(y)}>.",
+    "Can't {action}{x_name}<{x_type}> {separator}{y_name}<{y_type}>.",
     details
   )
 }

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -89,6 +89,37 @@ df_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
   .Call(vctrs_df_ptype2, x, y, x_arg, y_arg)
 }
 
+# Fallback for data frame subclasses (#981)
+vec_ptype2_df_fallback <- function(x, y, x_arg = "", y_arg = "") {
+  ptype <- vec_ptype2(
+    new_data_frame(x),
+    new_data_frame(y)
+  )
+
+  if (!is_df_fallback(x) && !is_df_fallback(y)) {
+    msg <- cnd_type_message(x, y, x_arg, y_arg, NULL, "combine", NULL)
+    warn(c(
+      msg,
+      i = "vctrs coercion methods should be implemented for these classes.",
+      i = "Falling back to <data.frame>."
+    ))
+  }
+
+  # Return a fallback class so we don't warn multiple times. This
+  # fallback class is stripped in `vec_ptype_finalise()`.
+  new_fallback_df(ptype)
+}
+
+is_df_subclass <- function(x) {
+  inherits(x, "data.frame") && !identical(class(x), "data.frame")
+}
+is_df_fallback <- function(x) {
+  inherits(x, "vctrs:::df_fallback")
+}
+new_fallback_df <- function(x, n = nrow(x)) {
+  new_data_frame(x, n = n, class = "vctrs:::df_fallback")
+}
+
 
 # Cast --------------------------------------------------------------------
 

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -96,19 +96,39 @@ vec_ptype2_df_fallback <- function(x, y, x_arg = "", y_arg = "") {
     new_data_frame(y)
   )
 
-  if (!is_df_fallback(x) && !is_df_fallback(y)) {
-    types <- c(class(x)[[1]], class(y)[[1]])
-    msg <- cnd_type_message(x, y, x_arg, y_arg, NULL, "combine", NULL, types = types)
+  classes <- NULL
+  if (is_df_fallback(x)) {
+    classes <- c(classes, known_classes(x))
+    x_class <- "data.frame"
+    x_abbr <- "df"
+  } else {
+    x_class <- class(x)[[1]]
+    x_abbr <- class(x)[[1]]
+  }
+  if (is_df_fallback(y)) {
+    classes <- c(classes, known_classes(y))
+    y_class <- "data.frame"
+    y_abbr <- "df"
+  } else {
+    y_class <- class(y)[[1]]
+    y_abbr <- class(y)[[1]]
+  }
+
+  if (!all(c(x_class, y_class) %in% classes)) {
+    msg <- cnd_type_message(x, y, x_arg, y_arg, NULL, "combine", NULL, types = c(x_abbr, y_abbr))
     warn(c(
       msg,
-      i = "vctrs coercion methods should be implemented for these classes.",
+      i = "Convert all inputs to the same class to avoid this warning.",
       i = "Falling back to <data.frame>."
     ))
   }
 
   # Return a fallback class so we don't warn multiple times. This
   # fallback class is stripped in `vec_ptype_finalise()`.
-  new_fallback_df(ptype)
+  new_fallback_df(
+    ptype,
+    known_classes = unique(c(classes, x_class, y_class))
+  )
 }
 
 is_df_subclass <- function(x) {
@@ -117,8 +137,19 @@ is_df_subclass <- function(x) {
 is_df_fallback <- function(x) {
   inherits(x, "vctrs:::df_fallback")
 }
-new_fallback_df <- function(x, n = nrow(x)) {
-  new_data_frame(x, n = n, class = "vctrs:::df_fallback")
+new_fallback_df <- function(x, known_classes, n = nrow(x)) {
+  new_data_frame(
+    x,
+    n = n,
+    known_classes = known_classes,
+    class = "vctrs:::df_fallback"
+  )
+}
+
+known_classes <- function(x) {
+  if (is_df_fallback(x)) {
+    attr(x, "known_classes")
+  }
 }
 
 

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -97,7 +97,8 @@ vec_ptype2_df_fallback <- function(x, y, x_arg = "", y_arg = "") {
   )
 
   if (!is_df_fallback(x) && !is_df_fallback(y)) {
-    msg <- cnd_type_message(x, y, x_arg, y_arg, NULL, "combine", NULL)
+    types <- c(class(x)[[1]], class(y)[[1]])
+    msg <- cnd_type_message(x, y, x_arg, y_arg, NULL, "combine", NULL, types = types)
     warn(c(
       msg,
       i = "vctrs coercion methods should be implemented for these classes.",

--- a/R/type2.R
+++ b/R/type2.R
@@ -79,6 +79,13 @@ vec_default_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
     return(vec_ptype(x, x_arg = x_arg))
   }
 
+  if (is_df_subclass(x) && is.data.frame(y)) {
+    return(vec_ptype2_df_fallback(x, y))
+  }
+  if (is_df_subclass(y) && is.data.frame(x)) {
+    return(vec_ptype2_df_fallback(x, y))
+  }
+
   stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
 }
 

--- a/src/type.c
+++ b/src/type.c
@@ -105,7 +105,14 @@ SEXP vec_ptype_finalise(SEXP x) {
     return bare_df_map(x, &vec_ptype_finalise);
 
   case vctrs_class_data_frame:
-    return df_map(x, &vec_ptype_finalise);
+    x = PROTECT(df_map(x, &vec_ptype_finalise));
+
+    if (Rf_inherits(x, "vctrs:::df_fallback")) {
+      r_poke_class(x, classes_data_frame);
+    }
+
+    UNPROTECT(1);
+    return x;
 
   case vctrs_class_none:
     Rf_errorcall(R_NilValue, "Internal error: Non-S3 classes should have returned by now");

--- a/src/type.c
+++ b/src/type.c
@@ -109,6 +109,7 @@ SEXP vec_ptype_finalise(SEXP x) {
 
     if (Rf_inherits(x, "vctrs:::df_fallback")) {
       r_poke_class(x, classes_data_frame);
+      Rf_setAttrib(x, Rf_install("known_classes"), R_NilValue);
     }
 
     UNPROTECT(1);

--- a/tests/testthat/error/test-type-data-frame.txt
+++ b/tests/testthat/error/test-type-data-frame.txt
@@ -3,12 +3,29 @@ combining data frames with foreign classes uses fallback
 ========================================================
 
 > foo <- structure(mtcars[1:3], class = c("foo", "data.frame"))
-> bar <- structure(mtcars[9:11], class = c("bar", "data.frame"))
-> vec_ptype_common(foo, bar)
+> bar <- structure(mtcars[4:6], class = c("bar", "data.frame"))
+> baz <- structure(mtcars[7:9], class = c("baz", "data.frame"))
+> vec_ptype_common(foo, bar, baz)
 Warning: Can't combine <foo> and <bar>.
-i vctrs coercion methods should be implemented for these classes.
+i Convert all inputs to the same class to avoid this warning.
 i Falling back to <data.frame>.
 
-[1] mpg  cyl  disp am   gear carb
+Warning: Can't combine <df> and <baz>.
+i Convert all inputs to the same class to avoid this warning.
+i Falling back to <data.frame>.
+
+[1] mpg  cyl  disp hp   drat wt   qsec vs   am  
+<0 rows> (or 0-length row.names)
+
+> vec_ptype_common(foo, baz, bar, baz, foo, bar)
+Warning: Can't combine <foo> and <baz>.
+i Convert all inputs to the same class to avoid this warning.
+i Falling back to <data.frame>.
+
+Warning: Can't combine <df> and <bar>.
+i Convert all inputs to the same class to avoid this warning.
+i Falling back to <data.frame>.
+
+[1] mpg  cyl  disp qsec vs   am   hp   drat wt  
 <0 rows> (or 0-length row.names)
 

--- a/tests/testthat/error/test-type-data-frame.txt
+++ b/tests/testthat/error/test-type-data-frame.txt
@@ -1,0 +1,22 @@
+
+combining data frames with foreign classes uses fallback
+========================================================
+
+> foo <- structure(mtcars[1:3], class = c("foo", "data.frame"))
+> bar <- structure(mtcars[9:11], class = c("bar", "data.frame"))
+> vec_ptype_common(foo, bar)
+Warning: Can't combine <foo<
+  mpg : double
+  cyl : double
+  disp: double
+>> and <bar<
+  am  : double
+  gear: double
+  carb: double
+>>.
+i vctrs coercion methods should be implemented for these classes.
+i Falling back to <data.frame>.
+
+[1] mpg  cyl  disp am   gear carb
+<0 rows> (or 0-length row.names)
+

--- a/tests/testthat/error/test-type-data-frame.txt
+++ b/tests/testthat/error/test-type-data-frame.txt
@@ -5,15 +5,7 @@ combining data frames with foreign classes uses fallback
 > foo <- structure(mtcars[1:3], class = c("foo", "data.frame"))
 > bar <- structure(mtcars[9:11], class = c("bar", "data.frame"))
 > vec_ptype_common(foo, bar)
-Warning: Can't combine <foo<
-  mpg : double
-  cyl : double
-  disp: double
->> and <bar<
-  am  : double
-  gear: double
-  carb: double
->>.
+Warning: Can't combine <foo> and <bar>.
 i vctrs coercion methods should be implemented for these classes.
 i Falling back to <data.frame>.
 

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -88,3 +88,7 @@ expect_error_cnd <- function(object, class, message = NULL, ..., .fixed = TRUE) 
   expect_true(is_empty(setdiff(!!names(exp_fields), names(cnd))))
   expect_equal(cnd[names(exp_fields)], exp_fields)
 }
+
+expect_df_fallback <- function(expr) {
+  expect_warning({{ expr }}, "Falling back")
+}

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -55,6 +55,54 @@ test_that("empty data frame still has names", {
   expect_equal(names(out), character())
 })
 
+test_that("combining data frames with foreign classes uses fallback", {
+  new_foo <- function(x) structure(x, class = c("foo", "data.frame"))
+
+  foo <- new_foo(data.frame())
+  df <- data.frame()
+
+  # Same type fallback
+  expect_identical(vec_ptype_common(foo, foo, foo), foo)
+
+  expect_identical(expect_df_fallback(vec_ptype2(foo, df)), new_fallback_df(df))
+  expect_identical(expect_df_fallback(vec_ptype2(df, foo)), new_fallback_df(df))
+  expect_identical(expect_df_fallback(vec_ptype_common(foo, df)), df)
+  expect_identical(expect_df_fallback(vec_ptype_common(df, foo)), df)
+
+  cnds <- list()
+  withCallingHandlers(
+    warning = function(cnd) {
+      cnds <<- append(cnds, list(cnd))
+      invokeRestart("muffleWarning")
+    },
+    expect_identical(
+      vec_ptype_common(foo, df, foo, foo),
+      df
+    )
+  )
+
+  # There should be only one warning even if many fallbacks
+  expect_length(cnds, 1)
+  expect_is(cnds[[1]], "warning")
+  expect_match(cnds[[1]]$message, "Falling back")
+
+  expect_identical(
+    expect_df_fallback(vec_rbind(foo, data.frame(), foo)),
+    df
+  )
+  expect_identical(
+    expect_df_fallback(vec_cbind(new_foo(data.frame(x = 1)), data.frame(y = 2))),
+    data.frame(x = 1, y = 2)
+  )
+
+  verify_errors({
+    foo <- structure(mtcars[1:3], class = c("foo", "data.frame"))
+    bar <- structure(mtcars[9:11], class = c("bar", "data.frame"))
+    expect_warning(vec_ptype_common(foo, bar), "Falling back")
+  })
+})
+
+
 # casting -----------------------------------------------------------------
 
 test_that("safe casts work as expected", {
@@ -338,4 +386,13 @@ test_that("new_data_frame() zaps existing attributes", {
     attributes(new_data_frame(struct, bar = 2)),
     attributes(new_data_frame(list(), bar = 2)),
   )
+})
+
+test_that("data frame output is informative", {
+  verify_output(test_path("error", "test-type-data-frame.txt"), {
+    "# combining data frames with foreign classes uses fallback"
+    foo <- structure(mtcars[1:3], class = c("foo", "data.frame"))
+    bar <- structure(mtcars[9:11], class = c("bar", "data.frame"))
+    vec_ptype_common(foo, bar)
+  })
 })

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -64,8 +64,8 @@ test_that("combining data frames with foreign classes uses fallback", {
   # Same type fallback
   expect_identical(vec_ptype_common(foo, foo, foo), foo)
 
-  expect_identical(expect_df_fallback(vec_ptype2(foo, df)), new_fallback_df(df))
-  expect_identical(expect_df_fallback(vec_ptype2(df, foo)), new_fallback_df(df))
+  expect_identical(expect_df_fallback(vec_ptype2(foo, df)), new_fallback_df(df, c("foo", "data.frame")))
+  expect_identical(expect_df_fallback(vec_ptype2(df, foo)), new_fallback_df(df, c("data.frame", "foo")))
   expect_identical(expect_df_fallback(vec_ptype_common(foo, df)), df)
   expect_identical(expect_df_fallback(vec_ptype_common(df, foo)), df)
 
@@ -97,8 +97,10 @@ test_that("combining data frames with foreign classes uses fallback", {
 
   verify_errors({
     foo <- structure(mtcars[1:3], class = c("foo", "data.frame"))
-    bar <- structure(mtcars[9:11], class = c("bar", "data.frame"))
-    expect_warning(vec_ptype_common(foo, bar), "Falling back")
+    bar <- structure(mtcars[4:6], class = c("bar", "data.frame"))
+    baz <- structure(mtcars[7:9], class = c("baz", "data.frame"))
+    expect_warning(vec_ptype_common(foo, bar, baz))
+    expect_warning(vec_ptype_common(foo, baz, bar, baz, foo, bar))
   })
 })
 
@@ -392,7 +394,9 @@ test_that("data frame output is informative", {
   verify_output(test_path("error", "test-type-data-frame.txt"), {
     "# combining data frames with foreign classes uses fallback"
     foo <- structure(mtcars[1:3], class = c("foo", "data.frame"))
-    bar <- structure(mtcars[9:11], class = c("bar", "data.frame"))
-    vec_ptype_common(foo, bar)
+    bar <- structure(mtcars[4:6], class = c("bar", "data.frame"))
+    baz <- structure(mtcars[7:9], class = c("baz", "data.frame"))
+    vec_ptype_common(foo, bar, baz)
+    vec_ptype_common(foo, baz, bar, baz, foo, bar)
   })
 })

--- a/tests/testthat/test-type-dplyr.R
+++ b/tests/testthat/test-type-dplyr.R
@@ -161,8 +161,9 @@ test_that("can cbind rowwise data frames", {
 })
 
 test_that("no common type between rowwise and grouped data frames", {
-  expect_error(
-    vec_ptype2(dplyr::rowwise(mtcars), dplyr::group_by(mtcars, cyl)),
-    class = "vctrs_error_incompatible_type"
+  expect_warning(
+    out <- vec_ptype_common(dplyr::rowwise(mtcars), dplyr::group_by(mtcars, cyl)),
+    "Falling back"
   )
+  expect_identical(out, unrownames(mtcars[0, ]))
 })

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -161,8 +161,15 @@ test_that("Subclasses of data.frame dispatch to `vec_ptype2()` methods", {
 test_that("Subclasses of `tbl_df` do not have `tbl_df` common type (#481)", {
   quux <- tibble()
   quux <- structure(quux, class = c("quux", class(quux)))
-  expect_error(vec_ptype2(quux, tibble()), class = "vctrs_error_incompatible_type")
-  expect_error(vec_ptype2(tibble(), quux), class = "vctrs_error_incompatible_type")
+
+  expect_df_fallback(expect_identical(
+    vec_ptype_common(quux, tibble()),
+    data.frame()
+  ))
+  expect_df_fallback(expect_identical(
+    vec_ptype_common(tibble(), quux),
+    data.frame()
+  ))
 })
 
 test_that("Column name encodings are handled correctly in the common type (#553)", {


### PR DESCRIPTION
Closes #981 

The warning is thrown during the ptype2 reduction. A sentinel data frame class avoids repeat warnings. I haven't implemented a fallback in `vec_cast()` because it isn't necessary for `vec_cbind()` and `vec_rbind()`.

```r
foo <- structure(mtcars[1:3], class = c("foo", "data.frame"))
bar <- structure(mtcars[9:11], class = c("bar", "data.frame"))

vec_ptype_common(foo, bar)
#> [1] mpg  cyl  disp am   gear carb
#> <0 rows> (or 0-length row.names)
#> Warning: Can't combine <foo> and <bar>.
#> i vctrs coercion methods should be implemented for these classes.
#> i Falling back to <data.frame>.
```

The warning should eventually refer to a FAQ about normalising inputs to `data.frame`. This is tracked in #1016.