### PR TITLE
Fix performance issues in R 4.0.0 with an `owned` argument for assignment

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -183,8 +183,8 @@ vec_assign_seq <- function(x, value, start, size, increasing = TRUE) {
   .Call(vctrs_assign_seq, x, value, start, size, increasing)
 }
 
-vec_assign_params <- function(x, i, value, assign_names = FALSE) {
-  .Call(vctrs_assign_params, x, i, value, assign_names)
+vec_assign_params <- function(x, i, value, assign_names = FALSE, owned = FALSE) {
+  .Call(vctrs_assign_params, x, i, value, assign_names, owned)
 }
 
 vec_remove <- function(x, i) {

--- a/src/bind.c
+++ b/src/bind.c
@@ -150,7 +150,8 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
   R_len_t counter = 0;
 
   const struct vec_assign_opts bind_assign_opts = {
-    .assign_names = true
+    .assign_names = true,
+    .owned = true
   };
 
   for (R_len_t i = 0; i < n; ++i) {

--- a/src/bind.c
+++ b/src/bind.c
@@ -181,7 +181,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
       PROTECT(rn);
 
       if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
-        rownames = chr_assign(rownames, idx, rn);
+        rownames = chr_assign(rownames, idx, rn, true);
         REPROTECT(rownames, rownames_pi);
       }
 
@@ -420,12 +420,12 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
 
     R_len_t xn = Rf_length(x);
     init_compact_seq(idx_ptr, counter, xn, true);
-    out = list_assign(out, idx, x);
+    out = list_assign(out, idx, x, true);
     REPROTECT(out, out_pi);
 
     SEXP xnms = PROTECT(r_names(x));
     if (xnms != R_NilValue) {
-      names = chr_assign(names, idx, xnms);
+      names = chr_assign(names, idx, xnms, true);
       REPROTECT(names, names_pi);
     }
     UNPROTECT(1);

--- a/src/c.c
+++ b/src/c.c
@@ -99,7 +99,7 @@ SEXP vec_c(SEXP xs,
       SEXP x_nms = PROTECT(apply_name_spec(name_spec, outer, inner, size));
 
       if (x_nms != R_NilValue) {
-        out_names = chr_assign(out_names, idx, x_nms);
+        out_names = chr_assign(out_names, idx, x_nms, true);
         REPROTECT(out_names, out_names_pi);
       }
 

--- a/src/c.c
+++ b/src/c.c
@@ -74,7 +74,8 @@ SEXP vec_c(SEXP xs,
   R_len_t counter = 0;
 
   const struct vec_assign_opts c_assign_opts = {
-    .assign_names = true
+    .assign_names = true,
+    .owned = true
   };
 
   for (R_len_t i = 0; i < n; ++i) {

--- a/src/init.c
+++ b/src/init.c
@@ -102,7 +102,7 @@ extern SEXP vctrs_equal_scalar(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_linked_version();
 extern SEXP vctrs_tib_ptype2(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_);
 extern SEXP vctrs_tib_cast(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_);
-extern SEXP vctrs_assign_params(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_assign_params(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_has_dim(SEXP);
 extern SEXP vctrs_rep(SEXP, SEXP);
 extern SEXP vctrs_rep_each(SEXP, SEXP);
@@ -239,7 +239,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_linked_version",             (DL_FUNC) &vctrs_linked_version, 0},
   {"vctrs_tib_ptype2",                 (DL_FUNC) &vctrs_tib_ptype2, 4},
   {"vctrs_tib_cast",                   (DL_FUNC) &vctrs_tib_cast, 4},
-  {"vctrs_assign_params",              (DL_FUNC) &vctrs_assign_params, 4},
+  {"vctrs_assign_params",              (DL_FUNC) &vctrs_assign_params, 5},
   {"vctrs_has_dim",                    (DL_FUNC) &vctrs_has_dim, 1},
   {"vctrs_rep",                        (DL_FUNC) &vctrs_rep, 2},
   {"vctrs_rep_each",                   (DL_FUNC) &vctrs_rep_each, 2},

--- a/src/init.c
+++ b/src/init.c
@@ -106,8 +106,8 @@ extern SEXP vctrs_assign_params(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_has_dim(SEXP);
 extern SEXP vctrs_rep(SEXP, SEXP);
 extern SEXP vctrs_rep_each(SEXP, SEXP);
-extern SEXP vctrs_maybe_referenced_col(SEXP, SEXP);
-extern SEXP vctrs_new_df_unreferenced_col();
+extern SEXP vctrs_maybe_shared_col(SEXP, SEXP);
+extern SEXP vctrs_new_df_unshared_col();
 extern SEXP vctrs_shaped_ptype(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_shape2(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_new_date(SEXP);
@@ -243,8 +243,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_has_dim",                    (DL_FUNC) &vctrs_has_dim, 1},
   {"vctrs_rep",                        (DL_FUNC) &vctrs_rep, 2},
   {"vctrs_rep_each",                   (DL_FUNC) &vctrs_rep_each, 2},
-  {"vctrs_maybe_referenced_col",       (DL_FUNC) &vctrs_maybe_referenced_col, 2},
-  {"vctrs_new_df_unreferenced_col",    (DL_FUNC) &vctrs_new_df_unreferenced_col, 0},
+  {"vctrs_maybe_shared_col",           (DL_FUNC) &vctrs_maybe_shared_col, 2},
+  {"vctrs_new_df_unshared_col",        (DL_FUNC) &vctrs_new_df_unshared_col, 0},
   {"vctrs_shaped_ptype",               (DL_FUNC) &vctrs_shaped_ptype, 5},
   {"vctrs_shape2",                     (DL_FUNC) &vctrs_shape2, 4},
   {"vctrs_new_date",                   (DL_FUNC) &vctrs_new_date, 1},

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -23,10 +23,8 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
   attrib = PROTECT(Rf_shallow_duplicate(attrib));
   ++n_protect;
 
-  if (MAYBE_REFERENCED(x)) {
-    x = PROTECT(Rf_shallow_duplicate(x));
-    ++n_protect;
-  }
+  x = PROTECT(r_maybe_duplicate(x));
+  ++n_protect;
 
   // Remove vectorised attributes which might be incongruent after reshaping.
   // Shouldn't matter for GNU R but other R implementations might have checks.

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -179,7 +179,7 @@ SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
     REPROTECT(index, index_pi);
     out = PROTECT(vec_assign_fallback(proxy, index, value));
   } else if (has_dim(proxy)) {
-    out = PROTECT(vec_assign_shaped(proxy, index, value_info.proxy));
+    out = PROTECT(vec_assign_shaped(proxy, index, value_info.proxy, opts));
   } else {
     out = PROTECT(vec_assign_switch(proxy, index, value_info.proxy, opts));
   }

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -9,7 +9,8 @@ SEXP syms_vec_assign_fallback = NULL;
 SEXP fns_vec_assign_fallback = NULL;
 
 const struct vec_assign_opts vec_assign_default_opts = {
-  .assign_names = false
+  .assign_names = false,
+  .owned = false
 };
 
 static SEXP vec_assign_fallback(SEXP x, SEXP index, SEXP value);
@@ -28,6 +29,7 @@ SEXP vctrs_assign(SEXP x, SEXP index, SEXP value, SEXP x_arg_, SEXP value_arg_) 
 
   const struct vec_assign_opts opts = {
     .assign_names = false,
+    .owned = false,
     .x_arg = &x_arg,
     .value_arg = &value_arg
   };
@@ -94,9 +96,10 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
 
 // [[ register() ]]
 SEXP vctrs_assign_params(SEXP x, SEXP index, SEXP value,
-                         SEXP assign_names) {
+                         SEXP assign_names, SEXP owned) {
   const struct vec_assign_opts opts =  {
-    .assign_names = r_bool_as_int(assign_names)
+    .assign_names = r_bool_as_int(assign_names),
+    .owned = r_bool_as_int(owned)
   };
   return vec_assign_opts(x, index, value, &opts);
 }

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -3,6 +3,7 @@
 
 struct vec_assign_opts {
   bool assign_names;
+  bool owned;
   struct vctrs_arg* x_arg;
   struct vctrs_arg* value_arg;
 };

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -14,8 +14,8 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
 SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
                            const struct vec_assign_opts* opts);
 
-SEXP chr_assign(SEXP out, SEXP index, SEXP value);
-SEXP list_assign(SEXP out, SEXP index, SEXP value);
+SEXP chr_assign(SEXP out, SEXP index, SEXP value, bool owned);
+SEXP list_assign(SEXP out, SEXP index, SEXP value, bool owned);
 SEXP df_assign(SEXP x, SEXP index, SEXP value,
                const struct vec_assign_opts* opts);
 

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -19,4 +19,6 @@ SEXP list_assign(SEXP out, SEXP index, SEXP value, bool owned);
 SEXP df_assign(SEXP x, SEXP index, SEXP value,
                const struct vec_assign_opts* opts);
 
+SEXP vec_assign_shaped(SEXP proxy, SEXP index, SEXP value, const struct vec_assign_opts* opts);
+
 #endif

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -506,7 +506,7 @@ static SEXP vec_unchop(SEXP x,
       SEXP inner = PROTECT(vec_names(elt));
       SEXP elt_names = PROTECT(apply_name_spec(name_spec, outer, inner, size));
       if (elt_names != R_NilValue) {
-        out_names = chr_assign(out_names, index, elt_names);
+        out_names = chr_assign(out_names, index, elt_names, true);
         REPROTECT(out_names, out_names_pi);
       }
       UNPROTECT(2);

--- a/src/utils.c
+++ b/src/utils.c
@@ -188,19 +188,23 @@ static SEXP vctrs_eval_mask_n_impl(SEXP fn, SEXP* syms, SEXP* args, SEXP mask) {
 }
 
 // [[ register() ]]
-SEXP vctrs_maybe_referenced_col(SEXP x, SEXP i) {
+SEXP vctrs_maybe_shared_col(SEXP x, SEXP i) {
   int i_ = r_int_get(i, 0) - 1;
   SEXP col = VECTOR_ELT(x, i_);
-  bool out = MAYBE_REFERENCED(col);
+  bool out = MAYBE_SHARED(col);
   return Rf_ScalarLogical(out);
 }
 
 // [[ register() ]]
-SEXP vctrs_new_df_unreferenced_col() {
+SEXP vctrs_new_df_unshared_col() {
   SEXP col = PROTECT(Rf_allocVector(INTSXP, 1));
   INTEGER(col)[0] = 1;
 
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 1));
+
+  // In R 4.0.0, `SET_VECTOR_ELT()` bumps the REFCNT of
+  // `col`. Because of this, `col` is now referenced (refcnt > 0),
+  // but it isn't shared (refcnt > 1).
   SET_VECTOR_ELT(out, 0, col);
 
   SEXP names = PROTECT(Rf_allocVector(STRSXP, 1));

--- a/src/utils.c
+++ b/src/utils.c
@@ -225,10 +225,8 @@ SEXP vctrs_set_attributes(SEXP x, SEXP attrib) {
   R_len_t n_attrib = Rf_length(attrib);
   int n_protect = 0;
 
-  if (MAYBE_REFERENCED(x)) {
-    x = PROTECT(Rf_shallow_duplicate(x));
-    ++n_protect;
-  }
+  x = PROTECT(r_maybe_duplicate(x));
+  ++n_protect;
 
   // Remove existing attributes, and unset the object bit
   SET_ATTRIB(x, R_NilValue);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1257,6 +1257,14 @@ SEXP r_maybe_duplicate(SEXP x) {
   }
 }
 
+SEXP r_maybe_duplicate_shared(SEXP x) {
+  if (MAYBE_SHARED(x)) {
+    return Rf_shallow_duplicate(x);
+  } else {
+    return x;
+  }
+}
+
 bool r_is_names(SEXP names) {
   if (names == R_NilValue) {
     return false;

--- a/src/utils.h
+++ b/src/utils.h
@@ -208,6 +208,7 @@ bool r_is_string(SEXP x);
 bool r_is_number(SEXP x);
 SEXP r_peek_option(const char* option);
 SEXP r_maybe_duplicate(SEXP x);
+SEXP r_maybe_duplicate_shared(SEXP x);
 
 SEXP r_pairlist(SEXP* tags, SEXP* cars);
 SEXP r_call(SEXP fn, SEXP* tags, SEXP* cars);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -366,7 +366,6 @@ SEXP vec_chop(SEXP x, SEXP indices);
 SEXP vec_slice_shaped(enum vctrs_type type, SEXP x, SEXP index);
 SEXP vec_assign(SEXP x, SEXP index, SEXP value);
 SEXP vec_proxy_assign(SEXP proxy, SEXP index, SEXP value);
-SEXP vec_assign_shaped(SEXP proxy, SEXP index, SEXP value);
 bool vec_requires_fallback(SEXP x, struct vctrs_proxy_info info);
 SEXP vec_init(SEXP x, R_len_t n);
 SEXP vec_ptype(SEXP x, struct vctrs_arg* x_arg);

--- a/tests/testthat/helper-memory.R
+++ b/tests/testthat/helper-memory.R
@@ -1,7 +1,7 @@
-maybe_referenced_col <- function(x, i) {
-  .Call(vctrs_maybe_referenced_col, x, i)
+maybe_shared_col <- function(x, i) {
+  .Call(vctrs_maybe_shared_col, x, i)
 }
 
-new_df_unreferenced_col <- function() {
-  .Call(vctrs_new_df_unreferenced_col)
+new_df_unshared_col <- function() {
+  .Call(vctrs_new_df_unshared_col)
 }

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -257,6 +257,16 @@ test_that("can assign row names in vec_rbind()", {
   expect_identical(out, exp)
 })
 
+test_that("monitoring: name repair while rbinding doesn't modify in place", {
+  df <- new_data_frame(list(x = 1, x = 1))
+  expect <- new_data_frame(list(x = 1, x = 1))
+
+  # Name repair occurs
+  expect_named(vec_rbind(df), c("x...1", "x...2"))
+
+  # No changes to `df`
+  expect_identical(df, expect)
+})
 
 # cols --------------------------------------------------------------------
 
@@ -441,6 +451,17 @@ test_that("vec_cbind() fails with arrays of dimensionality > 3", {
   a <- array(NA, c(1, 1, 1))
   expect_error(vec_cbind(a), "Can't bind arrays")
   expect_error(vec_cbind(x = a), "Can't bind arrays")
+})
+
+test_that("monitoring: name repair while cbinding doesn't modify in place", {
+  df <- new_data_frame(list(x = 1, x = 1))
+  expect <- new_data_frame(list(x = 1, x = 1))
+
+  # Name repair occurs
+  expect_named(vec_cbind(df), c("x...1", "x...2"))
+
+  # No changes to `df`
+  expect_identical(df, expect)
 })
 
 test_that("vec_rbind() consistently handles unnamed outputs", {

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -590,7 +590,7 @@ test_that("can optionally assign names", {
   )
 })
 
-test_that("assignment to a data frame with unreferenced columns doesn't overwrite (#986)", {
+test_that("monitoring: assignment to a data frame with unreferenced columns doesn't overwrite (#986)", {
   x <- new_df_unshared_col()
   value <- new_data_frame(list(x = 2))
   expect <- new_data_frame(list(x = 1L))
@@ -628,6 +628,15 @@ test_that("assignment to a data frame with unreferenced columns doesn't overwrit
   }
 
   # Expect no changes to `x`!
+  expect_identical(x, expect)
+})
+
+test_that("monitoring: assignment to atomic vectors doesn't modify by reference", {
+  x <- c(1, 2, 3)
+  expect <- c(1, 2, 3)
+
+  vec_assign(x, 2, 3)
+
   expect_identical(x, expect)
 })
 

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -590,7 +590,7 @@ test_that("can optionally assign names", {
   )
 })
 
-test_that("monitoring: assignment to a data frame with unreferenced columns doesn't overwrite (#986)", {
+test_that("monitoring: assignment to a data frame with unshared columns doesn't overwrite (#986)", {
   x <- new_df_unshared_col()
   value <- new_data_frame(list(x = 2))
   expect <- new_data_frame(list(x = 1L))
@@ -629,6 +629,21 @@ test_that("monitoring: assignment to a data frame with unreferenced columns does
 
   # Expect no changes to `x`!
   expect_identical(x, expect)
+})
+
+test_that("monitoring: can assign in place with unshared columns when `owned = TRUE`", {
+  expect1 <- new_data_frame(list(x = 1L))
+  expect2 <- new_data_frame(list(x = 2L))
+
+  value <- new_data_frame(list(x = 2L))
+
+  x <- new_df_unshared_col()
+  .Call(vctrs_assign_params, x, 1L, value, assign_named = FALSE, owned = FALSE)
+  expect_identical(x, expect1)
+
+  x <- new_df_unshared_col()
+  .Call(vctrs_assign_params, x, 1L, value, assign_named = FALSE, owned = TRUE)
+  expect_identical(x, expect2)
 })
 
 test_that("monitoring: assignment to atomic vectors doesn't modify by reference", {


### PR DESCRIPTION
Closes #1057 

After speaking with @lionel- about this, it seems like this is an alternate approach to fixing the performance issues seen in R 4.0.0.

@lionel- also reminded me that this is very similar to the old way `vec_assign()` used to work, with a `clone` parameter.

This approach uses an `owned` argument to decide how to _potentially_ duplicate the proxy. The core change is:

```c
if (owned) {
  out = r_maybe_duplicate_shared(x);
} else {
  out = r_maybe_duplicate(x);
}
```

Where:
- `r_maybe_duplicate_shared()` duplicates if `refcount(x) > 1`
- `r_maybe_duplicate()` duplicates if `refcount(x) > 0`

This distinction matters on R 4.0.0 now, because freshly created data frames created through `vec_init()` will have columns that all have a refcount of 1. The increment of the refcount happens when the columns are assigned into the data frame with `SET_VECTOR_ELT()`.

Practically this makes a difference in `vec_rbind()` where we assign into a fresh data frame in a loop, repeatedly calling `df_assign()`. Since each column is already _referenced_, the old scheme with `r_maybe_duplicate()` would duplicate the column at every iteration of the rbind loop. The new scheme allows us to take advantage of `owned = true` here because each column is referenced _but not shared_.

The usage of `owned = true` should be done incredibly sparingly. It should only be done when you recursively own the data structure you just created, and are filling it in some way.