### PR TITLE
Silently fall back to base data frame type in comparison operators

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -63,6 +63,11 @@ vec_cast_dispatch <- function(x, to, ..., x_arg = "", to_arg = "") {
 vec_cast_common <- function(..., .to = NULL) {
   .External2(vctrs_cast_common, .to)
 }
+vec_cast_common_params <- function(...,
+                                   .to = NULL,
+                                   .df_fallback = DF_FALLBACK_NONE) {
+  .External2(vctrs_cast_common_params, .to, .df_fallback)
+}
 
 #' @rdname vec_default_ptype2
 #' @inheritParams vec_cast

--- a/R/compare.R
+++ b/R/compare.R
@@ -78,7 +78,11 @@ vec_compare <- function(x, y, na_equal = FALSE, .ptype = NULL) {
   vec_assert(na_equal, ptype = logical(), size = 1L)
 
   args <- vec_recycle_common(x, y)
-  args <- vec_cast_common(!!!args, .to = .ptype)
+  args <- vec_cast_common_params(
+    !!!args,
+    .to = .ptype,
+    .df_fallback = DF_FALLBACK_QUIET
+  )
 
   .Call(vctrs_compare, vec_proxy_compare(args[[1]]), vec_proxy_compare(args[[2]]), na_equal)
 }

--- a/R/equal.R
+++ b/R/equal.R
@@ -63,7 +63,11 @@ vec_proxy_equal.default <- function(x, ...) {
 vec_equal <- function(x, y, na_equal = FALSE, .ptype = NULL) {
   vec_assert(na_equal, ptype = logical(), size = 1L)
   args <- vec_recycle_common(x, y)
-  args <- vec_cast_common(!!!args, .to = .ptype)
+  args <- vec_cast_common_params(
+    !!!args,
+    .to = .ptype,
+    .df_fallback = DF_FALLBACK_QUIET
+  )
   .Call(vctrs_equal, args[[1]], args[[2]], na_equal)
 }
 

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -217,7 +217,8 @@ vec_ptype2_df_fallback <- function(x, y, df_fallback, x_arg = "", y_arg = "") {
   x_class <- class(x)[[1]]
   y_class <- class(y)[[1]]
 
-  if (df_fallback < 2L && !all(c(x_class, y_class) %in% c(classes, "tbl_df"))) {
+  if (df_fallback < DF_FALLBACK_QUIET &&
+      !all(c(x_class, y_class) %in% c(classes, "tbl_df"))) {
     fallback_class <- if (seen_tibble) "<tibble>" else "<data.frame>"
     msg <- cnd_type_message(
       x, y,

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -196,7 +196,7 @@ df_needs_normalisation <- function(x, y) {
 }
 
 # Fallback for data frame subclasses (#981)
-vec_ptype2_df_fallback <- function(x, y, x_arg = "", y_arg = "") {
+vec_ptype2_df_fallback <- function(x, y, df_fallback, x_arg = "", y_arg = "") {
   seen_tibble <- inherits(x, "tbl_df") || inherits(y, "tbl_df")
 
   ptype <- vec_ptype2_params(
@@ -217,7 +217,7 @@ vec_ptype2_df_fallback <- function(x, y, x_arg = "", y_arg = "") {
   x_class <- class(x)[[1]]
   y_class <- class(y)[[1]]
 
-  if (!all(c(x_class, y_class) %in% c(classes, "tbl_df"))) {
+  if (df_fallback < 2L && !all(c(x_class, y_class) %in% c(classes, "tbl_df"))) {
     fallback_class <- if (seen_tibble) "<tibble>" else "<data.frame>"
     msg <- cnd_type_message(
       x, y,

--- a/R/type2.R
+++ b/R/type2.R
@@ -131,6 +131,10 @@ vec_ptype2_params <- function(x,
   .Call(vctrs_ptype2_params, x, y, x_arg, y_arg, df_fallback)
 }
 
+DF_FALLBACK_NONE <- 0L
+DF_FALLBACK_WARN <- 1L
+DF_FALLBACK_QUIET <- 2L
+
 vec_typeof2 <- function(x, y) {
   .Call(vctrs_typeof2, x, y)
 }

--- a/R/type2.R
+++ b/R/type2.R
@@ -85,13 +85,14 @@ vec_default_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
   }
 
   internal <- match_ptype2_params(...)
+  df_fallback <- internal$df_fallback
 
-  if (has_df_fallback() && internal$df_fallback) {
+  if (has_df_fallback() && df_fallback) {
     if (is_df_subclass(x) && is.data.frame(y)) {
-      return(vec_ptype2_df_fallback(x, y))
+      return(vec_ptype2_df_fallback(x, y, df_fallback))
     }
     if (is_df_subclass(y) && is.data.frame(x)) {
-      return(vec_ptype2_df_fallback(x, y))
+      return(vec_ptype2_df_fallback(x, y, df_fallback))
     }
   }
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -160,7 +160,10 @@ static SEXP vec_rbind(SEXP xs, SEXP ptype, SEXP names_to, struct name_repair_opt
     }
     SEXP x = VECTOR_ELT(xs, i);
 
-    SEXP tbl = PROTECT(vec_cast_params(x, ptype, args_empty, args_empty, true));
+    SEXP tbl = vec_cast_params(x, ptype,
+                               args_empty, args_empty,
+                               DF_FALLBACK_WARN);
+    PROTECT(tbl);
     init_compact_seq(idx_ptr, counter, size, true);
 
     // Total ownership of `out` because it was freshly created with `vec_init()`

--- a/src/cast.c
+++ b/src/cast.c
@@ -128,19 +128,23 @@ SEXP vec_cast_switch_native(const struct cast_opts* opts,
 
 static SEXP syms_vec_cast_default = NULL;
 
-static inline SEXP vec_cast_default(SEXP x,
-                                    SEXP y,
-                                    SEXP x_arg,
-                                    SEXP to_arg,
-                                    bool df_fallback) {
-  return vctrs_eval_mask6(syms_vec_cast_default,
-                          syms_x, x,
-                          syms_to, y,
-                          syms_x_arg, x_arg,
-                          syms_to_arg, to_arg,
-                          syms_from_dispatch, vctrs_shared_true,
-                          syms_df_fallback, r_lgl(df_fallback),
-                          vctrs_ns_env);
+static inline
+SEXP vec_cast_default(SEXP x,
+                      SEXP y,
+                      SEXP x_arg,
+                      SEXP to_arg,
+                      enum df_fallback df_fallback) {
+  SEXP df_fallback_obj = PROTECT(r_int(df_fallback));
+  SEXP out = vctrs_eval_mask6(syms_vec_cast_default,
+                              syms_x, x,
+                              syms_to, y,
+                              syms_x_arg, x_arg,
+                              syms_to_arg, to_arg,
+                              syms_from_dispatch, vctrs_shared_true,
+                              syms_df_fallback, df_fallback_obj,
+                              vctrs_ns_env);
+  UNPROTECT(1);
+  return out;
 }
 
 static

--- a/src/cast.h
+++ b/src/cast.h
@@ -44,6 +44,8 @@ SEXP vec_cast_params(SEXP x,
   return vec_cast_opts(&opts);
 }
 
+SEXP vec_cast_common_params(SEXP xs, SEXP to, enum df_fallback df_fallback);
+
 SEXP vec_cast_dispatch(const struct cast_opts* opts,
                        enum vctrs_type x_type,
                        enum vctrs_type to_type,

--- a/src/cast.h
+++ b/src/cast.h
@@ -1,13 +1,15 @@
 #ifndef VCTRS_CAST_H
 #define VCTRS_CAST_H
 
+#include "ptype2.h"
+
 
 struct cast_opts {
   SEXP x;
   SEXP to;
   struct vctrs_arg* x_arg;
   struct vctrs_arg* to_arg;
-  bool df_fallback;
+  enum df_fallback df_fallback;
 };
 
 SEXP df_cast_opts(const struct cast_opts* opts);
@@ -31,7 +33,7 @@ SEXP vec_cast_params(SEXP x,
                      SEXP to,
                      struct vctrs_arg* x_arg,
                      struct vctrs_arg* to_arg,
-                     bool df_fallback) {
+                     enum df_fallback df_fallback) {
   const struct cast_opts opts = {
     .x = x,
     .to = to,

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -513,10 +513,21 @@ SEXP vec_match_params(SEXP needles,
                       struct vctrs_arg* haystack_arg) {
   int nprot = 0;
   int _;
-  SEXP type = PROTECT_N(vec_ptype2(needles, haystack, needles_arg, haystack_arg, &_), &nprot);
+  SEXP type = vec_ptype2_params(needles, haystack,
+                                needles_arg, haystack_arg,
+                                DF_FALLBACK_QUIET,
+                                &_);
+  PROTECT_N(type, &nprot);
 
-  needles = PROTECT_N(vec_cast(needles, type, needles_arg, args_empty), &nprot);
-  haystack = PROTECT_N(vec_cast(haystack, type, haystack_arg, args_empty), &nprot);
+  needles = vec_cast_params(needles, type,
+                            needles_arg, args_empty,
+                            DF_FALLBACK_QUIET);
+  PROTECT_N(needles, &nprot);
+
+  haystack = vec_cast_params(haystack, type,
+                             haystack_arg, args_empty,
+                             DF_FALLBACK_QUIET);
+  PROTECT_N(haystack, &nprot);
 
   needles = PROTECT_N(vec_proxy_equal(needles), &nprot);
   haystack = PROTECT_N(vec_proxy_equal(haystack), &nprot);
@@ -602,10 +613,22 @@ SEXP vctrs_in(SEXP needles, SEXP haystack, SEXP na_equal_,
   int _;
   struct vctrs_arg needles_arg = vec_as_arg(needles_arg_);
   struct vctrs_arg haystack_arg = vec_as_arg(haystack_arg_);
-  SEXP type = PROTECT_N(vec_ptype2(needles, haystack, &needles_arg, &haystack_arg, &_), &nprot);
 
-  needles = PROTECT_N(vec_cast(needles, type, args_empty, args_empty), &nprot);
-  haystack = PROTECT_N(vec_cast(haystack, type, args_empty, args_empty), &nprot);
+  SEXP type = vec_ptype2_params(needles, haystack,
+                                &needles_arg, &haystack_arg,
+                                DF_FALLBACK_QUIET,
+                                &_);
+  PROTECT_N(type, &nprot);
+
+  needles = vec_cast_params(needles, type,
+                            &needles_arg, args_empty,
+                            DF_FALLBACK_QUIET);
+  PROTECT_N(needles, &nprot);
+
+  haystack = vec_cast_params(haystack, type,
+                             &haystack_arg, args_empty,
+                             DF_FALLBACK_QUIET);
+  PROTECT_N(haystack, &nprot);
 
   needles = PROTECT_N(vec_proxy_equal(needles), &nprot);
   haystack = PROTECT_N(vec_proxy_equal(haystack), &nprot);

--- a/src/init.c
+++ b/src/init.c
@@ -263,6 +263,7 @@ extern SEXP vctrs_ptype_common_params(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_size_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_recycle_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cast_common(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_cast_common_params(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_rbind(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cbind(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_c(SEXP, SEXP, SEXP, SEXP);
@@ -274,6 +275,7 @@ static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_size_common",                (DL_FUNC) &vctrs_size_common, 2},
   {"vctrs_recycle_common",             (DL_FUNC) &vctrs_recycle_common, 1},
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 1},
+  {"vctrs_cast_common_params",         (DL_FUNC) &vctrs_cast_common_params, 2},
   {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 3},
   {"vctrs_cbind",                      (DL_FUNC) &vctrs_cbind, 3},
   {"vctrs_c",                          (DL_FUNC) &vctrs_c, 3},

--- a/src/ptype-common.h
+++ b/src/ptype-common.h
@@ -1,6 +1,10 @@
 #ifndef VCTRS_PTYPE_COMMON_H
 #define VCTRS_PTYPE_COMMON_H
 
-SEXP vec_ptype_common_params(SEXP dots, SEXP ptype, bool df_fallback);
+#include "ptype2.h"
+
+
+SEXP vec_ptype_common_params(SEXP dots, SEXP ptype, enum df_fallback df_fallback);
+
 
 #endif

--- a/src/ptype2-dispatch.c
+++ b/src/ptype2-dispatch.c
@@ -48,19 +48,24 @@ SEXP vec_ptype2_dispatch(const struct ptype2_opts* opts,
 
 // Initialised at load time
 static SEXP syms_vec_ptype2_default = NULL;
-static inline SEXP vec_ptype2_default(SEXP x,
-                                      SEXP y,
-                                      SEXP x_arg,
-                                      SEXP y_arg,
-                                      bool df_fallback) {
-  return vctrs_eval_mask6(syms_vec_ptype2_default,
-                          syms_x, x,
-                          syms_y, y,
-                          syms_x_arg, x_arg,
-                          syms_y_arg, y_arg,
-                          syms_from_dispatch, vctrs_shared_true,
-                          syms_df_fallback, r_lgl(df_fallback),
-                          vctrs_ns_env);
+
+static inline
+SEXP vec_ptype2_default(SEXP x,
+                        SEXP y,
+                        SEXP x_arg,
+                        SEXP y_arg,
+                        enum df_fallback df_fallback) {
+  SEXP df_fallback_obj = PROTECT(r_int(df_fallback));
+  SEXP out = vctrs_eval_mask6(syms_vec_ptype2_default,
+                              syms_x, x,
+                              syms_y, y,
+                              syms_x_arg, x_arg,
+                              syms_y_arg, y_arg,
+                              syms_from_dispatch, vctrs_shared_true,
+                              syms_df_fallback, df_fallback_obj,
+                              vctrs_ns_env);
+  UNPROTECT(1);
+  return out;
 }
 
 // [[ include("vctrs.h") ]]

--- a/src/ptype2.h
+++ b/src/ptype2.h
@@ -2,12 +2,18 @@
 #define VCTRS_PTYPE2_H
 
 
+enum df_fallback {
+  DF_FALLBACK_NONE,
+  DF_FALLBACK_WARN,
+  DF_FALLBACK_QUIET
+};
+
 struct ptype2_opts {
   SEXP x;
   SEXP y;
   struct vctrs_arg* x_arg;
   struct vctrs_arg* y_arg;
-  bool df_fallback;
+  enum df_fallback df_fallback;
 };
 
 SEXP vec_ptype2_dispatch(const struct ptype2_opts* opts,
@@ -23,7 +29,7 @@ SEXP vec_ptype2_params(SEXP x,
                        SEXP y,
                        struct vctrs_arg* x_arg,
                        struct vctrs_arg* y_arg,
-                       bool df_fallback,
+                       enum df_fallback df_fallback,
                        int* left) {
   const struct ptype2_opts opts = {
     .x = x,

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -447,7 +447,7 @@ SEXP df_ptype2_loop(const struct ptype2_opts* opts,
 SEXP vctrs_df_cast_params(SEXP x, SEXP to, SEXP x_arg_, SEXP to_arg_, SEXP df_fallback_) {
   struct vctrs_arg x_arg = vec_as_arg(x_arg_);
   struct vctrs_arg to_arg = vec_as_arg(to_arg_);;
-  bool df_fallback = r_lgl_get(df_fallback_, 0);
+  enum df_fallback df_fallback = r_int_get(df_fallback_, 0);
 
   const struct cast_opts opts = {
     .x = x,

--- a/src/type-data-frame.h
+++ b/src/type-data-frame.h
@@ -38,7 +38,7 @@ SEXP df_ptype2_params(SEXP x,
                       SEXP y,
                       struct vctrs_arg* x_arg,
                       struct vctrs_arg* y_arg,
-                      bool df_fallback) {
+                      enum df_fallback df_fallback) {
   const struct ptype2_opts opts = {
     .x = x,
     .y = y,

--- a/src/type.c
+++ b/src/type.c
@@ -198,14 +198,14 @@ SEXP vctrs_ptype_common_params(SEXP call, SEXP op, SEXP args, SEXP env) {
   SEXP ptype = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
   SEXP df_fallback = PROTECT(Rf_eval(CAR(args), env));
 
-  SEXP out = vec_ptype_common_params(types, ptype, r_lgl_get(df_fallback, 0));
+  SEXP out = vec_ptype_common_params(types, ptype, r_int_get(df_fallback, 0));
 
   UNPROTECT(3);
   return out;
 }
 
 // [[ include("ptype-common.h") ]]
-SEXP vec_ptype_common_params(SEXP dots, SEXP ptype, bool df_fallback) {
+SEXP vec_ptype_common_params(SEXP dots, SEXP ptype, enum df_fallback df_fallback) {
   if (!vec_is_partial(ptype)) {
     return vec_ptype(ptype, args_dot_ptype);
   }
@@ -228,7 +228,7 @@ static SEXP vctrs_type2_common(SEXP current,
                                struct counters* counters,
                                void* data) {
   int left = -1;
-  bool df_fallback = *((bool*) data);
+  enum df_fallback df_fallback = *((enum df_fallback*) data);
 
   const struct ptype2_opts opts = {
     .x = current,

--- a/src/type2.c
+++ b/src/type2.c
@@ -24,7 +24,7 @@ SEXP vctrs_ptype2_params(SEXP x,
     .y = y,
     .x_arg = &x_arg_,
     .y_arg = &y_arg_,
-    .df_fallback = r_lgl_get(df_fallback, 0)
+    .df_fallback = r_int_get(df_fallback, 0)
   };
 
   int _left;
@@ -161,7 +161,7 @@ bool vec_is_coercible(const struct ptype2_opts* opts,
 SEXP vctrs_is_coercible(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_, SEXP df_fallback_) {
   struct vctrs_arg x_arg = vec_as_arg(x_arg_);
   struct vctrs_arg y_arg = vec_as_arg(y_arg_);;
-  bool df_fallback = r_lgl_get(df_fallback_, 0);
+  enum df_fallback df_fallback = r_int_get(df_fallback_, 0);
 
   const struct ptype2_opts opts = {
     .x = x,

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -230,6 +230,13 @@ test_that("can't supply NA as `na_equal`", {
   expect_error(vec_compare(NA, NA, na_equal = NA), "single `TRUE` or `FALSE`")
 })
 
+test_that("vec_compare() silently falls back to base data frame", {
+  expect_silent(expect_identical(
+    vec_compare(foobar(mtcars), foobar(tibble::as_tibble(mtcars))),
+    rep(0L, 32)
+  ))
+})
+
 # order/sort --------------------------------------------------------------
 
 test_that("can request NAs sorted first", {

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -325,3 +325,14 @@ test_that("dictionary tools have informative errors", {
     vec_in(df1, df2, needles_arg = "n", haystack_arg = "h")
   })
 })
+
+test_that("vec_match() and vec_in() silently fall back to base data frame", {
+  expect_silent(expect_identical(
+    vec_match(foobar(mtcars), foobar(tibble::as_tibble(mtcars))),
+    1:32
+  ))
+  expect_silent(expect_identical(
+    vec_in(foobar(mtcars), foobar(tibble::as_tibble(mtcars))),
+    rep(TRUE, 32)
+  ))
+})

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -221,6 +221,13 @@ test_that("equal_scalar() compares", {
   expect_error(test_equal_scalar(expression(0), 0, expression(1), 1), "Unsupported")
 })
 
+test_that("vec_equal() silently falls back to base data frame", {
+  expect_silent(expect_identical(
+    vec_equal(foobar(mtcars), foobar(tibble::as_tibble(mtcars))),
+    rep(TRUE, 32)
+  ))
+})
+
 
 # object ------------------------------------------------------------------
 


### PR DESCRIPTION
`vec_match()`, `vec_in()`, `vec_equal()`, and `vec_compare()` now will compare any data frame subclasses. Currently uses the inefficient fallback path, this will need to be improved later.

Eventually we'll probably want to do this for any class that explictly inherits from its base type (i.e. one of the supported proxy type).

Also puts in place some infrastructure for falling back without warning, which we'll need for cbind and rbind prior to release.