### PR TITLE
Force `details` to be passed by name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -233,6 +233,16 @@ The following errors are caused by breaking changes.
 * `vec_as_names()` gains a `repair_arg` argument that when set will cause
   `repair = "check_unique"` to generate an informative hint (#692).
 
+
+## Conditions
+
+* `stop_` functions now take `details` after the dots. This argument
+  can no longer be passed by position.
+
+* Supplying both `details` and `message` to the `stop_` functions is
+  now an internal error.
+
+
 ## CRAN results
 
 * Fixed clang-UBSAN error "nan is outside the range of representable

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -6,9 +6,11 @@
 #' testing easier.
 #'
 #' @param x,y Vectors
-#' @param details Any additional human readable details
-#' @param subclass Use if you want to further customise the class
-#' @param ...,message,class Only use these fields when creating a subclass.
+#' @param subclass Use if you want to further customise the class.
+#' @param ...,class Only use these fields when creating a subclass.
+#' @param details Any additional human readable details.
+#' @param message An overriding message for the error. `details` and
+#'   `message` are mutually exclusive, supplying both is an error.
 #'
 #' @section Lossy cast errors:
 #'
@@ -44,7 +46,12 @@ stop_vctrs <- function(message = NULL, class = NULL, ...) {
   abort(message, class = c(class, "vctrs_error"), ...)
 }
 
-stop_incompatible <- function(x, y, details = NULL, ..., message = NULL, class = NULL) {
+stop_incompatible <- function(x,
+                              y,
+                              ...,
+                              details = NULL,
+                              message = NULL,
+                              class = NULL) {
   stop_vctrs(
     message,
     class = c(class, "vctrs_error_incompatible"),
@@ -65,8 +72,8 @@ stop_incompatible_type <- function(x,
                                    y,
                                    x_arg = "",
                                    y_arg = "",
-                                   details = NULL,
                                    ...,
+                                   details = NULL,
                                    message = NULL,
                                    class = NULL) {
   stop_incompatible_type_combine(
@@ -74,8 +81,8 @@ stop_incompatible_type <- function(x,
     y = y,
     x_arg = x_arg,
     y_arg = y_arg,
-    details = details,
     ...,
+    details = details,
     message = message,
     class = class
   )
@@ -85,10 +92,10 @@ stop_incompatible_type <- function(x,
 #' @export
 stop_incompatible_cast <- function(x,
                                    y,
-                                   details = NULL,
                                    ...,
                                    x_arg = "",
                                    to_arg = "",
+                                   details = NULL,
                                    message = NULL,
                                    class = NULL) {
   stop_incompatible_type_convert(
@@ -96,8 +103,8 @@ stop_incompatible_cast <- function(x,
     y = y,
     x_arg = x_arg,
     y_arg = to_arg,
-    details = details,
     ...,
+    details = details,
     message = message,
     class = class
   )
@@ -114,8 +121,8 @@ stop_incompatible_type_convert <- function(x,
                                            y,
                                            x_arg = "",
                                            y_arg = "",
-                                           details = NULL,
                                            ...,
+                                           details = NULL,
                                            message = NULL,
                                            class = NULL) {
   stop_incompatible_type_impl(
@@ -123,9 +130,9 @@ stop_incompatible_type_convert <- function(x,
     y = y,
     x_arg = x_arg,
     y_arg = y_arg,
-    details = details,
     action = "convert",
     ...,
+    details = details,
     message = message,
     class = class
   )
@@ -135,8 +142,8 @@ stop_incompatible_type_combine <- function(x,
                                            y,
                                            x_arg = "",
                                            y_arg = "",
-                                           details = NULL,
                                            ...,
+                                           details = NULL,
                                            message = NULL,
                                            class = NULL) {
   stop_incompatible_type_impl(
@@ -144,9 +151,9 @@ stop_incompatible_type_combine <- function(x,
     y = y,
     x_arg = x_arg,
     y_arg = y_arg,
-    details = details,
     action = "combine",
     ...,
+    details = details,
     message = message,
     class = class
   )
@@ -156,9 +163,9 @@ stop_incompatible_type_impl <- function(x,
                                         y,
                                         x_arg,
                                         y_arg,
-                                        details,
                                         action,
                                         ...,
+                                        details,
                                         message,
                                         class) {
   vec_assert(x)
@@ -221,6 +228,9 @@ cnd_type_message <- function(x,
                              from_dispatch = FALSE,
                              fallback = NULL) {
   if (!is_null(message)) {
+    if (!is_null(details)) {
+      abort("Can't supply both `message` and `details`.")
+    }
     return(message)
   }
 
@@ -324,8 +334,8 @@ stop_incompatible_op <- function(op, x, y, details = NULL, ..., message = NULL, 
 stop_incompatible_size <- function(x, y,
                                    x_size, y_size,
                                    x_arg = "", y_arg = "",
-                                   details = NULL,
                                    ...,
+                                   details = NULL,
                                    message = NULL,
                                    class = NULL) {
   vec_assert(x)
@@ -358,8 +368,8 @@ stop_incompatible_size <- function(x, y,
     y_size = y_size,
     x_arg = x_arg,
     y_arg = y_arg,
-    details = details,
     ...,
+    details = details,
     message = message,
     class = c(class, "vctrs_error_incompatible_size")
   )
@@ -384,10 +394,10 @@ stop_incompatible_size <- function(x, y,
 maybe_lossy_cast <- function(result, x, to,
                              lossy = NULL,
                              locations = NULL,
-                             details = NULL,
                              ...,
                              x_arg = "",
                              to_arg = "",
+                             details = NULL,
                              message = NULL,
                              class = NULL,
                              .deprecation = FALSE) {
@@ -408,10 +418,10 @@ maybe_lossy_cast <- function(result, x, to,
       to = to,
       result = result,
       locations = locations,
-      details = details,
       ...,
       x_arg = x_arg,
       to_arg = to_arg,
+      details = details,
       message = message,
       class = class
     )
@@ -419,10 +429,10 @@ maybe_lossy_cast <- function(result, x, to,
 }
 stop_lossy_cast <- function(x, to, result,
                             locations = NULL,
-                            details = NULL,
                             ...,
                             x_arg = "",
                             to_arg = "",
+                            details = NULL,
                             message = NULL,
                             class = NULL) {
   stop_vctrs(
@@ -434,8 +444,8 @@ stop_lossy_cast <- function(x, to, result,
     x_arg = x_arg,
     to_arg = to_arg,
     locations = locations,
-    details = details,
     ...,
+    details = details,
     class = c(class, "vctrs_error_cast_lossy")
   )
 }

--- a/man/vctrs-conditions.Rd
+++ b/man/vctrs-conditions.Rd
@@ -15,8 +15,8 @@ stop_incompatible_type(
   y,
   x_arg = "",
   y_arg = "",
-  details = NULL,
   ...,
+  details = NULL,
   message = NULL,
   class = NULL
 )
@@ -24,10 +24,10 @@ stop_incompatible_type(
 stop_incompatible_cast(
   x,
   y,
-  details = NULL,
   ...,
   x_arg = "",
   to_arg = "",
+  details = NULL,
   message = NULL,
   class = NULL
 )
@@ -49,8 +49,8 @@ stop_incompatible_size(
   y_size,
   x_arg = "",
   y_arg = "",
-  details = NULL,
   ...,
+  details = NULL,
   message = NULL,
   class = NULL
 )
@@ -61,10 +61,10 @@ maybe_lossy_cast(
   to,
   lossy = NULL,
   locations = NULL,
-  details = NULL,
   ...,
   x_arg = "",
   to_arg = "",
+  details = NULL,
   message = NULL,
   class = NULL,
   .deprecation = FALSE
@@ -75,9 +75,12 @@ allow_lossy_cast(expr, x_ptype = NULL, to_ptype = NULL)
 \arguments{
 \item{x, y}{Vectors}
 
-\item{details}{Any additional human readable details}
+\item{..., class}{Only use these fields when creating a subclass.}
 
-\item{..., message, class}{Only use these fields when creating a subclass.}
+\item{details}{Any additional human readable details.}
+
+\item{message}{An overriding message for the error. \code{details} and
+\code{message} are mutually exclusive, supplying both is an error.}
 
 \item{result}{The result of a potentially lossy cast.}
 
@@ -101,7 +104,7 @@ to wrap their code with \code{allow_lossy_cast()}.}
 \item{x_ptype, to_ptype}{Suppress only the casting errors where \code{x}
 or \code{to} match these \link[=vec_ptype]{prototypes}.}
 
-\item{subclass}{Use if you want to further customise the class}
+\item{subclass}{Use if you want to further customise the class.}
 }
 \value{
 \verb{stop_incompatible_*()} unconditionally raise an error of class

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -102,6 +102,18 @@ test_that("unique names errors are informative", {
   })
 })
 
+test_that("can't supply both `message` and `details`", {
+  expect_error(
+    stop_incompatible_type(1, 2, message = "my message"),
+    "my message",
+    class = "vctrs_error_incompatible_type"
+  )
+  expect_error(
+    stop_incompatible_type(1, 2, message = "my message", details = "my details"),
+    "Can't supply both `message` and `details`."
+  )
+})
+
 verify_output(test_path("error", "test-conditions.txt"), {
   "# can override arg in OOB conditions"
   with_subscript_data(


### PR DESCRIPTION
And prevent it from being supplied with `message`