### PR TITLE
Ignore names when an `rlang::zap()` is supplied as `.name_spec`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -190,6 +190,11 @@ The following errors are caused by breaking changes.
 
 * `new_data_frame()` infers size from row names when `n = NULL` (#894).
 
+* `vec_c()` now accepts `rlang::zap()` as `.name_spec` input. The
+  returned vector is then always unnamed, and the names do not cause
+  errors when they can't be combined. They are still used to create
+  more informative messages when the inputs have incompatible types (#232).
+
 
 ## Classes
 

--- a/R/c.R
+++ b/R/c.R
@@ -7,7 +7,10 @@
 #' * `vec_ptype(vec_c(x, y)) == vec_ptype_common(x, y)`.
 #'
 #' @param ... Vectors to coerce.
-#' @param .name_repair How to repair names, see `repair` options in [vec_as_names()].
+#' @param .name_repair How to repair names, see `repair` options in
+#'   [vec_as_names()].  Can also be [rlang::zap()] to ignore names
+#'   during concatenation. The names are still used to give
+#'   informative error messages, e.g. with coercion errors.
 #' @return A vector with class given by `.ptype`, and length equal to the
 #'   sum of the `vec_size()` of the contents of `...`.
 #'

--- a/man/vec_c.Rd
+++ b/man/vec_c.Rd
@@ -37,7 +37,10 @@ are passed as second argument.
 
 See the \link[=name_spec]{name specification topic}.}
 
-\item{.name_repair}{How to repair names, see \code{repair} options in \code{\link[=vec_as_names]{vec_as_names()}}.}
+\item{.name_repair}{How to repair names, see \code{repair} options in
+\code{\link[=vec_as_names]{vec_as_names()}}.  Can also be \code{\link[rlang:zap]{rlang::zap()}} to ignore names
+during concatenation. The names are still used to give
+informative error messages, e.g. with coercion errors.}
 }
 \value{
 A vector with class given by \code{.ptype}, and length equal to the

--- a/man/vec_chop.Rd
+++ b/man/vec_chop.Rd
@@ -48,7 +48,10 @@ are passed as second argument.
 
 See the \link[=name_spec]{name specification topic}.}
 
