### PR TITLE
Make tag arguments compulsory in `stop_` functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -242,6 +242,9 @@ The following errors are caused by breaking changes.
 * Supplying both `details` and `message` to the `stop_` functions is
   now an internal error.
 
+* `x_arg`, `y_arg`, and `to_arg` are now compulsory arguments in
+  `stop_` functions like `stop_incompatible_type()`.
+
 
 ## CRAN results
 

--- a/R/cast-list.R
+++ b/R/cast-list.R
@@ -34,8 +34,15 @@ vec_list_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
   }
 
   if (!is.object(to)) {
-    out <- shape_broadcast(out, to)
+    out <- shape_broadcast(out, to, x_arg = x_arg, to_arg = to_arg)
   }
 
-  maybe_lossy_cast(out, x, to, lossy = !ns %in% c(0L, 1L))
+  maybe_lossy_cast(
+    out,
+    x,
+    to,
+    lossy = !ns %in% c(0L, 1L),
+    x_arg = x_arg,
+    to_arg = to_arg
+  )
 }

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -28,14 +28,35 @@
 #' @examples
 #'
 #' # Most of the time, `maybe_lossy_cast()` returns its input normally:
-#' maybe_lossy_cast(c("foo", "bar"), NULL, "", lossy = c(FALSE, FALSE))
+#' maybe_lossy_cast(
+#'   c("foo", "bar"),
+#'   NULL,
+#'   "",
+#'   lossy = c(FALSE, FALSE),
+#'   x_arg = "",
+#'   to_arg = ""
+#' )
 #'
 #' # If `lossy` has any `TRUE`, an error is thrown:
-#' try(maybe_lossy_cast(c("foo", "bar"), NULL, "", lossy = c(FALSE, TRUE)))
+#' try(maybe_lossy_cast(
+#'   c("foo", "bar"),
+#'   NULL,
+#'   "",
+#'   lossy = c(FALSE, TRUE),
+#'   x_arg = "",
+#'   to_arg = ""
+#' ))
 #'
 #' # Unless lossy casts are allowed:
 #' allow_lossy_cast(
-#'   maybe_lossy_cast(c("foo", "bar"), NULL, "", lossy = c(FALSE, TRUE))
+#'   maybe_lossy_cast(
+#'     c("foo", "bar"),
+#'     NULL,
+#'     "",
+#'     lossy = c(FALSE, TRUE),
+#'     x_arg = "",
+#'     to_arg = ""
+#'   )
 #' )
 #'
 #' @keywords internal
