### PR TITLE
Handle different column specs in df fallback

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -162,6 +162,12 @@ vec_default_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
     return(UseMethod("vec_cast", to))
   }
 
+  # If both data frames, first find the `to` type of columns before
+  # the same-type fallback
+  if (is.data.frame(x) && is.data.frame(to) && df_is_coercible(x, to)) {
+    x <- vec_cast_df_fallback_normalise(x, to)
+  }
+
   if (is_same_type(x, to)) {
     return(x)
   }

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -102,6 +102,9 @@ df_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
 }
 
 vec_ptype2_df_fallback_normalise <- function(x, y) {
+  x_orig <- x
+  y_orig <- y
+
   ptype <- df_ptype2(x, y)
 
   # Empty columns first to avoid name repairs
@@ -111,9 +114,19 @@ vec_ptype2_df_fallback_normalise <- function(x, y) {
   x[seq_along(ptype)] <- ptype
   y[seq_along(ptype)] <- ptype
 
+  # Restore attributes if no `[` method is implemented
+  if (df_has_base_subset(x)) {
+    x <- vec_restore(x, x_orig)
+  }
+  if (df_has_base_subset(y)) {
+    y <- vec_restore(y, y_orig)
+  }
+
   list(x = x, y = y)
 }
 vec_cast_df_fallback_normalise <- function(x, to) {
+  orig <- x
+
   cast <- df_cast(x, to)
 
   # Empty columns first to avoid name repairs
@@ -121,6 +134,11 @@ vec_cast_df_fallback_normalise <- function(x, to) {
 
   # Seq-assign should be more widely implemented than empty-assign?
   x[seq_along(to)] <- cast
+
+  # Restore attributes if no `[` method is implemented
+  if (df_has_base_subset(x)) {
+    x <- vec_restore(x, orig)
+  }
 
   x
 }

--- a/R/type2.R
+++ b/R/type2.R
@@ -83,6 +83,14 @@ vec_default_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
     return(UseMethod("vec_ptype2"))
   }
 
+  # If both data frames, first find common type of columns before the
+  # same-type fallback
+  if (is.data.frame(x) && is.data.frame(y) && df_is_coercible(x, y)) {
+    out <- vec_ptype2_df_fallback_normalise(x, y)
+    x <- out$x
+    y <- out$y
+  }
+
   if (is_same_type(x, y)) {
     return(vec_ptype(x, x_arg = x_arg))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -159,5 +159,5 @@ ns_methods <- function(name) {
 df_has_base_subset <- function(x) {
   table <- ns_methods(.BaseNamespaceEnv)
   method <- .Call(vctrs_s3_find_method, "[", x, table)
-  identical(method, `[.data.frame`)
+  is_null(method) || identical(method, `[.data.frame`)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -151,3 +151,13 @@ try_catch_impl <- function(data, ...) {
     ...
   )
 }
+
+ns_methods <- function(name) {
+  ns_env(name)$.__S3MethodsTable__.
+}
+
+df_has_base_subset <- function(x) {
+  table <- ns_methods(.BaseNamespaceEnv)
+  method <- .Call(vctrs_s3_find_method, "[", x, table)
+  identical(method, `[.data.frame`)
+}

--- a/src/init.c
+++ b/src/init.c
@@ -115,6 +115,8 @@ extern SEXP vctrs_date_validate(SEXP);
 extern SEXP vctrs_new_datetime(SEXP, SEXP);
 extern SEXP vctrs_datetime_validate(SEXP);
 extern SEXP vctrs_ptype2_params(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_s3_find_method(SEXP, SEXP, SEXP);
+
 
 // Maturing
 // In the public header
@@ -250,6 +252,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_new_datetime",               (DL_FUNC) &vctrs_new_datetime, 2},
   {"vctrs_datetime_validate",          (DL_FUNC) &vctrs_datetime_validate, 1},
   {"vctrs_ptype2_params",              (DL_FUNC) &vctrs_ptype2_params, 5},
+  {"vctrs_s3_find_method",             (DL_FUNC) &vctrs_s3_find_method, 3},
   {NULL, NULL, 0}
 };
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -369,6 +369,12 @@ SEXP s3_sym_get_method(SEXP sym, SEXP table) {
   return R_NilValue;
 }
 
+// [[ register() ]]
+SEXP vctrs_s3_find_method(SEXP generic, SEXP x, SEXP table) {
+  return s3_find_method(r_chr_get_c_string(generic, 0), x, table);
+}
+
+// [[ include("utils.h") ]]
 SEXP s3_find_method(const char* generic, SEXP x, SEXP table) {
   if (!OBJECT(x)) {
     return R_NilValue;

--- a/tests/testthat/error/test-type2.txt
+++ b/tests/testthat/error/test-type2.txt
@@ -68,6 +68,11 @@ common type warnings for data frames take attributes into account
 > foobar_bud <- foobar(mtcars, bud = TRUE)
 > foobar_boo <- foobar(mtcars, boo = TRUE)
 > vec_ptype2_fallback(foobar_bud, foobar_boo)
+Warning: Can't combine <vctrs_foobar> and <vctrs_foobar>; falling back to <data.frame>.
+x Some attributes are incompatible.
+i The author of the class should implement vctrs methods.
+i See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
+
  [1] mpg  cyl  disp hp   drat wt   qsec vs   am   gear carb
 <0 rows> (or 0-length row.names)
 

--- a/tests/testthat/error/test-type2.txt
+++ b/tests/testthat/error/test-type2.txt
@@ -68,11 +68,6 @@ common type warnings for data frames take attributes into account
 > foobar_bud <- foobar(mtcars, bud = TRUE)
 > foobar_boo <- foobar(mtcars, boo = TRUE)
 > vec_ptype2_fallback(foobar_bud, foobar_boo)
-Warning: Can't combine <vctrs_foobar> and <vctrs_foobar>; falling back to <data.frame>.
-x Some attributes are incompatible.
-i The author of the class should implement vctrs methods.
-i See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
-
  [1] mpg  cyl  disp hp   drat wt   qsec vs   am   gear carb
 <0 rows> (or 0-length row.names)
 

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -394,6 +394,39 @@ test_that("new_data_frame() zaps existing attributes", {
   )
 })
 
+test_that("data frame fallback handles column types (#999)", {
+  df1 <- foobar(data.frame(x = 1))
+  df2 <- foobar(data.frame(x = 1, y = 2))
+  df3 <- foobar(data.frame(x = "", y = 2))
+
+  common <- foobar(data.frame(x = dbl(), y = dbl()))
+  expect_identical(vec_ptype2(df1, df2), common)
+  expect_identical(vec_ptype2(df2, df1), common)
+
+  expect_error(
+    vec_ptype2(df1, df3),
+    class = "vctrs_error_incompatible_type"
+  )
+  expect_error(
+    vec_ptype2(df3, df1),
+    class = "vctrs_error_incompatible_type"
+  )
+
+  expect_identical(
+    vec_cast(df1, df2),
+    foobar(data.frame(x = 1, y = na_dbl))
+  )
+  expect_error(
+    vec_cast(df2, df1),
+    class = "vctrs_error_cast_lossy"
+  )
+
+  expect_identical(
+    vec_rbind(df1, df2),
+    foobar(data.frame(x = c(1, 1), y = c(NA, 2)))
+  )
+})
+
 test_that("data frame output is informative", {
   verify_output(test_path("error", "test-type-data-frame.txt"), {
     "# combining data frames with foreign classes uses fallback"

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -425,6 +425,19 @@ test_that("data frame fallback handles column types (#999)", {
     vec_rbind(df1, df2),
     foobar(data.frame(x = c(1, 1), y = c(NA, 2)))
   )
+
+  # Attributes are not restored
+  df1_attrib <- foobar(df1, foo = "foo")
+  df2_attrib <- foobar(df2, bar = "bar")
+  exp <- data.frame(x = c(1, 1), y = c(NA, 2))
+  out <- expect_df_fallback(vec_rbind(df1_attrib, df2_attrib))
+  expect_identical(out, exp)
+
+  out <- with_methods(
+    `[.vctrs_foobar` = function(x, i, ...) structure(NextMethod(), dispatched = TRUE),
+    vec_rbind(df1_attrib, df2_attrib)
+  )
+  expect_identical(out, foobar(exp, dispatched = TRUE))
 })
 
 test_that("data frame output is informative", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,7 +1,5 @@
 context("test-utils")
 
-# outer_names --------------------------------------------------------------
-
 test_that("names preserved if outer name is missing", {
   x <- c("a", "z", "")
 
@@ -37,10 +35,17 @@ test_that("can't supply unknown option", {
   )
 })
 
-# has_dim ------------------------------------------------------------------
-
 test_that("`has_dim()` doesn't partial match on the `dim` attribute (#948)", {
   x <- structure(1, dimB = 1)
   expect_false(has_dim(x))
 })
 
+test_that("df_has_base_subset() detects `[` methods", {
+  expect_true(df_has_base_subset(foobar(mtcars)))
+
+  out <- with_methods(
+    `[.vctrs_foobar` = function(x, i, ...) structure(NextMethod(), dispatched = TRUE),
+    df_has_base_subset(foobar(mtcars))
+  )
+  expect_false(out)
+})


### PR DESCRIPTION
Closes #999.

This is a bit tricky.

* Use df-ptype2 and df-cast to find the proper data frame shape before falling back.

* Use `[` to insert that shape in the inputs, dispatching on df subclass implementations for subset as needed.

* Restore attributes if there is no `[` implementation, so that we can give a proper warning about implementing ptype2 methods.

```r
df1 <- data.table::data.table(x = 1, y = 2)
df2 <- data.table::data.table(x = 3)

# Before
dplyr::bind_rows(df1, df2)
#>   x  y
#> 1 1  2
#> 2 3 NA
#> Warning message:
#> Can't combine <data.table> and <data.table>.
#> ✖ Some attributes are incompatible.
#> ℹ The author of the class should implement vctrs methods.
#> ℹ See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
#> ℹ Falling back to <data.frame>.


# After
dplyr::bind_rows(df1, df2)
#>    x  y
#> 1: 1  2
#> 2: 3 NA
```