### PR TITLE
Improve `vec_cast()` error messages

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -242,6 +242,9 @@ cnd_type_message <- function(x,
     return(message)
   }
 
+  x_arg <- arg_as_string(x_arg)
+  y_arg <- arg_as_string(y_arg)
+
   if (nzchar(x_arg)) {
     x_name <- paste0(" `", x_arg, "` ")
   } else {
@@ -286,10 +289,13 @@ cnd_type_message <- function(x,
     end <- glue::glue("; falling back to {fallback}.")
   }
 
-  glue_lines(
-    "Can't {action}{x_name}<{x_type}> {separator}{y_name}<{y_type}>{end}",
-    details
-  )
+  if (action == "convert" && nzchar(y_arg)) {
+    header <- glue::glue("Can't convert{x_name}<{x_type}> to match type of{y_name}<{y_type}>{end}")
+  } else {
+    header <- glue::glue("Can't {action}{x_name}<{x_type}> {separator}{y_name}<{y_type}>{end}")
+  }
+
+  paste_line(header, details)
 }
 
 cnd_type_message_type_label <- function(x) {

--- a/tests/testthat/error/test-cast.txt
+++ b/tests/testthat/error/test-cast.txt
@@ -1,0 +1,10 @@
+
+Casting to named argument mentions 'match type <foo>'
+=====================================================
+
+> vec_cast(1, "", x_arg = "foo", to_arg = "bar")
+Error: Can't convert `foo` <double> to match type of `bar` <character>.
+
+> vec_cast(1, "", x_arg = "foo")
+Error: Can't convert `foo` <double> to <character>.
+

--- a/tests/testthat/error/test-slice-assign.txt
+++ b/tests/testthat/error/test-slice-assign.txt
@@ -60,7 +60,7 @@ i Subscript has a missing value at location 2.
 ===========================================
 
 > vec_assign(1:2, 1L, "x", x_arg = "foo", value_arg = "bar")
-Error: Can't convert `bar` <character> to `foo` <integer>.
+Error: Can't convert `bar` <character> to match type of `foo` <integer>.
 
 > vec_assign(1:2, 1L, 1:2, value_arg = "bar")
 Error: Input `bar` can't be recycled to size 1.

--- a/tests/testthat/test-cast-error-nested.txt
+++ b/tests/testthat/test-cast-error-nested.txt
@@ -11,12 +11,12 @@ Can't convert <factor<bd40e>> to <double>.
 
 vec_cast(x, y):
 
-Can't convert `a$b` <character> to `a$b` <double>. 
+Can't convert `a$b` <character> to match type of `a$b` <double>. 
 
 
 vec_cast(x, y):
 
-Can't convert `a$b` <factor<bd40e>> to `a$b` <double>. 
+Can't convert `a$b` <factor<bd40e>> to match type of `a$b` <double>. 
 
 
 vec_cast_common(x, y):

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -1,5 +1,14 @@
 context("test-cast")
 
+test_that("vec_cast() has helpful error messages", {
+  verify_output(test_path("error", "test-cast.txt"), {
+    "# Casting to named argument mentions 'match type <foo>'"
+    vec_cast(1, "", x_arg = "foo", to_arg = "bar")
+    vec_cast(1, "", x_arg = "foo")
+  })
+})
+
+
 # vec_cast ---------------------------------------------------------------
 
 test_that("new classes are uncoercible by default", {


### PR DESCRIPTION
```r
vec_cast(1, "", x_arg = "foo", to_arg = "bar")
#> Error: Can't convert `foo` <double> to match type of `bar` <character>.
```

```r
vec_cast(1, "", x_arg = "foo")
#> Error: Can't convert `foo` <double> to <character>.
```