-\item{name_repair}{How to repair names, see \code{repair} options in \code{\link[=vec_as_names]{vec_as_names()}}.}
+\item{name_repair}{How to repair names, see \code{repair} options in
+\code{\link[=vec_as_names]{vec_as_names()}}.  Can also be \code{\link[rlang:zap]{rlang::zap()}} to ignore names
+during concatenation. The names are still used to give
+informative error messages, e.g. with coercion errors.}
 }
 \value{
 \itemize{

--- a/src/names.c
+++ b/src/names.c
@@ -515,6 +515,10 @@ static SEXP glue_as_name_spec(SEXP spec);
 
 // [[ include("utils.h") ]]
 SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n) {
+  if (Rf_inherits(name_spec, "rlang_zap")) {
+    return R_NilValue;
+  }
+
   if (outer == R_NilValue) {
     return inner;
   }

--- a/tests/testthat/error/test-c.txt
+++ b/tests/testthat/error/test-c.txt
@@ -34,3 +34,10 @@ See <https://vctrs.r-lib.org/articles/s3-vector.html>.
 > with_c_foobar(vec_c(foobar(1), foobar(2), .ptype = ""))
 Error: Can't convert <vctrs_foobar> to <character>.
 
+
+can ignore names by providing a `zap()` name-spec (#232)
+========================================================
+
+> vec_c(a = c(b = letters), b = 1, .name_spec = zap())
+Error: Can't combine `a` <character> and `b` <double>.
+

--- a/tests/testthat/error/test-unchop.txt
+++ b/tests/testthat/error/test-unchop.txt
@@ -72,3 +72,10 @@ Error: Must subset elements with a valid subscript vector.
 x Subscript has the wrong type `vctrs_foobar`.
 i It must be numeric.
 
+
+can ignore names in `vec_unchop()` by providing a `zap()` name-spec (#232)
+==========================================================================
+
+> vec_unchop(list(a = c(b = letters), b = 3L), name_spec = zap())
+Error: Can't combine `a` <character> and `b` <integer>.
+

--- a/tests/testthat/error/test-unchop.txt
+++ b/tests/testthat/error/test-unchop.txt
@@ -79,3 +79,7 @@ can ignore names in `vec_unchop()` by providing a `zap()` name-spec (#232)
 > vec_unchop(list(a = c(b = letters), b = 3L), name_spec = zap())
 Error: Can't combine `a` <character> and `b` <integer>.
 
+> vec_unchop(list(a = c(foo = 1:2), b = c(bar = "")), indices = list(2:1, 3),
++ name_spec = zap())
+Error: Can't combine `a` <integer> and `b` <character>.
+

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -324,7 +324,7 @@ test_that("vec_implements_ptype2() and vec_c() fallback are compatible with old 
   expect_identical(vec_c(bar), bar)
 })
 
-test_that("can ignore names by providing a `zap()` name-spec (#232)", {
+test_that("can ignore names in `vec_c()` by providing a `zap()` name-spec (#232)", {
   expect_error(vec_c(a = c(b = 1:2)))
   expect_identical(vec_c(a = c(b = 1:2), b = 3L, .name_spec = zap()), 1:3)
   verify_errors({

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -324,6 +324,17 @@ test_that("vec_implements_ptype2() and vec_c() fallback are compatible with old 
   expect_identical(vec_c(bar), bar)
 })
 
+test_that("can ignore names by providing a `zap()` name-spec (#232)", {
+  expect_error(vec_c(a = c(b = 1:2)))
+  expect_identical(vec_c(a = c(b = 1:2), b = 3L, .name_spec = zap()), 1:3)
+  verify_errors({
+    expect_error(
+      vec_c(a = c(b = letters), b = 1, .name_spec = zap()),
+      class = "vctrs_error_incompatible_type"
+    )
+  })
+})
+
 test_that("vec_c() has informative error messages", {
   verify_output(test_path("error", "test-c.txt"), {
     "# vec_c() fails with complex foreign S3 classes"
@@ -339,5 +350,8 @@ test_that("vec_c() has informative error messages", {
     "# vec_c() fallback doesn't support `name_spec` or `ptype`"
     with_c_foobar(vec_c(foobar(1), foobar(2), .name_spec = "{outer}_{inner}"))
     with_c_foobar(vec_c(foobar(1), foobar(2), .ptype = ""))
+
+    "# can ignore names by providing a `zap()` name-spec (#232)"
+    vec_c(a = c(b = letters), b = 1, .name_spec = zap())
   })
 })

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -689,10 +689,30 @@ test_that("vec_unchop() does not support non-numeric S3 indices", {
 
 test_that("can ignore names in `vec_unchop()` by providing a `zap()` name-spec (#232)", {
   expect_error(vec_unchop(list(a = c(b = 1:2))))
-  expect_identical(vec_unchop(list(a = c(b = 1:2), b = 3L), name_spec = zap()), 1:3)
+  expect_identical(
+    vec_unchop(list(a = c(b = 1:2), b = 3L), name_spec = zap()),
+    1:3
+  )
+  expect_identical(
+    vec_unchop(
+      list(a = c(foo = 1:2), b = c(bar = 3L)),
+      indices = list(2:1, 3),
+      name_spec = zap()
+    ),
+    c(2L, 1L, 3L)
+  )
+
   verify_errors({
     expect_error(
       vec_unchop(list(a = c(b = letters), b = 3L), name_spec = zap()),
+      class = "vctrs_error_incompatible_type"
+    )
+    expect_error(
+      vec_unchop(
+        list(a = c(foo = 1:2), b = c(bar = "")),
+        indices = list(2:1, 3),
+        name_spec = zap()
+      ),
       class = "vctrs_error_incompatible_type"
     )
   })
@@ -731,5 +751,10 @@ test_that("vec_unchop() has informative error messages", {
 
     "# can ignore names in `vec_unchop()` by providing a `zap()` name-spec (#232)"
     vec_unchop(list(a = c(b = letters), b = 3L), name_spec = zap())
+    vec_unchop(
+        list(a = c(foo = 1:2), b = c(bar = "")),
+        indices = list(2:1, 3),
+        name_spec = zap()
+      )
   })
 })

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -687,6 +687,17 @@ test_that("vec_unchop() does not support non-numeric S3 indices", {
   })
 })
 
+test_that("can ignore names in `vec_unchop()` by providing a `zap()` name-spec (#232)", {
+  expect_error(vec_unchop(list(a = c(b = 1:2))))
+  expect_identical(vec_unchop(list(a = c(b = 1:2), b = 3L), name_spec = zap()), 1:3)
+  verify_errors({
+    expect_error(
+      vec_unchop(list(a = c(b = letters), b = 3L), name_spec = zap()),
+      class = "vctrs_error_incompatible_type"
+    )
+  })
+})
+
 test_that("vec_unchop() has informative error messages", {
   verify_output(test_path("error", "test-unchop.txt"), {
     "# vec_unchop() errors on unsupported location values"
@@ -717,5 +728,8 @@ test_that("vec_unchop() has informative error messages", {
     "# vec_unchop() does not support non-numeric S3 indices"
     vec_unchop(list(1), list(factor("x")))
     vec_unchop(list(1), list(foobar(1L)))
+
+    "# can ignore names in `vec_unchop()` by providing a `zap()` name-spec (#232)"
+    vec_unchop(list(a = c(b = letters), b = 3L), name_spec = zap())
   })
 })


### PR DESCRIPTION
Closes #232

Part of tidyverse/dplyr#5099