### PR TITLE
Fix normalisation of data frames

### DIFF
--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -107,12 +107,15 @@ vec_ptype2_df_fallback_normalise <- function(x, y) {
 
   ptype <- df_ptype2(x, y)
 
-  # Empty columns first to avoid name repairs
-  x <- x[0, 0, drop = FALSE]
-  y <- y[0, 0, drop = FALSE]
+  x <- x[0, , drop = FALSE]
+  y <- y[0, , drop = FALSE]
 
   x[seq_along(ptype)] <- ptype
   y[seq_along(ptype)] <- ptype
+
+  # Names might have been repaired by `[<-`
+  names(x) <- names(ptype)
+  names(y) <- names(ptype)
 
   # Restore attributes if no `[` method is implemented
   if (df_has_base_subset(x)) {
@@ -126,14 +129,13 @@ vec_ptype2_df_fallback_normalise <- function(x, y) {
 }
 vec_cast_df_fallback_normalise <- function(x, to) {
   orig <- x
-
   cast <- df_cast(x, to)
-
-  # Empty columns first to avoid name repairs
-  x <- x[0]
 
   # Seq-assign should be more widely implemented than empty-assign?
   x[seq_along(to)] <- cast
+
+  # Names might have been repaired by `[<-`
+  names(x) <- names(cast)
 
   # Restore attributes if no `[` method is implemented
   if (df_has_base_subset(x)) {

--- a/revdep-all/tidyr/README.md
+++ b/revdep-all/tidyr/README.md
@@ -61,16 +61,13 @@
 |vlad            |0.2.0   |1     |        |     |
 |vroom           |1.2.0   |1     |        |     |
 
-## New problems (8)
+## New problems (5)
 
-|package                                  |version |error     |warning |note   |
-|:----------------------------------------|:-------|:---------|:-------|:------|
-|[anomalize](problems.md#anomalize)       |0.2.0   |__+2__    |        |       |
-|[BiocPkgTools](problems.md#biocpkgtools) |1.4.6   |__+1__    |        |1      |
-|[brendaDb](problems.md#brendadb)         |1.0.0   |-1 __+1__ |        |1      |
-|[cutpointr](problems.md#cutpointr)       |1.0.2   |__+1__    |        |       |
-|[ggmap](problems.md#ggmap)               |3.0.0   |          |        |__+1__ |
-|[idiogramFISH](problems.md#idiogramfish) |1.14.7  |          |        |__+1__ |
-|[simTool](problems.md#simtool)           |1.1.5   |__+1__    |        |       |
-|[tidyjson](problems.md#tidyjson)         |0.2.4   |__+1__    |        |       |
+|package                                  |version |error  |warning |note |
+|:----------------------------------------|:-------|:------|:-------|:----|
+|[anomalize](problems.md#anomalize)       |0.2.0   |__+2__ |        |     |
+|[BiocPkgTools](problems.md#biocpkgtools) |1.4.6   |__+1__ |        |1    |
+|[cutpointr](problems.md#cutpointr)       |1.0.2   |__+1__ |        |     |
+|[simTool](problems.md#simtool)           |1.1.5   |__+1__ |        |     |
+|[tidyjson](problems.md#tidyjson)         |0.2.4   |__+1__ |        |     |
 

--- a/revdep-all/tidyr/problems.md
+++ b/revdep-all/tidyr/problems.md
@@ -21,7 +21,10 @@ Run `revdep_details(,"anomalize")` for more info
     > tidyverse_cran_downloads %>%
     +     time_decompose(count, method = "stl") %>%
     +     anomalize(remainder, method = "iqr")
-    Error: Can't convert <tibble> to <tbl_time>.
+    Error: Can't combine `..1$nested.col` <tbl_time> and `..2$nested.col` <tbl_time>.
+    ✖ Some attributes are incompatible.
+    ℹ The author of the class should implement vctrs methods.
+    ℹ See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
     Backtrace:
          █
       1. ├─`%>%`(...)
@@ -30,14 +33,11 @@ Run `revdep_details(,"anomalize")` for more info
       4. │   └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
       5. │     └─`_fseq`(`_lhs`)
       6. │       └─magrittr::freduce(value, `_function_list`)
-      7. │         ├─base::withVisible(function_list[[k]](value))
-      8. │         └─function_list[[k]](value)
-      9. │           ├─anomalize::anomalize(., remainder, method = "iqr")
-     10. │           └─anomalize:::anomalize.grouped_df(., remainder, method = "iqr") 00_pkg_src/anomalize/R/anomalize.R:92:4
-     11. │             └─`%>%`(...) 00_pkg_src/anomalize/R/anomalize.R:174:4
-     12. │               ├─base::withVisible(eval(quote(`_fseq`(`_lhs`)), env, env))
-     13. │               └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
-     14. │                 └─base::eval(quote(`_fseq`(`
+      7. │         └─function_list[[i]](value)
+      8. │           ├─anomalize::time_decompose(., count, method = "stl")
+      9. │           └─anomalize:::time_decompose.grouped_tbl_time(., count, method = "stl") 00_pkg_src/anomalize/R/time_decompose.R:102:4
+     10. │             └─`%>%`(...) 00_pkg_src/anomalize/R/time_decompose.R:183:4
+     11. │               ├─base::withVisible(e
     Execution halted
     ```
 
@@ -96,7 +96,8 @@ Run `revdep_details(,"BiocPkgTools")` for more info
     +   dependencies=c("Depends", "Imports"), 
     +   repo=c("BioCsoft", "CRAN")
     + )
-    Error in readRDS(gzcon(con)) : error reading from connection
+    Error in readRDS(gzcon(con)) : 
+      ReadItem: unknown type 101, perhaps written by later version of R
     Calls: buildPkgDependencyDataFrame ... biocPkgList -> lapply -> FUN -> as.data.frame -> readRDS
     Execution halted
     ```
@@ -109,77 +110,6 @@ Run `revdep_details(,"BiocPkgTools")` for more info
       All declared Imports should be used.
     Unexported object imported by a ':::' call: ‘BiocManager:::.repositories’
       See the note in ?`:::` about the use of this operator.
-    ```
-
-# brendaDb
-
-<details>
-
-* Version: 1.0.0
-* Source code: https://github.com/cran/brendaDb
-* URL: https://github.com/y1zhou/brendaDb
-* BugReports: https://github.com/y1zhou/brendaDb/issues
-* Date/Publication: 2019-10-29
-* Number of recursive dependencies: 99
-
-Run `revdep_details(,"brendaDb")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking tests ...
-    ```
-     ERROR
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-        1. testthat::expect_message(...)
-        6. brendaDb::BiocycPathwayGenes(org.id = "HUMAN", pathway = "PWY66666")
-        7. base::tryCatch(...) revdep-all/tidyr/checks.noindex/brendaDb/new/brendaDb.Rcheck/00_pkg_src/brendaDb/R/biocyc.R:104:2
-        8. base:::tryCatchList(expr, classes, parentenv, handlers)
-        9. base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-       10. value[[3L]](cond)
-       12. base::close.connection(con)
-      
-      ══ testthat results  ═══════════════════════════════════════════════════════════
-      [ OK: 109 | SKIPPED: 0 | WARNINGS: 0 | FAILED: 2 ]
-      1. Error: Get enzymes in BioCyc pathway  (@test-biocyc.R#7) 
-      2. Error: Get genes in BioCyc pathway  (@test-biocyc.R#18) 
-      
-      Error: testthat unit tests failed
-      Execution halted
-    ```
-
-## Newly fixed
-
-*   checking examples ... ERROR
-    ```
-    Running examples in ‘brendaDb-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: BiocycPathwayEnzymes
-    > ### Title: Get all EC numbers involved in a BioCyc pathway.
-    > ### Aliases: BiocycPathwayEnzymes
-    > 
-    > ### ** Examples
-    > 
-    > BiocycPathwayEnzymes("HUMAN", "PWY66-400")
-    Found 10 reactions for HUMAN pathway PWY66-400.
-    Error in read_xml.raw(raw, encoding = encoding, base_url = base_url, as_html = as_html,  : 
-      Failed to parse text
-    Calls: BiocycPathwayEnzymes ... read_xml.character -> read_xml.connection -> read_xml.raw
-    Execution halted
-    ```
-
-## In both
-
-*   checking for hidden files and directories ... NOTE
-    ```
-    Found the following hidden files and directories:
-      .travis.yml
-      .github
-    These were most likely included in error. See section ‘Package structure’ in
-    the ‘Writing R Extensions’ manual.
     ```
 
 # cutpointr
@@ -219,54 +149,6 @@ Run `revdep_details(,"cutpointr")` for more info
       
       Error: testthat unit tests failed
       Execution halted
-    ```
-
-# ggmap
-
-<details>
-
-* Version: 3.0.0
-* Source code: https://github.com/cran/ggmap
-* URL: https://github.com/dkahle/ggmap
-* BugReports: https://github.com/dkahle/ggmap/issues
-* Date/Publication: 2019-02-05 10:19:04
-* Number of recursive dependencies: 69
-
-Run `revdep_details(,"ggmap")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking installed package size ... NOTE
-    ```
-      installed size is  5.3Mb
-      sub-directories of 1Mb or more:
-        data   4.8Mb
-    ```
-
-# idiogramFISH
-
-<details>
-
-* Version: 1.14.7
-* Source code: https://github.com/cran/idiogramFISH
-* URL: https://ferroao.gitlab.io/manualidiogramfish/, https://ferroao.gitlab.io/idiogramFISH
-* BugReports: https://gitlab.com/ferroao/idiogramFISH/issues
-* Date/Publication: 2020-03-28 08:20:12 UTC
-* Number of recursive dependencies: 117
-
-Run `revdep_details(,"idiogramFISH")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking installed package size ... NOTE
-    ```
-      installed size is  5.0Mb
-      sub-directories of 1Mb or more:
-        doc   3.7Mb
     ```
 
 # simTool

--- a/revdep-all/vctrs/README.md
+++ b/revdep-all/vctrs/README.md
@@ -10,7 +10,7 @@
 |collate  |en_US.UTF-8                  |
 |ctype    |en_US.UTF-8                  |
 |tz       |Europe/Brussels              |
-|date     |2020-04-24                   |
+|date     |2020-04-25                   |
 
 # Dependencies
 
@@ -34,14 +34,14 @@
 
 ## New problems (8)
 
-|package                              |version |error    |warning |note |
-|:------------------------------------|:-------|:--------|:-------|:----|
-|[dm](problems.md#dm)                 |0.1.1   |1 __+1__ |        |1    |
-|[glue](problems.md#glue)             |1.4.0   |__+1__   |        |     |
-|[hardhat](problems.md#hardhat)       |0.1.2   |__+1__   |        |     |
-|[probably](problems.md#probably)     |0.0.4   |__+1__   |        |     |
-|[projects](problems.md#projects)     |2.1.0   |__+1__   |        |1    |
-|[slider](problems.md#slider)         |0.1.2   |__+2__   |        |     |
-|[tibbletime](problems.md#tibbletime) |0.1.3   |__+2__   |        |     |
-|[tidyr](problems.md#tidyr)           |1.0.2   |__+2__   |        |1    |
+|package                                |version |error    |warning |note |
+|:--------------------------------------|:-------|:--------|:-------|:----|
+|[dm](problems.md#dm)                   |0.1.1   |1 __+1__ |        |1    |
+|[glue](problems.md#glue)               |1.4.0   |__+1__   |        |     |
+|[hardhat](problems.md#hardhat)         |0.1.2   |__+1__   |        |     |
+|[probably](problems.md#probably)       |0.0.4   |__+1__   |        |     |
+|[projects](problems.md#projects)       |2.1.0   |__+1__   |        |1    |
+|[slider](problems.md#slider)           |0.1.2   |__+2__   |        |     |
+|[textrecipes](problems.md#textrecipes) |0.2.0   |__+1__   |        |1    |
+|[tidyr](problems.md#tidyr)             |1.0.2   |__+2__   |        |1    |
 

--- a/revdep-all/vctrs/failures.md
+++ b/revdep-all/vctrs/failures.md
@@ -30,19 +30,58 @@ Run `revdep_details(,"arrow")` for more info
 ** package ‘arrow’ successfully unpacked and MD5 sums checked
 ** using staged installation
 *** Downloading apache-arrow
-rm: /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/Library/Homebrew/test/os/linux: Invalid argument
-Fri Apr 24 21:26:21 CEST 2020: Auto-brewing apache-arrow in /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow...
+Sat Apr 25 12:16:34 CEST 2020: Auto-brewing apache-arrow in /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow...
+Error: No available formula with the name "apache-arrow" 
+==> Searching for a previously deleted formula (in the last month)...
+Error: No previously deleted formula found.
+Error: No similarly named formulae found.
+==> Searching taps on GitHub...
+==> Searching for similarly named formulae...
+==> Searching taps...
+These formulae were found in taps:
+homebrew/linuxbrew-core/apache-arrow
+homebrew/linuxbrew-core/apache-arrow-glib
+To install one of them, run (for example):
+  brew install homebrew/linuxbrew-core/apache-arrow
+cp: /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/Cellar/*/*/lib/*.a: No such file or directory
+created /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/lib/libbrew.a
+PKG_CFLAGS=-I/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/opt/apache-arrow/include -DARROW_R_WITH_ARROW
+PKG_LIBS=-L/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/opt/apache-arrow/lib -L/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/lib -lbrewparquet -lbrewarrow_dataset -lbrewarrow -lbrewthrift -lbrewlz4 -lbrewsnappy
+** libs
+clang++ -std=gnu++11 -std=c++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/opt/apache-arrow/include -DARROW_R_WITH_ARROW -I"/Users/lionel/Dropbox/Projects/R/hadley/vctrs/revdep-all/vctrs/library.noindex/arrow/Rcpp/include" -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/usr/local/include  -fPIC  -Wall -g -O2  -arch x86_64 -ftemplate-depth-256 -Wall -pedantic -c array.cpp -o array.o
+In file included from array.cpp:18:
+././arrow_types.h:199:10: fatal error: 'arrow/api.h' file not found
+#include <arrow/api.h>
+         ^~~~~~~~~~~~~
+1 error generated.
+make: *** [array.o] Error 1
+ERROR: compilation failed for package ‘arrow’
+* removing ‘/Users/lionel/Dropbox/Projects/R/hadley/vctrs/revdep-all/vctrs/checks.noindex/arrow/new/arrow.Rcheck/arrow’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘arrow’ ...
+** package ‘arrow’ successfully unpacked and MD5 sums checked
+** using staged installation
+*** Downloading apache-arrow
+rm: fts_read: No such file or directory
+Sat Apr 25 12:16:33 CEST 2020: Auto-brewing apache-arrow in /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow...
 ==> Tapping autobrew/core from https://github.com/autobrew/homebrew-core
+Cloning into '/private/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T/build-apache-arrow/Library/Taps/autobrew/homebrew-core'...
+Updating files:  72% (3521/4863)Updating files:  73% (3550/4863)Updating files:  74% (3599/4863)Updating files:  75% (3648/4863)Updating files:  76% (3696/4863)Updating files:  77% (3745/4863)Updating files:  78% (3794/4863)Updating files:  79% (3842/4863)Updating files:  80% (3891/4863)Updating files:  81% (3940/4863)Updating files:  82% (3988/4863)Updating files:  83% (4037/4863)Updating files:  84% (4085/4863)Updating files:  85% (4134/4863)Updating files:  86% (4183/4863)Updating files:  87% (4231/4863)Updating files:  88% (4280/4863)Updating files:  89% (4329/4863)Updating files:  90% (4377/4863)Updating files:  91% (4426/4863)Updating files:  92% (4474/4863)Updating files:  93% (4523/4863)Updating files:  94% (4572/4863)Updating files:  95% (4620/4863)Updating files:  96% (4669/4863)Updating files:  97% (4718/4863)Updating files:  98% (4766/4863)Updating files:  99% (4815/4863)Updating files: 100% (4863/4863)Updating files: 100% (4863/4863), done.
 Tapped 2 commands and 4640 formulae (4,889 files, 12.7MB).
-lz4
-openssl
-thrift
-snappy
+==> Installing dependencies for apache-arrow: lz4, openssl, thrift, snappy
+==> Installing apache-arrow dependency: lz4
 ==> Downloading https://homebrew.bintray.com/bottles/lz4-1.8.3.mojave.bottle.tar.gz
+Already downloaded: /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T/downloads/b4158ef68d619dbf78935df6a42a70b8339a65bc8876cbb4446355ccd40fa5de--lz4-1.8.3.mojave.bottle.tar.gz
 ==> Pouring lz4-1.8.3.mojave.bottle.tar.gz
 ==> Skipping post_install step for autobrew...
 🍺  /private/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T/build-apache-arrow/Cellar/lz4/1.8.3: 22 files, 512.7KB
+==> Installing apache-arrow dependency: openssl
 ==> Downloading https://homebrew.bintray.com/bottles/openssl-1.0.2p.mojave.bottle.tar.gz
+Already downloaded: /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T/downloads/fbb493745981c8b26c0fab115c76c2a70142bfde9e776c450277e9dfbbba0bb2--openssl-1.0.2p.mojave.bottle.tar.gz
 ==> Pouring openssl-1.0.2p.mojave.bottle.tar.gz
 ==> Skipping post_install step for autobrew...
 ==> Caveats
@@ -61,7 +100,9 @@ For pkg-config to find openssl you may need to set:
 
 ==> Summary
 🍺  /private/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T/build-apache-arrow/Cellar/openssl/1.0.2p: 1,793 files, 12MB
+==> Installing apache-arrow dependency: thrift
 ==> Downloading https://homebrew.bintray.com/bottles/thrift-0.11.0.mojave.bottle.tar.gz
+Already downloaded: /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T/downloads/7e05ea11a9f7f924dd7f8f36252ec73a24958b7f214f71e3752a355e75e589bd--thrift-0.11.0.mojave.bottle.tar.gz
 ==> Pouring thrift-0.11.0.mojave.bottle.tar.gz
 ==> Skipping post_install step for autobrew...
 ==> Caveats
@@ -69,11 +110,15 @@ To install Ruby binding:
   gem install thrift
 ==> Summary
 🍺  /private/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T/build-apache-arrow/Cellar/thrift/0.11.0: 102 files, 7MB
+==> Installing apache-arrow dependency: snappy
 ==> Downloading https://homebrew.bintray.com/bottles/snappy-1.1.7_1.mojave.bottle.tar.gz
+Already downloaded: /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T/downloads/1f09938804055499d1dd951b13b26d80c56eae359aa051284bf4f51d109a9f73--snappy-1.1.7_1.mojave.bottle.tar.gz
 ==> Pouring snappy-1.1.7_1.mojave.bottle.tar.gz
 ==> Skipping post_install step for autobrew...
 🍺  /private/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T/build-apache-arrow/Cellar/snappy/1.1.7_1: 18 files, 115.8KB
+==> Installing apache-arrow
 ==> Downloading https://autobrew.github.io/bottles/apache-arrow-0.17.0.el_capitan.bottle.tar.gz
+Already downloaded: /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T/downloads/7dcf2302ba174a5efb32eaa5b8fe0ae874f4a4671f575e126c79a524830054ae--apache-arrow-0.17.0.el_capitan.bottle.tar.gz
 ==> Pouring apache-arrow-0.17.0.el_capitan.bottle.tar.gz
 ==> Skipping post_install step for autobrew...
 🍺  /private/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T/build-apache-arrow/Cellar/apache-arrow/0.17.0: 294 files, 49.7MB
@@ -155,34 +200,6 @@ typedef __darwin_uid_t        uid_t;
                               ^
 5 errors generated.
 make: *** [array_to_vector.o] Error 1
-ERROR: compilation failed for package ‘arrow’
-* removing ‘/Users/lionel/Dropbox/Projects/R/hadley/vctrs/revdep-all/vctrs/checks.noindex/arrow/new/arrow.Rcheck/arrow’
-
-```
-### CRAN
-
-```
-* installing *source* package ‘arrow’ ...
-** package ‘arrow’ successfully unpacked and MD5 sums checked
-** using staged installation
-*** Downloading apache-arrow
-rm: /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/manpages: Invalid argument
-Fri Apr 24 21:26:21 CEST 2020: Auto-brewing apache-arrow in /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow...
-Error: Another active Homebrew vendor-install-ruby process is already in progress.
-Please wait for it to finish or terminate it to continue.
-Error: Failed to install vendor Ruby.
-cp: /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/Cellar/*/*/lib/*.a: No such file or directory
-created /var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/lib/libbrew.a
-PKG_CFLAGS=-I/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/opt/apache-arrow/include -DARROW_R_WITH_ARROW
-PKG_LIBS=-L/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/opt/apache-arrow/lib -L/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/lib -lbrewparquet -lbrewarrow_dataset -lbrewarrow -lbrewthrift -lbrewlz4 -lbrewsnappy
-** libs
-clang++ -std=gnu++11 -std=c++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I/var/folders/b9/1vbq6rn93_1fk71sn95dqb8r0000gn/T//build-apache-arrow/opt/apache-arrow/include -DARROW_R_WITH_ARROW -I"/Users/lionel/Dropbox/Projects/R/hadley/vctrs/revdep-all/vctrs/library.noindex/arrow/Rcpp/include" -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/usr/local/include  -fPIC  -Wall -g -O2  -arch x86_64 -ftemplate-depth-256 -Wall -pedantic -c array.cpp -o array.o
-In file included from array.cpp:18:
-././arrow_types.h:199:10: fatal error: 'arrow/api.h' file not found
-#include <arrow/api.h>
-         ^~~~~~~~~~~~~
-1 error generated.
-make: *** [array.o] Error 1
 ERROR: compilation failed for package ‘arrow’
 * removing ‘/Users/lionel/Dropbox/Projects/R/hadley/vctrs/revdep-all/vctrs/checks.noindex/arrow/old/arrow.Rcheck/arrow’
 

--- a/revdep-all/vctrs/problems.md
+++ b/revdep-all/vctrs/problems.md
@@ -301,69 +301,52 @@ Run `revdep_details(,"slider")` for more info
       Execution halted
     ```
 
-# tibbletime
+# textrecipes
 
 <details>
 
-* Version: 0.1.3
-* Source code: https://github.com/cran/tibbletime
-* URL: https://github.com/business-science/tibbletime
-* BugReports: https://github.com/business-science/tibbletime/issues
-* Date/Publication: 2019-09-20 05:00:02 UTC
-* Number of recursive dependencies: 64
+* Version: 0.2.0
+* Source code: https://github.com/cran/textrecipes
+* URL: https://github.com/tidymodels/textrecipes
+* BugReports: https://github.com/tidymodels/textrecipes/issues
+* Date/Publication: 2020-04-14 05:00:03 UTC
+* Number of recursive dependencies: 112
 
-Run `revdep_details(,"tibbletime")` for more info
+Run `revdep_details(,"textrecipes")` for more info
 
 </details>
 
 ## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    ...
-    Error: Can't convert <tibble> to <tbl_time>.
-    Backtrace:
-         █
-      1. ├─`%>%`(...)
-      2. │ ├─base::withVisible(eval(quote(`_fseq`(`_lhs`)), env, env))
-      3. │ └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
-      4. │   └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
-      5. │     └─`_fseq`(`_lhs`)
-      6. │       └─magrittr::freduce(value, `_function_list`)
-      7. │         ├─base::withVisible(function_list[[k]](value))
-      8. │         └─function_list[[k]](value)
-      9. │           ├─tidyr::nest(.)
-     10. │           └─tibbletime:::nest.tbl_time(.)
-     11. │             ├─dplyr::mutate(...) 00_pkg_src/tibbletime/R/compat-tidyr.R:44:6
-     12. │             └─dplyr:::mutate.tbl_df(...)
-     13. │               └─dplyr:::mutate_impl(.data, dots, caller_env())
-     14. ├─vctrs::as_list_of(data, .ptype = data[[1]])
-     15. ├─vctrs:::as_list_of.list(data, .ptype = data[[1]])
-     16. │ └─vctrs::list_of(!!!x, .ptype = .ptype)
-     17. │   └─
-    Execution halted
-    ```
 
 *   checking tests ...
     ```
      ERROR
     Running the tests in ‘tests/testthat.R’ failed.
     Last 13 lines of output:
-       47. testthat:::failure_summary(result, self$n_fail)
-       50. testthat:::format.expectation(x)
-       51. testthat:::format_with_trace(x)
-       53. rlang:::format.rlang_trace(...)
-       54. rlang:::trace_format_branch(x, max_frames, dir, srcrefs)
-       55. rlang:::branch_uncollapse_pipe(trace)
+      Backtrace:
+        1. testthat::expect_error(...)
+       10. vctrs::vec_default_cast(...)
+       11. vctrs::stop_incompatible_cast(...)
+       12. vctrs:::stop_incompatible_type_convert(...)
+       13. vctrs:::stop_incompatible_type_impl(...)
+       14. vctrs:::stop_incompatible(...)
+       15. vctrs:::stop_vctrs(...)
       
       ══ testthat results  ═══════════════════════════════════════════════════════════
-      [ OK: 126 | SKIPPED: 0 | WARNINGS: 0 | FAILED: 3 ]
-      1. Error: nest() with index creates tbl_df (@test_compat-tidyr.R#22) 
-      2. Error: nest() with index creates tbl_df (@test_compat-tidyr.R#20) 
-      3. Error: (unknown) (@test_compat-tidyr.R#20) 
+      [ OK: 203 | SKIPPED: 8 | WARNINGS: 1 | FAILED: 1 ]
+      1. Failure: tokenlist_pos_filter works (@test-tokenlist.R#399) 
       
       Error: testthat unit tests failed
       Execution halted
+    ```
+
+## In both
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespaces in Imports field not imported from:
+      ‘dials’ ‘modeldata’
+      All declared Imports should be used.
     ```
 
 # tidyr

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -434,9 +434,16 @@ test_that("data frame fallback handles column types (#999)", {
   expect_identical(out, exp)
 
   out <- with_methods(
-    `[.vctrs_foobar` = function(x, i, ...) structure(NextMethod(), dispatched = TRUE),
+    `[.vctrs_foobar` = function(x, i, ...) {
+      new_data_frame(
+        NextMethod(),
+        dispatched = TRUE,
+        class = "vctrs_foobar"
+      )
+    },
     vec_rbind(df1_attrib, df2_attrib)
   )
+
   expect_identical(out, foobar(exp, dispatched = TRUE))
 })
 


### PR DESCRIPTION
Don't empty the data frame before assignment as that may remove the class. Patch the names after assignment instead.

Fixes three revdep failures.