### PR TITLE
Refine `vec_assign()` ownership semantics

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -183,8 +183,8 @@ vec_assign_seq <- function(x, value, start, size, increasing = TRUE) {
   .Call(vctrs_assign_seq, x, value, start, size, increasing)
 }
 
-vec_assign_params <- function(x, i, value, assign_names = FALSE, ownership = "shared") {
-  .Call(vctrs_assign_params, x, i, value, assign_names, ownership)
+vec_assign_params <- function(x, i, value, assign_names = FALSE) {
+  .Call(vctrs_assign_params, x, i, value, assign_names)
 }
 
 vec_remove <- function(x, i) {

--- a/R/slice.R
+++ b/R/slice.R
@@ -183,7 +183,7 @@ vec_assign_seq <- function(x, value, start, size, increasing = TRUE) {
   .Call(vctrs_assign_seq, x, value, start, size, increasing)
 }
 
-vec_assign_params <- function(x, i, value, assign_names = FALSE, ownership = "unknown") {
+vec_assign_params <- function(x, i, value, assign_names = FALSE, ownership = "shared") {
   .Call(vctrs_assign_params, x, i, value, assign_names, ownership)
 }
 

--- a/R/slice.R
+++ b/R/slice.R
@@ -183,8 +183,8 @@ vec_assign_seq <- function(x, value, start, size, increasing = TRUE) {
   .Call(vctrs_assign_seq, x, value, start, size, increasing)
 }
 
-vec_assign_params <- function(x, i, value, assign_names = FALSE, owned = FALSE) {
-  .Call(vctrs_assign_params, x, i, value, assign_names, owned)
+vec_assign_params <- function(x, i, value, assign_names = FALSE, ownership = "unknown") {
+  .Call(vctrs_assign_params, x, i, value, assign_names, ownership)
 }
 
 vec_remove <- function(x, i) {

--- a/src/bind.c
+++ b/src/bind.c
@@ -150,8 +150,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
   R_len_t counter = 0;
 
   const struct vec_assign_opts bind_assign_opts = {
-    .assign_names = true,
-    .ownership = vctrs_ownership_owned
+    .assign_names = true
   };
 
   for (R_len_t i = 0; i < n; ++i) {
@@ -163,7 +162,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
 
     SEXP tbl = PROTECT(vec_cast_params(x, ptype, args_empty, args_empty, true));
     init_compact_seq(idx_ptr, counter, size, true);
-    out = df_assign(out, idx, tbl, &bind_assign_opts);
+    out = df_assign(out, idx, tbl, vctrs_ownership_owned, &bind_assign_opts);
     REPROTECT(out, out_pi);
 
     if (has_rownames) {

--- a/src/bind.c
+++ b/src/bind.c
@@ -162,7 +162,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
 
     SEXP tbl = PROTECT(vec_cast_params(x, ptype, args_empty, args_empty, true));
     init_compact_seq(idx_ptr, counter, size, true);
-    out = df_assign(out, idx, tbl, vctrs_ownership_owned, &bind_assign_opts);
+    out = df_assign(out, idx, tbl, vctrs_ownership_total, &bind_assign_opts);
     REPROTECT(out, out_pi);
 
     if (has_rownames) {
@@ -180,7 +180,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
       PROTECT(rn);
 
       if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
-        rownames = chr_assign(rownames, idx, rn, vctrs_ownership_owned);
+        rownames = chr_assign(rownames, idx, rn, vctrs_ownership_total);
         REPROTECT(rownames, rownames_pi);
       }
 
@@ -419,12 +419,12 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
 
     R_len_t xn = Rf_length(x);
     init_compact_seq(idx_ptr, counter, xn, true);
-    out = list_assign(out, idx, x, vctrs_ownership_owned);
+    out = list_assign(out, idx, x, vctrs_ownership_total);
     REPROTECT(out, out_pi);
 
     SEXP xnms = PROTECT(r_names(x));
     if (xnms != R_NilValue) {
-      names = chr_assign(names, idx, xnms, vctrs_ownership_owned);
+      names = chr_assign(names, idx, xnms, vctrs_ownership_total);
       REPROTECT(names, names_pi);
     }
     UNPROTECT(1);

--- a/src/bind.c
+++ b/src/bind.c
@@ -162,6 +162,8 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
 
     SEXP tbl = PROTECT(vec_cast_params(x, ptype, args_empty, args_empty, true));
     init_compact_seq(idx_ptr, counter, size, true);
+
+    // Total ownership of `out` because it was freshly created with `vec_init()`
     out = df_assign(out, idx, tbl, vctrs_ownership_total, &bind_assign_opts);
     REPROTECT(out, out_pi);
 
@@ -419,6 +421,8 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
 
     R_len_t xn = Rf_length(x);
     init_compact_seq(idx_ptr, counter, xn, true);
+
+    // Total ownership of `out` because it was freshly created with `Rf_allocVector()`
     out = list_assign(out, idx, x, vctrs_ownership_total);
     REPROTECT(out, out_pi);
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -252,7 +252,7 @@ static SEXP as_df_row_impl(SEXP x, struct name_repair_opts* name_repair) {
 
   // Remove names as they are promoted to data frame column names
   if (nms != R_NilValue) {
-    x = PROTECT_N(r_maybe_duplicate(x), &nprot);
+    x = PROTECT_N(r_clone_referenced(x), &nprot);
     r_poke_names(x, R_NilValue);
   }
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -151,7 +151,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
 
   const struct vec_assign_opts bind_assign_opts = {
     .assign_names = true,
-    .owned = true
+    .ownership = vctrs_ownership_owned
   };
 
   for (R_len_t i = 0; i < n; ++i) {
@@ -181,7 +181,7 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
       PROTECT(rn);
 
       if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
-        rownames = chr_assign(rownames, idx, rn, true);
+        rownames = chr_assign(rownames, idx, rn, vctrs_ownership_owned);
         REPROTECT(rownames, rownames_pi);
       }
 
@@ -420,12 +420,12 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
 
     R_len_t xn = Rf_length(x);
     init_compact_seq(idx_ptr, counter, xn, true);
-    out = list_assign(out, idx, x, true);
+    out = list_assign(out, idx, x, vctrs_ownership_owned);
     REPROTECT(out, out_pi);
 
     SEXP xnms = PROTECT(r_names(x));
     if (xnms != R_NilValue) {
-      names = chr_assign(names, idx, xnms, true);
+      names = chr_assign(names, idx, xnms, vctrs_ownership_owned);
       REPROTECT(names, names_pi);
     }
     UNPROTECT(1);

--- a/src/c.c
+++ b/src/c.c
@@ -75,7 +75,7 @@ SEXP vec_c(SEXP xs,
 
   const struct vec_assign_opts c_assign_opts = {
     .assign_names = true,
-    .owned = true
+    .ownership = vctrs_ownership_owned
   };
 
   for (R_len_t i = 0; i < n; ++i) {
@@ -99,7 +99,7 @@ SEXP vec_c(SEXP xs,
       SEXP x_nms = PROTECT(apply_name_spec(name_spec, outer, inner, size));
 
       if (x_nms != R_NilValue) {
-        out_names = chr_assign(out_names, idx, x_nms, true);
+        out_names = chr_assign(out_names, idx, x_nms, vctrs_ownership_owned);
         REPROTECT(out_names, out_names_pi);
       }
 

--- a/src/c.c
+++ b/src/c.c
@@ -74,8 +74,7 @@ SEXP vec_c(SEXP xs,
   R_len_t counter = 0;
 
   const struct vec_assign_opts c_assign_opts = {
-    .assign_names = true,
-    .ownership = vctrs_ownership_owned
+    .assign_names = true
   };
 
   for (R_len_t i = 0; i < n; ++i) {
@@ -90,7 +89,7 @@ SEXP vec_c(SEXP xs,
 
     init_compact_seq(idx_ptr, counter, size, true);
 
-    out = vec_proxy_assign_opts(out, idx, elt, &c_assign_opts);
+    out = vec_proxy_assign_opts(out, idx, elt, vctrs_ownership_owned, &c_assign_opts);
     REPROTECT(out, out_pi);
 
     if (has_names) {

--- a/src/c.c
+++ b/src/c.c
@@ -89,6 +89,7 @@ SEXP vec_c(SEXP xs,
 
     init_compact_seq(idx_ptr, counter, size, true);
 
+    // Total ownership of `out` because it was freshly created with `vec_init()`
     out = vec_proxy_assign_opts(out, idx, elt, vctrs_ownership_total, &c_assign_opts);
     REPROTECT(out, out_pi);
 

--- a/src/c.c
+++ b/src/c.c
@@ -89,7 +89,7 @@ SEXP vec_c(SEXP xs,
 
     init_compact_seq(idx_ptr, counter, size, true);
 
-    out = vec_proxy_assign_opts(out, idx, elt, vctrs_ownership_owned, &c_assign_opts);
+    out = vec_proxy_assign_opts(out, idx, elt, vctrs_ownership_total, &c_assign_opts);
     REPROTECT(out, out_pi);
 
     if (has_names) {
@@ -98,7 +98,7 @@ SEXP vec_c(SEXP xs,
       SEXP x_nms = PROTECT(apply_name_spec(name_spec, outer, inner, size));
 
       if (x_nms != R_NilValue) {
-        out_names = chr_assign(out_names, idx, x_nms, vctrs_ownership_owned);
+        out_names = chr_assign(out_names, idx, x_nms, vctrs_ownership_total);
         REPROTECT(out_names, out_names_pi);
       }
 

--- a/src/init.c
+++ b/src/init.c
@@ -102,7 +102,7 @@ extern SEXP vctrs_equal_scalar(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_linked_version();
 extern SEXP vctrs_tib_ptype2(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_);
 extern SEXP vctrs_tib_cast(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_);
-extern SEXP vctrs_assign_params(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_assign_params(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_has_dim(SEXP);
 extern SEXP vctrs_rep(SEXP, SEXP);
 extern SEXP vctrs_rep_each(SEXP, SEXP);
@@ -239,7 +239,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_linked_version",             (DL_FUNC) &vctrs_linked_version, 0},
   {"vctrs_tib_ptype2",                 (DL_FUNC) &vctrs_tib_ptype2, 4},
   {"vctrs_tib_cast",                   (DL_FUNC) &vctrs_tib_cast, 4},
-  {"vctrs_assign_params",              (DL_FUNC) &vctrs_assign_params, 5},
+  {"vctrs_assign_params",              (DL_FUNC) &vctrs_assign_params, 4},
   {"vctrs_has_dim",                    (DL_FUNC) &vctrs_has_dim, 1},
   {"vctrs_rep",                        (DL_FUNC) &vctrs_rep, 2},
   {"vctrs_rep_each",                   (DL_FUNC) &vctrs_rep_each, 2},

--- a/src/names.c
+++ b/src/names.c
@@ -696,7 +696,7 @@ SEXP vec_set_rownames(SEXP x, SEXP names) {
     }
   }
 
-  x = PROTECT_N(r_maybe_duplicate(x), &nprot);
+  x = PROTECT_N(r_clone_referenced(x), &nprot);
 
   if (dim_names == R_NilValue) {
     dim_names = PROTECT_N(Rf_allocVector(VECSXP, vec_dim_n(x)), &nprot);
@@ -716,7 +716,7 @@ SEXP vec_set_df_rownames(SEXP x, SEXP names) {
       return(x);
     }
 
-    x = PROTECT(r_maybe_duplicate(x));
+    x = PROTECT(r_clone_referenced(x));
     init_compact_rownames(x, vec_size(x));
 
     UNPROTECT(1);
@@ -726,7 +726,7 @@ SEXP vec_set_df_rownames(SEXP x, SEXP names) {
   // Repair row names silently
   names = PROTECT(vec_as_names(names, p_unique_repair_silent_opts));
 
-  x = PROTECT(r_maybe_duplicate(x));
+  x = PROTECT(r_clone_referenced(x));
   Rf_setAttrib(x, R_RowNamesSymbol, names);
 
   UNPROTECT(2);
@@ -756,7 +756,7 @@ SEXP vec_set_names(SEXP x, SEXP names) {
     return x;
   }
 
-  x = PROTECT(r_maybe_duplicate(x));
+  x = PROTECT(r_clone_referenced(x));
   Rf_setAttrib(x, R_NamesSymbol, names);
 
   UNPROTECT(1);

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -23,7 +23,7 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
   attrib = PROTECT(Rf_shallow_duplicate(attrib));
   ++n_protect;
 
-  x = PROTECT(r_maybe_duplicate(x));
+  x = PROTECT(r_clone_referenced(x));
   ++n_protect;
 
   // Remove vectorised attributes which might be incongruent after reshaping.
@@ -114,7 +114,7 @@ static SEXP vec_restore_dispatch(SEXP x, SEXP to, SEXP n) {
 }
 
 static SEXP bare_df_restore_impl(SEXP x, SEXP to, R_len_t size) {
-  x = PROTECT(r_maybe_duplicate(x));
+  x = PROTECT(r_clone_referenced(x));
   x = PROTECT(vec_restore_default(x, to));
 
   if (Rf_getAttrib(x, R_NamesSymbol) == R_NilValue) {

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -58,7 +58,7 @@ static SEXP vec_proxy_unwrap(SEXP x) {
 
 // [[ register() ]]
 SEXP vctrs_unset_s4(SEXP x) {
-  x = r_maybe_duplicate(x);
+  x = r_clone_referenced(x);
   r_unmark_s4(x);
   return x;
 }
@@ -82,7 +82,7 @@ SEXP vec_proxy_recursive(SEXP x, enum vctrs_proxy_kind kind) {
   PROTECT(x);
 
   if (is_data_frame(x)) {
-    x = PROTECT(r_maybe_duplicate(x));
+    x = PROTECT(r_clone_referenced(x));
     R_len_t n = Rf_length(x);
 
     for (R_len_t i = 0; i < n; ++i) {

--- a/src/shape.c
+++ b/src/shape.c
@@ -25,7 +25,7 @@ SEXP vec_shaped_ptype(SEXP ptype,
     return ptype;
   }
 
-  ptype = PROTECT(r_maybe_duplicate(ptype));
+  ptype = PROTECT(r_clone_referenced(ptype));
 
   r_poke_dim(ptype, ptype_dimensions);
 
@@ -137,7 +137,7 @@ static SEXP vec_shape(SEXP dimensions) {
     return R_NilValue;
   }
 
-  dimensions = PROTECT(r_maybe_duplicate(dimensions));
+  dimensions = PROTECT(r_clone_referenced(dimensions));
 
   if (Rf_length(dimensions) == 0) {
     Rf_errorcall(R_NilValue, "Internal error: `dimensions` must have length.");

--- a/src/size-common.c
+++ b/src/size-common.c
@@ -107,7 +107,7 @@ SEXP vec_recycle_common(SEXP xs, R_len_t size) {
     return xs;
   }
 
-  xs = PROTECT(r_maybe_duplicate(xs));
+  xs = PROTECT(r_clone_referenced(xs));
 
   R_len_t n = vec_size(xs);
 

--- a/src/slice-assign-array.c
+++ b/src/slice-assign-array.c
@@ -87,32 +87,32 @@
   }
 
 static inline SEXP lgl_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     enum vctrs_ownership ownership,
+                                     const enum vctrs_ownership ownership,
                                      struct strides_info* p_info) {
   ASSIGN_SHAPED(int, LOGICAL, LOGICAL_RO);
 }
 static inline SEXP int_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     enum vctrs_ownership ownership,
+                                     const enum vctrs_ownership ownership,
                                      struct strides_info* p_info) {
   ASSIGN_SHAPED(int, INTEGER, INTEGER_RO);
 }
 static inline SEXP dbl_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     enum vctrs_ownership ownership,
+                                     const enum vctrs_ownership ownership,
                                      struct strides_info* p_info) {
   ASSIGN_SHAPED(double, REAL, REAL_RO);
 }
 static inline SEXP cpl_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     enum vctrs_ownership ownership,
+                                     const enum vctrs_ownership ownership,
                                      struct strides_info* p_info) {
   ASSIGN_SHAPED(Rcomplex, COMPLEX, COMPLEX_RO);
 }
 static inline SEXP chr_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     enum vctrs_ownership ownership,
+                                     const enum vctrs_ownership ownership,
                                      struct strides_info* p_info) {
   ASSIGN_SHAPED(SEXP, STRING_PTR, STRING_PTR_RO);
 }
 static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     enum vctrs_ownership ownership,
+                                     const enum vctrs_ownership ownership,
                                      struct strides_info* p_info) {
   ASSIGN_SHAPED(Rbyte, RAW, RAW_RO);
 }
@@ -203,7 +203,7 @@ static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value,
   }
 
 static SEXP list_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                               enum vctrs_ownership ownership,
+                               const enum vctrs_ownership ownership,
                                struct strides_info* p_info) {
   ASSIGN_BARRIER_SHAPED(VECTOR_ELT, SET_VECTOR_ELT);
 }
@@ -217,7 +217,7 @@ static SEXP list_assign_shaped(SEXP proxy, SEXP index, SEXP value,
 static inline SEXP vec_assign_shaped_switch(SEXP proxy,
                                             SEXP index,
                                             SEXP value,
-                                            enum vctrs_ownership ownership,
+                                            const enum vctrs_ownership ownership,
                                             struct strides_info* p_info) {
   switch (vec_proxy_typeof(proxy)) {
   case vctrs_type_logical:   return lgl_assign_shaped(proxy, index, value, ownership, p_info);
@@ -236,7 +236,7 @@ static inline SEXP vec_assign_shaped_switch(SEXP proxy,
 
 // [[ include("vctrs.h") ]]
 SEXP vec_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                       enum vctrs_ownership ownership,
+                       const enum vctrs_ownership ownership,
                        const struct vec_assign_opts* opts) {
   int n_protect = 0;
 

--- a/src/slice-assign-array.c
+++ b/src/slice-assign-array.c
@@ -235,13 +235,15 @@ static inline SEXP vec_assign_shaped_switch(SEXP proxy,
 // -----------------------------------------------------------------------------
 
 // [[ include("vctrs.h") ]]
-SEXP vec_assign_shaped(SEXP proxy, SEXP index, SEXP value, const struct vec_assign_opts* opts) {
+SEXP vec_assign_shaped(SEXP proxy, SEXP index, SEXP value,
+                       enum vctrs_ownership ownership,
+                       const struct vec_assign_opts* opts) {
   int n_protect = 0;
 
   struct strides_info info = new_strides_info(proxy, index);
   PROTECT_STRIDES_INFO(&info, &n_protect);
 
-  SEXP out = vec_assign_shaped_switch(proxy, index, value, opts->ownership, &info);
+  SEXP out = vec_assign_shaped_switch(proxy, index, value, ownership, &info);
 
   UNPROTECT(n_protect);
   return out;

--- a/src/slice-assign-array.c
+++ b/src/slice-assign-array.c
@@ -5,7 +5,7 @@
 
 #define ASSIGN_SHAPED_INDEX(CTYPE, DEREF, CONST_DEREF)   \
   SEXP out;                                              \
-  if (ownership == vctrs_ownership_owned) {              \
+  if (ownership == vctrs_ownership_total) {              \
     out = PROTECT(r_clone_shared(proxy));                \
   } else {                                               \
     out = PROTECT(r_clone_referenced(proxy));            \
@@ -43,7 +43,7 @@
 
 #define ASSIGN_SHAPED_COMPACT(CTYPE, DEREF, CONST_DEREF) \
   SEXP out;                                              \
-  if (ownership == vctrs_ownership_owned) {              \
+  if (ownership == vctrs_ownership_total) {              \
     out = PROTECT(r_clone_shared(proxy));                \
   } else {                                               \
     out = PROTECT(r_clone_referenced(proxy));            \
@@ -125,7 +125,7 @@ static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value,
 
 #define ASSIGN_BARRIER_SHAPED_INDEX(GET, SET)            \
   SEXP out;                                              \
-  if (ownership == vctrs_ownership_owned) {              \
+  if (ownership == vctrs_ownership_total) {              \
     out = PROTECT(r_clone_shared(proxy));                \
   } else {                                               \
     out = PROTECT(r_clone_referenced(proxy));            \
@@ -161,7 +161,7 @@ static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value,
 
 #define ASSIGN_BARRIER_SHAPED_COMPACT(GET, SET)         \
   SEXP out;                                             \
-  if (ownership == vctrs_ownership_owned) {             \
+  if (ownership == vctrs_ownership_total) {             \
     out = PROTECT(r_clone_shared(proxy));               \
   } else {                                              \
     out = PROTECT(r_clone_referenced(proxy));           \

--- a/src/slice-assign-array.c
+++ b/src/slice-assign-array.c
@@ -6,9 +6,9 @@
 #define ASSIGN_SHAPED_INDEX(CTYPE, DEREF, CONST_DEREF)   \
   SEXP out;                                              \
   if (ownership == vctrs_ownership_owned) {              \
-    out = PROTECT(r_maybe_duplicate_shared(proxy));      \
+    out = PROTECT(r_clone_shared(proxy));                \
   } else {                                               \
-    out = PROTECT(r_maybe_duplicate(proxy));             \
+    out = PROTECT(r_clone_referenced(proxy));            \
   }                                                      \
                                                          \
   CTYPE* p_out = DEREF(out);                             \
@@ -44,9 +44,9 @@
 #define ASSIGN_SHAPED_COMPACT(CTYPE, DEREF, CONST_DEREF) \
   SEXP out;                                              \
   if (ownership == vctrs_ownership_owned) {              \
-    out = PROTECT(r_maybe_duplicate_shared(proxy));      \
+    out = PROTECT(r_clone_shared(proxy));                \
   } else {                                               \
-    out = PROTECT(r_maybe_duplicate(proxy));             \
+    out = PROTECT(r_clone_referenced(proxy));            \
   }                                                      \
                                                          \
   CTYPE* p_out = DEREF(out);                             \
@@ -126,9 +126,9 @@ static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value,
 #define ASSIGN_BARRIER_SHAPED_INDEX(GET, SET)            \
   SEXP out;                                              \
   if (ownership == vctrs_ownership_owned) {              \
-    out = PROTECT(r_maybe_duplicate_shared(proxy));      \
+    out = PROTECT(r_clone_shared(proxy));                \
   } else {                                               \
-    out = PROTECT(r_maybe_duplicate(proxy));             \
+    out = PROTECT(r_clone_referenced(proxy));            \
   }                                                      \
                                                          \
   R_len_t k = 0;                                         \
@@ -162,9 +162,9 @@ static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value,
 #define ASSIGN_BARRIER_SHAPED_COMPACT(GET, SET)         \
   SEXP out;                                             \
   if (ownership == vctrs_ownership_owned) {             \
-    out = PROTECT(r_maybe_duplicate_shared(proxy));     \
+    out = PROTECT(r_clone_shared(proxy));               \
   } else {                                              \
-    out = PROTECT(r_maybe_duplicate(proxy));            \
+    out = PROTECT(r_clone_referenced(proxy));           \
   }                                                     \
                                                         \
   const R_len_t start = p_info->p_index[0];             \

--- a/src/slice-assign-array.c
+++ b/src/slice-assign-array.c
@@ -5,7 +5,7 @@
 
 #define ASSIGN_SHAPED_INDEX(CTYPE, DEREF, CONST_DEREF)   \
   SEXP out;                                              \
-  if (owned) {                                           \
+  if (ownership == vctrs_ownership_owned) {              \
     out = PROTECT(r_maybe_duplicate_shared(proxy));      \
   } else {                                               \
     out = PROTECT(r_maybe_duplicate(proxy));             \
@@ -43,7 +43,7 @@
 
 #define ASSIGN_SHAPED_COMPACT(CTYPE, DEREF, CONST_DEREF) \
   SEXP out;                                              \
-  if (owned) {                                           \
+  if (ownership == vctrs_ownership_owned) {              \
     out = PROTECT(r_maybe_duplicate_shared(proxy));      \
   } else {                                               \
     out = PROTECT(r_maybe_duplicate(proxy));             \
@@ -86,22 +86,34 @@
     ASSIGN_SHAPED_INDEX(CTYPE, DEREF, CONST_DEREF);   \
   }
 
-static inline SEXP lgl_assign_shaped(SEXP proxy, SEXP index, SEXP value, bool owned, struct strides_info* p_info) {
+static inline SEXP lgl_assign_shaped(SEXP proxy, SEXP index, SEXP value,
+                                     enum vctrs_ownership ownership,
+                                     struct strides_info* p_info) {
   ASSIGN_SHAPED(int, LOGICAL, LOGICAL_RO);
 }
-static inline SEXP int_assign_shaped(SEXP proxy, SEXP index, SEXP value, bool owned, struct strides_info* p_info) {
+static inline SEXP int_assign_shaped(SEXP proxy, SEXP index, SEXP value,
+                                     enum vctrs_ownership ownership,
+                                     struct strides_info* p_info) {
   ASSIGN_SHAPED(int, INTEGER, INTEGER_RO);
 }
-static inline SEXP dbl_assign_shaped(SEXP proxy, SEXP index, SEXP value, bool owned, struct strides_info* p_info) {
+static inline SEXP dbl_assign_shaped(SEXP proxy, SEXP index, SEXP value,
+                                     enum vctrs_ownership ownership,
+                                     struct strides_info* p_info) {
   ASSIGN_SHAPED(double, REAL, REAL_RO);
 }
-static inline SEXP cpl_assign_shaped(SEXP proxy, SEXP index, SEXP value, bool owned, struct strides_info* p_info) {
+static inline SEXP cpl_assign_shaped(SEXP proxy, SEXP index, SEXP value,
+                                     enum vctrs_ownership ownership,
+                                     struct strides_info* p_info) {
   ASSIGN_SHAPED(Rcomplex, COMPLEX, COMPLEX_RO);
 }
-static inline SEXP chr_assign_shaped(SEXP proxy, SEXP index, SEXP value, bool owned, struct strides_info* p_info) {
+static inline SEXP chr_assign_shaped(SEXP proxy, SEXP index, SEXP value,
+                                     enum vctrs_ownership ownership,
+                                     struct strides_info* p_info) {
   ASSIGN_SHAPED(SEXP, STRING_PTR, STRING_PTR_RO);
 }
-static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value, bool owned, struct strides_info* p_info) {
+static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value,
+                                     enum vctrs_ownership ownership,
+                                     struct strides_info* p_info) {
   ASSIGN_SHAPED(Rbyte, RAW, RAW_RO);
 }
 
@@ -113,7 +125,7 @@ static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value, bool ow
 
 #define ASSIGN_BARRIER_SHAPED_INDEX(GET, SET)            \
   SEXP out;                                              \
-  if (owned) {                                           \
+  if (ownership == vctrs_ownership_owned) {              \
     out = PROTECT(r_maybe_duplicate_shared(proxy));      \
   } else {                                               \
     out = PROTECT(r_maybe_duplicate(proxy));             \
@@ -149,7 +161,7 @@ static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value, bool ow
 
 #define ASSIGN_BARRIER_SHAPED_COMPACT(GET, SET)         \
   SEXP out;                                             \
-  if (owned) {                                          \
+  if (ownership == vctrs_ownership_owned) {             \
     out = PROTECT(r_maybe_duplicate_shared(proxy));     \
   } else {                                              \
     out = PROTECT(r_maybe_duplicate(proxy));            \
@@ -190,7 +202,9 @@ static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value, bool ow
     ASSIGN_BARRIER_SHAPED_INDEX(GET, SET);   \
   }
 
-static SEXP list_assign_shaped(SEXP proxy, SEXP index, SEXP value, bool owned, struct strides_info* p_info) {
+static SEXP list_assign_shaped(SEXP proxy, SEXP index, SEXP value,
+                               enum vctrs_ownership ownership,
+                               struct strides_info* p_info) {
   ASSIGN_BARRIER_SHAPED(VECTOR_ELT, SET_VECTOR_ELT);
 }
 
@@ -203,16 +217,16 @@ static SEXP list_assign_shaped(SEXP proxy, SEXP index, SEXP value, bool owned, s
 static inline SEXP vec_assign_shaped_switch(SEXP proxy,
                                             SEXP index,
                                             SEXP value,
-                                            bool owned,
+                                            enum vctrs_ownership ownership,
                                             struct strides_info* p_info) {
   switch (vec_proxy_typeof(proxy)) {
-  case vctrs_type_logical:   return lgl_assign_shaped(proxy, index, value, owned, p_info);
-  case vctrs_type_integer:   return int_assign_shaped(proxy, index, value, owned, p_info);
-  case vctrs_type_double:    return dbl_assign_shaped(proxy, index, value, owned, p_info);
-  case vctrs_type_complex:   return cpl_assign_shaped(proxy, index, value, owned, p_info);
-  case vctrs_type_character: return chr_assign_shaped(proxy, index, value, owned, p_info);
-  case vctrs_type_raw:       return raw_assign_shaped(proxy, index, value, owned, p_info);
-  case vctrs_type_list:      return list_assign_shaped(proxy, index, value, owned, p_info);
+  case vctrs_type_logical:   return lgl_assign_shaped(proxy, index, value, ownership, p_info);
+  case vctrs_type_integer:   return int_assign_shaped(proxy, index, value, ownership, p_info);
+  case vctrs_type_double:    return dbl_assign_shaped(proxy, index, value, ownership, p_info);
+  case vctrs_type_complex:   return cpl_assign_shaped(proxy, index, value, ownership, p_info);
+  case vctrs_type_character: return chr_assign_shaped(proxy, index, value, ownership, p_info);
+  case vctrs_type_raw:       return raw_assign_shaped(proxy, index, value, ownership, p_info);
+  case vctrs_type_list:      return list_assign_shaped(proxy, index, value, ownership, p_info);
   default: Rf_error("Internal error: Non-vector type `%s` in `vec_assign_shaped_switch()`",
                     vec_type_as_str(vec_proxy_typeof(proxy)));
   }
@@ -227,7 +241,7 @@ SEXP vec_assign_shaped(SEXP proxy, SEXP index, SEXP value, const struct vec_assi
   struct strides_info info = new_strides_info(proxy, index);
   PROTECT_STRIDES_INFO(&info, &n_protect);
 
-  SEXP out = vec_assign_shaped_switch(proxy, index, value, opts->owned, &info);
+  SEXP out = vec_assign_shaped_switch(proxy, index, value, opts->ownership, &info);
 
   UNPROTECT(n_protect);
   return out;

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -35,11 +35,6 @@ SEXP vctrs_assign(SEXP x, SEXP index, SEXP value, SEXP x_arg_, SEXP value_arg_) 
   return vec_assign_opts(x, index, value, vctrs_ownership_unknown, &opts);
 }
 
-// [[ include("vctrs.h") ]]
-SEXP vec_assign(SEXP x, SEXP index, SEXP value) {
-  return vec_assign_opts(x, index, value, vctrs_ownership_unknown, &vec_assign_default_opts);
-}
-
 // Exported for testing
 // [[ register() ]]
 SEXP vctrs_assign_seq(SEXP x, SEXP value, SEXP start, SEXP size, SEXP increasing) {

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -93,6 +93,20 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
   return out;
 }
 
+static enum vctrs_ownership parse_ownership(SEXP ownership) {
+  if (!r_is_string(ownership)) {
+    Rf_errorcall(R_NilValue, "Internal error: `ownership` must be a string.");
+  }
+
+  const char* str = CHAR(STRING_ELT(ownership, 0));
+
+  if (!strcmp(str, "owned")) return vctrs_ownership_owned;
+  if (!strcmp(str, "shared")) return vctrs_ownership_shared;
+  if (!strcmp(str, "unknown")) return vctrs_ownership_unknown;
+
+  Rf_errorcall(R_NilValue, "Internal error: `ownership` must be one of 'owned', 'shared', or 'unknown'.");
+}
+
 // [[ register() ]]
 SEXP vctrs_assign_params(SEXP x, SEXP index, SEXP value,
                          SEXP assign_names, SEXP ownership) {

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -32,7 +32,7 @@ SEXP vctrs_assign(SEXP x, SEXP index, SEXP value, SEXP x_arg_, SEXP value_arg_) 
     .value_arg = &value_arg
   };
 
-  return vec_assign_opts(x, index, value, vctrs_ownership_unknown, &opts);
+  return vec_assign_opts(x, index, value, vctrs_ownership_shared, &opts);
 }
 
 // Exported for testing
@@ -51,7 +51,7 @@ SEXP vctrs_assign_seq(SEXP x, SEXP value, SEXP start, SEXP size, SEXP increasing
   value = PROTECT(vec_recycle(value, vec_subscript_size(index), opts->value_arg));
 
   SEXP proxy = PROTECT(vec_proxy(x));
-  proxy = PROTECT(vec_proxy_assign_opts(proxy, index, value, vctrs_ownership_unknown, opts));
+  proxy = PROTECT(vec_proxy_assign_opts(proxy, index, value, vctrs_ownership_shared, opts));
 
   SEXP out = vec_restore(proxy, x, R_NilValue);
 
@@ -139,17 +139,17 @@ SEXP vec_proxy_assign_names(SEXP proxy, SEXP index, SEXP value) {
 
   SEXP proxy_nms = PROTECT(vec_names(proxy));
   if (proxy_nms == R_NilValue) {
-    proxy_nms = Rf_allocVector(STRSXP, vec_size(proxy));
-    UNPROTECT(1);
-    PROTECT(proxy_nms);
+    proxy_nms = PROTECT(Rf_allocVector(STRSXP, vec_size(proxy)));
+  } else {
+    proxy_nms = PROTECT(r_clone_referenced(proxy_nms));
   }
 
-  proxy_nms = PROTECT(chr_assign(proxy_nms, index, value_nms, vctrs_ownership_unknown));
+  proxy_nms = PROTECT(chr_assign(proxy_nms, index, value_nms, vctrs_ownership_total));
 
   proxy = PROTECT(r_clone_referenced(proxy));
   proxy = vec_set_names(proxy, proxy_nms);
 
-  UNPROTECT(4);
+  UNPROTECT(5);
   return proxy;
 }
 

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -12,7 +12,7 @@ const struct vec_assign_opts vec_assign_default_opts = {
   .assign_names = false
 };
 
-static const enum vctrs_ownership determine_ownership(SEXP x);
+static const enum vctrs_ownership proxy_ownership(SEXP x);
 
 static SEXP vec_assign_fallback(SEXP x, SEXP index, SEXP value);
 static SEXP lgl_assign(SEXP x, SEXP index, SEXP value, const enum vctrs_ownership ownership);
@@ -53,7 +53,7 @@ SEXP vctrs_assign_seq(SEXP x, SEXP value, SEXP start, SEXP size, SEXP increasing
   value = PROTECT(vec_recycle(value, vec_subscript_size(index), opts->value_arg));
 
   SEXP proxy = PROTECT(vec_proxy(x));
-  const enum vctrs_ownership ownership = determine_ownership(proxy);
+  const enum vctrs_ownership ownership = proxy_ownership(proxy);
   proxy = PROTECT(vec_proxy_assign_opts(proxy, index, value, ownership, opts));
 
   SEXP out = vec_restore(proxy, x, R_NilValue);
@@ -82,7 +82,7 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
   value = PROTECT(vec_recycle(value, vec_size(index), opts->value_arg));
 
   SEXP proxy = PROTECT(vec_proxy(x));
-  const enum vctrs_ownership ownership = determine_ownership(proxy);
+  const enum vctrs_ownership ownership = proxy_ownership(proxy);
   proxy = PROTECT(vec_proxy_assign_opts(proxy, index, value, ownership, opts));
 
   SEXP out = vec_restore(proxy, x, R_NilValue);
@@ -198,7 +198,7 @@ SEXP vec_proxy_assign_names(SEXP proxy, SEXP index, SEXP value) {
  */
 SEXP vec_proxy_assign(SEXP proxy, SEXP index, SEXP value) {
   return vec_proxy_assign_opts(proxy, index, value,
-                               determine_ownership(proxy),
+                               proxy_ownership(proxy),
                                &vec_assign_default_opts);
 }
 SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
@@ -461,8 +461,8 @@ static SEXP vec_assign_fallback(SEXP x, SEXP index, SEXP value) {
                          syms_value, value);
 }
 
-static const enum vctrs_ownership determine_ownership(SEXP x) {
-  return NO_REFERENCES(x) ? vctrs_ownership_total : vctrs_ownership_shared;
+static const enum vctrs_ownership proxy_ownership(SEXP proxy) {
+  return NO_REFERENCES(proxy) ? vctrs_ownership_total : vctrs_ownership_shared;
 }
 
 void vctrs_init_slice_assign(SEXP ns) {

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -137,7 +137,7 @@ SEXP vec_proxy_assign_names(SEXP proxy, SEXP index, SEXP value) {
 
   proxy_nms = PROTECT(chr_assign(proxy_nms, index, value_nms, vctrs_ownership_unknown));
 
-  proxy = PROTECT(r_maybe_duplicate(proxy));
+  proxy = PROTECT(r_clone_referenced(proxy));
   proxy = vec_set_names(proxy, proxy_nms);
 
   UNPROTECT(4);
@@ -235,9 +235,9 @@ SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
                                                                 \
   SEXP out;                                                     \
   if (ownership == vctrs_ownership_owned) {                     \
-    out = PROTECT(r_maybe_duplicate_shared(x));                 \
+    out = PROTECT(r_clone_shared(x));                           \
   } else {                                                      \
-    out = PROTECT(r_maybe_duplicate(x));                        \
+    out = PROTECT(r_clone_referenced(x));                       \
   }                                                             \
                                                                 \
   CTYPE* out_data = DEREF(out);                                 \
@@ -267,9 +267,9 @@ SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
                                                                 \
   SEXP out;                                                     \
   if (ownership == vctrs_ownership_owned) {                     \
-    out = PROTECT(r_maybe_duplicate_shared(x));                 \
+    out = PROTECT(r_clone_shared(x));                           \
   } else {                                                      \
-    out = PROTECT(r_maybe_duplicate(x));                        \
+    out = PROTECT(r_clone_referenced(x));                       \
   }                                                             \
                                                                 \
   CTYPE* out_data = DEREF(out) + start;                         \
@@ -323,9 +323,9 @@ static SEXP raw_assign(SEXP x, SEXP index, SEXP value, enum vctrs_ownership owne
                                                                 \
   SEXP out;                                                     \
   if (ownership == vctrs_ownership_owned) {                     \
-    out = PROTECT(r_maybe_duplicate_shared(x));                 \
+    out = PROTECT(r_clone_shared(x));                           \
   } else {                                                      \
-    out = PROTECT(r_maybe_duplicate(x));                        \
+    out = PROTECT(r_clone_referenced(x));                       \
   }                                                             \
                                                                 \
   for (R_len_t i = 0; i < n; ++i) {                             \
@@ -351,9 +351,9 @@ static SEXP raw_assign(SEXP x, SEXP index, SEXP value, enum vctrs_ownership owne
                                                                 \
   SEXP out;                                                     \
   if (ownership == vctrs_ownership_owned) {                     \
-    out = PROTECT(r_maybe_duplicate_shared(x));                 \
+    out = PROTECT(r_clone_shared(x));                           \
   } else {                                                      \
-    out = PROTECT(r_maybe_duplicate(x));                        \
+    out = PROTECT(r_clone_referenced(x));                       \
   }                                                             \
                                                                 \
   for (R_len_t i = 0; i < n; ++i, start += step) {              \
@@ -385,12 +385,12 @@ SEXP list_assign(SEXP x, SEXP index, SEXP value, enum vctrs_ownership ownership)
  *
  * Performance and safety notes:
  * If `x` is a fresh data frame (which would be the case in `vec_c()` and
- * `vec_rbind()`) then `r_maybe_duplicate()` will return it untouched. Each
+ * `vec_rbind()`) then `r_clone_referenced()` will return it untouched. Each
  * column will also be fresh, so if `vec_proxy()` just returns its input then
  * `vec_proxy_assign_opts()` will directly assign to that column in `x`. This
  * makes it extremely fast to assign to a data frame.
  *
- * If `x` is referenced already, then `r_maybe_duplicate()` will call
+ * If `x` is referenced already, then `r_clone_referenced()` will call
  * `Rf_shallow_duplicate()`. For lists, this loops over the list and marks
  * each list element with max namedness. This is helpful for us, because
  * it is possible to have a data frame that is itself referenced, with columns
@@ -405,9 +405,9 @@ SEXP df_assign(SEXP x, SEXP index, SEXP value,
                const struct vec_assign_opts* opts) {
   SEXP out;
   if (ownership == vctrs_ownership_owned) {
-    out = PROTECT(r_maybe_duplicate_shared(x));
+    out = PROTECT(r_clone_shared(x));
   } else {
-    out = PROTECT(r_maybe_duplicate(x));
+    out = PROTECT(r_clone_referenced(x));
   }
 
   R_len_t n = Rf_length(out);

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -3,6 +3,7 @@
 
 #include "utils.h"
 
+// Ownership is recursive
 enum vctrs_ownership {
   vctrs_ownership_total,
   vctrs_ownership_shared,

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -23,22 +23,26 @@ static inline enum vctrs_ownership parse_ownership(SEXP ownership) {
 
 struct vec_assign_opts {
   bool assign_names;
-  enum vctrs_ownership ownership;
   struct vctrs_arg* x_arg;
   struct vctrs_arg* value_arg;
 };
 
 SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
+                     enum vctrs_ownership ownership,
                      const struct vec_assign_opts* opts);
 
 SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
+                           enum vctrs_ownership ownership,
                            const struct vec_assign_opts* opts);
 
 SEXP chr_assign(SEXP out, SEXP index, SEXP value, enum vctrs_ownership ownership);
 SEXP list_assign(SEXP out, SEXP index, SEXP value, enum vctrs_ownership ownership);
 SEXP df_assign(SEXP x, SEXP index, SEXP value,
+               enum vctrs_ownership ownership,
                const struct vec_assign_opts* opts);
 
-SEXP vec_assign_shaped(SEXP proxy, SEXP index, SEXP value, const struct vec_assign_opts* opts);
+SEXP vec_assign_shaped(SEXP proxy, SEXP index, SEXP value,
+                       enum vctrs_ownership ownership,
+                       const struct vec_assign_opts* opts);
 
 #endif

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -1,6 +1,8 @@
 #ifndef VCTRS_SLICE_ASSIGN_H
 #define VCTRS_SLICE_ASSIGN_H
 
+#include "utils.h"
+
 enum vctrs_ownership {
   vctrs_ownership_owned,
   vctrs_ownership_shared,
@@ -8,7 +10,7 @@ enum vctrs_ownership {
 };
 
 static inline enum vctrs_ownership parse_ownership(SEXP ownership) {
-  if (TYPEOF(ownership) != STRSXP || Rf_length(ownership) != 1) {
+  if (!r_is_string(ownership)) {
     Rf_errorcall(R_NilValue, "Internal error: `ownership` must be a string.");
   }
 

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -3,8 +3,8 @@
 
 // Ownership is recursive
 enum vctrs_ownership {
-  vctrs_ownership_total,
-  vctrs_ownership_shared
+  vctrs_ownership_shared,
+  vctrs_ownership_total
 };
 
 struct vec_assign_opts {

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -1,8 +1,6 @@
 #ifndef VCTRS_SLICE_ASSIGN_H
 #define VCTRS_SLICE_ASSIGN_H
 
-#include "utils.h"
-
 // Ownership is recursive
 enum vctrs_ownership {
   vctrs_ownership_total,

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -6,8 +6,7 @@
 // Ownership is recursive
 enum vctrs_ownership {
   vctrs_ownership_total,
-  vctrs_ownership_shared,
-  vctrs_ownership_unknown
+  vctrs_ownership_shared
 };
 
 struct vec_assign_opts {
@@ -17,21 +16,21 @@ struct vec_assign_opts {
 };
 
 SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
-                     enum vctrs_ownership ownership,
+                     const enum vctrs_ownership ownership,
                      const struct vec_assign_opts* opts);
 
 SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
-                           enum vctrs_ownership ownership,
+                           const enum vctrs_ownership ownership,
                            const struct vec_assign_opts* opts);
 
-SEXP chr_assign(SEXP out, SEXP index, SEXP value, enum vctrs_ownership ownership);
-SEXP list_assign(SEXP out, SEXP index, SEXP value, enum vctrs_ownership ownership);
+SEXP chr_assign(SEXP out, SEXP index, SEXP value, const enum vctrs_ownership ownership);
+SEXP list_assign(SEXP out, SEXP index, SEXP value, const enum vctrs_ownership ownership);
 SEXP df_assign(SEXP x, SEXP index, SEXP value,
-               enum vctrs_ownership ownership,
+               const enum vctrs_ownership ownership,
                const struct vec_assign_opts* opts);
 
 SEXP vec_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                       enum vctrs_ownership ownership,
+                       const enum vctrs_ownership ownership,
                        const struct vec_assign_opts* opts);
 
 #endif

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -9,20 +9,6 @@ enum vctrs_ownership {
   vctrs_ownership_unknown
 };
 
-static inline enum vctrs_ownership parse_ownership(SEXP ownership) {
-  if (!r_is_string(ownership)) {
-    Rf_errorcall(R_NilValue, "Internal error: `ownership` must be a string.");
-  }
-
-  const char* str = CHAR(STRING_ELT(ownership, 0));
-
-  if (!strcmp(str, "owned")) return vctrs_ownership_owned;
-  if (!strcmp(str, "shared")) return vctrs_ownership_shared;
-  if (!strcmp(str, "unknown")) return vctrs_ownership_unknown;
-
-  Rf_errorcall(R_NilValue, "Internal error: `ownership` must be one of 'owned', 'shared', or 'unknown'.");
-}
-
 struct vec_assign_opts {
   bool assign_names;
   struct vctrs_arg* x_arg;

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -1,9 +1,29 @@
 #ifndef VCTRS_SLICE_ASSIGN_H
 #define VCTRS_SLICE_ASSIGN_H
 
+enum vctrs_ownership {
+  vctrs_ownership_owned,
+  vctrs_ownership_shared,
+  vctrs_ownership_unknown
+};
+
+static inline enum vctrs_ownership parse_ownership(SEXP ownership) {
+  if (TYPEOF(ownership) != STRSXP || Rf_length(ownership) != 1) {
+    Rf_errorcall(R_NilValue, "Internal error: `ownership` must be a string.");
+  }
+
+  const char* str = CHAR(STRING_ELT(ownership, 0));
+
+  if (!strcmp(str, "owned")) return vctrs_ownership_owned;
+  if (!strcmp(str, "shared")) return vctrs_ownership_shared;
+  if (!strcmp(str, "unknown")) return vctrs_ownership_unknown;
+
+  Rf_errorcall(R_NilValue, "Internal error: `ownership` must be one of 'owned', 'shared', or 'unknown'.");
+}
+
 struct vec_assign_opts {
   bool assign_names;
-  bool owned;
+  enum vctrs_ownership ownership;
   struct vctrs_arg* x_arg;
   struct vctrs_arg* value_arg;
 };
@@ -14,8 +34,8 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
 SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
                            const struct vec_assign_opts* opts);
 
-SEXP chr_assign(SEXP out, SEXP index, SEXP value, bool owned);
-SEXP list_assign(SEXP out, SEXP index, SEXP value, bool owned);
+SEXP chr_assign(SEXP out, SEXP index, SEXP value, enum vctrs_ownership ownership);
+SEXP list_assign(SEXP out, SEXP index, SEXP value, enum vctrs_ownership ownership);
 SEXP df_assign(SEXP x, SEXP index, SEXP value,
                const struct vec_assign_opts* opts);
 

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -4,7 +4,7 @@
 #include "utils.h"
 
 enum vctrs_ownership {
-  vctrs_ownership_owned,
+  vctrs_ownership_total,
   vctrs_ownership_shared,
   vctrs_ownership_unknown
 };

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -16,7 +16,6 @@ struct vec_assign_opts {
 };
 
 SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
-                     const enum vctrs_ownership ownership,
                      const struct vec_assign_opts* opts);
 
 SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -538,7 +538,7 @@ static inline bool needs_vec_unchop_fallback(SEXP x, SEXP ptype) {
 // with recycling of each element of `x` to the corresponding index size
 static SEXP vec_unchop_fallback(SEXP x, SEXP indices, SEXP name_spec) {
   R_len_t x_size = vec_size(x);
-  x = PROTECT(r_maybe_duplicate(x));
+  x = PROTECT(r_clone_referenced(x));
 
   R_len_t out_size = 0;
 
@@ -605,7 +605,7 @@ static SEXP vec_as_indices(SEXP indices, R_len_t n, SEXP names) {
     Rf_errorcall(R_NilValue, "`indices` must be a list of index values, or `NULL`.");
   }
 
-  indices = PROTECT(r_maybe_duplicate(indices));
+  indices = PROTECT(r_clone_referenced(indices));
 
   R_len_t size = vec_size(indices);
 

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -506,7 +506,7 @@ static SEXP vec_unchop(SEXP x,
       SEXP inner = PROTECT(vec_names(elt));
       SEXP elt_names = PROTECT(apply_name_spec(name_spec, outer, inner, size));
       if (elt_names != R_NilValue) {
-        out_names = chr_assign(out_names, index, elt_names, vctrs_ownership_owned);
+        out_names = chr_assign(out_names, index, elt_names, vctrs_ownership_total);
         REPROTECT(out_names, out_names_pi);
       }
       UNPROTECT(2);

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -506,7 +506,7 @@ static SEXP vec_unchop(SEXP x,
       SEXP inner = PROTECT(vec_names(elt));
       SEXP elt_names = PROTECT(apply_name_spec(name_spec, outer, inner, size));
       if (elt_names != R_NilValue) {
-        out_names = chr_assign(out_names, index, elt_names, true);
+        out_names = chr_assign(out_names, index, elt_names, vctrs_ownership_owned);
         REPROTECT(out_names, out_names_pi);
       }
       UNPROTECT(2);

--- a/src/subscript.c
+++ b/src/subscript.c
@@ -95,7 +95,7 @@ SEXP vec_as_subscript_opts(SEXP subscript,
 
   if (orig_names != R_NilValue) {
     // FIXME: Handle names in cast methods
-    subscript = r_maybe_duplicate(subscript);
+    subscript = r_clone_referenced(subscript);
     REPROTECT(subscript, subscript_pi);
     r_poke_names(subscript, orig_names);
   }

--- a/src/translate.c
+++ b/src/translate.c
@@ -212,7 +212,7 @@ static SEXP chr_translate_encoding(SEXP x, R_len_t size) {
 
   const SEXP* p_x = STRING_PTR_RO(x);
 
-  SEXP out = PROTECT(r_maybe_duplicate(x));
+  SEXP out = PROTECT(r_clone_referenced(x));
   SEXP* p_out = STRING_PTR(out);
 
   const void *vmax = vmaxget();
@@ -234,7 +234,7 @@ static SEXP chr_translate_encoding(SEXP x, R_len_t size) {
 }
 
 static SEXP list_translate_encoding(SEXP x, R_len_t size) {
-  x = PROTECT(r_maybe_duplicate(x));
+  x = PROTECT(r_clone_referenced(x));
 
   for (int i = 0; i < size; ++i) {
     SEXP elt = VECTOR_ELT(x, i);
@@ -248,7 +248,7 @@ static SEXP list_translate_encoding(SEXP x, R_len_t size) {
 static SEXP df_translate_encoding(SEXP x, R_len_t size) {
   int n_col = Rf_length(x);
 
-  x = PROTECT(r_maybe_duplicate(x));
+  x = PROTECT(r_clone_referenced(x));
 
   for (int i = 0; i < n_col; ++i) {
     SEXP col = VECTOR_ELT(x, i);
@@ -304,7 +304,7 @@ static SEXP list_maybe_translate_encoding(SEXP x, R_len_t size) {
 static SEXP df_maybe_translate_encoding(SEXP x, R_len_t size) {
   int n_col = Rf_length(x);
 
-  x = PROTECT(r_maybe_duplicate(x));
+  x = PROTECT(r_clone_referenced(x));
 
   for (int i = 0; i < n_col; ++i) {
     SEXP elt = VECTOR_ELT(x, i);
@@ -392,8 +392,8 @@ static SEXP list_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len
 static SEXP df_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   int n_col = Rf_length(x);
 
-  x = PROTECT(r_maybe_duplicate(x));
-  y = PROTECT(r_maybe_duplicate(y));
+  x = PROTECT(r_clone_referenced(x));
+  y = PROTECT(r_clone_referenced(y));
 
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
 

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -41,7 +41,7 @@ bool is_bare_tibble(SEXP x) {
 
 // [[ include("type-data-frame.h") ]]
 SEXP new_data_frame(SEXP x, R_len_t n) {
-  x = PROTECT(r_maybe_duplicate(x));
+  x = PROTECT(r_clone_referenced(x));
   init_data_frame(x, n);
 
   UNPROTECT(1);
@@ -72,7 +72,7 @@ SEXP vctrs_new_data_frame(SEXP args) {
   bool has_rownames = false;
   R_len_t size = df_size_from_list(x, n);
 
-  SEXP out = PROTECT(r_maybe_duplicate(x));
+  SEXP out = PROTECT(r_clone_referenced(x));
 
   for (SEXP node = attrib; node != R_NilValue; node = CDR(node)) {
     SEXP tag = TAG(node);
@@ -632,7 +632,7 @@ SEXP df_repair_names(SEXP x, struct name_repair_opts* name_repair) {
   // update metadata and check invariants when special columns are
   // renamed?
   if (nms != repaired) {
-    x = PROTECT(r_maybe_duplicate(x));
+    x = PROTECT(r_clone_referenced(x));
     r_poke_names(x, repaired);
     UNPROTECT(1);
   }

--- a/src/type-date-time.c
+++ b/src/type-date-time.c
@@ -275,7 +275,7 @@ static SEXP new_date(SEXP x) {
 
   SEXP names = PROTECT(r_names(x));
 
-  SEXP out = PROTECT(r_maybe_duplicate(x));
+  SEXP out = PROTECT(r_clone_referenced(x));
 
   SET_ATTRIB(out, R_NilValue);
 
@@ -309,7 +309,7 @@ static SEXP new_datetime(SEXP x, SEXP tzone) {
 
   SEXP names = PROTECT(r_names(x));
 
-  SEXP out = PROTECT(r_maybe_duplicate(x));
+  SEXP out = PROTECT(r_clone_referenced(x));
 
   SET_ATTRIB(out, R_NilValue);
 
@@ -371,7 +371,7 @@ static SEXP datetime_validate_tzone(SEXP x) {
     return x;
   }
 
-  x = PROTECT(r_maybe_duplicate(x));
+  x = PROTECT(r_clone_referenced(x));
 
   Rf_setAttrib(x, syms_tzone, chrs_empty);
 
@@ -407,7 +407,7 @@ static SEXP datetime_rezone(SEXP x, SEXP tzone) {
     return x;
   }
 
-  SEXP out = PROTECT(r_maybe_duplicate(x));
+  SEXP out = PROTECT(r_clone_referenced(x));
 
   Rf_setAttrib(out, syms_tzone, tzone);
 

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -301,9 +301,9 @@ static SEXP fct_as_factor_impl(SEXP x, SEXP x_levels, SEXP to_levels, bool* loss
 
   // No recoding required if contiguous subset.
   // Duplicate, strip non-factor attributes, and re-initialize with new levels.
-  // Using `r_maybe_duplicate()` avoids an immediate copy using ALTREP wrappers.
+  // Using `r_clone_referenced()` avoids an immediate copy using ALTREP wrappers.
   if (is_contiguous_subset) {
-    SEXP out = PROTECT(r_maybe_duplicate(x));
+    SEXP out = PROTECT(r_clone_referenced(x));
     SET_ATTRIB(out, R_NilValue);
 
     if (ordered) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -225,7 +225,7 @@ SEXP vctrs_set_attributes(SEXP x, SEXP attrib) {
   R_len_t n_attrib = Rf_length(attrib);
   int n_protect = 0;
 
-  x = PROTECT(r_maybe_duplicate(x));
+  x = PROTECT(r_clone_referenced(x));
   ++n_protect;
 
   // Remove existing attributes, and unset the object bit
@@ -1251,7 +1251,7 @@ bool r_is_function(SEXP x) {
   }
 }
 
-SEXP r_maybe_duplicate(SEXP x) {
+SEXP r_clone_referenced(SEXP x) {
   if (MAYBE_REFERENCED(x)) {
     return Rf_shallow_duplicate(x);
   } else {
@@ -1259,7 +1259,7 @@ SEXP r_maybe_duplicate(SEXP x) {
   }
 }
 
-SEXP r_maybe_duplicate_shared(SEXP x) {
+SEXP r_clone_shared(SEXP x) {
   if (MAYBE_SHARED(x)) {
     return Rf_shallow_duplicate(x);
   } else {

--- a/src/utils.h
+++ b/src/utils.h
@@ -207,8 +207,8 @@ bool r_is_true(SEXP x);
 bool r_is_string(SEXP x);
 bool r_is_number(SEXP x);
 SEXP r_peek_option(const char* option);
-SEXP r_maybe_duplicate(SEXP x);
-SEXP r_maybe_duplicate_shared(SEXP x);
+SEXP r_clone_referenced(SEXP x);
+SEXP r_clone_shared(SEXP x);
 
 SEXP r_pairlist(SEXP* tags, SEXP* cars);
 SEXP r_call(SEXP fn, SEXP* tags, SEXP* cars);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -364,7 +364,6 @@ SEXP vec_slice(SEXP x, SEXP subscript);
 SEXP vec_slice_impl(SEXP x, SEXP subscript);
 SEXP vec_chop(SEXP x, SEXP indices);
 SEXP vec_slice_shaped(enum vctrs_type type, SEXP x, SEXP index);
-SEXP vec_assign(SEXP x, SEXP index, SEXP value);
 SEXP vec_proxy_assign(SEXP proxy, SEXP index, SEXP value);
 bool vec_requires_fallback(SEXP x, struct vctrs_proxy_info info);
 SEXP vec_init(SEXP x, R_len_t n);

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -631,21 +631,6 @@ test_that("monitoring: assignment to a data frame with unshared columns doesn't 
   expect_identical(x, expect)
 })
 
-test_that("monitoring: can assign in place with unshared columns when totally owned", {
-  expect1 <- new_data_frame(list(x = 1L))
-  expect2 <- new_data_frame(list(x = 2L))
-
-  value <- new_data_frame(list(x = 2L))
-
-  x <- new_df_unshared_col()
-  .Call(vctrs_assign_params, x, 1L, value, assign_named = FALSE, ownership = "shared")
-  expect_identical(x, expect1)
-
-  x <- new_df_unshared_col()
-  .Call(vctrs_assign_params, x, 1L, value, assign_named = FALSE, ownership = "total")
-  expect_identical(x, expect2)
-})
-
 test_that("monitoring: assignment to atomic vectors doesn't modify by reference", {
   x <- c(1, 2, 3)
   expect <- c(1, 2, 3)

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -631,18 +631,18 @@ test_that("monitoring: assignment to a data frame with unshared columns doesn't 
   expect_identical(x, expect)
 })
 
-test_that("monitoring: can assign in place with unshared columns when `owned = TRUE`", {
+test_that("monitoring: can assign in place with unshared columns when owned", {
   expect1 <- new_data_frame(list(x = 1L))
   expect2 <- new_data_frame(list(x = 2L))
 
   value <- new_data_frame(list(x = 2L))
 
   x <- new_df_unshared_col()
-  .Call(vctrs_assign_params, x, 1L, value, assign_named = FALSE, owned = FALSE)
+  .Call(vctrs_assign_params, x, 1L, value, assign_named = FALSE, ownership = "shared")
   expect_identical(x, expect1)
 
   x <- new_df_unshared_col()
-  .Call(vctrs_assign_params, x, 1L, value, assign_named = FALSE, owned = TRUE)
+  .Call(vctrs_assign_params, x, 1L, value, assign_named = FALSE, owned = "owned")
   expect_identical(x, expect2)
 })
 

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -631,7 +631,7 @@ test_that("monitoring: assignment to a data frame with unshared columns doesn't 
   expect_identical(x, expect)
 })
 
-test_that("monitoring: can assign in place with unshared columns when owned", {
+test_that("monitoring: can assign in place with unshared columns when totally owned", {
   expect1 <- new_data_frame(list(x = 1L))
   expect2 <- new_data_frame(list(x = 2L))
 
@@ -642,7 +642,7 @@ test_that("monitoring: can assign in place with unshared columns when owned", {
   expect_identical(x, expect1)
 
   x <- new_df_unshared_col()
-  .Call(vctrs_assign_params, x, 1L, value, assign_named = FALSE, owned = "owned")
+  .Call(vctrs_assign_params, x, 1L, value, assign_named = FALSE, ownership = "total")
   expect_identical(x, expect2)
 })
 


### PR DESCRIPTION
Follow up to #1062 

This PR refines the ownership model of `vec_assign()`. It changes from a boolean ownership model to one with 3 states: owned, shared, or unknown.

It works similarly to how it was set up before, except for calls to `vec_proxy_assign_opts()`. Now, if `vec_proxy_assign_opts()` is called with `vctrs_ownership_unknown` then it will attempt to determine the ownership for the data structure by a call to `NO_REFERENCES()` on the proxy. If there are no references, it is owned.

This change helps with slider. If slider creates a data frame at the C level and then calls `vec_proxy_assign()` to fill it, a default of `vctrs_ownership_unknown` is assumed. But `NO_REFERENCES(proxy)` will be true on the fresh data frame, so the ownership is updated to `vctrs_ownership_owned`. The columns of the data frame are all passed this updated ownership value, so no copies are made.

In the obscure case where we create a data frame at the C level, and then set one of the columns in this freshly created data frame to be a vector that is already referenced somewhere else, we are still safe. Assigning into that fresh data frame will use `vctrs_ownership_owned`, which will be passed on to each column, but columns that are also referenced elsewhere will have a refcount of at least 2. One from being referenced elsewhere, and one from being set in this fresh data frame. So `r_maybe_duplicate_shared()` will copy it as needed to not modify it by reference accidentally. But again, I don't see this case ever arising.