### PR TITLE
Fix data frame fallback

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -172,11 +172,15 @@ vec_default_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
     return(x)
   }
 
+  if (match_df_fallback(...)) {
+    return(df_cast(x, to, ..., x_arg = x_arg, to_arg = to_arg))
+  }
+
   stop_incompatible_cast(
     x,
     to,
     x_arg = x_arg,
     to_arg = to_arg,
-    `vctrs:::from_dispatch` = from_dispatch(...)
+    `vctrs:::from_dispatch` = match_from_dispatch(...)
   )
 }

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -218,7 +218,8 @@ cnd_type_message <- function(x,
                              details,
                              action,
                              message,
-                             from_dispatch = FALSE) {
+                             from_dispatch = FALSE,
+                             fallback = NULL) {
   if (!is_null(message)) {
     return(message)
   }
@@ -261,8 +262,14 @@ cnd_type_message <- function(x,
     details <- format_error_bullets(details)
   }
 
+  if (is_null(fallback)) {
+    end <- "."
+  } else {
+    end <- glue::glue("; falling back to {fallback}.")
+  }
+
   glue_lines(
-    "Can't {action}{x_name}<{x_type}> {separator}{y_name}<{y_type}>.",
+    "Can't {action}{x_name}<{x_type}> {separator}{y_name}<{y_type}>{end}",
     details
   )
 }

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -172,7 +172,7 @@ stop_incompatible_type_impl <- function(x,
     details,
     action,
     message,
-    from_dispatch = from_dispatch(...)
+    from_dispatch = match_from_dispatch(...)
   )
 
   stop_incompatible(

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -114,20 +114,25 @@ vec_ptype2_df_fallback <- function(x, y, x_arg = "", y_arg = "") {
   y_class <- class(y)[[1]]
 
   if (!all(c(x_class, y_class) %in% classes)) {
-    msg <- cnd_type_message(x, y, x_arg, y_arg, NULL, "combine", NULL)
+    msg <- cnd_type_message(
+      x, y,
+      x_arg, y_arg,
+      NULL,
+      "combine",
+      NULL,
+      fallback = "<data.frame>"
+    )
 
     if (identical(x_class, y_class)) {
       msg <- c(
         msg,
-        incompatible_attrib_bullets(),
-        i = "Falling back to <data.frame>."
+        incompatible_attrib_bullets()
       )
     } else {
       msg <- c(
         msg,
         i = "Convert all inputs to the same class to avoid this warning.",
-        i = "See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.",
-        i = "Falling back to <data.frame>."
+        i = "See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>."
       )
     }
 

--- a/R/type.R
+++ b/R/type.R
@@ -95,7 +95,7 @@ vec_ptype <- function(x, ..., x_arg = "") {
 vec_ptype_common <- function(..., .ptype = NULL) {
   .External2(vctrs_type_common, .ptype)
 }
-vec_ptype_common_params <- function(..., .ptype = NULL, .df_fallback = TRUE) {
+vec_ptype_common_params <- function(..., .ptype = NULL, .df_fallback = FALSE) {
   .External2(vctrs_ptype_common_params, .ptype, .df_fallback)
 }
 

--- a/R/type.R
+++ b/R/type.R
@@ -95,6 +95,9 @@ vec_ptype <- function(x, ..., x_arg = "") {
 vec_ptype_common <- function(..., .ptype = NULL) {
   .External2(vctrs_type_common, .ptype)
 }
+vec_ptype_common_params <- function(..., .ptype = NULL, .df_fallback = TRUE) {
+  .External2(vctrs_ptype_common_params, .ptype, .df_fallback)
+}
 
 #' @export
 #' @rdname vec_ptype

--- a/R/type2.R
+++ b/R/type2.R
@@ -84,24 +84,47 @@ vec_default_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
     return(vec_ptype(x, x_arg = x_arg))
   }
 
-  if (is_df_subclass(x) && is.data.frame(y)) {
-    return(vec_ptype2_df_fallback(x, y))
-  }
-  if (is_df_subclass(y) && is.data.frame(x)) {
-    return(vec_ptype2_df_fallback(x, y))
+  internal <- ptype2_params(...)
+
+  if (internal$df_fallback) {
+    if (is_df_subclass(x) && is.data.frame(y)) {
+      return(vec_ptype2_df_fallback(x, y))
+    }
+    if (is_df_subclass(y) && is.data.frame(x)) {
+      return(vec_ptype2_df_fallback(x, y))
+    }
   }
 
+  # The from-dispatch parameter is set only when called from our S3
+  # dispatch mechanism, when there is no methods. It indicates whether
+  # the error message should provide advice about diverging attributes.
   stop_incompatible_type(
     x,
     y,
     x_arg = x_arg,
     y_arg = y_arg,
-    `vctrs:::from_dispatch` = from_dispatch(...)
+    `vctrs:::from_dispatch` = internal$from_dispatch
   )
 }
 
+ptype2_params <- function(...,
+                          `vctrs:::df_fallback` = FALSE) {
+  list(
+    from_dispatch = from_dispatch(...),
+    df_fallback = `vctrs:::df_fallback`
+  )
+}
 from_dispatch <- function(..., `vctrs:::from_dispatch` = FALSE) {
   `vctrs:::from_dispatch`
+}
+
+vec_ptype2_params <- function(x,
+                              y,
+                              ...,
+                              df_fallback = FALSE,
+                              x_arg = "",
+                              y_arg = "") {
+  .Call(vctrs_ptype2_params, x, y, df_fallback, x_arg, y_arg)
 }
 
 vec_typeof2 <- function(x, y) {

--- a/R/type2.R
+++ b/R/type2.R
@@ -84,7 +84,7 @@ vec_default_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
     return(vec_ptype(x, x_arg = x_arg))
   }
 
-  internal <- ptype2_params(...)
+  internal <- match_ptype2_params(...)
 
   if (internal$df_fallback) {
     if (is_df_subclass(x) && is.data.frame(y)) {
@@ -107,14 +107,16 @@ vec_default_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
   )
 }
 
-ptype2_params <- function(...,
-                          `vctrs:::df_fallback` = FALSE) {
+match_ptype2_params <- function(...) {
   list(
-    from_dispatch = from_dispatch(...),
-    df_fallback = `vctrs:::df_fallback`
+    from_dispatch = match_from_dispatch(...),
+    df_fallback = match_df_fallback(...)
   )
 }
-from_dispatch <- function(..., `vctrs:::from_dispatch` = FALSE) {
+match_df_fallback <- function(..., `vctrs:::df_fallback` = FALSE) {
+  `vctrs:::df_fallback`
+}
+match_from_dispatch <- function(..., `vctrs:::from_dispatch` = FALSE) {
   `vctrs:::from_dispatch`
 }
 

--- a/src/arg-counter.h
+++ b/src/arg-counter.h
@@ -52,7 +52,8 @@ void counters_shift(struct counters* counters);
 
 SEXP reduce(SEXP current, struct vctrs_arg* current_arg,
             SEXP rest,
-            SEXP (*impl)(SEXP current, SEXP next, struct counters* counters));
+            SEXP (*impl)(SEXP current, SEXP next, struct counters* counters, void* data),
+            void* data);
 
 
 #endif

--- a/src/bind.c
+++ b/src/bind.c
@@ -159,7 +159,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
     }
     SEXP x = VECTOR_ELT(xs, i);
 
-    SEXP tbl = PROTECT(vec_cast(x, ptype, args_empty, args_empty));
+    SEXP tbl = PROTECT(vec_cast_params(x, ptype, args_empty, args_empty, true));
     init_compact_seq(idx_ptr, counter, size, true);
     out = df_assign(out, idx, tbl, &bind_assign_opts);
     REPROTECT(out, out_pi);

--- a/src/bind.c
+++ b/src/bind.c
@@ -1,8 +1,9 @@
 #include "vctrs.h"
+#include "dim.h"
+#include "ptype-common.h"
 #include "slice-assign.h"
 #include "type-data-frame.h"
 #include "utils.h"
-#include "dim.h"
 
 
 static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP id, struct name_repair_opts* name_repair);
@@ -42,9 +43,6 @@ SEXP vctrs_rbind(SEXP call, SEXP op, SEXP args, SEXP env) {
 }
 
 
-// From type.c
-SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype);
-
 static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opts* name_repair) {
   int nprot = 0;
   R_len_t n = Rf_length(xs);
@@ -56,7 +54,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
   // The common type holds information about common column names,
   // types, etc. Each element of `xs` needs to be cast to that type
   // before assignment.
-  ptype = PROTECT_N(vctrs_type_common_impl(xs, ptype), &nprot);
+  ptype = PROTECT_N(vec_ptype_common_params(xs, ptype, true), &nprot);
 
   if (ptype == R_NilValue) {
     UNPROTECT(nprot);
@@ -332,7 +330,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
   SEXP containers = PROTECT(map_with_data(xs, &cbind_container_type, &rownames));
   ptype = PROTECT(cbind_container_type(ptype, &rownames));
 
-  SEXP type = PROTECT(vctrs_type_common_impl(containers, ptype));
+  SEXP type = PROTECT(vec_ptype_common_params(containers, ptype, true));
   if (type == R_NilValue) {
     type = new_data_frame(vctrs_shared_empty_list, 0);
   } else if (!is_data_frame(type)) {

--- a/src/c.c
+++ b/src/c.c
@@ -1,9 +1,7 @@
 #include "vctrs.h"
+#include "ptype-common.h"
 #include "slice-assign.h"
 #include "utils.h"
-
-// From type.c
-SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype);
 
 
 // [[ register(external = TRUE) ]]
@@ -35,7 +33,7 @@ SEXP vec_c(SEXP xs,
     return vec_c_fallback(xs, ptype, name_spec);
   }
 
-  ptype = PROTECT(vctrs_type_common_impl(xs, ptype));
+  ptype = PROTECT(vec_ptype_common_params(xs, ptype, true));
 
   if (ptype == R_NilValue) {
     UNPROTECT(1);

--- a/src/cast.c
+++ b/src/cast.c
@@ -1,8 +1,9 @@
 #include "vctrs.h"
 #include "cast.h"
+#include "dim.h"
+#include "ptype-common.h"
 #include "type-data-frame.h"
 #include "utils.h"
-#include "dim.h"
 
 static SEXP vec_cast_switch_native(SEXP x,
                                    SEXP to,
@@ -274,11 +275,9 @@ SEXP vec_cast_e(SEXP x,
 }
 
 
-SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype);
-
 // [[ include("vctrs.h") ]]
 SEXP vec_cast_common(SEXP xs, SEXP to) {
-  SEXP type = PROTECT(vctrs_type_common_impl(xs, to));
+  SEXP type = PROTECT(vec_ptype_common_params(xs, to, true));
 
   R_len_t n = Rf_length(xs);
   SEXP out = PROTECT(Rf_allocVector(VECSXP, n));

--- a/src/cast.h
+++ b/src/cast.h
@@ -2,6 +2,12 @@
 #define VCTRS_CAST_H
 
 
+SEXP vec_cast_params(SEXP x,
+                     SEXP to,
+                     struct vctrs_arg* x_arg,
+                     struct vctrs_arg* to_arg,
+                     bool df_fallback);
+
 SEXP vec_cast_dispatch(SEXP x,
                        SEXP to,
                        enum vctrs_type x_type,

--- a/src/init.c
+++ b/src/init.c
@@ -114,6 +114,7 @@ extern SEXP vctrs_new_date(SEXP);
 extern SEXP vctrs_date_validate(SEXP);
 extern SEXP vctrs_new_datetime(SEXP, SEXP);
 extern SEXP vctrs_datetime_validate(SEXP);
+extern SEXP vctrs_ptype2_params(SEXP, SEXP, SEXP, SEXP, SEXP);
 
 // Maturing
 // In the public header
@@ -248,10 +249,12 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_date_validate",              (DL_FUNC) &vctrs_date_validate, 1},
   {"vctrs_new_datetime",               (DL_FUNC) &vctrs_new_datetime, 2},
   {"vctrs_datetime_validate",          (DL_FUNC) &vctrs_datetime_validate, 1},
+  {"vctrs_ptype2_params",              (DL_FUNC) &vctrs_ptype2_params, 5},
   {NULL, NULL, 0}
 };
 
 extern SEXP vctrs_type_common(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_ptype_common_params(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_size_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_recycle_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cast_common(SEXP, SEXP, SEXP, SEXP);
@@ -262,6 +265,7 @@ extern SEXP vctrs_new_data_frame(SEXP);
 
 static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_type_common",                (DL_FUNC) &vctrs_type_common, 1},
+  {"vctrs_ptype_common_params",        (DL_FUNC) &vctrs_ptype_common_params, 2},
   {"vctrs_size_common",                (DL_FUNC) &vctrs_size_common, 2},
   {"vctrs_recycle_common",             (DL_FUNC) &vctrs_recycle_common, 1},
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 1},

--- a/src/ptype-common.h
+++ b/src/ptype-common.h
@@ -1,0 +1,6 @@
+#ifndef VCTRS_PTYPE_COMMON_H
+#define VCTRS_PTYPE_COMMON_H
+
+SEXP vec_ptype_common_params(SEXP dots, SEXP ptype, bool df_fallback);
+
+#endif

--- a/src/ptype2-dispatch.c
+++ b/src/ptype2-dispatch.c
@@ -7,7 +7,8 @@ SEXP vec_ptype2_dispatch(SEXP x, SEXP y,
                          enum vctrs_type y_type,
                          struct vctrs_arg* x_arg,
                          struct vctrs_arg* y_arg,
-                         int* left) {
+                         int* left,
+                         bool df_fallback) {
   enum vctrs_type2_s3 type2_s3 = vec_typeof2_s3_impl(x, y, x_type, y_type, left);
 
   switch (type2_s3) {
@@ -38,7 +39,7 @@ SEXP vec_ptype2_dispatch(SEXP x, SEXP y,
     return tib_ptype2(x, y, x_arg, y_arg);
 
   default:
-    return vec_ptype2_dispatch_s3(x, y, x_arg, y_arg);
+    return vec_ptype2_dispatch_s3(x, y, x_arg, y_arg, df_fallback);
   }
 }
 
@@ -47,13 +48,15 @@ static SEXP syms_vec_ptype2_default = NULL;
 static inline SEXP vec_ptype2_default(SEXP x,
                                       SEXP y,
                                       SEXP x_arg,
-                                      SEXP y_arg) {
-  return vctrs_eval_mask5(syms_vec_ptype2_default,
+                                      SEXP y_arg,
+                                      bool df_fallback) {
+  return vctrs_eval_mask6(syms_vec_ptype2_default,
                           syms_x, x,
                           syms_y, y,
                           syms_x_arg, x_arg,
                           syms_y_arg, y_arg,
                           syms_from_dispatch, vctrs_shared_true,
+                          syms_df_fallback, r_lgl(df_fallback),
                           vctrs_ns_env);
 }
 
@@ -61,7 +64,8 @@ static inline SEXP vec_ptype2_default(SEXP x,
 SEXP vec_ptype2_dispatch_s3(SEXP x,
                             SEXP y,
                             struct vctrs_arg* x_arg,
-                            struct vctrs_arg* y_arg) {
+                            struct vctrs_arg* y_arg,
+                            bool df_fallback) {
   SEXP x_arg_obj = PROTECT(vctrs_arg(x_arg));
   SEXP y_arg_obj = PROTECT(vctrs_arg(y_arg));
 
@@ -72,7 +76,7 @@ SEXP vec_ptype2_dispatch_s3(SEXP x,
                                           &x_method_sym));
 
   if (x_method == R_NilValue) {
-    SEXP out = vec_ptype2_default(x, y, x_arg_obj, y_arg_obj);
+    SEXP out = vec_ptype2_default(x, y, x_arg_obj, y_arg_obj, df_fallback);
     UNPROTECT(3);
     return out;
   }
@@ -87,7 +91,7 @@ SEXP vec_ptype2_dispatch_s3(SEXP x,
                                           &y_method_sym));
 
   if (y_method == R_NilValue) {
-    SEXP out = vec_ptype2_default(x, y, x_arg_obj, y_arg_obj);
+    SEXP out = vec_ptype2_default(x, y, x_arg_obj, y_arg_obj, df_fallback);
     UNPROTECT(4);
     return out;
   }

--- a/src/size-common.c
+++ b/src/size-common.c
@@ -36,11 +36,11 @@ SEXP vctrs_size_common(SEXP call, SEXP op, SEXP args, SEXP env) {
 }
 
 
-static SEXP vctrs_size2_common(SEXP x, SEXP y, struct counters* counters);
+static SEXP vctrs_size2_common(SEXP x, SEXP y, struct counters* counters, void* data);
 
 // [[ include("vctrs.h") ]]
 R_len_t vec_size_common(SEXP xs, R_len_t absent) {
-  SEXP common = PROTECT(reduce(R_NilValue, args_empty, xs, &vctrs_size2_common));
+  SEXP common = PROTECT(reduce(R_NilValue, args_empty, xs, &vctrs_size2_common, NULL));
   R_len_t out;
 
   if (common == R_NilValue) {
@@ -53,7 +53,7 @@ R_len_t vec_size_common(SEXP xs, R_len_t absent) {
   return out;
 }
 
-static SEXP vctrs_size2_common(SEXP x, SEXP y, struct counters* counters) {
+static SEXP vctrs_size2_common(SEXP x, SEXP y, struct counters* counters, void* data) {
   if (x == R_NilValue) {
     counters_shift(counters);
     return y;

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -2,6 +2,7 @@
 #include "slice.h"
 #include "slice-assign.h"
 #include "subscript-loc.h"
+#include "ptype-common.h"
 #include "type-data-frame.h"
 #include "utils.h"
 #include "dim.h"
@@ -379,9 +380,6 @@ static SEXP chop_fallback_shaped(SEXP x, SEXP indices, struct vctrs_chop_info in
 
 // -----------------------------------------------------------------------------
 
-// From type.c
-SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype);
-
 static SEXP vec_unchop(SEXP x,
                        SEXP indices,
                        SEXP ptype,
@@ -431,7 +429,7 @@ static SEXP vec_unchop(SEXP x,
     return vec_unchop_fallback(x, indices, ptype, name_spec);
   }
 
-  ptype = PROTECT(vctrs_type_common_impl(x, ptype));
+  ptype = PROTECT(vec_ptype_common_params(x, ptype, true));
 
   if (ptype == R_NilValue) {
     UNPROTECT(1);

--- a/src/type.c
+++ b/src/type.c
@@ -146,7 +146,7 @@ static SEXP vec_ptype_finalise_dispatch(SEXP x) {
 
 
 SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype);
-static SEXP vctrs_type2_common(SEXP current, SEXP next, struct counters* counters);
+static SEXP vctrs_type2_common(SEXP current, SEXP next, struct counters* counters, void* data);
 
 // [[ register(external = TRUE) ]]
 SEXP vctrs_type_common(SEXP call, SEXP op, SEXP args, SEXP env) {
@@ -171,7 +171,7 @@ SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype) {
   }
 
   // Start reduction with the `.ptype` argument
-  SEXP type = PROTECT(reduce(ptype, args_dot_ptype, dots, &vctrs_type2_common));
+  SEXP type = PROTECT(reduce(ptype, args_dot_ptype, dots, &vctrs_type2_common, NULL));
   type = vec_ptype_finalise(type);
 
   UNPROTECT(1);
@@ -179,7 +179,10 @@ SEXP vctrs_type_common_impl(SEXP dots, SEXP ptype) {
 }
 
 
-static SEXP vctrs_type2_common(SEXP current, SEXP next, struct counters* counters) {
+static SEXP vctrs_type2_common(SEXP current,
+                               SEXP next,
+                               struct counters* counters,
+                               void* data) {
   int left = -1;
   current = vec_ptype2(current, next, counters->curr_arg, counters->next_arg, &left);
 

--- a/src/type.c
+++ b/src/type.c
@@ -154,7 +154,7 @@ SEXP vctrs_type_common(SEXP call, SEXP op, SEXP args, SEXP env) {
   SEXP types = PROTECT(rlang_env_dots_values(env));
   SEXP ptype = PROTECT(Rf_eval(CAR(args), env));
 
-  SEXP out = vec_ptype_common_params(types, ptype, true);
+  SEXP out = vec_ptype_common_params(types, ptype, false);
 
   UNPROTECT(2);
   return out;

--- a/src/type2.c
+++ b/src/type2.c
@@ -9,13 +9,29 @@ static SEXP vec_ptype2_switch_native(SEXP x,
                                      enum vctrs_type y_type,
                                      struct vctrs_arg* x_arg,
                                      struct vctrs_arg* y_arg,
-                                     int* left);
+                                     int* left,
+                                     bool df_fallback);
+
+// [[ register() ]]
+SEXP vctrs_ptype2_params(SEXP x,
+                         SEXP y,
+                         SEXP df_fallback,
+                         SEXP x_arg,
+                         SEXP y_arg) {
+  struct vctrs_arg x_arg_ = vec_as_arg(x_arg);
+  struct vctrs_arg y_arg_ = vec_as_arg(y_arg);
+  bool df_fallback_ = LOGICAL(df_fallback)[0];
+  int _left;
+  return vec_ptype2_params(x, y, df_fallback_, &y_arg_, &x_arg_, &_left);
+}
 
 // [[ include("vctrs.h") ]]
-SEXP vec_ptype2(SEXP x, SEXP y,
-               struct vctrs_arg* x_arg,
-               struct vctrs_arg* y_arg,
-               int* left) {
+SEXP vec_ptype2_params(SEXP x,
+                       SEXP y,
+                       bool df_fallback,
+                       struct vctrs_arg* x_arg,
+                       struct vctrs_arg* y_arg,
+                       int* left) {
   if (x == R_NilValue) {
     *left = y == R_NilValue;
     return vec_ptype(y, y_arg);
@@ -43,9 +59,9 @@ SEXP vec_ptype2(SEXP x, SEXP y,
   }
 
   if (type_x == vctrs_type_s3 || type_y == vctrs_type_s3) {
-    return vec_ptype2_dispatch(x, y, type_x, type_y, x_arg, y_arg, left);
+    return vec_ptype2_dispatch(x, y, type_x, type_y, x_arg, y_arg, left, df_fallback);
   } else {
-    return vec_ptype2_switch_native(x, y, type_x, type_y, x_arg, y_arg, left);
+    return vec_ptype2_switch_native(x, y, type_x, type_y, x_arg, y_arg, left, df_fallback);
   }
 }
 
@@ -55,7 +71,8 @@ static SEXP vec_ptype2_switch_native(SEXP x,
                                      enum vctrs_type y_type,
                                      struct vctrs_arg* x_arg,
                                      struct vctrs_arg* y_arg,
-                                     int* left) {
+                                     int* left,
+                                     bool df_fallback) {
   enum vctrs_type2 type2 = vec_typeof2_impl(x_type, y_type, left);
 
   switch (type2) {
@@ -92,7 +109,7 @@ static SEXP vec_ptype2_switch_native(SEXP x,
     return df_ptype2(x, y, x_arg, y_arg);
 
   default:
-    return vec_ptype2_dispatch_s3(x, y, x_arg, y_arg);
+    return vec_ptype2_dispatch_s3(x, y, x_arg, y_arg, df_fallback);
   }
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -108,6 +108,18 @@ SEXP vctrs_eval_mask5(SEXP fn,
   SEXP args[6] = { x1, x2, x3, x4, x5, NULL };
   return vctrs_eval_mask_n(fn, syms, args, env);
 }
+SEXP vctrs_eval_mask6(SEXP fn,
+                      SEXP x1_sym, SEXP x1,
+                      SEXP x2_sym, SEXP x2,
+                      SEXP x3_sym, SEXP x3,
+                      SEXP x4_sym, SEXP x4,
+                      SEXP x5_sym, SEXP x5,
+                      SEXP x6_sym, SEXP x6,
+                      SEXP env) {
+  SEXP syms[7] = { x1_sym, x2_sym, x3_sym, x4_sym, x5_sym, x6_sym, NULL };
+  SEXP args[7] = { x1, x2, x3, x4, x5, x6, NULL };
+  return vctrs_eval_mask_n(fn, syms, args, env);
+}
 
 /**
  * Dispatch in the global environment
@@ -1443,6 +1455,7 @@ SEXP syms_body = NULL;
 SEXP syms_parent = NULL;
 SEXP syms_s3_methods_table = NULL;
 SEXP syms_from_dispatch = NULL;
+SEXP syms_df_fallback = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -1664,6 +1677,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_parent = Rf_install("parent");
   syms_s3_methods_table = Rf_install(".__S3MethodsTable__.");
   syms_from_dispatch = Rf_install("vctrs:::from_dispatch");
+  syms_df_fallback= Rf_install("vctrs:::df_fallback");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.h
+++ b/src/utils.h
@@ -58,6 +58,14 @@ SEXP vctrs_eval_mask5(SEXP fn,
                       SEXP x4_sym, SEXP x4,
                       SEXP x5_sym, SEXP x5,
                       SEXP env);
+SEXP vctrs_eval_mask6(SEXP fn,
+                      SEXP x1_sym, SEXP x1,
+                      SEXP x2_sym, SEXP x2,
+                      SEXP x3_sym, SEXP x3,
+                      SEXP x4_sym, SEXP x4,
+                      SEXP x5_sym, SEXP x5,
+                      SEXP x6_sym, SEXP x6,
+                      SEXP env);
 
 SEXP vctrs_dispatch_n(SEXP fn_sym, SEXP fn,
                       SEXP* syms, SEXP* args);
@@ -456,6 +464,7 @@ extern SEXP syms_character;
 extern SEXP syms_body;
 extern SEXP syms_parent;
 extern SEXP syms_from_dispatch;
+extern SEXP syms_df_fallback;
 
 #define syms_names R_NamesSymbol
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -396,6 +396,21 @@ SEXP vec_c(SEXP xs,
 SEXP vec_c_fallback(SEXP xs, SEXP ptype, SEXP name_spec);
 bool needs_vec_c_fallback(SEXP xs);
 
+SEXP vec_ptype2_params(SEXP x,
+                       SEXP y,
+                       bool df_fallback,
+                       struct vctrs_arg* x_arg,
+                       struct vctrs_arg* y_arg,
+                       int* left);
+
+static inline
+SEXP vec_ptype2(SEXP x, SEXP y,
+                struct vctrs_arg* x_arg,
+                struct vctrs_arg* y_arg,
+                int* left) {
+  return vec_ptype2_params(x, y, true, x_arg, y_arg, left);
+}
+
 SEXP vec_ptype2(SEXP x,
                SEXP y,
                struct vctrs_arg* x_arg,
@@ -407,12 +422,14 @@ SEXP vec_ptype2_dispatch(SEXP x, SEXP y,
                          enum vctrs_type y_type,
                          struct vctrs_arg* x_arg,
                          struct vctrs_arg* y_arg,
-                         int* left);
+                         int* left,
+                         bool df_fallback);
 
 SEXP vec_ptype2_dispatch_s3(SEXP x,
                             SEXP y,
                             struct vctrs_arg* x_arg,
-                            struct vctrs_arg* y_arg);
+                            struct vctrs_arg* y_arg,
+                            bool df_fallback);
 
 SEXP df_ptype2(SEXP x, SEXP y, struct vctrs_arg* x_arg, struct vctrs_arg* y_arg);
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -408,7 +408,7 @@ SEXP vec_ptype2(SEXP x, SEXP y,
                 struct vctrs_arg* x_arg,
                 struct vctrs_arg* y_arg,
                 int* left) {
-  return vec_ptype2_params(x, y, true, x_arg, y_arg, left);
+  return vec_ptype2_params(x, y, false, x_arg, y_arg, left);
 }
 
 SEXP vec_ptype2(SEXP x,

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -359,7 +359,6 @@ SEXP vec_restore(SEXP x, SEXP to, SEXP i);
 SEXP vec_restore_default(SEXP x, SEXP to);
 R_len_t vec_size(SEXP x);
 R_len_t vec_size_common(SEXP xs, R_len_t absent);
-SEXP vec_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg);
 SEXP vec_cast_common(SEXP xs, SEXP to);
 SEXP vec_cast_e(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg, ERR* err);
 bool vec_is_coercible(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg, int* dir);
@@ -382,6 +381,11 @@ SEXP vec_names(SEXP x);
 SEXP vec_group_loc(SEXP x);
 SEXP vec_match_params(SEXP needles, SEXP haystack, bool na_equal,
                       struct vctrs_arg* needles_arg, struct vctrs_arg* haystack_arg);
+
+#include "cast.h"
+static inline SEXP vec_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg) {
+  return vec_cast_params(x, to, x_arg, to_arg, false);
+}
 
 static inline SEXP vec_match(SEXP needles, SEXP haystack) {
   return vec_match_params(needles, haystack, true, NULL, NULL);

--- a/tests/testthat/error/test-type-data-frame.txt
+++ b/tests/testthat/error/test-type-data-frame.txt
@@ -6,64 +6,54 @@ combining data frames with foreign classes uses fallback
 > bar <- structure(mtcars[4:6], class = c("bar", "data.frame"))
 > baz <- structure(mtcars[7:9], class = c("baz", "data.frame"))
 > vec_ptype_common_fallback(foo, bar, baz)
-Warning: Can't combine <foo> and <bar>.
+Warning: Can't combine <foo> and <bar>; falling back to <data.frame>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
-i Falling back to <data.frame>.
 
-Warning: Can't combine <data.frame> and <baz>.
+Warning: Can't combine <data.frame> and <baz>; falling back to <data.frame>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
-i Falling back to <data.frame>.
 
 [1] mpg  cyl  disp hp   drat wt   qsec vs   am  
 <0 rows> (or 0-length row.names)
 
 > vec_ptype_common_fallback(foo, baz, bar, baz, foo, bar)
-Warning: Can't combine <foo> and <baz>.
+Warning: Can't combine <foo> and <baz>; falling back to <data.frame>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
-i Falling back to <data.frame>.
 
-Warning: Can't combine <data.frame> and <bar>.
+Warning: Can't combine <data.frame> and <bar>; falling back to <data.frame>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
-i Falling back to <data.frame>.
 
 [1] mpg  cyl  disp qsec vs   am   hp   drat wt  
 <0 rows> (or 0-length row.names)
 
 > invisible(vec_rbind(foo, data.frame(), foo))
-Warning: Can't combine <foo> and <data.frame>.
+Warning: Can't combine <foo> and <data.frame>; falling back to <data.frame>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
-i Falling back to <data.frame>.
 
 > invisible(vec_rbind(foo, baz, bar, baz, foo, bar))
-Warning: Can't combine <foo> and <baz>.
+Warning: Can't combine <foo> and <baz>; falling back to <data.frame>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
-i Falling back to <data.frame>.
 
-Warning: Can't combine <data.frame> and <bar>.
+Warning: Can't combine <data.frame> and <bar>; falling back to <data.frame>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
-i Falling back to <data.frame>.
 
 > invisible(vec_cbind(foo, data.frame(x = 1)))
-Warning: Can't combine <foo> and <data.frame>.
+Warning: Can't combine <foo> and <data.frame>; falling back to <data.frame>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
-i Falling back to <data.frame>.
 
 > invisible(vec_cbind(foo, data.frame(x = 1), bar))
-Warning: Can't combine <foo> and <data.frame>.
+Warning: Can't combine <foo> and <data.frame>; falling back to <data.frame>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
-i Falling back to <data.frame>.
 
-Warning: Can't combine <data.frame> and <bar>.
+Warning: Can't combine <data.frame> and <bar>; falling back to <data.frame>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
-i Falling back to <data.frame>.
 

--- a/tests/testthat/error/test-type-data-frame.txt
+++ b/tests/testthat/error/test-type-data-frame.txt
@@ -5,7 +5,7 @@ combining data frames with foreign classes uses fallback
 > foo <- structure(mtcars[1:3], class = c("foo", "data.frame"))
 > bar <- structure(mtcars[4:6], class = c("bar", "data.frame"))
 > baz <- structure(mtcars[7:9], class = c("baz", "data.frame"))
-> vec_ptype_common(foo, bar, baz)
+> vec_ptype_common_fallback(foo, bar, baz)
 Warning: Can't combine <foo> and <bar>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
@@ -19,7 +19,7 @@ i Falling back to <data.frame>.
 [1] mpg  cyl  disp hp   drat wt   qsec vs   am  
 <0 rows> (or 0-length row.names)
 
-> vec_ptype_common(foo, baz, bar, baz, foo, bar)
+> vec_ptype_common_fallback(foo, baz, bar, baz, foo, bar)
 Warning: Can't combine <foo> and <baz>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.

--- a/tests/testthat/error/test-type-data-frame.txt
+++ b/tests/testthat/error/test-type-data-frame.txt
@@ -50,3 +50,20 @@ i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
 i Falling back to <data.frame>.
 
+> invisible(vec_cbind(foo, data.frame(x = 1)))
+Warning: Can't combine <foo> and <data.frame>.
+i Convert all inputs to the same class to avoid this warning.
+i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
+i Falling back to <data.frame>.
+
+> invisible(vec_cbind(foo, data.frame(x = 1), bar))
+Warning: Can't combine <foo> and <data.frame>.
+i Convert all inputs to the same class to avoid this warning.
+i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
+i Falling back to <data.frame>.
+
+Warning: Can't combine <data.frame> and <bar>.
+i Convert all inputs to the same class to avoid this warning.
+i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
+i Falling back to <data.frame>.
+

--- a/tests/testthat/error/test-type-data-frame.txt
+++ b/tests/testthat/error/test-type-data-frame.txt
@@ -33,3 +33,20 @@ i Falling back to <data.frame>.
 [1] mpg  cyl  disp qsec vs   am   hp   drat wt  
 <0 rows> (or 0-length row.names)
 
+> invisible(vec_rbind(foo, data.frame(), foo))
+Warning: Can't combine <foo> and <data.frame>.
+i Convert all inputs to the same class to avoid this warning.
+i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
+i Falling back to <data.frame>.
+
+> invisible(vec_rbind(foo, baz, bar, baz, foo, bar))
+Warning: Can't combine <foo> and <baz>.
+i Convert all inputs to the same class to avoid this warning.
+i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
+i Falling back to <data.frame>.
+
+Warning: Can't combine <data.frame> and <bar>.
+i Convert all inputs to the same class to avoid this warning.
+i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
+i Falling back to <data.frame>.
+

--- a/tests/testthat/error/test-type2.txt
+++ b/tests/testthat/error/test-type2.txt
@@ -68,21 +68,19 @@ common type warnings for data frames take attributes into account
 > foobar_bud <- foobar(mtcars, bud = TRUE)
 > foobar_boo <- foobar(mtcars, boo = TRUE)
 > vec_ptype2_fallback(foobar_bud, foobar_boo)
-Warning: Can't combine <vctrs_foobar> and <vctrs_foobar>.
+Warning: Can't combine <vctrs_foobar> and <vctrs_foobar>; falling back to <data.frame>.
 x Some attributes are incompatible.
 i The author of the class should implement vctrs methods.
 i See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
-i Falling back to <data.frame>.
 
  [1] mpg  cyl  disp hp   drat wt   qsec vs   am   gear carb
 <0 rows> (or 0-length row.names)
 
 > # For reference, warning for incompatible classes
 > vec_ptype2_fallback(foobar(mtcars), foobaz(mtcars))
-Warning: Can't combine <vctrs_foobar> and <vctrs_foobaz>.
+Warning: Can't combine <vctrs_foobar> and <vctrs_foobaz>; falling back to <data.frame>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
-i Falling back to <data.frame>.
 
  [1] mpg  cyl  disp hp   drat wt   qsec vs   am   gear carb
 <0 rows> (or 0-length row.names)

--- a/tests/testthat/error/test-type2.txt
+++ b/tests/testthat/error/test-type2.txt
@@ -67,7 +67,7 @@ common type warnings for data frames take attributes into account
 
 > foobar_bud <- foobar(mtcars, bud = TRUE)
 > foobar_boo <- foobar(mtcars, boo = TRUE)
-> vec_ptype2(foobar_bud, foobar_boo)
+> vec_ptype2_fallback(foobar_bud, foobar_boo)
 Warning: Can't combine <vctrs_foobar> and <vctrs_foobar>.
 x Some attributes are incompatible.
 i The author of the class should implement vctrs methods.
@@ -78,7 +78,7 @@ i Falling back to <data.frame>.
 <0 rows> (or 0-length row.names)
 
 > # For reference, warning for incompatible classes
-> vec_ptype2(foobar(mtcars), foobaz(mtcars))
+> vec_ptype2_fallback(foobar(mtcars), foobaz(mtcars))
 Warning: Can't combine <vctrs_foobar> and <vctrs_foobaz>.
 i Convert all inputs to the same class to avoid this warning.
 i See <https://vctrs.r-lib.org/reference/faq-warning-convert-inputs.html>.
@@ -86,4 +86,8 @@ i Falling back to <data.frame>.
 
  [1] mpg  cyl  disp hp   drat wt   qsec vs   am   gear carb
 <0 rows> (or 0-length row.names)
+
+> # For reference, error when fallback is disabled
+> vec_ptype2(foobar(mtcars), foobaz(mtcars))
+Error: Can't combine <vctrs_foobar> and <vctrs_foobaz>.
 

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -90,5 +90,5 @@ expect_error_cnd <- function(object, class, message = NULL, ..., .fixed = TRUE) 
 }
 
 expect_df_fallback <- function(expr) {
-  expect_warning({{ expr }}, "Falling back")
+  expect_warning({{ expr }}, "falling back to <data.frame>")
 }

--- a/tests/testthat/helper-vctrs.R
+++ b/tests/testthat/helper-vctrs.R
@@ -3,3 +3,10 @@ import_from <- function(ns, names, env = caller_env()) {
   objs <- env_get_list(ns_env(ns), names)
   env_bind(env, !!!objs)
 }
+
+vec_ptype2_fallback <- function(x, y, ...) {
+  vec_ptype2_params(x, y, ..., df_fallback = TRUE)
+}
+vec_ptype_common_fallback <- function(..., .ptype = NULL) {
+  vec_ptype_common_params(..., .ptype = .ptype, .df_fallback = TRUE)
+}

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -100,7 +100,11 @@ test_that("combining data frames with foreign classes uses fallback", {
     baz <- structure(mtcars[7:9], class = c("baz", "data.frame"))
     expect_warning(vec_ptype_common_fallback(foo, bar, baz))
     expect_warning(vec_ptype_common_fallback(foo, baz, bar, baz, foo, bar))
+
     expect_df_fallback(invisible(vec_rbind(foo, data.frame(), foo)))
+
+    expect_df_fallback(invisible(vec_cbind(foo, data.frame(x = 1))))
+    expect_df_fallback(invisible(vec_cbind(foo, data.frame(x = 1), bar)))
   })
 })
 
@@ -398,7 +402,11 @@ test_that("data frame output is informative", {
     baz <- structure(mtcars[7:9], class = c("baz", "data.frame"))
     vec_ptype_common_fallback(foo, bar, baz)
     vec_ptype_common_fallback(foo, baz, bar, baz, foo, bar)
+
     invisible(vec_rbind(foo, data.frame(), foo))
     invisible(vec_rbind(foo, baz, bar, baz, foo, bar))
+
+    invisible(vec_cbind(foo, data.frame(x = 1)))
+    invisible(vec_cbind(foo, data.frame(x = 1), bar))
   })
 })

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -83,7 +83,7 @@ test_that("combining data frames with foreign classes uses fallback", {
   # There should be only one warning even if many fallbacks
   expect_length(cnds, 1)
   expect_is(cnds[[1]], "warning")
-  expect_match(cnds[[1]]$message, "Falling back")
+  expect_match(cnds[[1]]$message, "falling back to <data.frame>")
 
   expect_identical(
     expect_df_fallback(vec_cbind(foobar(data.frame(x = 1)), data.frame(y = 2))),

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -89,6 +89,10 @@ test_that("combining data frames with foreign classes uses fallback", {
     expect_df_fallback(vec_cbind(foobar(data.frame(x = 1)), data.frame(y = 2))),
     data.frame(x = 1, y = 2)
   )
+  expect_identical(
+    expect_df_fallback(vec_rbind(foo, data.frame(), foo)),
+    df
+  )
 
   verify_errors({
     foo <- structure(mtcars[1:3], class = c("foo", "data.frame"))
@@ -96,13 +100,8 @@ test_that("combining data frames with foreign classes uses fallback", {
     baz <- structure(mtcars[7:9], class = c("baz", "data.frame"))
     expect_warning(vec_ptype_common_fallback(foo, bar, baz))
     expect_warning(vec_ptype_common_fallback(foo, baz, bar, baz, foo, bar))
+    expect_df_fallback(invisible(vec_rbind(foo, data.frame(), foo)))
   })
-
-  skip("FIXME - cast fallback")
-  expect_identical(
-    expect_df_fallback(vec_rbind(foo, data.frame(), foo)),
-    df
-  )
 })
 
 
@@ -399,5 +398,7 @@ test_that("data frame output is informative", {
     baz <- structure(mtcars[7:9], class = c("baz", "data.frame"))
     vec_ptype_common_fallback(foo, bar, baz)
     vec_ptype_common_fallback(foo, baz, bar, baz, foo, bar)
+    invisible(vec_rbind(foo, data.frame(), foo))
+    invisible(vec_rbind(foo, baz, bar, baz, foo, bar))
   })
 })

--- a/tests/testthat/test-type-dplyr.R
+++ b/tests/testthat/test-type-dplyr.R
@@ -161,9 +161,8 @@ test_that("can cbind rowwise data frames", {
 })
 
 test_that("no common type between rowwise and grouped data frames", {
-  expect_warning(
-    out <- vec_ptype_common(dplyr::rowwise(mtcars), dplyr::group_by(mtcars, cyl)),
-    "Falling back"
+  expect_df_fallback(
+    out <- vec_ptype_common_fallback(dplyr::rowwise(mtcars), dplyr::group_by(mtcars, cyl))
   )
   expect_identical(out, unrownames(mtcars[0, ]))
 })

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -160,14 +160,23 @@ test_that("Subclasses of data.frame dispatch to `vec_ptype2()` methods", {
 
 test_that("Subclasses of `tbl_df` do not have `tbl_df` common type (#481)", {
   quux <- tibble()
-  quux <- structure(quux, class = c("quux", class(quux)))
+  quux <- foobar(quux)
+
+  expect_error(
+    vec_ptype_common(quux, tibble()),
+    class = "vctrs_error_incompatible_type"
+  )
+  expect_error(
+    vec_ptype_common(tibble(), quux),
+    class = "vctrs_error_incompatible_type"
+  )
 
   expect_df_fallback(expect_identical(
-    vec_ptype_common(quux, tibble()),
+    vec_ptype_common_fallback(quux, tibble()),
     data.frame()
   ))
   expect_df_fallback(expect_identical(
-    vec_ptype_common(tibble(), quux),
+    vec_ptype_common_fallback(tibble(), quux),
     data.frame()
   ))
 })
@@ -263,10 +272,13 @@ test_that("common type warnings for data frames take attributes into account", {
   verify_errors({
     foobar_bud <- foobar(mtcars, bud = TRUE)
     foobar_boo <- foobar(mtcars, boo = TRUE)
-    expect_df_fallback(vec_ptype2(foobar_bud, foobar_boo))
+    expect_df_fallback(vec_ptype2_fallback(foobar_bud, foobar_boo))
 
     "For reference, warning for incompatible classes"
-    expect_df_fallback(vec_ptype2(foobar(mtcars), foobaz(mtcars)))
+    expect_df_fallback(vec_ptype2_fallback(foobar(mtcars), foobaz(mtcars)))
+
+    "For reference, error when fallback is disabled"
+    expect_error(vec_ptype2(foobar(mtcars), foobaz(mtcars)), class = "vctrs_error_incompatible_type")
   })
 })
 
@@ -311,9 +323,12 @@ test_that("vec_ptype2() errors have informative output", {
     "# common type warnings for data frames take attributes into account"
     foobar_bud <- foobar(mtcars, bud = TRUE)
     foobar_boo <- foobar(mtcars, boo = TRUE)
-    vec_ptype2(foobar_bud, foobar_boo)
+    vec_ptype2_fallback(foobar_bud, foobar_boo)
 
     "For reference, warning for incompatible classes"
+    vec_ptype2_fallback(foobar(mtcars), foobaz(mtcars))
+
+    "For reference, error when fallback is disabled"
     vec_ptype2(foobar(mtcars), foobaz(mtcars))
   })
 })


### PR DESCRIPTION
* Don't fall back to data frame by default, only from `vec_rbind()` and `vec_cbind()`.

* Add `vec_cast()` fallback. The binding functions would previously only work if the is-same-type fallback kicked in, which is not the case when attributes differ. Closes #1028.