### PR TITLE
Preserve type of row names in `vec_ptype()`

### DIFF
--- a/tests/testthat/test-type-dplyr.R
+++ b/tests/testthat/test-type-dplyr.R
@@ -1,51 +1,53 @@
 
 # `grouped_df` -------------------------------------------------------
 
+bare_mtcars <- unrownames(mtcars)
+
 test_that("grouped-df is proxied and restored", {
-  gdf <- dplyr::group_by(mtcars, cyl)
+  gdf <- dplyr::group_by(bare_mtcars, cyl)
 
   expect_identical(vec_proxy(gdf), gdf)
-  expect_identical(vec_restore(mtcars, gdf), gdf)
+  expect_identical(vec_restore(bare_mtcars, gdf), gdf)
 
   expect_identical(vec_ptype(gdf), gdf[0, ])
 
-  gdf <- dplyr::group_by(mtcars, cyl, am, vs)
+  gdf <- dplyr::group_by(bare_mtcars, cyl, am, vs)
   expect_identical(gdf[0, ], vec_ptype(gdf))
 
-  out <- vec_ptype(dplyr::group_by(mtcars, cyl, .drop = FALSE))
+  out <- vec_ptype(dplyr::group_by(bare_mtcars, cyl, .drop = FALSE))
   expect_drop(out, FALSE)
 })
 
 test_that("can take the common type of grouped tibbles and tibbles", {
-  gdf <- dplyr::group_by(mtcars, cyl)
+  gdf <- dplyr::group_by(bare_mtcars, cyl)
   expect_identical(vec_ptype2(gdf, data.frame()), vec_ptype(gdf))
   expect_identical(vec_ptype2(data.frame(), gdf), vec_ptype(gdf))
   expect_identical(vec_ptype2(gdf, tibble()), vec_ptype(gdf))
   expect_identical(vec_ptype2(tibble(), gdf), vec_ptype(gdf))
 
-  gdf_nodrop <- dplyr::group_by(mtcars, cyl, .drop = FALSE)
+  gdf_nodrop <- dplyr::group_by(bare_mtcars, cyl, .drop = FALSE)
   expect_drop(vec_ptype2(gdf, gdf_nodrop), FALSE)
   expect_drop(vec_ptype2(gdf_nodrop, gdf), FALSE)
-  expect_drop(vec_ptype2(gdf_nodrop, mtcars), FALSE)
-  expect_drop(vec_ptype2(mtcars, gdf_nodrop), FALSE)
+  expect_drop(vec_ptype2(gdf_nodrop, bare_mtcars), FALSE)
+  expect_drop(vec_ptype2(bare_mtcars, gdf_nodrop), FALSE)
 })
 
 test_that("the common type of grouped tibbles includes the union of grouping variables", {
-  gdf1 <- dplyr::group_by(mtcars, cyl)
-  gdf2 <- dplyr::group_by(mtcars, am, vs)
+  gdf1 <- dplyr::group_by(bare_mtcars, cyl)
+  gdf2 <- dplyr::group_by(bare_mtcars, am, vs)
   expect_identical(
     vec_ptype2(gdf1, gdf2),
-    vec_ptype(dplyr::group_by(mtcars, cyl, am, vs))
+    vec_ptype(dplyr::group_by(bare_mtcars, cyl, am, vs))
   )
 })
 
 test_that("can cast to and from `grouped_df`", {
-  gdf <- dplyr::group_by(unrownames(mtcars), cyl)
-  input <- mtcars[10]
-  cast_gdf <- dplyr::group_by(vec_cast(mtcars[10], mtcars), cyl)
+  gdf <- dplyr::group_by(unrownames(bare_mtcars), cyl)
+  input <- bare_mtcars[10]
+  cast_gdf <- dplyr::group_by(vec_cast(bare_mtcars[10], bare_mtcars), cyl)
 
   expect_error(
-    vec_cast(input, dplyr::group_by(mtcars["cyl"], cyl)),
+    vec_cast(input, dplyr::group_by(bare_mtcars["cyl"], cyl)),
     class = "vctrs_error_cast_lossy"
   )
 
@@ -54,15 +56,15 @@ test_that("can cast to and from `grouped_df`", {
     cast_gdf
   )
   expect_identical(
-    vec_cast(gdf, mtcars),
-    unrownames(mtcars)
+    vec_cast(gdf, bare_mtcars),
+    unrownames(bare_mtcars)
   )
 
   expect_identical(
     vec_cast(tibble::as_tibble(input), gdf),
     unrownames(cast_gdf)
   )
-  tib <- tibble::as_tibble(mtcars)
+  tib <- tibble::as_tibble(bare_mtcars)
   expect_identical(
     unrownames(vec_cast(gdf, tib)),
     tib
@@ -71,30 +73,30 @@ test_that("can cast to and from `grouped_df`", {
 
 test_that("casting to `grouped_df` doesn't require grouping variables", {
   expect_identical(
-    vec_cast(mtcars[10], dplyr::group_by(mtcars, cyl)),
-    dplyr::group_by(vec_cast(mtcars[10], mtcars), cyl)
+    vec_cast(bare_mtcars[10], dplyr::group_by(bare_mtcars, cyl)),
+    dplyr::group_by(vec_cast(bare_mtcars[10], bare_mtcars), cyl)
   )
 })
 
 test_that("casting to `grouped_df` handles `drop`", {
-  gdf_nodrop <- dplyr::group_by(mtcars, cyl, .drop = FALSE)
-  expect_identical(vec_cast(mtcars, gdf_nodrop), gdf_nodrop)
+  gdf_nodrop <- dplyr::group_by(bare_mtcars, cyl, .drop = FALSE)
+  expect_identical(vec_cast(bare_mtcars, gdf_nodrop), gdf_nodrop)
 })
 
 test_that("can cbind grouped data frames", {
-  gdf <- dplyr::group_by(mtcars[-10], cyl)
-  df <- unrownames(mtcars)[10]
+  gdf <- dplyr::group_by(bare_mtcars[-10], cyl)
+  df <- unrownames(bare_mtcars)[10]
 
   expect_identical(
     unrownames(vec_cbind(gdf, df)),
-    tibble::as_tibble(mtcars)[c(1:9, 11, 10)]
+    tibble::as_tibble(bare_mtcars)[c(1:9, 11, 10)]
   )
 
-  gdf1 <- dplyr::group_by(mtcars[2], cyl)
-  gdf2 <- dplyr::group_by(mtcars[8:9], vs, am)
+  gdf1 <- dplyr::group_by(bare_mtcars[2], cyl)
+  gdf2 <- dplyr::group_by(bare_mtcars[8:9], vs, am)
   expect_identical(
     unrownames(vec_cbind(gdf1, gdf2)),
-    tibble::as_tibble(mtcars)[c(2, 8, 9)]
+    tibble::as_tibble(bare_mtcars)[c(2, 8, 9)]
   )
 })
 
@@ -102,16 +104,16 @@ test_that("can cbind grouped data frames", {
 # `rowwise` ----------------------------------------------------------
 
 test_that("rowwise can be proxied and restored", {
-  rww <- dplyr::rowwise(unrownames(mtcars))
+  rww <- dplyr::rowwise(unrownames(bare_mtcars))
 
   expect_identical(vec_proxy(rww), rww)
-  expect_identical(vec_restore(unrownames(mtcars), rww), rww)
+  expect_identical(vec_restore(unrownames(bare_mtcars), rww), rww)
 
   expect_identical(vec_ptype(rww), rww[0, ])
 })
 
 test_that("can take the common type of rowwise tibbles and tibbles", {
-  rww <- dplyr::rowwise(mtcars)
+  rww <- dplyr::rowwise(bare_mtcars)
   expect_identical(vec_ptype2(rww, data.frame()), vec_ptype(rww))
   expect_identical(vec_ptype2(data.frame(), rww), vec_ptype(rww))
   expect_identical(vec_ptype2(rww, tibble()), vec_ptype(rww))
@@ -119,12 +121,12 @@ test_that("can take the common type of rowwise tibbles and tibbles", {
 })
 
 test_that("can cast to and from `rowwise_df`", {
-  rww <- unrownames(dplyr::rowwise(mtcars))
-  input <- mtcars[10]
-  cast_rww <- dplyr::rowwise(vec_cast(mtcars[10], mtcars))
+  rww <- unrownames(dplyr::rowwise(bare_mtcars))
+  input <- bare_mtcars[10]
+  cast_rww <- dplyr::rowwise(vec_cast(bare_mtcars[10], bare_mtcars))
 
   expect_error(
-    vec_cast(input, dplyr::rowwise(mtcars["cyl"])),
+    vec_cast(input, dplyr::rowwise(bare_mtcars["cyl"])),
     class = "vctrs_error_cast_lossy"
   )
 
@@ -133,15 +135,15 @@ test_that("can cast to and from `rowwise_df`", {
     cast_rww
   )
   expect_identical(
-    vec_cast(rww, mtcars),
-    unrownames(mtcars)
+    vec_cast(rww, bare_mtcars),
+    unrownames(bare_mtcars)
   )
 
   expect_identical(
     vec_cast(tibble::as_tibble(input), rww),
     unrownames(cast_rww)
   )
-  tib <- tibble::as_tibble(mtcars)
+  tib <- tibble::as_tibble(bare_mtcars)
   expect_identical(
     unrownames(vec_cast(rww, tib)),
     tib
@@ -149,7 +151,7 @@ test_that("can cast to and from `rowwise_df`", {
 })
 
 test_that("can cbind rowwise data frames", {
-  df <- unrownames(mtcars)
+  df <- unrownames(bare_mtcars)
   rww <- dplyr::rowwise(df[-2])
   gdf <- dplyr::group_by(df[2], cyl)
 
@@ -162,7 +164,7 @@ test_that("can cbind rowwise data frames", {
 
 test_that("no common type between rowwise and grouped data frames", {
   expect_df_fallback(
-    out <- vec_ptype_common_fallback(dplyr::rowwise(mtcars), dplyr::group_by(mtcars, cyl))
+    out <- vec_ptype_common_fallback(dplyr::rowwise(bare_mtcars), dplyr::group_by(bare_mtcars, cyl))
   )
-  expect_identical(out, tibble::as_tibble(mtcars[0, ]))
+  expect_identical(out, tibble::as_tibble(bare_mtcars[0, ]))
 })

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -221,3 +221,11 @@ test_that("vec_ptype_finalise() requires vector types", {
   expect_error(vec_ptype_finalise(quote(name)), class = "vctrs_error_scalar_type")
   expect_error(vec_ptype_finalise(foobar()), class = "vctrs_error_scalar_type")
 })
+
+# This might change in the future if we decide that prototypes don't
+# have names
+test_that("vec_ptype() preserves type of names and row names", {
+  expect_identical(vec_ptype(c(foo = 1)), named(dbl()))
+  expect_identical(vec_ptype(mtcars), mtcars[0, ])
+  expect_identical(vec_ptype(foobar(mtcars)), foobar(mtcars[0, ]))
+})

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -296,7 +296,6 @@ test_that("vec_ptype2() methods get prototypes", {
   expect_identical(x, foobar(int()))
   expect_identical(y, foobar(chr()))
 
-  skip("Figure out what to do with row names in `vec_ptype()`")
   vec_ptype2(foobar(mtcars), foobar(iris))
   expect_identical(x, foobar(mtcars[0, , drop = FALSE]))
   expect_identical(y, foobar(iris[0, , drop = FALSE]))


### PR DESCRIPTION
Follow up to #1049 (and branched from it).
Extracted from #1020.

Preserve the type of row names in `vec_ptype()`, for consistency with vectors.