### PR TITLE
Adjust vignette to new date conversion error on r-devel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -263,6 +263,9 @@ The following errors are caused by breaking changes.
 * Fixed clang-UBSAN error "nan is outside the range of representable
   values of type 'int'" (#902).
 
+* Fixed compilation of stability vignette following the date
+  conversion changes on R-devel.
+
 
 # vctrs 0.2.4
 

--- a/vignettes/stability.Rmd
+++ b/vignettes/stability.Rmd
@@ -162,18 +162,26 @@ c(FALSE, list(1))
 vec_c(FALSE, list(1))
 ```
 
-### Non-vectors
+### Incompatible vectors and non-vectors
 
-As far as I can tell, `c()` never throws an error. No matter how bizarre the inputs, it always returns something:
+In general, most base methods do not throw an error:
 
 ```{r}
-c(Sys.Date(), factor("x"), "x")
+c(10.5, factor("x"))
 ```
 
 If the inputs aren't vectors, `c()` automatically puts them in a list:
 
 ```{r}
 c(mean, globalenv())
+```
+
+For numeric versions, this depends on the order of inputs. Version first is an error, otherwise the input is wrapped in a list:
+
+```{r, error = TRUE}
+c(getRversion(), "x")
+
+c("x", getRversion())
 ```
 
 `vec_c()` throws an error if the inputs are not vectors or not automatically coercible:
@@ -183,6 +191,7 @@ vec_c(mean, globalenv())
 
 vec_c(Sys.Date(), factor("x"), "x")
 ```
+
 
 ### Factors
 


### PR DESCRIPTION
Follow-up to Kurt's mail about new date conversion behaviour:

```r
c(Sys.Date(), factor("x"), "x")
#> Error: character string is not in a standard unambiguous format

#> Backtrace:
#>      █
#>   1. ├─base::c(Sys.Date(), factor("x"), "x")
#>   2. ├─base::c.Date(Sys.Date(), factor("x"), "x")
#>   3. │ ├─base::.Date(c(unlist(lapply(list(...), function(e) unclass(as.Date(e))))))
#>   4. │ ├─base::unlist(lapply(list(...), function(e) unclass(as.Date(e))))
#>   5. │ └─base::lapply(list(...), function(e) unclass(as.Date(e)))
#>   6. │   └─base:::FUN(X[[i]], ...)
#>   7. │     ├─base::as.Date(e)
#>   8. │     └─base::as.Date.factor(e)
#>   9. │       ├─base::as.Date(as.character(x), ...)
#>  10. │       └─base::as.Date.character(as.character(x), ...)
#>  11. │         └─base:::charToDate(x)
#>  12. │           └─base::stop("character string is not in a standard unambiguous format")
#>  13. └─base::.handleSimpleError(...)
#>  14.   └─global::h(simpleError(msg, call))

# Not symmetric though:
c("x", Sys.Date())
#> [1] "x"     "18386"
```

Fixes the macOS r-devel build.