### PR TITLE
Remove `"list"` base class from list-of

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,13 @@
 
 # vctrs (development version)
 
-* `new_vctr()` now always appends a base `"list"` class to list `.data` to
-  be compatible with changes to `vec_is_list()`. This affects `new_list_of()`,
-  which now returns an object with a base class of `"list"`.
+* `new_vctr()` now defaults to `inherit_base_type = TRUE` for list `.data`, as
+  generally they should be considered lists by `vec_is_list()`.
 
 * `vec_is_list()` no longer allows S3 lists that implement a `vec_proxy()`
   method to automatically be considered lists. A S3 list must explicitly
-  inherit from `"list"` in the base class to be considered a list.
+  inherit from `"list"` or `"vctrs_list_of"` in the base class to be considered
+  a list.
 
 * `vec_rbind()` gains option to treat input names as row names. This
   is disabled by default (#966).

--- a/R/assert.R
+++ b/R/assert.R
@@ -154,7 +154,7 @@ vec_is_vector <- function(x) {
 #' returns `TRUE` if:
 #'
 #' * `x` is a bare list with no class.
-#' * `x` is a list explicitly inheriting from `"list"`.
+#' * `x` is a list explicitly inheriting from `"list"` or `"vctrs_list_of"`.
 #'
 #' @param x An object.
 #'
@@ -162,8 +162,9 @@ vec_is_vector <- function(x) {
 #' Notably, data frames and S3 record style classes like POSIXlt are not
 #' considered lists.
 #'
-#' If `x` inherits explicitly from `"list"`, it is also required that the
-#' proxy returned by [vec_proxy()] is a list. If it is not, an error is thrown.
+#' If `x` inherits explicitly from `"list"` or `"vctrs_list_of"`, it is also
+#' required that the proxy returned by [vec_proxy()] is a list. If it is not,
+#' an error is thrown.
 #' @export
 #' @examples
 #' vec_is_list(list())

--- a/R/type-list-of.R
+++ b/R/type-list-of.R
@@ -67,7 +67,15 @@ new_list_of <- function(x = list(), ptype = logical(), ..., class = character())
     abort("`ptype` must have size 0.")
   }
 
-  new_vctr(x, ..., ptype = ptype, class = c(class, "vctrs_list_of"))
+  # Don't inherit the base type of `"list"` explicitly. A vctrs_list_of is
+  # still considered a list because of special casing in `vec_is_list()`.
+  new_vctr(
+    x,
+    ...,
+    ptype = ptype,
+    class = c(class, "vctrs_list_of"),
+    inherit_base_type = FALSE
+  )
 }
 
 #' @export

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -7,10 +7,13 @@
 #' vector classes.
 #'
 #' @details
-#' List vctrs are special cases. When created through `new_vctr()`, the
-#' resulting list vctr should always be recognized as a list by
-#' `vec_is_list()`. Because of this, if `inherit_base_type` is `FALSE`
-#' an error is thrown.
+#' List vctrs are special cases. Generally you'll want to create a vctr which
+#' is recognized by [vec_is_list()] as a list. For that reason,
+#' `inherit_base_type` defaults to `TRUE` for lists. However, in rare cases
+#' you might want to create a list vctr that acts like an atomic vector. The
+#' base R class [numeric_version()] is one such example. This is a vector, so
+#' [vec_is()] should return `TRUE`, but it isn't a list even though it is
+#' internally stored as one, so `vec_is_list()` should return `FALSE`.
 #'
 #' @section Base methods:
 #' The vctr class provides methods for many base generics using a smaller
@@ -60,7 +63,7 @@
 #'   A single logical, or `NULL`. Does this class extend the base type of
 #'   `.data`? i.e. does the resulting object extend the behaviour of the
 #'   underlying type? Defaults to `FALSE` for all types except lists, which
-#'   are required to inherit from the base type.
+#'   defaults to `TRUE`.
 #' @export
 #' @keywords internal
 #' @aliases vctr
@@ -78,11 +81,8 @@ new_vctr <- function(.data,
     if (is.data.frame(.data)) {
       abort("`.data` can't be a data frame.")
     }
-
     if (is.null(inherit_base_type)) {
       inherit_base_type <- TRUE
-    } else if (is_false(inherit_base_type)) {
-      abort("List `.data` must inherit from the base type.")
     }
   }
 

--- a/man/new_vctr.Rd
+++ b/man/new_vctr.Rd
@@ -18,7 +18,7 @@ new_vctr(.data, ..., class = character(), inherit_base_type = NULL)
 A single logical, or \code{NULL}. Does this class extend the base type of
 \code{.data}? i.e. does the resulting object extend the behaviour of the
 underlying type? Defaults to \code{FALSE} for all types except lists, which
-are required to inherit from the base type.}
+defaults to \code{TRUE}.}
 }
 \description{
 This abstract class provides a set of useful default methods that makes it
@@ -27,10 +27,13 @@ considerably easier to get started with a new S3 vector class. See
 vector classes.
 }
 \details{
-List vctrs are special cases. When created through \code{new_vctr()}, the
-resulting list vctr should always be recognized as a list by
-\code{vec_is_list()}. Because of this, if \code{inherit_base_type} is \code{FALSE}
-an error is thrown.
+List vctrs are special cases. Generally you'll want to create a vctr which
+is recognized by \code{\link[=vec_is_list]{vec_is_list()}} as a list. For that reason,
+\code{inherit_base_type} defaults to \code{TRUE} for lists. However, in rare cases
+you might want to create a list vctr that acts like an atomic vector. The
+base R class \code{\link[=numeric_version]{numeric_version()}} is one such example. This is a vector, so
+\code{\link[=vec_is]{vec_is()}} should return \code{TRUE}, but it isn't a list even though it is
+internally stored as one, so \code{vec_is_list()} should return \code{FALSE}.
 }
 \section{Base methods}{
 

--- a/man/vec_is_list.Rd
+++ b/man/vec_is_list.Rd
@@ -14,15 +14,16 @@ vec_is_list(x)
 returns \code{TRUE} if:
 \itemize{
 \item \code{x} is a bare list with no class.
-\item \code{x} is a list explicitly inheriting from \code{"list"}.
+\item \code{x} is a list explicitly inheriting from \code{"list"} or \code{"vctrs_list_of"}.
 }
 }
 \details{
 Notably, data frames and S3 record style classes like POSIXlt are not
 considered lists.
 
-If \code{x} inherits explicitly from \code{"list"}, it is also required that the
-proxy returned by \code{\link[=vec_proxy]{vec_proxy()}} is a list. If it is not, an error is thrown.
+If \code{x} inherits explicitly from \code{"list"} or \code{"vctrs_list_of"}, it is also
+required that the proxy returned by \code{\link[=vec_proxy]{vec_proxy()}} is a list. If it is not,
+an error is thrown.
 }
 \examples{
 vec_is_list(list())

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -119,8 +119,11 @@ bool vec_is_list(SEXP x) {
     return true;
   }
 
-  // Classed VECSXP are only lists if the last class is explicitly `"list"`
-  if (class_type(x) != vctrs_class_list) {
+  enum vctrs_class_type type = class_type(x);
+
+  // Classed VECSXP are only lists if the last classes are explicitly either
+  // `"list"` or `c("vctrs_list_of", "vctrs_vctr")`
+  if (type != vctrs_class_list && type != vctrs_class_list_of) {
     return false;
   }
 
@@ -131,7 +134,7 @@ bool vec_is_list(SEXP x) {
 
   Rf_errorcall(
     R_NilValue,
-    "`x` inherits explicitly from \"list\", "
+    "`x` inherits explicitly from \"list\" or \"vctrs_list_of\", "
     "but the proxy returned by `vec_proxy()` is not a list."
   );
 }

--- a/src/utils-dispatch.c
+++ b/src/utils-dispatch.c
@@ -84,13 +84,18 @@ static enum vctrs_class_type class_type_impl(SEXP class) {
   }}
 
   // Now check for inherited classes
-  p = p + n - 1;
-  SEXP last = *p;
+  p = p + n - 2;
+  SEXP butlast = *p++;
+  SEXP last = *p++;
 
   if (last == strings_data_frame) {
     return vctrs_class_data_frame;
   } else if (last == strings_list) {
     return vctrs_class_list;
+  } else if (last == strings_vctrs_vctr) {
+    if (butlast == strings_vctrs_list_of) {
+      return vctrs_class_list_of;
+    }
   }
 
   return vctrs_class_unknown;
@@ -99,6 +104,7 @@ static enum vctrs_class_type class_type_impl(SEXP class) {
 static const char* class_type_as_str(enum vctrs_class_type type) {
   switch (type) {
   case vctrs_class_list: return "list";
+  case vctrs_class_list_of: return "list_of";
   case vctrs_class_data_frame: return "data_frame";
   case vctrs_class_bare_data_frame: return "bare_data_frame";
   case vctrs_class_bare_tibble: return "bare_tibble";

--- a/src/utils.c
+++ b/src/utils.c
@@ -23,6 +23,8 @@ SEXP strings_posixt = NULL;
 SEXP strings_factor = NULL;
 SEXP strings_ordered = NULL;
 SEXP strings_list = NULL;
+SEXP strings_vctrs_vctr = NULL;
+SEXP strings_vctrs_list_of = NULL;
 
 SEXP classes_data_frame = NULL;
 SEXP classes_factor = NULL;
@@ -1482,7 +1484,7 @@ void vctrs_init_utils(SEXP ns) {
 
   // Holds the CHARSXP objects because unlike symbols they can be
   // garbage collected
-  strings = r_new_shared_vector(STRSXP, 19);
+  strings = r_new_shared_vector(STRSXP, 21);
 
   strings_dots = Rf_mkChar("...");
   SET_STRING_ELT(strings, 0, strings_dots);
@@ -1541,6 +1543,12 @@ void vctrs_init_utils(SEXP ns) {
   strings_list = Rf_mkChar("list");
   SET_STRING_ELT(strings, 18, strings_list);
 
+  strings_vctrs_vctr = Rf_mkChar("vctrs_vctr");
+  SET_STRING_ELT(strings, 19, strings_vctrs_vctr);
+
+  strings_vctrs_list_of = Rf_mkChar("vctrs_list_of");
+  SET_STRING_ELT(strings, 20, strings_vctrs_list_of);
+
 
   classes_data_frame = r_new_shared_vector(STRSXP, 1);
   strings_data_frame = Rf_mkChar("data.frame");
@@ -1592,7 +1600,7 @@ void vctrs_init_utils(SEXP ns) {
   classes_vctrs_group_rle = r_new_shared_vector(STRSXP, 3);
   SET_STRING_ELT(classes_vctrs_group_rle, 0, Rf_mkChar("vctrs_group_rle"));
   SET_STRING_ELT(classes_vctrs_group_rle, 1, Rf_mkChar("vctrs_rcrd"));
-  SET_STRING_ELT(classes_vctrs_group_rle, 2, Rf_mkChar("vctrs_vctr"));
+  SET_STRING_ELT(classes_vctrs_group_rle, 2, strings_vctrs_vctr);
 
 
   vctrs_shared_empty_lgl = r_new_shared_vector(LGLSXP, 0);

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,6 +15,7 @@
 
 enum vctrs_class_type {
   vctrs_class_list,
+  vctrs_class_list_of,
   vctrs_class_data_frame,
   vctrs_class_bare_data_frame,
   vctrs_class_bare_tibble,
@@ -388,6 +389,8 @@ extern SEXP strings_posixt;
 extern SEXP strings_factor;
 extern SEXP strings_ordered;
 extern SEXP strings_list;
+extern SEXP strings_vctrs_vctr;
+extern SEXP strings_vctrs_list_of;
 extern SEXP strings_none;
 extern SEXP strings_minimal;
 extern SEXP strings_unique;

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -33,12 +33,12 @@ test_that("Can opt out of base type", {
   expect_s3_class(x, c("x", "vctrs_vctr"), exact = TRUE)
 })
 
-test_that("base type is always set for lists", {
+test_that("base type is set by default for lists", {
   expect_s3_class(new_vctr(list()), "list")
 })
 
-test_that("cannot opt out of the base type with lists", {
-  expect_error(new_vctr(list(), inherit_base_type = FALSE), "must inherit from the base type")
+test_that("can opt out of the base type with lists", {
+  expect_s3_class(new_vctr(list(), inherit_base_type = FALSE), "vctrs_vctr", exact = TRUE)
 })
 
 test_that("data frames are not allowed", {

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -141,6 +141,9 @@ test_that("class_type() detects classes", {
   expect_identical(class_type(structure(list(), class = "list")), "list")
   expect_identical(class_type(subclass(structure(list(), class = "list"))), "list")
 
+  expect_identical(class_type(new_list_of()), "list_of")
+  expect_identical(class_type(subclass(new_list_of())), "list_of")
+
   expect_identical(class_type(data.frame()), "bare_data_frame")
   expect_identical(class_type(tibble::tibble()), "bare_tibble")
   expect_identical(class_type(subclass(data.frame())), "data_frame")


### PR DESCRIPTION
Reverts part of #1003 

After speaking with @lionel-, it seems that adding a base `"list"` class to list-of might not be the best idea in the long run. In the future, we might allow classes that explicitly inherit from a base type to be coercible to those base types automatically, but we probably wouldn't want that with list-ofs (we want them to be strict and not lose information easily).

This required tweaking `vec_is_list()` to know about `vctrs_list_of` and allow explicit inheritance from `"vctrs_list_of"` to be a sufficient condition for being a list.

This additionally required that `new_vctr()` be less strict about `inherit_base_type = FALSE` with list input. We need to do this in `new_list_of()`. Separately, this is also how we would create list-vctrs that are treated as atomic vectors. `numeric_version` is one such example of this. It is implemented internally as a list, but it should not be treated as one. So `vec_is()` should return `TRUE`, but `vec_is_list()` should return `FALSE`.