### PR TITLE
Alter `new_data_frame()` signature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # vctrs (development version)
 
+* The signature of `new_data_frame()` has been changed to avoid collisions
+  when setting attributes with names that are identical to the argument
+  names (#949).
+
 * `new_vctr()` now always appends a base `"list"` class to list `.data` to
   be compatible with changes to `vec_is_list()`. This affects `new_list_of()`,
   which now returns an object with a base class of `"list"`.
@@ -168,7 +172,7 @@
 
 * `POSIXlt` and `POSIXct` vectors are handled more consistently (#901).
 
-* `new_data_frame()` infers size from row names when `n = NULL` (#894).
+* `new_data_frame()` infers size from row names when `.size = NULL` (#894).
 
 
 ## Breaking changes

--- a/R/partial-frame.R
+++ b/R/partial-frame.R
@@ -18,7 +18,7 @@ partial_frame <- function(...) {
   args <- list2(...)
   args <- lapply(args, vec_ptype)
 
-  partial <- new_data_frame(args, n = 0L)
+  partial <- new_data_frame(args, .size = 0L)
   new_partial_frame(partial)
 }
 

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -153,10 +153,10 @@ is_df_subclass <- function(x) {
 is_df_fallback <- function(x) {
   inherits(x, "vctrs:::df_fallback")
 }
-new_fallback_df <- function(x, known_classes, n = nrow(x)) {
+new_fallback_df <- function(x, known_classes, size = nrow(x)) {
   new_data_frame(
     x,
-    .size = n,
+    .size = size,
     known_classes = known_classes,
     .class = "vctrs:::df_fallback"
   )

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -5,27 +5,27 @@
 #' help the base data.frame classes fit in to the vctrs type system by
 #' providing constructors, coercion functions, and casting functions.
 #'
-#' @param x A named list of equal-length vectors. The lengths are not
+#' @param .x A named list of equal-length vectors. The lengths are not
 #'   checked; it is responsibility of the caller to make sure they are
 #'   equal.
-#' @param n Number of rows. If `NULL`, will be computed from the length of
-#'   the first element of `x`.
-#' @param ...,class Additional arguments for creating subclasses.
-#'   The `"names"` and `"row.names"` attributes override input in `x` and `n`,
-#'   respectively:
+#' @param .size Number of rows. If `NULL`, will be computed from the length of
+#'   the first element of `.x`.
+#' @param ...,.class Additional arguments for creating subclasses.
+#'   The `"names"` and `"row.names"` attributes override input in `.x` and
+#'   `.size`, respectively:
 #'
-#'   - `"names"` is used if provided, overriding existing names in `x`
-#'   - `"row.names"` is used if provided, if `n` is provided it must be
+#'   - `"names"` is used if provided, overriding existing names in `.x`.
+#'   - `"row.names"` is used if provided, if `.size` is provided it must be
 #'     consistent.
 #'
 #' @export
 #' @keywords internal
 #' @examples
 #' new_data_frame(list(x = 1:10, y = 10:1))
-new_data_frame <- function(x = list(), n = NULL, ..., class = NULL) {
-  .External(vctrs_new_data_frame, x, n, class, ...)
+new_data_frame <- function(.x = list(), ..., .size = NULL, .class = NULL) {
+  .External(vctrs_new_data_frame, .x, .size, .class, ...)
 }
-new_data_frame <- fn_inline_formals(new_data_frame, "x")
+new_data_frame <- fn_inline_formals(new_data_frame, ".x")
 
 
 # Light weight constructor used for tests - avoids having to repeatedly do
@@ -71,7 +71,7 @@ vec_ptype_abbr.data.frame <- function(x, ...) {
 #' @export
 vec_proxy_compare.data.frame <- function(x, ..., relax = FALSE) {
   out <- lapply(as.list(x), vec_proxy_compare, relax = TRUE)
-  new_data_frame(out, nrow(x))
+  new_data_frame(out, .size = nrow(x))
 }
 
 
@@ -156,9 +156,9 @@ is_df_fallback <- function(x) {
 new_fallback_df <- function(x, known_classes, n = nrow(x)) {
   new_data_frame(
     x,
-    n = n,
+    .size = n,
     known_classes = known_classes,
-    class = "vctrs:::df_fallback"
+    .class = "vctrs:::df_fallback"
   )
 }
 

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -1,8 +1,8 @@
 #' Data frame class
 #'
-#' A `data.frame` [data.frame()] is a list with "row.names" attribute. Each
+#' A `data.frame` is a list with a "row.names" attribute. Each
 #' element of the list must be named, and of the same length. These functions
-#' help the base data.frame classes fit in to the vctrs type system by
+#' help the base data.frame class fit in to the vctrs type system by
 #' providing constructors, coercion functions, and casting functions.
 #'
 #' @param .x A named list of equal-length vectors. The lengths are not

--- a/R/type-rcrd.R
+++ b/R/type-rcrd.R
@@ -183,7 +183,7 @@ as.list.vctrs_rcrd <- function(x, ...) {
 
 #' @export
 vec_proxy_compare.vctrs_rcrd <- function(x, ..., relax = FALSE) {
-  new_data_frame(vec_data(x), n = length(x))
+  new_data_frame(vec_data(x), .size = length(x))
 }
 
 #' @export

--- a/R/type-sclr.R
+++ b/R/type-sclr.R
@@ -57,7 +57,7 @@ as.data.frame.vctrs_sclr <- function(x,
     names(cols) <- nm
   }
 
-  new_data_frame(cols, n = 1L)
+  new_data_frame(cols, .size = 1L)
 }
 
 # Vector behaviours -------------------------------------------------------

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -368,7 +368,7 @@ as.data.frame.vctrs_vctr <- function(x,
     names(cols) <- nm
   }
 
-  new_data_frame(cols, n = vec_size(x))
+  new_data_frame(cols, .size = vec_size(x))
 }
 
 # Dynamically registered in .onLoad()

--- a/man/new_data_frame.Rd
+++ b/man/new_data_frame.Rd
@@ -30,9 +30,9 @@ consistent.
 the first element of \code{.x}.}
 }
 \description{
-A \code{data.frame} \code{\link[=data.frame]{data.frame()}} is a list with "row.names" attribute. Each
+A \code{data.frame} is a list with a "row.names" attribute. Each
 element of the list must be named, and of the same length. These functions
-help the base data.frame classes fit in to the vctrs type system by
+help the base data.frame class fit in to the vctrs type system by
 providing constructors, coercion functions, and casting functions.
 }
 \examples{

--- a/man/new_data_frame.Rd
+++ b/man/new_data_frame.Rd
@@ -6,28 +6,28 @@
 \alias{vec_cast.data.frame}
 \title{Data frame class}
 \usage{
-new_data_frame(x = list(), n = NULL, ..., class = NULL)
+new_data_frame(.x = list(), ..., .size = NULL, .class = NULL)
 
 \method{vec_ptype2}{data.frame}(x, y, ...)
 
 \method{vec_cast}{data.frame}(x, to, ...)
 }
 \arguments{
-\item{x}{A named list of equal-length vectors. The lengths are not
+\item{.x}{A named list of equal-length vectors. The lengths are not
 checked; it is responsibility of the caller to make sure they are
 equal.}
 
-\item{n}{Number of rows. If \code{NULL}, will be computed from the length of
-the first element of \code{x}.}
-
-\item{..., class}{Additional arguments for creating subclasses.
-The \code{"names"} and \code{"row.names"} attributes override input in \code{x} and \code{n},
-respectively:
+\item{..., .class}{Additional arguments for creating subclasses.
+The \code{"names"} and \code{"row.names"} attributes override input in \code{.x} and
+\code{.size}, respectively:
 \itemize{
-\item \code{"names"} is used if provided, overriding existing names in \code{x}
-\item \code{"row.names"} is used if provided, if \code{n} is provided it must be
+\item \code{"names"} is used if provided, overriding existing names in \code{.x}.
+\item \code{"row.names"} is used if provided, if \code{.size} is provided it must be
 consistent.
 }}
+
+\item{.size}{Number of rows. If \code{NULL}, will be computed from the length of
+the first element of \code{.x}.}
 }
 \description{
 A \code{data.frame} \code{\link[=data.frame]{data.frame()}} is a list with "row.names" attribute. Each

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -5,7 +5,7 @@
 static SEXP syms_df_lossy_cast = NULL;
 static SEXP fns_df_lossy_cast = NULL;
 
-static SEXP new_compact_rownames(R_len_t n);
+static SEXP new_compact_rownames(R_len_t size);
 
 
 // [[ include("type-data-frame.h") ]]
@@ -40,9 +40,9 @@ bool is_bare_tibble(SEXP x) {
 }
 
 // [[ include("type-data-frame.h") ]]
-SEXP new_data_frame(SEXP x, R_len_t n) {
+SEXP new_data_frame(SEXP x, R_len_t size) {
   x = PROTECT(r_maybe_duplicate(x));
-  init_data_frame(x, n);
+  init_data_frame(x, size);
 
   UNPROTECT(1);
   return x;
@@ -218,43 +218,43 @@ R_len_t rownames_size(SEXP rn) {
   never_reached("rownames_size");
 }
 
-static void init_bare_data_frame(SEXP x, R_len_t n);
+static void init_bare_data_frame(SEXP x, R_len_t size);
 
 // [[ include("type-data-frame.h") ]]
-void init_data_frame(SEXP x, R_len_t n) {
+void init_data_frame(SEXP x, R_len_t size) {
   Rf_setAttrib(x, R_ClassSymbol, classes_data_frame);
-  init_bare_data_frame(x, n);
+  init_bare_data_frame(x, size);
 }
 // [[ include("type-data-frame.h") ]]
-void init_tibble(SEXP x, R_len_t n) {
+void init_tibble(SEXP x, R_len_t size) {
   Rf_setAttrib(x, R_ClassSymbol, classes_tibble);
-  init_bare_data_frame(x, n);
+  init_bare_data_frame(x, size);
 }
 
-static void init_bare_data_frame(SEXP x, R_len_t n) {
+static void init_bare_data_frame(SEXP x, R_len_t size) {
   if (Rf_length(x) == 0) {
     Rf_setAttrib(x, R_NamesSymbol, vctrs_shared_empty_chr);
   }
 
-  init_compact_rownames(x, n);
+  init_compact_rownames(x, size);
 }
 
 // [[ include("type-data-frame.h") ]]
-void init_compact_rownames(SEXP x, R_len_t n) {
-  SEXP rn = PROTECT(new_compact_rownames(n));
+void init_compact_rownames(SEXP x, R_len_t size) {
+  SEXP rn = PROTECT(new_compact_rownames(size));
   Rf_setAttrib(x, R_RowNamesSymbol, rn);
   UNPROTECT(1);
 }
 
-static SEXP new_compact_rownames(R_len_t n) {
-  if (n <= 0) {
+static SEXP new_compact_rownames(R_len_t size) {
+  if (size <= 0) {
     return vctrs_shared_empty_int;
   }
 
   SEXP out = Rf_allocVector(INTSXP, 2);
   int* out_data = INTEGER(out);
   out_data[0] = NA_INTEGER;
-  out_data[1] = -n;
+  out_data[1] = -size;
   return out;
 }
 

--- a/src/type-data-frame.h
+++ b/src/type-data-frame.h
@@ -2,10 +2,10 @@
 #define VCTRS_TYPE_DATA_FRAME_H
 
 
-SEXP new_data_frame(SEXP x, R_len_t n);
-void init_data_frame(SEXP x, R_len_t n);
-void init_tibble(SEXP x, R_len_t n);
-void init_compact_rownames(SEXP x, R_len_t n);
+SEXP new_data_frame(SEXP x, R_len_t size);
+void init_data_frame(SEXP x, R_len_t size);
+void init_tibble(SEXP x, R_len_t size);
+void init_compact_rownames(SEXP x, R_len_t size);
 SEXP df_rownames(SEXP x);
 
 bool is_native_df(SEXP x);

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -168,12 +168,12 @@ test_that("can rbind unspecified vectors", {
 })
 
 test_that("vec_rbind() respects size invariants (#286)", {
-  expect_identical(vec_rbind(), new_data_frame(n = 0L))
+  expect_identical(vec_rbind(), new_data_frame(.size = 0L))
 
-  expect_identical(vec_rbind(int(), int()), new_data_frame(n = 2L))
+  expect_identical(vec_rbind(int(), int()), new_data_frame(.size = 2L))
   expect_identical(vec_rbind(int(), TRUE), new_data_frame(list(...1 = lgl(NA, TRUE))))
 
-  expect_identical(vec_rbind(int(), new_data_frame(n = 2L), int()), new_data_frame(n = 4L))
+  expect_identical(vec_rbind(int(), new_data_frame(.size = 2L), int()), new_data_frame(.size = 4L))
 })
 
 test_that("can repair names in `vec_rbind()` (#229)", {

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -168,7 +168,7 @@ test_that("vec_proxy_compare.POSIXlt() correctly orders around DST", {
 })
 
 test_that("error is thrown with data frames with 0 columns", {
-  x <- new_data_frame(n = 1L)
+  x <- new_data_frame(.size = 1L)
   expect_error(vec_compare(x, x), "data frame with zero columns")
 })
 
@@ -288,7 +288,7 @@ test_that("can order data frames with data frame columns (#527)", {
 })
 
 test_that("can order data frames (and subclasses) with matrix columns", {
-  df <- new_data_frame(n = 2L)
+  df <- new_data_frame(.size = 2L)
 
   df$x <- new_data_frame(list(y = matrix(1:2, 2)))
   expect_identical(vec_order(df), 1:2)

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -239,8 +239,8 @@ test_that("can opt out of NA matching", {
 
 test_that("vec_match works with empty data frame", {
   out <- vec_match(
-    new_data_frame(n = 3L),
-    new_data_frame(n = 0L)
+    new_data_frame(.size = 3L),
+    new_data_frame(.size = 0L)
   )
   expect_equal(out, vec_init(integer(), 3))
 })

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -141,7 +141,7 @@ test_that("data frames must have same size and columns", {
 })
 
 test_that("can compare data frames with 0 columns", {
-  x <- new_data_frame(n = 1L)
+  x <- new_data_frame(.size = 1L)
   expect_true(vec_equal(x, x))
 })
 

--- a/tests/testthat/test-fields.R
+++ b/tests/testthat/test-fields.R
@@ -78,11 +78,11 @@ test_that("field<- checks inputs", {
 })
 
 test_that("field<- respects size, not length (#450)", {
-  r1 <- new_rcrd(list(df = new_data_frame(n = 2L)))
+  r1 <- new_rcrd(list(df = new_data_frame(.size = 2L)))
   new_df <- data.frame(x = 1:2)
 
   field(r1, 'df') <- new_df
   expect_equal(field(r1, "df"), new_df)
 
-  expect_error(field(r1, 'df') <- new_data_frame(n = 3L), "Invalid value")
+  expect_error(field(r1, 'df') <- new_data_frame(.size = 3L), "Invalid value")
 })

--- a/tests/testthat/test-proxy-restore.R
+++ b/tests/testthat/test-proxy-restore.R
@@ -82,7 +82,7 @@ test_that("arguments are not inlined in the dispatch call (#300)", {
 
 test_that("restoring to non-bare data frames calls `vec_bare_df_restore()` before dispatching", {
   x <- list(x = numeric())
-  to <- new_data_frame(x, class = "tbl_foobar")
+  to <- new_data_frame(x, .class = "tbl_foobar")
 
   local_methods(
     vec_restore.tbl_foobar = function(x, to, ..., n) {

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -123,7 +123,7 @@ test_that("can subset data frame columns", {
 })
 
 test_that("can subset empty data frames", {
-  df <- new_data_frame(n = 3L)
+  df <- new_data_frame(.size = 3L)
   expect_equal(vec_size(vec_slice(df, integer())), 0)
   expect_equal(vec_size(vec_slice(df, 1L)), 1)
   expect_equal(vec_size(vec_slice(df, 1:3)), 3)

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -160,8 +160,8 @@ test_that("can find a common encoding with data frames with character columns", 
 test_that("can find a common encoding with data frame subclasses with character columns", {
   encs <- encodings()
 
-  df_utf8 <- new_data_frame(list(x = encs$utf8), class = "subclass")
-  df_unknown <- new_data_frame(list(x = encs$unknown), class = "subclass")
+  df_utf8 <- new_data_frame(list(x = encs$utf8), .class = "subclass")
+  df_unknown <- new_data_frame(list(x = encs$unknown), .class = "subclass")
 
   results <- obj_maybe_translate_encoding2(df_utf8, df_unknown)
 

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -279,14 +279,6 @@ test_that("class attribute", {
     class(new_data_frame(list(a = 1), .class = "foo_frame")),
     c("foo_frame", "data.frame")
   )
-  expect_identical(
-    class(exec(new_data_frame, list(a = 1), !!!attributes(new_data_frame(list(), .class = "tbl_df")))),
-    c("tbl_df", "data.frame", "data.frame")
-  )
-  expect_identical(
-    class(exec(new_data_frame, list(a = 1), !!!attributes(new_data_frame(list(b = 1), .class = "tbl_df")))),
-    c("tbl_df", "data.frame", "data.frame")
-  )
 })
 
 test_that("attributes with special names are merged", {

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -178,7 +178,7 @@ test_that("restore keeps automatic row/col names", {
 })
 
 test_that("cast to empty data frame preserves number of rows", {
-  out <- vec_cast(new_data_frame(n = 10L), new_data_frame())
+  out <- vec_cast(new_data_frame(.size = 10L), new_data_frame())
   expect_equal(nrow(out), 10L)
 })
 
@@ -233,12 +233,12 @@ test_that("can validly set the number of rows when there are no columns", {
     names = character()
   )
 
-  expect_identical(new_data_frame(n = 2L), expect)
+  expect_identical(new_data_frame(.size = 2L), expect)
 })
 
 test_that("can add additional classes", {
-  expect_s3_class(new_data_frame(class = "foobar"), "foobar")
-  expect_s3_class(new_data_frame(class = c("foo", "bar")), c("foo", "bar"))
+  expect_s3_class(new_data_frame(.class = "foobar"), "foobar")
+  expect_s3_class(new_data_frame(.class = c("foo", "bar")), c("foo", "bar"))
 })
 
 test_that("can add additional attributes", {
@@ -268,23 +268,23 @@ test_that("class attribute", {
     "data.frame"
   )
   expect_identical(
-    class(new_data_frame(list(a = 1), class = "tbl_df")),
+    class(new_data_frame(list(a = 1), .class = "tbl_df")),
     c("tbl_df", "data.frame")
   )
   expect_identical(
-    class(new_data_frame(list(a = 1), class = c("tbl_df", "tbl", "data.frame"))),
+    class(new_data_frame(list(a = 1), .class = c("tbl_df", "tbl", "data.frame"))),
     c("tbl_df", "tbl", "data.frame", "data.frame")
   )
   expect_identical(
-    class(new_data_frame(list(a = 1), class = "foo_frame")),
+    class(new_data_frame(list(a = 1), .class = "foo_frame")),
     c("foo_frame", "data.frame")
   )
   expect_identical(
-    class(exec(new_data_frame, list(a = 1), !!!attributes(new_data_frame(list(), class = "tbl_df")))),
+    class(exec(new_data_frame, list(a = 1), !!!attributes(new_data_frame(list(), .class = "tbl_df")))),
     c("tbl_df", "data.frame", "data.frame")
   )
   expect_identical(
-    class(exec(new_data_frame, list(a = 1), !!!attributes(new_data_frame(list(b = 1), class = "tbl_df")))),
+    class(exec(new_data_frame, list(a = 1), !!!attributes(new_data_frame(list(b = 1), .class = "tbl_df")))),
     c("tbl_df", "data.frame", "data.frame")
   )
 })
@@ -311,30 +311,30 @@ test_that("attributes with special names are merged", {
   )
 
   expect_identical(
-    .row_names_info(new_data_frame(list(), n = 3L)),
+    .row_names_info(new_data_frame(list(), .size = 3L)),
     -3L
   )
 
-  expect_error(new_data_frame(list(), n = 1L, row.names = 1:3), ".")
+  expect_error(new_data_frame(list(), .size = 1L, row.names = 1:3), ".")
 
   expect_identical(
-    .row_names_info(new_data_frame(list(), n = 3L, row.names = 1:3)),
+    .row_names_info(new_data_frame(list(), .size = 3L, row.names = 1:3)),
     3L
   )
 
   expect_identical(
-    .row_names_info(new_data_frame(list(), n = 3L, row.names = c(NA, -3L))),
+    .row_names_info(new_data_frame(list(), .size = 3L, row.names = c(NA, -3L))),
     -3L
   )
 
   expect_identical(
-    attr(new_data_frame(list(), n = 1L, row.names = "rowname"), "row.names"),
+    attr(new_data_frame(list(), .size = 1L, row.names = "rowname"), "row.names"),
     "rowname"
   )
 })
 
-test_that("n and row.names (#894)", {
-  # Can omit n if row.names attribute is given
+test_that("`.size` and `row.names` (#894)", {
+  # Can omit .size if row.names attribute is given
   expect_identical(
     row.names(new_data_frame(list(), row.names = "rowname")),
     "rowname"
@@ -349,17 +349,17 @@ test_that("n and row.names (#894)", {
   )
 })
 
-test_that("`x` must be a list", {
-  expect_error(new_data_frame(1), "`x` must be a list")
+test_that("`.x` must be a list", {
+  expect_error(new_data_frame(1), "`.x` must be a list")
 })
 
-test_that("if supplied, `n` must be an integer of size 1", {
-  expect_error(new_data_frame(n = c(1L, 2L)), "must be an integer of size 1")
-  expect_error(new_data_frame(n = "x"), "must be an integer of size 1")
+test_that("if supplied, `.size` must be an integer of size 1", {
+  expect_error(new_data_frame(.size = c(1L, 2L)), "must be an integer of size 1")
+  expect_error(new_data_frame(.size = "x"), "must be an integer of size 1")
 })
 
-test_that("`class` must be a character vector", {
-  expect_error(new_data_frame(class = 1), "must be NULL or a character vector")
+test_that("`.class` must be a character vector", {
+  expect_error(new_data_frame(.class = 1), "must be NULL or a character vector")
 })
 
 test_that("flat width is computed", {


### PR DESCRIPTION
Closes #949

This is a breaking change, but I think it will be good in the long run. The signature is now:

```r
new_data_frame(x = list(), n = NULL, ..., class = NULL)

|
v

new_data_frame(.x = list(), ..., .size = NULL, .class = NULL)
```

This should avoid most collisions.

While I was there, I standardized the internal code to use `size` where we used to use `n`.

Two tests that used to splice in attributes were removed, since they splice in a `class` attribute and the signature now expects `.class`.