### PR TITLE
Mention loss of generality instead of precision when relevant

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -248,6 +248,12 @@ The following errors are caused by breaking changes.
 * Lossy cast errors are now considered internal. Please don't test for
   the class or explicitly handle them.
 
+* New argument `loss_type` for the experimental function
+  `maybe_lossy_cast()`. It can take the values "precision" or
+  "generality" to indicate in the error message which kind of loss is
+  the error about (double to integer loses precision, character to
+  factor loses generality).
+
 
 ## CRAN results
 

--- a/R/type-factor.R
+++ b/R/type-factor.R
@@ -150,7 +150,15 @@ fct_cast_impl <- function(x, to, ..., x_arg = "", to_arg = "", ordered = FALSE) 
   } else {
     lossy <- !(x %in% levels(to) | is.na(x))
     out <- factor(x, levels = levels(to), ordered = ordered, exclude = NULL)
-    maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
+    maybe_lossy_cast(
+      out,
+      x,
+      to,
+      lossy,
+      loss_type = "generality",
+      x_arg = x_arg,
+      to_arg = to_arg
+    )
   }
 }
 

--- a/man/maybe_lossy_cast.Rd
+++ b/man/maybe_lossy_cast.Rd
@@ -11,6 +11,7 @@ maybe_lossy_cast(
   lossy = NULL,
   locations = NULL,
   ...,
+  loss_type = c("precision", "generality"),
   x_arg,
   to_arg,
   details = NULL,
@@ -37,6 +38,10 @@ own location vector, possibly empty.}
 locations where \code{x} lost information.}
 
 \item{...}{Only use these fields when creating a subclass.}
+
+\item{loss_type}{The kind of lossy cast to be mentioned in error
+messages. Can be loss of precision (for instance from double to
+integer) or loss of generality (from character to factor).}
 
 \item{x_arg}{Argument names for \code{x} and \code{to}. These are used
 in error messages to inform the user about the locations of

--- a/tests/testthat/error/test-conditions.txt
+++ b/tests/testthat/error/test-conditions.txt
@@ -85,3 +85,11 @@ x These names are duplicated:
   * "d" at locations 24 and 29.
   * ...
 
+
+lossy cast from character to factor mention loss of generality
+==============================================================
+
+> vec_cast("a", factor("b"))
+Error: Can't convert from <character> to <factor<ddf10>> due to loss of generality.
+* Locations: 1
+

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -123,6 +123,12 @@ test_that("lossy cast errors are internal", {
   expect_error(vec_cast(1.5, int()), "convert")
 })
 
+test_that("lossy cast from character to factor mentions loss of generality", {
+  verify_errors({
+    expect_error(vec_cast("a", factor("b")), class = "vctrs_error_cast_lossy")
+  })
+})
+
 verify_output(test_path("error", "test-conditions.txt"), {
   "# can override arg in OOB conditions"
   with_subscript_data(
@@ -158,4 +164,7 @@ verify_output(test_path("error", "test-conditions.txt"), {
   "# unique names errors are informative"
   vec_as_names(c("x", "x", "x", "y", "y", "z"), repair = "check_unique")
   vec_as_names(c(rep("x", 20), rep(c("a", "b", "c", "d", "e"), 2)), repair = "check_unique")
+
+  "# lossy cast from character to factor mention loss of generality"
+  vec_cast("a", factor("b"))
 })


### PR DESCRIPTION
`maybe_lossy_cast()` gains a `loss_type` argument that can take values `c("precision", "generality")` to indicate the kind of lossy cast in the error message. We now use "generality" for character -> factor conversions.

Before:

```r
vec_cast("a", factor("b"))
#> Error: Can't convert from <character> to <factor<ddf10>> due to loss of precision.
#> * Locations: 1
```

After:

```r
vec_cast("a", factor("b"))
#> Error: Can't convert from <character> to <factor<ddf10>> due to loss of generality.
#> * Locations: 1
```