### PR TITLE
Mark lossy-cast-dropped errors as internal

### DIFF
--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -297,3 +297,7 @@ df_lossy_cast <- function(out, x, to) {
     class = "vctrs_error_cast_lossy_dropped"
   )
 }
+
+is_informative_error.vctrs_error_cast_lossy_dropped <- function(x, ...) {
+  TRUE
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -12,6 +12,10 @@ on_package_load <- function(pkg, expr) {
 .onLoad <- function(libname, pkgname) {
   check_linked_version(pkgname)
 
+  on_package_load("testthat", {
+    s3_register("testthat::is_informative_error", "vctrs_error_cast_lossy_dropped")
+  })
+
   s3_register("generics::as.factor", "vctrs_vctr")
   s3_register("generics::as.ordered", "vctrs_vctr")
   s3_register("generics::as.difftime", "vctrs_vctr")

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -491,6 +491,11 @@ test_that("fallback is recursive", {
   expect_identical(expect_df_fallback(vec_rbind(foo, baz)), exp)
 })
 
+test_that("lossy-cast-dropped error is internal", {
+  # Should not trigger testthat warning about untested class
+  expect_error(vec_cast(mtcars, mtcars[1:3]), "convert")
+})
+
 test_that("data frame output is informative", {
   verify_output(test_path("error", "test-type-data-frame.txt"), {
     "# combining data frames with foreign classes uses fallback"


### PR DESCRIPTION
This is the lossy cast errors that is thrown when columns are missing. I'm not sure this should be a subclass. Marking it internal seems safer so that testthat users are not advised to test for the class. Maybe we should do this with all lossy cast errors? They feel a little less mature than incompatible type errors.