### PR TITLE
Fix performance in R 4.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,8 +45,7 @@ Suggests:
     xml2,
     zeallot
 Remotes: 
-    r-lib/pillar,
-    r-lib/rlang#963
+    r-lib/pillar
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,8 @@ Suggests:
     xml2,
     zeallot
 Remotes: 
-    r-lib/pillar
+    r-lib/pillar,
+    r-lib/rlang#963
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/R/bind.R
+++ b/R/bind.R
@@ -162,7 +162,7 @@ vec_cbind <- function(...,
                       .ptype = NULL,
                       .size = NULL,
                       .name_repair = c("unique", "universal", "check_unique", "minimal")) {
-  .External2(vctrs_cbind, .ptype, .size, .name_repair)
+  .External(vctrs_cbind, list2(...), .ptype, .size, .name_repair)
 }
 vec_cbind <- fn_inline_formals(vec_cbind, ".name_repair")
 

--- a/R/bind.R
+++ b/R/bind.R
@@ -147,7 +147,7 @@ vec_rbind <- function(...,
                       .ptype = NULL,
                       .names_to = rlang::zap(),
                       .name_repair = c("unique", "universal", "check_unique")) {
-  .External2(vctrs_rbind, .ptype, .names_to, .name_repair)
+  .External(vctrs_rbind, list2(...), .ptype, .names_to, .name_repair)
 }
 vec_rbind <- fn_inline_formals(vec_rbind, ".name_repair")
 

--- a/R/c.R
+++ b/R/c.R
@@ -47,6 +47,6 @@ vec_c <- function(...,
                   .ptype = NULL,
                   .name_spec = NULL,
                   .name_repair = c("minimal", "unique", "check_unique", "universal")) {
-  .External2(vctrs_c, .ptype, .name_spec, .name_repair)
+  .External(vctrs_c, list2(...), .ptype, .name_spec, .name_repair)
 }
 vec_c <- fn_inline_formals(vec_c, ".name_repair")