@@ -70,18 +91,18 @@ stop_incompatible <- function(x,
 #' @export
 stop_incompatible_type <- function(x,
                                    y,
-                                   x_arg = "",
-                                   y_arg = "",
                                    ...,
+                                   x_arg,
+                                   y_arg,
                                    details = NULL,
                                    message = NULL,
                                    class = NULL) {
   stop_incompatible_type_combine(
     x = x,
     y = y,
+    ...,
     x_arg = x_arg,
     y_arg = y_arg,
-    ...,
     details = details,
     message = message,
     class = class
@@ -93,17 +114,17 @@ stop_incompatible_type <- function(x,
 stop_incompatible_cast <- function(x,
                                    y,
                                    ...,
-                                   x_arg = "",
-                                   to_arg = "",
+                                   x_arg,
+                                   to_arg,
                                    details = NULL,
                                    message = NULL,
                                    class = NULL) {
   stop_incompatible_type_convert(
     x = x,
     y = y,
+    ...,
     x_arg = x_arg,
     y_arg = to_arg,
-    ...,
     details = details,
     message = message,
     class = class
@@ -114,24 +135,24 @@ stop_incompatible_shape <- function(x, y, x_size, y_size, axis, x_arg, y_arg) {
   details <- format_error_bullets(c(
     x = glue::glue("Incompatible sizes {x_size} and {y_size} along axis {axis}.")
   ))
-  stop_incompatible_type(x, y, x_arg, y_arg, details = details)
+  stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg, details = details)
 }
 
 stop_incompatible_type_convert <- function(x,
                                            y,
-                                           x_arg = "",
-                                           y_arg = "",
                                            ...,
+                                           x_arg,
+                                           y_arg,
                                            details = NULL,
                                            message = NULL,
                                            class = NULL) {
   stop_incompatible_type_impl(
     x = x,
     y = y,
-    x_arg = x_arg,
-    y_arg = y_arg,
     action = "convert",
     ...,
+    x_arg = x_arg,
+    y_arg = y_arg,
     details = details,
     message = message,
     class = class
@@ -140,19 +161,19 @@ stop_incompatible_type_convert <- function(x,
 
 stop_incompatible_type_combine <- function(x,
                                            y,
-                                           x_arg = "",
-                                           y_arg = "",
                                            ...,
+                                           x_arg,
+                                           y_arg,
                                            details = NULL,
                                            message = NULL,
                                            class = NULL) {
   stop_incompatible_type_impl(
     x = x,
     y = y,
-    x_arg = x_arg,
-    y_arg = y_arg,
     action = "combine",
     ...,
+    x_arg = x_arg,
+    y_arg = y_arg,
     details = details,
     message = message,
     class = class
@@ -161,10 +182,10 @@ stop_incompatible_type_combine <- function(x,
 
 stop_incompatible_type_impl <- function(x,
                                         y,
-                                        x_arg,
-                                        y_arg,
                                         action,
                                         ...,
+                                        x_arg,
+                                        y_arg,
                                         details,
                                         message,
                                         class) {
@@ -331,10 +352,13 @@ stop_incompatible_op <- function(op, x, y, details = NULL, ..., message = NULL, 
 
 #' @rdname vctrs-conditions
 #' @export
-stop_incompatible_size <- function(x, y,
-                                   x_size, y_size,
-                                   x_arg = "", y_arg = "",
+stop_incompatible_size <- function(x,
+                                   y,
+                                   x_size,
+                                   y_size,
                                    ...,
+                                   x_arg,
+                                   y_arg,
                                    details = NULL,
                                    message = NULL,
                                    class = NULL) {
@@ -366,9 +390,9 @@ stop_incompatible_size <- function(x, y,
     x, y,
     x_size = x_size,
     y_size = y_size,
+    ...,
     x_arg = x_arg,
     y_arg = y_arg,
-    ...,
     details = details,
     message = message,
     class = c(class, "vctrs_error_incompatible_size")
@@ -395,8 +419,8 @@ maybe_lossy_cast <- function(result, x, to,
                              lossy = NULL,
                              locations = NULL,
                              ...,
-                             x_arg = "",
-                             to_arg = "",
+                             x_arg,
+                             to_arg,
                              details = NULL,
                              message = NULL,
                              class = NULL,
@@ -430,8 +454,8 @@ maybe_lossy_cast <- function(result, x, to,
 stop_lossy_cast <- function(x, to, result,
                             locations = NULL,
                             ...,
-                            x_arg = "",
-                            to_arg = "",
+                            x_arg,
+                            to_arg,
                             details = NULL,
                             message = NULL,
                             class = NULL) {
@@ -441,10 +465,10 @@ stop_lossy_cast <- function(x, to, result,
     y = to,
     to = to,
     result = result,
-    x_arg = x_arg,
-    to_arg = to_arg,
     locations = locations,
     ...,
+    x_arg = x_arg,
+    to_arg = to_arg,
     details = details,
     class = c(class, "vctrs_error_cast_lossy")
   )

--- a/R/shape.R
+++ b/R/shape.R
@@ -21,7 +21,8 @@ vec_shape2 <- function(x, y, ..., x_arg = "", y_arg = "") {
   .Call(vctrs_shape2, x, y, x_arg, y_arg)
 }
 
-shape_broadcast <- function(x, to) {
+# Should take same signature as `vec_cast()`
+shape_broadcast <- function(x, to, ..., x_arg, to_arg) {
   if (is.null(x) || is.null(to)) {
     return(x)
   }
@@ -35,14 +36,26 @@ shape_broadcast <- function(x, to) {
   }
 
   if (length(dim_x) > length(dim_to)) {
-    stop_incompatible_cast(x, to, details = "Can not decrease dimensions")
+    stop_incompatible_cast(
+      x,
+      to,
+      details = "Cannot decrease dimensions.",
+      x_arg = x_arg,
+      to_arg = to_arg
+    )
   }
 
   dim_x <- n_dim2(dim_x, dim_to)$x
   dim_to[[1]] <- dim_x[[1]] # don't change number of observations
   ok <- dim_x == dim_to | dim_x == 1
   if (any(!ok)) {
-    stop_incompatible_cast(x, to, details = "Non-recyclable dimensions")
+    stop_incompatible_cast(
+      x,
+      to,
+      details = "Non-recyclable dimensions.",
+      x_arg = x_arg,
+      to_arg = to_arg
+    )
   }
 
   # Increase dimensionality if required

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -172,14 +172,14 @@ vec_cast.logical <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.logical logical
-vec_cast.logical.logical <- function(x, to, ..., x_arg = "", to_arg = "") {
-  shape_broadcast(x, to)
+vec_cast.logical.logical <- function(x, to, ...) {
+  shape_broadcast(x, to, ...)
 }
 #' @export
 #' @method vec_cast.logical integer
 vec_cast.logical.integer <- function(x, to, ..., x_arg = "", to_arg = "") {
   out <- vec_coerce_bare(x, "logical")
-  out <- shape_broadcast(out, to)
+  out <- shape_broadcast(out, to, x_arg = x_arg, to_arg = to_arg)
   lossy <- !x %in% c(0L, 1L, NA_integer_)
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
@@ -187,7 +187,7 @@ vec_cast.logical.integer <- function(x, to, ..., x_arg = "", to_arg = "") {
 #' @method vec_cast.logical double
 vec_cast.logical.double <- function(x, to, ..., x_arg = "", to_arg = "") {
   out <- vec_coerce_bare(x, "logical")
-  out <- shape_broadcast(out, to)
+  out <- shape_broadcast(out, to, x_arg = x_arg, to_arg = to_arg)
   lossy <- !x %in% c(0, 1, NA_real_)
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
@@ -201,14 +201,14 @@ vec_cast.integer <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.integer logical
-vec_cast.integer.logical <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.integer.logical <- function(x, to, ...) {
   x <- vec_coerce_bare(x, "integer")
-  shape_broadcast(x, to)
+  shape_broadcast(x, to, ...)
 }
 #' @export
 #' @method vec_cast.integer integer
-vec_cast.integer.integer <- function(x, to, ..., x_arg = "", to_arg = "") {
-  shape_broadcast(x, to)
+vec_cast.integer.integer <- function(x, to, ...) {
+  shape_broadcast(x, to, ...)
 }
 #' @export
 #' @method vec_cast.integer double
@@ -216,7 +216,7 @@ vec_cast.integer.double <- function(x, to, ..., x_arg = "", to_arg = "") {
   out <- suppressWarnings(vec_coerce_bare(x, "integer"))
   x_na <- is.na(x)
   lossy <- (out != x & !x_na) | xor(x_na, is.na(out))
-  out <- shape_broadcast(out, to)
+  out <- shape_broadcast(out, to, x_arg = x_arg, to_arg = to_arg)
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -229,17 +229,17 @@ vec_cast.double <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.double logical
-vec_cast.double.logical <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.double.logical <- function(x, to, ...) {
   x <- vec_coerce_bare(x, "double")
-  shape_broadcast(x, to)
+  shape_broadcast(x, to, ...)
 }
 #' @export
 #' @method vec_cast.double integer
 vec_cast.double.integer <- vec_cast.double.logical
 #' @export
 #' @method vec_cast.double double
-vec_cast.double.double <- function(x, to, ..., x_arg = "", to_arg = "") {
-  shape_broadcast(x, to)
+vec_cast.double.double <- function(x, to, ...) {
+  shape_broadcast(x, to, ...)
 }
 
 #' @export
@@ -251,9 +251,9 @@ vec_cast.complex <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.complex logical
-vec_cast.complex.logical <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.complex.logical <- function(x, to, ...) {
   x <- vec_coerce_bare(x, "complex")
-  shape_broadcast(x, to)
+  shape_broadcast(x, to, ...)
 }
 #' @export
 #' @method vec_cast.complex integer
@@ -263,8 +263,8 @@ vec_cast.complex.integer <- vec_cast.complex.logical
 vec_cast.complex.double <- vec_cast.complex.logical
 #' @export
 #' @method vec_cast.complex complex
-vec_cast.complex.complex <- function(x, to, ..., x_arg = "", to_arg = "") {
-  shape_broadcast(x, to)
+vec_cast.complex.complex <- function(x, to, ...) {
+  shape_broadcast(x, to, ...)
 }
 
 #' @export
@@ -276,8 +276,8 @@ vec_cast.raw <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.raw raw
-vec_cast.raw.raw <- function(x, to, ..., x_arg = "", to_arg = "") {
-  shape_broadcast(x, to)
+vec_cast.raw.raw <- function(x, to, ...) {
+  shape_broadcast(x, to, ...)
 }
 
 #' @export
@@ -289,8 +289,8 @@ vec_cast.character <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.character character
-vec_cast.character.character <- function(x, to, ..., x_arg = "", to_arg = "") {
-  shape_broadcast(x, to)
+vec_cast.character.character <- function(x, to, ...) {
+  shape_broadcast(x, to, ...)
 }
 
 #' @rdname vec_cast
@@ -302,8 +302,8 @@ vec_cast.list <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.list list
-vec_cast.list.list <- function(x, to, ..., x_arg = "", to_arg = "") {
-  shape_broadcast(x, to)
+vec_cast.list.list <- function(x, to, ...) {
+  shape_broadcast(x, to, ...)
 }
 
 

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -284,7 +284,7 @@ df_size <- function(x) {
   .Call(vctrs_df_size, x)
 }
 
-df_lossy_cast <- function(out, x, to) {
+df_lossy_cast <- function(out, x, to, ..., x_arg = "", to_arg = "") {
   extra <- setdiff(names(x), names(to))
 
   maybe_lossy_cast(
@@ -293,6 +293,8 @@ df_lossy_cast <- function(out, x, to) {
     to = to,
     lossy = length(extra) > 0,
     locations = int(),
+    x_arg = x_arg,
+    to_arg = to_arg,
     details = inline_list("Dropped variables: ", extra, quote = "`"),
     class = "vctrs_error_cast_lossy_dropped"
   )

--- a/R/type-rcrd.R
+++ b/R/type-rcrd.R
@@ -89,11 +89,11 @@ vec_cast.vctrs_rcrd <- function(x, to, ...) UseMethod("vec_cast.vctrs_rcrd")
 
 #' @method vec_cast.vctrs_rcrd vctrs_rcrd
 #' @export
-vec_cast.vctrs_rcrd.vctrs_rcrd <- function(x, to, ...) {
+vec_cast.vctrs_rcrd.vctrs_rcrd <- function(x, to, ..., x_arg = x_arg, to_arg = to_arg) {
   # This assumes that we don't have duplicate field names,
   # which is verified even in the constructor.
   if (!setequal(fields(x), fields(to))) {
-    stop_incompatible_cast(x, to)
+    stop_incompatible_cast(x, to, x_arg = x_arg, to_arg = to_arg)
   }
 
   new_data <- map2(

--- a/R/type-table.R
+++ b/R/type-table.R
@@ -49,8 +49,8 @@ vec_cast.table <- function(x, to, ..., x_arg = "", to_arg = "") {
 }
 #' @method vec_cast.table table
 #' @export
-vec_cast.table.table <- function(x, to, ..., x_arg = "", to_arg = "") {
-  shape_broadcast(x, to)
+vec_cast.table.table <- function(x, to, ...) {
+  shape_broadcast(x, to, ...)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -126,7 +126,7 @@ vec_proxy.vctrs_vctr <- function(x, ...) {
 #' @export
 vec_restore.vctrs_vctr <- function(x, to, ..., i = NULL) {
   if (typeof(x) != typeof(to)) {
-    stop_incompatible_cast(x, to)
+    stop_incompatible_cast(x, to, x_arg = "", to_arg = "")
   }
   NextMethod()
 }

--- a/man/vctrs-conditions.Rd
+++ b/man/vctrs-conditions.Rd
@@ -13,9 +13,9 @@
 stop_incompatible_type(
   x,
   y,
-  x_arg = "",
-  y_arg = "",
   ...,
+  x_arg,
+  y_arg,
   details = NULL,
   message = NULL,
   class = NULL
@@ -25,8 +25,8 @@ stop_incompatible_cast(
   x,
   y,
   ...,
-  x_arg = "",
-  to_arg = "",
+  x_arg,
+  to_arg,
   details = NULL,
   message = NULL,
   class = NULL
@@ -47,9 +47,9 @@ stop_incompatible_size(
   y,
   x_size,
   y_size,
-  x_arg = "",
-  y_arg = "",
   ...,
+  x_arg,
+  y_arg,
   details = NULL,
   message = NULL,
   class = NULL
@@ -62,8 +62,8 @@ maybe_lossy_cast(
   lossy = NULL,
   locations = NULL,
   ...,
-  x_arg = "",
-  to_arg = "",
+  x_arg,
+  to_arg,
   details = NULL,
   message = NULL,
   class = NULL,
@@ -134,14 +134,35 @@ returns the result silently.
 \examples{
 
 # Most of the time, `maybe_lossy_cast()` returns its input normally:
-maybe_lossy_cast(c("foo", "bar"), NULL, "", lossy = c(FALSE, FALSE))
+maybe_lossy_cast(
+  c("foo", "bar"),
+  NULL,
+  "",
+  lossy = c(FALSE, FALSE),
+  x_arg = "",
+  to_arg = ""
+)
 
 # If `lossy` has any `TRUE`, an error is thrown:
-try(maybe_lossy_cast(c("foo", "bar"), NULL, "", lossy = c(FALSE, TRUE)))
+try(maybe_lossy_cast(
+  c("foo", "bar"),
+  NULL,
+  "",
+  lossy = c(FALSE, TRUE),
+  x_arg = "",
+  to_arg = ""
+))
 
 # Unless lossy casts are allowed:
 allow_lossy_cast(
-  maybe_lossy_cast(c("foo", "bar"), NULL, "", lossy = c(FALSE, TRUE))
+  maybe_lossy_cast(
+    c("foo", "bar"),
+    NULL,
+    "",
+    lossy = c(FALSE, TRUE),
+    x_arg = "",
+    to_arg = ""
+  )
 )
 
 }

--- a/tests/testthat/helper-shape.R
+++ b/tests/testthat/helper-shape.R
@@ -1,0 +1,4 @@
+
+shape_broadcast_ <- function(x, to, x_arg = "x", to_arg = "to") {
+  shape_broadcast(x, to, x_arg = x_arg, to_arg = to_arg)
+}

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -102,7 +102,15 @@ test_that("can signal deprecation warnings for lossy casts", {
   local_lifecycle_warnings()
 
   lossy_cast <- function() {
-    maybe_lossy_cast(TRUE, factor("foo"), factor("bar"), lossy = TRUE, .deprecation = TRUE)
+    maybe_lossy_cast(
+      TRUE,
+      factor("foo"),
+      factor("bar"),
+      lossy = TRUE,
+      .deprecation = TRUE,
+      x_arg = "x",
+      to_arg = "to"
+    )
   }
 
   expect_true(expect_warning(lossy_cast(), "detected a lossy transformation"))

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -6,7 +6,7 @@ test_that("conditions inherit from `vctrs_error`", {
   expect_error(stop_incompatible_cast(NULL, NULL), class = "vctrs_error")
   expect_error(stop_incompatible_op("", NULL, NULL), class = "vctrs_error")
   expect_error(stop_incompatible_size(NULL, NULL, 0, 0), class = "vctrs_error")
-  expect_error(maybe_lossy_cast(NULL, NULL, NULL, TRUE), class = "vctrs_error")
+  expect_error(maybe_lossy_cast(NULL, NULL, NULL, TRUE, x_arg = "x", to_arg = "to"), class = "vctrs_error")
   expect_error(stop_unsupported("", ""), class = "vctrs_error")
   expect_error(stop_unimplemented("", ""), class = "vctrs_error")
   expect_error(stop_scalar_type(NULL), class = "vctrs_error")
@@ -17,7 +17,10 @@ test_that("conditions inherit from `vctrs_error`", {
 })
 
 test_that("incompatible cast throws an incompatible type error", {
-  expect_error(stop_incompatible_cast(1, 1), class = "vctrs_error_incompatible_type")
+  expect_error(
+    stop_incompatible_cast(1, 1, x_arg = "x", to_arg = "to"),
+    class = "vctrs_error_incompatible_type"
+  )
 })
 
 test_that("can override arg in OOB conditions", {
@@ -104,12 +107,12 @@ test_that("unique names errors are informative", {
 
 test_that("can't supply both `message` and `details`", {
   expect_error(
-    stop_incompatible_type(1, 2, message = "my message"),
+    stop_incompatible_type(1, 2, message = "my message", x_arg = "x", y_arg = "y"),
     "my message",
     class = "vctrs_error_incompatible_type"
   )
   expect_error(
-    stop_incompatible_type(1, 2, message = "my message", details = "my details"),
+    stop_incompatible_type(1, 2, message = "my message", details = "my details", x_arg = "x", y_arg = "y"),
     "Can't supply both `message` and `details`."
   )
 })

--- a/tests/testthat/test-shape.R
+++ b/tests/testthat/test-shape.R
@@ -34,47 +34,47 @@ test_that("can override error args", {
 # broadcasting -------------------------------------------------------------
 
 test_that("can broadcast to higher dimension, but not lower", {
-  expect_identical(shape_broadcast(1, NULL), 1)
-  expect_null(shape_broadcast(NULL, 1))
+  expect_identical(shape_broadcast_(1, NULL), 1)
+  expect_null(shape_broadcast_(NULL, 1))
 
   expect_equal(
-    shape_broadcast(1, shaped_int(0, 4)),
+    shape_broadcast_(1, shaped_int(0, 4)),
     array(1, c(1, 4))
   )
   expect_error(
-    shape_broadcast(shaped_int(1, 1, 1), shaped_int(4, 4)),
+    shape_broadcast_(shaped_int(1, 1, 1), shaped_int(4, 4)),
     class = "vctrs_error_incompatible_type"
   )
   expect_error(
-    shape_broadcast(shaped_int(3, 2), shaped_int(3, 3)),
+    shape_broadcast_(shaped_int(3, 2), shaped_int(3, 3)),
     class = "vctrs_error_incompatible_type"
   )
 })
 
 test_that("recycling rules applied", {
   expect_equal(
-    shape_broadcast(array(1:4, c(1, 1, 4)), shaped_int(0, 4, 4))[1, , ],
+    shape_broadcast_(array(1:4, c(1, 1, 4)), shaped_int(0, 4, 4))[1, , ],
     matrix(1:4, 4, 4, byrow = TRUE)
   )
 
   expect_equal(
-    shape_broadcast(array(1:4, c(1, 4, 1)), shaped_int(0, 4, 4))[1, , ],
+    shape_broadcast_(array(1:4, c(1, 4, 1)), shaped_int(0, 4, 4))[1, , ],
     matrix(1:4, 4, 4)
   )
 
   expect_equal(
-    shape_broadcast(array(1L, c(1, 1)), shaped_int(1, 0)),
+    shape_broadcast_(array(1L, c(1, 1)), shaped_int(1, 0)),
     matrix(integer(), nrow = 1)
   )
 
   expect_error(
-    shape_broadcast(array(1L, c(1, 2)), shaped_int(1, 0)),
+    shape_broadcast_(array(1L, c(1, 2)), shaped_int(1, 0)),
     "Non-recyclable dimensions",
     class = "vctrs_error_incompatible_type"
   )
 
   expect_error(
-    shape_broadcast(array(1L, c(1, 0)), shaped_int(1, 1)),
+    shape_broadcast_(array(1L, c(1, 0)), shaped_int(1, 1)),
     "Non-recyclable dimensions",
     class = "vctrs_error_incompatible_type"
   )


### PR DESCRIPTION
Branched from #1059.

Forces method implementations to pass them on. This revealed many places where we didn't.