### PR TITLE
Allow factor/ordered `vec_restore()` method to be inherited

### DIFF
--- a/R/type-date-time.R
+++ b/R/type-date-time.R
@@ -73,17 +73,17 @@ vec_proxy_compare.POSIXlt <- function(x, ...) {
 
 #' @export
 vec_restore.Date <- function(x, to, ...) {
-  stop_native_implementation("vec_restore.Date")
+  NextMethod()
 }
 
 #' @export
 vec_restore.POSIXct <- function(x, to, ...) {
-  stop_native_implementation("vec_restore.POSIXct")
+  NextMethod()
 }
 
 #' @export
 vec_restore.POSIXlt <- function(x, to, ...) {
-  stop_native_implementation("vec_restore.POSIXlt")
+  NextMethod()
 }
 
 # Print ------------------------------------------------------------------

--- a/R/type-factor.R
+++ b/R/type-factor.R
@@ -46,12 +46,12 @@ vec_proxy.ordered <- function(x, ...) {
 
 #' @export
 vec_restore.factor <- function(x, to, ...) {
-  stop_native_implementation("vec_restore.factor")
+  NextMethod()
 }
 
 #' @export
 vec_restore.ordered <- function(x, to, ...) {
-  stop_native_implementation("vec_restore.ordered")
+  NextMethod()
 }
 
 # Print -------------------------------------------------------------------

--- a/tests/testthat/test-type-date-time.R
+++ b/tests/testthat/test-type-date-time.R
@@ -410,6 +410,20 @@ test_that("POSIXlt roundtrips through proxy and restore", {
   expect_identical(out, x)
 })
 
+test_that("subclassed Dates / POSIXct / POSIXlt can be restored (#1015)", {
+  x <- subclass(new_date(0))
+  proxy <- vec_proxy(x)
+  expect_identical(vec_restore(proxy, x), x)
+
+  y <- subclass(new_datetime(0))
+  proxy <- vec_proxy(y)
+  expect_identical(vec_restore(proxy, y), y)
+
+  z <- subclass(as.POSIXlt(new_datetime(0)))
+  proxy <- vec_proxy(z)
+  expect_identical(vec_restore(proxy, z), z)
+})
+
 # arithmetic --------------------------------------------------------------
 
 test_that("default is error", {

--- a/tests/testthat/test-type-factor.R
+++ b/tests/testthat/test-type-factor.R
@@ -23,6 +23,14 @@ test_that("slicing factors uses a proxy to not go through `[.factor`", {
   expect_identical(vec_slice(y, 1), y)
 })
 
+test_that("`vec_c()` throws the right error with subclassed factors (#1015)", {
+  a <- subclass(factor("a"))
+  b <- subclass(factor("b"))
+
+  expect_identical(vec_c(a, a), subclass(factor(c("a", "a"))))
+  expect_error(vec_c(a, b), class = "vctrs_error_incompatible_type")
+})
+
 # Coercion ----------------------------------------------------------------
 
 test_that("factor/character coercions are symmetric and unchanging", {
@@ -161,6 +169,18 @@ test_that("Casting to a factor with explicit NA levels retains them", {
   f <- factor(c("x", NA), exclude = NULL)
   expect_identical(vec_cast(f, f), f)
   expect_identical(vec_cast(f, factor()), f)
+})
+
+# Proxy / restore ---------------------------------------------------------
+
+test_that("subclassed factors / ordered factors can be restored (#1015)", {
+  x <- subclass(factor("a"))
+  proxy <- vec_proxy(x)
+  expect_identical(vec_restore(proxy, x), x)
+
+  y <- subclass(ordered("a"))
+  proxy <- vec_proxy(y)
+  expect_identical(vec_restore(proxy, y), y)
 })
 
 # Arithmetic and factor ---------------------------------------------------


### PR DESCRIPTION
Closes #1015 

I got a little carried away and forgot that `vec_restore()` is still inherited.

This sort of begs the question, should it be? Related to https://github.com/r-lib/vctrs/issues/945