--- a/R/cast.R
+++ b/R/cast.R
@@ -127,7 +127,7 @@ vec_cast_dispatch <- function(x, to, ..., x_arg = "", to_arg = "") {
 #' @export
 #' @rdname vec_cast
 vec_cast_common <- function(..., .to = NULL) {
-  .External2(vctrs_cast_common, .to)
+  .External(vctrs_cast_common, list2(...), .to)
 }
 
 #' Default cast method

--- a/R/recycle.R
+++ b/R/recycle.R
@@ -55,5 +55,5 @@ vec_recycle <- function(x, size, ..., x_arg = "") {
 #' @export
 #' @rdname vec_recycle
 vec_recycle_common <- function(..., .size = NULL) {
-  .External2(vctrs_recycle_common, .size)
+  .External(vctrs_recycle_common, list2(...), .size)
 }

--- a/R/size.R
+++ b/R/size.R
@@ -83,7 +83,7 @@ vec_size <- function(x) {
 #' @export
 #' @rdname vec_size
 vec_size_common <- function(..., .size = NULL, .absent = 0L) {
-  .External2(vctrs_size_common, .size, .absent)
+  .External(vctrs_size_common, list2(...), .size, .absent)
 }
 
 #' @rdname vec_size

--- a/R/type.R
+++ b/R/type.R
@@ -93,7 +93,7 @@ vec_ptype <- function(x, ..., x_arg = "") {
 #' @export
 #' @rdname vec_ptype
 vec_ptype_common <- function(..., .ptype = NULL) {
-  .External2(vctrs_type_common, .ptype)
+  .External(vctrs_type_common, dots_values(...), .ptype)
 }
 vec_ptype_common_params <- function(..., .ptype = NULL, .df_fallback = FALSE) {
   .External2(vctrs_ptype_common_params, .ptype, .df_fallback)

--- a/R/type.R
+++ b/R/type.R
@@ -96,7 +96,7 @@ vec_ptype_common <- function(..., .ptype = NULL) {
   .External(vctrs_type_common, dots_values(...), .ptype)
 }
 vec_ptype_common_params <- function(..., .ptype = NULL, .df_fallback = FALSE) {
-  .External2(vctrs_ptype_common_params, .ptype, .df_fallback)
+  .External(vctrs_ptype_common_params, dots_values(...), .ptype, .df_fallback)
 }
 
 #' @export

--- a/src/bind.c
+++ b/src/bind.c
@@ -306,20 +306,20 @@ static SEXP as_df_col(SEXP x, SEXP outer, bool* allow_pack);
 static SEXP cbind_container_type(SEXP x, void* data);
 
 // [[ register(external = TRUE) ]]
-SEXP vctrs_cbind(SEXP call, SEXP op, SEXP args, SEXP env) {
+SEXP vctrs_cbind(SEXP args) {
   args = CDR(args);
 
-  SEXP xs = PROTECT(rlang_env_dots_list(env));
-  SEXP ptype = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
-  SEXP size = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
-  SEXP name_repair = PROTECT(Rf_eval(CAR(args), env));
+  SEXP xs = CAR(args); args = CDR(args);
+  SEXP ptype = CAR(args); args = CDR(args);
+  SEXP size = CAR(args); args = CDR(args);
+  SEXP name_repair = CAR(args);
 
   struct name_repair_opts name_repair_opts = validate_bind_name_repair(name_repair, true);
   PROTECT_NAME_REPAIR_OPTS(&name_repair_opts);
 
   SEXP out = vec_cbind(xs, ptype, size, &name_repair_opts);
 
-  UNPROTECT(5);
+  UNPROTECT(1);
   return out;
 }
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -14,13 +14,13 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
 static SEXP cbind_names_to(bool has_names, SEXP names_to, SEXP ptype);
 
 // [[ register(external = TRUE) ]]
-SEXP vctrs_rbind(SEXP call, SEXP op, SEXP args, SEXP env) {
+SEXP vctrs_rbind(SEXP args) {
   args = CDR(args);
 
-  SEXP xs = PROTECT(rlang_env_dots_list(env));
-  SEXP ptype = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
-  SEXP names_to = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
-  SEXP name_repair = PROTECT(Rf_eval(CAR(args), env));
+  SEXP xs = CAR(args); args = CDR(args);
+  SEXP ptype = CAR(args); args = CDR(args);
+  SEXP names_to = CAR(args); args = CDR(args);
+  SEXP name_repair = CAR(args);
 
   if (names_to != R_NilValue) {
     if (Rf_inherits(names_to, "rlang_zap")) {
@@ -38,7 +38,7 @@ SEXP vctrs_rbind(SEXP call, SEXP op, SEXP args, SEXP env) {
 
   SEXP out = vec_rbind(xs, ptype, names_to, &name_repair_opts);
 
-  UNPROTECT(5);
+  UNPROTECT(1);
   return out;
 }
 

--- a/src/c.c
+++ b/src/c.c
@@ -5,20 +5,20 @@
 
 
 // [[ register(external = TRUE) ]]
-SEXP vctrs_c(SEXP call, SEXP op, SEXP args, SEXP env) {
+SEXP vctrs_c(SEXP args) {
   args = CDR(args);
 
-  SEXP xs = PROTECT(rlang_env_dots_list(env));
-  SEXP ptype = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
-  SEXP name_spec = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
-  SEXP name_repair = PROTECT(Rf_eval(CAR(args), env));
+  SEXP xs = CAR(args); args = CDR(args);
+  SEXP ptype = CAR(args); args = CDR(args);
+  SEXP name_spec = CAR(args); args = CDR(args);
+  SEXP name_repair = CAR(args);
 
   struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair, args_empty, false);
   PROTECT_NAME_REPAIR_OPTS(&name_repair_opts);
 
   SEXP out = vec_c(xs, ptype, name_spec, &name_repair_opts);
 
-  UNPROTECT(5);
+  UNPROTECT(1);
   return out;
 }
 

--- a/src/cast.c
+++ b/src/cast.c
@@ -239,15 +239,14 @@ SEXP vec_cast_common(SEXP xs, SEXP to) {
 }
 
 // [[ register(external = TRUE) ]]
-SEXP vctrs_cast_common(SEXP call, SEXP op, SEXP args, SEXP env) {
+SEXP vctrs_cast_common(SEXP args) {
   args = CDR(args);
 
-  SEXP dots = PROTECT(rlang_env_dots_list(env));
-  SEXP to = PROTECT(Rf_eval(CAR(args), env));
+  SEXP dots = CAR(args); args = CDR(args);
+  SEXP to = CAR(args);
 
   SEXP out = vec_cast_common(dots, to);
 
-  UNPROTECT(2);
   return out;
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -260,7 +260,7 @@ extern SEXP vctrs_type_common(SEXP);
 extern SEXP vctrs_ptype_common_params(SEXP);
 extern SEXP vctrs_size_common(SEXP);
 extern SEXP vctrs_recycle_common(SEXP);
-extern SEXP vctrs_cast_common(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_cast_common(SEXP);
 extern SEXP vctrs_rbind(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cbind(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_c(SEXP, SEXP, SEXP, SEXP);
@@ -271,7 +271,7 @@ static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_ptype_common_params",        (DL_FUNC) &vctrs_ptype_common_params, 3},
   {"vctrs_size_common",                (DL_FUNC) &vctrs_size_common, 3},
   {"vctrs_recycle_common",             (DL_FUNC) &vctrs_recycle_common, 2},
-  {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 1},
+  {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 2},
   {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 3},
   {"vctrs_cbind",                      (DL_FUNC) &vctrs_cbind, 3},
   {"vctrs_c",                          (DL_FUNC) &vctrs_c, 3},

--- a/src/init.c
+++ b/src/init.c
@@ -259,7 +259,7 @@ static const R_CallMethodDef CallEntries[] = {
 extern SEXP vctrs_type_common(SEXP);
 extern SEXP vctrs_ptype_common_params(SEXP);
 extern SEXP vctrs_size_common(SEXP);
-extern SEXP vctrs_recycle_common(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_recycle_common(SEXP);
 extern SEXP vctrs_cast_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_rbind(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cbind(SEXP, SEXP, SEXP, SEXP);
@@ -270,7 +270,7 @@ static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_type_common",                (DL_FUNC) &vctrs_type_common, 2},
   {"vctrs_ptype_common_params",        (DL_FUNC) &vctrs_ptype_common_params, 3},
   {"vctrs_size_common",                (DL_FUNC) &vctrs_size_common, 3},
-  {"vctrs_recycle_common",             (DL_FUNC) &vctrs_recycle_common, 1},
+  {"vctrs_recycle_common",             (DL_FUNC) &vctrs_recycle_common, 2},
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 1},
   {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 3},
   {"vctrs_cbind",                      (DL_FUNC) &vctrs_cbind, 3},

--- a/src/init.c
+++ b/src/init.c
@@ -261,7 +261,7 @@ extern SEXP vctrs_ptype_common_params(SEXP);
 extern SEXP vctrs_size_common(SEXP);
 extern SEXP vctrs_recycle_common(SEXP);
 extern SEXP vctrs_cast_common(SEXP);
-extern SEXP vctrs_rbind(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_rbind(SEXP);
 extern SEXP vctrs_cbind(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_c(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_new_data_frame(SEXP);
@@ -272,7 +272,7 @@ static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_size_common",                (DL_FUNC) &vctrs_size_common, 3},
   {"vctrs_recycle_common",             (DL_FUNC) &vctrs_recycle_common, 2},
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 2},
-  {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 3},
+  {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 4},
   {"vctrs_cbind",                      (DL_FUNC) &vctrs_cbind, 3},
   {"vctrs_c",                          (DL_FUNC) &vctrs_c, 3},
   {"vctrs_new_data_frame",             (DL_FUNC) &vctrs_new_data_frame, -1},

--- a/src/init.c
+++ b/src/init.c
@@ -258,7 +258,7 @@ static const R_CallMethodDef CallEntries[] = {
 
 extern SEXP vctrs_type_common(SEXP);
 extern SEXP vctrs_ptype_common_params(SEXP);
-extern SEXP vctrs_size_common(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_size_common(SEXP);
 extern SEXP vctrs_recycle_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cast_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_rbind(SEXP, SEXP, SEXP, SEXP);
@@ -269,7 +269,7 @@ extern SEXP vctrs_new_data_frame(SEXP);
 static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_type_common",                (DL_FUNC) &vctrs_type_common, 2},
   {"vctrs_ptype_common_params",        (DL_FUNC) &vctrs_ptype_common_params, 3},
-  {"vctrs_size_common",                (DL_FUNC) &vctrs_size_common, 2},
+  {"vctrs_size_common",                (DL_FUNC) &vctrs_size_common, 3},
   {"vctrs_recycle_common",             (DL_FUNC) &vctrs_recycle_common, 1},
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 1},
   {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 3},

--- a/src/init.c
+++ b/src/init.c
@@ -257,7 +257,7 @@ static const R_CallMethodDef CallEntries[] = {
 };
 
 extern SEXP vctrs_type_common(SEXP);
-extern SEXP vctrs_ptype_common_params(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_ptype_common_params(SEXP);
 extern SEXP vctrs_size_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_recycle_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cast_common(SEXP, SEXP, SEXP, SEXP);
@@ -268,7 +268,7 @@ extern SEXP vctrs_new_data_frame(SEXP);
 
 static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_type_common",                (DL_FUNC) &vctrs_type_common, 2},
-  {"vctrs_ptype_common_params",        (DL_FUNC) &vctrs_ptype_common_params, 2},
+  {"vctrs_ptype_common_params",        (DL_FUNC) &vctrs_ptype_common_params, 3},
   {"vctrs_size_common",                (DL_FUNC) &vctrs_size_common, 2},
   {"vctrs_recycle_common",             (DL_FUNC) &vctrs_recycle_common, 1},
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -106,8 +106,8 @@ extern SEXP vctrs_assign_params(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_has_dim(SEXP);
 extern SEXP vctrs_rep(SEXP, SEXP);
 extern SEXP vctrs_rep_each(SEXP, SEXP);
-extern SEXP vctrs_maybe_referenced_col(SEXP, SEXP);
-extern SEXP vctrs_new_df_unreferenced_col();
+extern SEXP vctrs_maybe_shared_col(SEXP, SEXP);
+extern SEXP vctrs_new_df_unshared_col();
 extern SEXP vctrs_shaped_ptype(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_shape2(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_new_date(SEXP);
@@ -243,8 +243,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_has_dim",                    (DL_FUNC) &vctrs_has_dim, 1},
   {"vctrs_rep",                        (DL_FUNC) &vctrs_rep, 2},
   {"vctrs_rep_each",                   (DL_FUNC) &vctrs_rep_each, 2},
-  {"vctrs_maybe_referenced_col",       (DL_FUNC) &vctrs_maybe_referenced_col, 2},
-  {"vctrs_new_df_unreferenced_col",    (DL_FUNC) &vctrs_new_df_unreferenced_col, 0},
+  {"vctrs_maybe_shared_col",           (DL_FUNC) &vctrs_maybe_shared_col, 2},
+  {"vctrs_new_df_unshared_col",        (DL_FUNC) &vctrs_new_df_unshared_col, 0},
   {"vctrs_shaped_ptype",               (DL_FUNC) &vctrs_shaped_ptype, 5},
   {"vctrs_shape2",                     (DL_FUNC) &vctrs_shape2, 4},
   {"vctrs_new_date",                   (DL_FUNC) &vctrs_new_date, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -262,7 +262,7 @@ extern SEXP vctrs_size_common(SEXP);
 extern SEXP vctrs_recycle_common(SEXP);
 extern SEXP vctrs_cast_common(SEXP);
 extern SEXP vctrs_rbind(SEXP);
-extern SEXP vctrs_cbind(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_cbind(SEXP);
 extern SEXP vctrs_c(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_new_data_frame(SEXP);
 
@@ -273,7 +273,7 @@ static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_recycle_common",             (DL_FUNC) &vctrs_recycle_common, 2},
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 2},
   {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 4},
-  {"vctrs_cbind",                      (DL_FUNC) &vctrs_cbind, 3},
+  {"vctrs_cbind",                      (DL_FUNC) &vctrs_cbind, 4},
   {"vctrs_c",                          (DL_FUNC) &vctrs_c, 3},
   {"vctrs_new_data_frame",             (DL_FUNC) &vctrs_new_data_frame, -1},
   {NULL, NULL, 0}

--- a/src/init.c
+++ b/src/init.c
@@ -256,7 +256,7 @@ static const R_CallMethodDef CallEntries[] = {
   {NULL, NULL, 0}
 };
 
-extern SEXP vctrs_type_common(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_type_common(SEXP);
 extern SEXP vctrs_ptype_common_params(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_size_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_recycle_common(SEXP, SEXP, SEXP, SEXP);
@@ -267,7 +267,7 @@ extern SEXP vctrs_c(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_new_data_frame(SEXP);
 
 static const R_ExternalMethodDef ExtEntries[] = {
-  {"vctrs_type_common",                (DL_FUNC) &vctrs_type_common, 1},
+  {"vctrs_type_common",                (DL_FUNC) &vctrs_type_common, 2},
   {"vctrs_ptype_common_params",        (DL_FUNC) &vctrs_ptype_common_params, 2},
   {"vctrs_size_common",                (DL_FUNC) &vctrs_size_common, 2},
   {"vctrs_recycle_common",             (DL_FUNC) &vctrs_recycle_common, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -263,7 +263,7 @@ extern SEXP vctrs_recycle_common(SEXP);
 extern SEXP vctrs_cast_common(SEXP);
 extern SEXP vctrs_rbind(SEXP);
 extern SEXP vctrs_cbind(SEXP);
-extern SEXP vctrs_c(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_c(SEXP);
 extern SEXP vctrs_new_data_frame(SEXP);
 
 static const R_ExternalMethodDef ExtEntries[] = {
@@ -274,7 +274,7 @@ static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 2},
   {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 4},
   {"vctrs_cbind",                      (DL_FUNC) &vctrs_cbind, 4},
-  {"vctrs_c",                          (DL_FUNC) &vctrs_c, 3},
+  {"vctrs_c",                          (DL_FUNC) &vctrs_c, 4},
   {"vctrs_new_data_frame",             (DL_FUNC) &vctrs_new_data_frame, -1},
   {NULL, NULL, 0}
 };

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -23,10 +23,8 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
   attrib = PROTECT(Rf_shallow_duplicate(attrib));
   ++n_protect;
 
-  if (MAYBE_REFERENCED(x)) {
-    x = PROTECT(Rf_shallow_duplicate(x));
-    ++n_protect;
-  }
+  x = PROTECT(r_maybe_duplicate(x));
+  ++n_protect;
 
   // Remove vectorised attributes which might be incongruent after reshaping.
   // Shouldn't matter for GNU R but other R implementations might have checks.

--- a/src/size-common.c
+++ b/src/size-common.c
@@ -79,14 +79,13 @@ static SEXP vctrs_size2_common(SEXP x, SEXP y, struct counters* counters, void* 
 }
 
 // [[ register(external = TRUE) ]]
-SEXP vctrs_recycle_common(SEXP call, SEXP op, SEXP args, SEXP env) {
+SEXP vctrs_recycle_common(SEXP args) {
   args = CDR(args);
 
-  SEXP size = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
+  SEXP xs = CAR(args); args = CDR(args);
+  SEXP size = CAR(args);
 
   R_len_t common;
-
-  SEXP xs = PROTECT(rlang_env_dots_list(env));
 
   if (size != R_NilValue) {
     common = size_validate(size, ".size");
@@ -94,9 +93,8 @@ SEXP vctrs_recycle_common(SEXP call, SEXP op, SEXP args, SEXP env) {
     common = vec_size_common(xs, -1);
   }
 
-  SEXP out = PROTECT(vec_recycle_common(xs, common));
+  SEXP out = vec_recycle_common(xs, common);
 
-  UNPROTECT(3);
   return out;
 }
 

--- a/src/size-common.c
+++ b/src/size-common.c
@@ -3,22 +3,22 @@
 
 
 // [[ register(external = TRUE) ]]
-SEXP vctrs_size_common(SEXP call, SEXP op, SEXP args, SEXP env) {
+SEXP vctrs_size_common(SEXP args) {
   args = CDR(args);
 
-  SEXP size = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
+  SEXP xs = CAR(args); args = CDR(args);
+
+  SEXP size = CAR(args); args = CDR(args);
   if (size != R_NilValue) {
     R_len_t out = size_validate(size, ".size");
-    UNPROTECT(1);
     return r_int(out);
   }
 
-  SEXP absent = PROTECT(Rf_eval(CAR(args), env));
+  SEXP absent = CAR(args);
   if (absent != R_NilValue && (TYPEOF(absent) != INTSXP || Rf_length(absent) != 1)) {
     Rf_errorcall(R_NilValue, "`.absent` must be a single integer.");
   }
 
-  SEXP xs = PROTECT(rlang_env_dots_list(env));
   R_len_t common = vec_size_common(xs, -1);
 
   SEXP out;
@@ -31,7 +31,6 @@ SEXP vctrs_size_common(SEXP call, SEXP op, SEXP args, SEXP env) {
     out = r_int(common);
   }
 
-  UNPROTECT(3);
   return out;
 }
 

--- a/src/type.c
+++ b/src/type.c
@@ -190,16 +190,15 @@ SEXP vctrs_type_common(SEXP args) {
   return out;
 }
 
-SEXP vctrs_ptype_common_params(SEXP call, SEXP op, SEXP args, SEXP env) {
+SEXP vctrs_ptype_common_params(SEXP args) {
   args = CDR(args);
 
-  SEXP types = PROTECT(rlang_env_dots_values(env));
-  SEXP ptype = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
-  SEXP df_fallback = PROTECT(Rf_eval(CAR(args), env));
+  SEXP dots = CAR(args); args = CDR(args);
+  SEXP ptype = CAR(args); args = CDR(args);
+  SEXP df_fallback = CAR(args);
 
-  SEXP out = vec_ptype_common_params(types, ptype, r_lgl_get(df_fallback, 0));
+  SEXP out = vec_ptype_common_params(dots, ptype, r_lgl_get(df_fallback, 0));
 
-  UNPROTECT(3);
   return out;
 }
 

--- a/src/type.c
+++ b/src/type.c
@@ -179,15 +179,14 @@ static SEXP vec_ptype_finalise_dispatch(SEXP x) {
 static SEXP vctrs_type2_common(SEXP current, SEXP next, struct counters* counters, void* data);
 
 // [[ register(external = TRUE) ]]
-SEXP vctrs_type_common(SEXP call, SEXP op, SEXP args, SEXP env) {
+SEXP vctrs_type_common(SEXP args) {
   args = CDR(args);
 
-  SEXP types = PROTECT(rlang_env_dots_values(env));
-  SEXP ptype = PROTECT(Rf_eval(CAR(args), env));
+  SEXP dots = CAR(args); args = CDR(args);
+  SEXP ptype = CAR(args);
 
-  SEXP out = vec_ptype_common_params(types, ptype, false);
+  SEXP out = vec_ptype_common_params(dots, ptype, false);
 
-  UNPROTECT(2);
   return out;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1247,7 +1247,7 @@ bool r_is_function(SEXP x) {
 }
 
 SEXP r_maybe_duplicate(SEXP x) {
-  if (MAYBE_REFERENCED(x)) {
+  if (MAYBE_SHARED(x)) {
     return Rf_shallow_duplicate(x);
   } else {
     return x;

--- a/src/utils.c
+++ b/src/utils.c
@@ -221,10 +221,8 @@ SEXP vctrs_set_attributes(SEXP x, SEXP attrib) {
   R_len_t n_attrib = Rf_length(attrib);
   int n_protect = 0;
 
-  if (MAYBE_REFERENCED(x)) {
-    x = PROTECT(Rf_shallow_duplicate(x));
-    ++n_protect;
-  }
+  x = PROTECT(r_maybe_duplicate(x));
+  ++n_protect;
 
   // Remove existing attributes, and unset the object bit
   SET_ATTRIB(x, R_NilValue);

--- a/src/utils.c
+++ b/src/utils.c
@@ -188,19 +188,23 @@ static SEXP vctrs_eval_mask_n_impl(SEXP fn, SEXP* syms, SEXP* args, SEXP mask) {
 }
 
 // [[ register() ]]
-SEXP vctrs_maybe_referenced_col(SEXP x, SEXP i) {
+SEXP vctrs_maybe_shared_col(SEXP x, SEXP i) {
   int i_ = r_int_get(i, 0) - 1;
   SEXP col = VECTOR_ELT(x, i_);
-  bool out = MAYBE_REFERENCED(col);
+  bool out = MAYBE_SHARED(col);
   return Rf_ScalarLogical(out);
 }
 
 // [[ register() ]]
-SEXP vctrs_new_df_unreferenced_col() {
+SEXP vctrs_new_df_unshared_col() {
   SEXP col = PROTECT(Rf_allocVector(INTSXP, 1));
   INTEGER(col)[0] = 1;
 
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 1));
+
+  // In R 4.0.0, `SET_VECTOR_ELT()` bumps the REFCNT of
+  // `col`. Because of this, `col` is now referenced (refcnt > 0),
+  // but it isn't shared (refcnt > 1).
   SET_VECTOR_ELT(out, 0, col);
 
   SEXP names = PROTECT(Rf_allocVector(STRSXP, 1));

--- a/tests/testthat/helper-memory.R
+++ b/tests/testthat/helper-memory.R
@@ -1,7 +1,7 @@
-maybe_referenced_col <- function(x, i) {
-  .Call(vctrs_maybe_referenced_col, x, i)
+maybe_shared_col <- function(x, i) {
+  .Call(vctrs_maybe_shared_col, x, i)
 }
 
-new_df_unreferenced_col <- function() {
-  .Call(vctrs_new_df_unreferenced_col)
+new_df_unshared_col <- function() {
+  .Call(vctrs_new_df_unshared_col)
 }

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -595,12 +595,37 @@ test_that("assignment to a data frame with unreferenced columns doesn't overwrit
   value <- new_data_frame(list(x = 2))
   expect <- new_data_frame(list(x = 1L))
 
+  # - On R < 4.0.0, the NAMED value of the column is 0.
+  # - On R >= 4.0.0, the refcnt of the column is 1 from the call to
+  #   `SET_VECTOR_ELT()` in `new_df_unshared_col()`.
   expect_false(maybe_shared_col(x, 1L))
 
   new <- vec_assign(x, 1, value)
 
-  # Expect that the column continues to be unshared
-  expect_false(maybe_shared_col(x, 1L))
+  # On R < 4.0.0, `vec_assign()` shallow duplicates `x`, which recursively
+  # bumps the NAMED-ness of each column of `x` to the max value of 7 by
+  # calling `ENSURE_NAMEDMAX()` on it. So the columns of `x` are all considered
+  # shared from that.
+
+  # On R >= 4.0.0, references are tracked more precisely.
+  # - `new_df_unshared_col()` calls `SET_VECTOR_ELT()` when setting the
+  #   column into `x`, bumping the column's namedness to 1.
+  # - Then, at the start of `df_assign()`, `x` is shallow duplicated and
+  #   assigned to `out`. This calls `ENSURE_NAMEDMAX()` on each column,
+  #   however this does nothing on R 4.0.0. The refcnt of each column is instead
+  #   incremented by 1 by calls to `SET_VECTOR_ELT()` in `duplicate1()`.
+  #   So now it is at 2.
+  # - But then in `df_assign()` we use `SET_VECTOR_ELT()` on `out`, overwriting
+  #   each column. This actually decrements the refcnt on the value that was
+  #   in `out` before the column was overwritten. The column of `out` that it
+  #   decrements the refcnt for is the same SEXP as that column in `x`, so now
+  #   it is back to 1, and it is not considered shared.
+
+  if (getRversion() >= "4.0.0") {
+    expect_false(maybe_shared_col(x, 1L))
+  } else {
+    expect_true(maybe_shared_col(x, 1L))
+  }
 
   # Expect no changes to `x`!
   expect_identical(x, expect)

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -591,15 +591,16 @@ test_that("can optionally assign names", {
 })
 
 test_that("assignment to a data frame with unreferenced columns doesn't overwrite (#986)", {
-  x <- new_df_unreferenced_col()
+  x <- new_df_unshared_col()
   value <- new_data_frame(list(x = 2))
   expect <- new_data_frame(list(x = 1L))
 
-  expect_false(maybe_referenced_col(x, 1L))
+  expect_false(maybe_shared_col(x, 1L))
 
   new <- vec_assign(x, 1, value)
 
-  expect_true(maybe_referenced_col(x, 1L))
+  # Expect that the column continues to be unshared
+  expect_false(maybe_shared_col(x, 1L))
 
   # Expect no changes to `x`!
   expect_identical(x, expect)


### PR DESCRIPTION
Closes #838 

Requires https://github.com/r-lib/rlang/pull/963 to ensure that the NAMEDNESS of captured `...` is always set to the max value.

Unfortunately R 4.0.0 is going to cause a huge performance regression to `vec_rbind()`. It is very similar to the problem in https://github.com/r-lib/vctrs/issues/984

Here is current master, with R 4.0.0. This is supposed to take ~20ms.

```r
library(vctrs)
library(tibble)

x <- rep(list(data.frame(x = 1)), 10000)

fn <- function(x) {
  vec_rbind(!!!x)
}

# master
bench::mark(fn(x), iterations = 10)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fn(x)         285ms    311ms      3.12     764MB     54.2

# this PR
bench::mark(fn(x), iterations = 10)
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fn(x)        19.8ms   21.7ms      43.0     200KB     18.4
```

The performance regression here is basically the same as in https://github.com/r-lib/vctrs/issues/984, in `df_assign()` we are making a copy of the final output container every time we assign one of the 10000 data frames into it.

The main issue is that `SET_VECTOR_ELT()` now bumps the refcnt of the `value` you are assigning, where it didn't used to do that. This makes `MAYBE_REFERENCED()` return true more often, in cases where we really don't need to make a duplicate. The fix is to switch to `MAYBE_SHARED()`, but also requires a patch to rlang on R < 4.0.0 to ensure that the result of rlang's `rlang_env_dots_list()` C callable returns the captured `...` with max namedness. This is important because it forces us to always copy the dots so we don't accidentally modify by reference (the copying was already happening when we were using `MAYBE_REFERENCED()`).

I've left very detailed notes about this in one of the tests
https://github.com/r-lib/vctrs/pull/1057/files#diff-51c944df297abe15044974191b4f4ebbR593-R627