### PR TITLE
Use `assign_names` in `vec_unchop()`

### DIFF
--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -488,6 +488,10 @@ static SEXP vec_unchop(SEXP x,
   }
   PROTECT_WITH_INDEX(out_names, &out_names_pi);
 
+  const struct vec_assign_opts unchop_assign_opts = {
+    .assign_names = true
+  };
+
   for (R_len_t i = 0; i < x_size; ++i) {
     SEXP elt = VECTOR_ELT(x, i);
 
@@ -497,7 +501,8 @@ static SEXP vec_unchop(SEXP x,
 
     SEXP index = VECTOR_ELT(indices, i);
 
-    proxy = vec_proxy_assign(proxy, index, elt);
+    // Total ownership of `proxy` because it was freshly created with `vec_init()`
+    proxy = vec_proxy_assign_opts(proxy, index, elt, vctrs_ownership_total, &unchop_assign_opts);
     REPROTECT(proxy, proxy_pi);
 
     if (has_names) {

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -405,14 +405,17 @@ test_that("not all inputs have to be named", {
   expect_named(vec_unchop(x, indices), c("", "a", "c"))
 })
 
-test_that("data frame row names are never kept", {
+test_that("data frame row names are kept", {
   df1 <- data.frame(x = 1:2, row.names = c("r1", "r2"))
   df2 <- data.frame(x = 3:4, row.names = c("r3", "r4"))
 
   x <- list(df1, df2)
   indices <- list(c(3, 1), c(2, 4))
 
-  expect_identical(.row_names_info(vec_unchop(x, indices)), -4L)
+  result <- vec_unchop(x, indices)
+  expect <- c("r2", "r3", "r1", "r4")
+
+  expect_identical(vec_names(result), expect)
 })
 
 test_that("monitoring - can technically assign to the same location twice", {

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -418,6 +418,35 @@ test_that("data frame row names are kept", {
   expect_identical(vec_names(result), expect)
 })
 
+test_that("individual data frame columns retain vector names", {
+  df1 <- data_frame(x = c(a = 1, b = 2))
+  df2 <- data_frame(x = c(c = 3))
+
+  x <- list(df1, df2)
+  indices <- list(c(1, 2), 3)
+
+  result <- vec_unchop(x, indices = indices)
+
+  expect_named(result$x, c("a", "b", "c"))
+
+  # Names should be identical to equivalent `vec_c()` call
+  expect_identical(vec_unchop(x, indices = indices), vec_c(!!!x))
+})
+
+test_that("df-col row names are repaired silently", {
+  df1 <- data_frame(x = new_data_frame(list(a = 1), row.names = "inner"))
+  df2 <- data_frame(x = new_data_frame(list(a = 2), row.names = "inner"))
+
+  x <- list(df1, df2)
+  indices <- list(1, 2)
+
+  expect_silent({
+    result <- vec_unchop(x, indices = indices)
+  })
+
+  expect_identical(vec_names(result$x), c("inner...1", "inner...2"))
+})
+
 test_that("monitoring - can technically assign to the same location twice", {
   x <- list(1:2, 3L)
   indices <- list(1:2, 1L)


### PR DESCRIPTION
Closes #1071 

This PR uses the `assign_names = true` option in `vec_unchop()` to align it with `vec_c()`.