### PR TITLE
Expose `action` in `stop_incompatible_type()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,8 @@ The following errors are caused by breaking changes.
   aligns it with `vec_ptype2()` now that they are restricted to the same
   conversions.
 
+* The `y` argument of `stop_incompatible_cast()` has been renamed to `to` to
+  better match `to_arg`.
 
 ## Type system
 
@@ -243,6 +245,11 @@ The following errors are caused by breaking changes.
 
 
 ## Conditions
+
+* `stop_incompatible_type()` now has an `action` argument for customizing
+  whether the coercion error came from `vec_ptype2()` or `vec_cast()`.
+  `stop_incompatible_cast()` is now a thin wrapper around
+  `stop_incompatible_type(action = "convert")`.
 
 * `stop_` functions now take `details` after the dots. This argument
   can no longer be passed by position.

--- a/man/maybe_lossy_cast.Rd
+++ b/man/maybe_lossy_cast.Rd
@@ -43,13 +43,13 @@ locations where \code{x} lost information.}
 messages. Can be loss of precision (for instance from double to
 integer) or loss of generality (from character to factor).}
 
-\item{x_arg}{Argument names for \code{x} and \code{to}. These are used
-in error messages to inform the user about the locations of
-incompatible types (see \code{\link[=stop_incompatible_type]{stop_incompatible_type()}}).}
+\item{x_arg}{Argument names for \code{x}, \code{y}, and \code{to}. Used in
+error messages to inform the user about the locations of incompatible
+types.}
 
-\item{to_arg}{Argument names for \code{x} and \code{to}. These are used
-in error messages to inform the user about the locations of
-incompatible types (see \code{\link[=stop_incompatible_type]{stop_incompatible_type()}}).}
+\item{to_arg}{Argument names for \code{x}, \code{y}, and \code{to}. Used in
+error messages to inform the user about the locations of incompatible
+types.}
 
 \item{details}{Any additional human readable details.}
 

--- a/man/vctrs-conditions.Rd
+++ b/man/vctrs-conditions.Rd
@@ -15,6 +15,7 @@ stop_incompatible_type(
   ...,
   x_arg,
   y_arg,
+  action = c("combine", "convert"),
   details = NULL,
   message = NULL,
   class = NULL
@@ -22,7 +23,7 @@ stop_incompatible_type(
 
 stop_incompatible_cast(
   x,
-  y,
+  to,
   ...,
   x_arg,
   to_arg,
@@ -57,9 +58,17 @@ stop_incompatible_size(
 allow_lossy_cast(expr, x_ptype = NULL, to_ptype = NULL)
 }
 \arguments{
-\item{x, y}{Vectors}
+\item{x, y, to}{Vectors}
 
 \item{..., class}{Only use these fields when creating a subclass.}
+
+\item{x_arg, y_arg, to_arg}{Argument names for \code{x}, \code{y}, and \code{to}. Used in
+error messages to inform the user about the locations of incompatible
+types.}
+
+\item{action}{An option to customize the incompatible type message depending
+on the context. Errors thrown from \code{\link[=vec_ptype2]{vec_ptype2()}} use \code{"combine"} and
+those thrown from \code{\link[=vec_cast]{vec_cast()}} use \code{"convert"}.}
 
 \item{details}{Any additional human readable details.}
 
@@ -69,7 +78,7 @@ allow_lossy_cast(expr, x_ptype = NULL, to_ptype = NULL)
 \item{x_ptype, to_ptype}{Suppress only the casting errors where \code{x}
 or \code{to} match these \link[=vec_ptype]{prototypes}.}
 
-\item{subclass}{Use if you want to further customise the class.}
+\item{subclass}{Use if you want to further customize the class.}
 }
 \value{
 \verb{stop_incompatible_*()} unconditionally raise an error of class

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -16,48 +16,33 @@ void vec_assert(SEXP x, struct vctrs_arg* arg) {
   }
 }
 
-static __attribute__((noreturn))
-void stop_incompatible_type_impl(SEXP x,
-                                 SEXP y,
-                                 struct vctrs_arg* x_arg,
-                                 struct vctrs_arg* y_arg,
-                                 bool cast) {
-  SEXP syms[5] = {
-    syms_x,
-    syms_y,
-    syms_x_arg,
-    cast ? syms_to_arg : syms_y_arg,
-    NULL
-  };
-  SEXP args[5] = {
-    PROTECT(r_protect(x)),
-    PROTECT(r_protect(y)),
-    PROTECT(vctrs_arg(x_arg)),
-    PROTECT(vctrs_arg(y_arg)),
-    NULL
-  };
-
-  SEXP fn = cast ? syms_stop_incompatible_cast : syms_stop_incompatible_type;
-
-  SEXP call = PROTECT(r_call(fn, syms, args));
-  Rf_eval(call, vctrs_ns_env);
-
-  never_reached("stop_incompatible_type_impl");
-}
-
 // [[ include("vctrs.h") ]]
 void stop_incompatible_type(SEXP x,
                             SEXP y,
                             struct vctrs_arg* x_arg,
-                            struct vctrs_arg* y_arg) {
-  stop_incompatible_type_impl(x, y, x_arg, y_arg, false);
-}
-// [[ include("vctrs.h") ]]
-void stop_incompatible_cast(SEXP x,
-                            SEXP y,
-                            struct vctrs_arg* x_arg,
-                            struct vctrs_arg* y_arg) {
-  stop_incompatible_type_impl(x, y, x_arg, y_arg, true);
+                            struct vctrs_arg* y_arg,
+                            bool cast) {
+  SEXP syms[6] = {
+    syms_x,
+    syms_y,
+    syms_x_arg,
+    syms_y_arg,
+    syms_action,
+    NULL
+  };
+  SEXP args[6] = {
+    PROTECT(r_protect(x)),
+    PROTECT(r_protect(y)),
+    PROTECT(vctrs_arg(x_arg)),
+    PROTECT(vctrs_arg(y_arg)),
+    cast ? chrs_convert : chrs_combine,
+    NULL
+  };
+
+  SEXP call = PROTECT(r_call(syms_stop_incompatible_type, syms, args));
+  Rf_eval(call, vctrs_ns_env);
+
+  never_reached("stop_incompatible_type");
 }
 
 // [[ include("vctrs.h") ]]

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -50,11 +50,7 @@ SEXP ord_ptype2_validate(SEXP x,
   }
 
   if (!equal_object(x_levels, y_levels)) {
-    if (cast) {
-      stop_incompatible_cast(x, y, x_arg, y_arg);
-    } else {
-      stop_incompatible_type(x, y, x_arg, y_arg);
-    }
+    stop_incompatible_type(x, y, x_arg, y_arg, cast);
   }
 
   return x_levels;

--- a/src/utils.c
+++ b/src/utils.c
@@ -1478,6 +1478,8 @@ SEXP chrs_function = NULL;
 SEXP chrs_empty = NULL;
 SEXP chrs_cast = NULL;
 SEXP chrs_error = NULL;
+SEXP chrs_combine = NULL;
+SEXP chrs_convert = NULL;
 
 SEXP syms_i = NULL;
 SEXP syms_n = NULL;
@@ -1523,7 +1525,7 @@ SEXP syms_from_dispatch = NULL;
 SEXP syms_df_fallback = NULL;
 SEXP syms_stop_incompatible_type = NULL;
 SEXP syms_stop_incompatible_size = NULL;
-SEXP syms_stop_incompatible_cast = NULL;
+SEXP syms_action = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -1676,6 +1678,8 @@ void vctrs_init_utils(SEXP ns) {
   chrs_empty = r_new_shared_character("");
   chrs_cast = r_new_shared_character("cast");
   chrs_error = r_new_shared_character("error");
+  chrs_combine = r_new_shared_character("combine");
+  chrs_convert = r_new_shared_character("convert");
 
   classes_tibble = r_new_shared_vector(STRSXP, 3);
 
@@ -1767,7 +1771,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_df_fallback = Rf_install("vctrs:::df_fallback");
   syms_stop_incompatible_type = Rf_install("stop_incompatible_type");
   syms_stop_incompatible_size = Rf_install("stop_incompatible_size");
-  syms_stop_incompatible_cast = Rf_install("stop_incompatible_cast");
+  syms_action = Rf_install("action");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.h
+++ b/src/utils.h
@@ -433,6 +433,8 @@ extern SEXP chrs_function;
 extern SEXP chrs_empty;
 extern SEXP chrs_cast;
 extern SEXP chrs_error;
+extern SEXP chrs_combine;
+extern SEXP chrs_convert;
 
 extern SEXP syms_i;
 extern SEXP syms_n;
@@ -477,7 +479,7 @@ extern SEXP syms_from_dispatch;
 extern SEXP syms_df_fallback;
 extern SEXP syms_stop_incompatible_type;
 extern SEXP syms_stop_incompatible_size;
-extern SEXP syms_stop_incompatible_cast;
+extern SEXP syms_action;
 
 #define syms_names R_NamesSymbol
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -612,12 +612,8 @@ __attribute__((noreturn))
 void stop_incompatible_type(SEXP x,
                             SEXP y,
                             struct vctrs_arg* x_arg,
-                            struct vctrs_arg* y_arg);
-__attribute__((noreturn))
-void stop_incompatible_cast(SEXP x,
-                            SEXP y,
-                            struct vctrs_arg* x_arg,
-                            struct vctrs_arg* y_arg);
+                            struct vctrs_arg* y_arg,
+                            bool cast);
 __attribute__((noreturn))
 void stop_recycle_incompatible_size(R_len_t x_size, R_len_t size,
                                     struct vctrs_arg* x_arg);

--- a/tests/testthat/error/test-conditions.txt
+++ b/tests/testthat/error/test-conditions.txt
@@ -1,4 +1,15 @@
 
+incompatible type error validates `action`
+==========================================
+
+> stop_incompatible_type(1, 1, x_arg = "", y_arg = "", action = "conver")
+Error: `action` must be one of "combine" or "convert".
+Did you mean "convert"?
+
+> stop_incompatible_type(1, 1, x_arg = "", y_arg = "", action = 1)
+Error: `action` must be a character vector.
+
+
 can override arg in OOB conditions
 ==================================
 

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -2,8 +2,8 @@ context("conditions")
 
 test_that("conditions inherit from `vctrs_error`", {
   expect_error(stop_incompatible(NULL, NULL), class = "vctrs_error")
-  expect_error(stop_incompatible_type(NULL, NULL), class = "vctrs_error")
-  expect_error(stop_incompatible_cast(NULL, NULL), class = "vctrs_error")
+  expect_error(stop_incompatible_type(NULL, NULL, x_arg = "x", y_arg = "y"), class = "vctrs_error")
+  expect_error(stop_incompatible_cast(NULL, NULL, x_arg = "x", to_arg = "to"), class = "vctrs_error")
   expect_error(stop_incompatible_op("", NULL, NULL), class = "vctrs_error")
   expect_error(stop_incompatible_size(NULL, NULL, 0, 0), class = "vctrs_error")
   expect_error(maybe_lossy_cast(NULL, NULL, NULL, TRUE, x_arg = "x", to_arg = "to"), class = "vctrs_error")
@@ -21,6 +21,13 @@ test_that("incompatible cast throws an incompatible type error", {
     stop_incompatible_cast(1, 1, x_arg = "x", to_arg = "to"),
     class = "vctrs_error_incompatible_type"
   )
+})
+
+test_that("incompatible type error validates `action`", {
+  verify_errors({
+    expect_error(stop_incompatible_type(1, 1, x_arg = "", y_arg = "", action = "c"))
+    expect_error(stop_incompatible_type(1, 1, x_arg = "", y_arg = "", action = 1))
+  })
 })
 
 test_that("can override arg in OOB conditions", {
@@ -139,6 +146,10 @@ test_that("ordered cast failures mention conversion", {
 })
 
 verify_output(test_path("error", "test-conditions.txt"), {
+  "# incompatible type error validates `action`"
+  stop_incompatible_type(1, 1, x_arg = "", y_arg = "", action = "conver")
+  stop_incompatible_type(1, 1, x_arg = "", y_arg = "", action = 1)
+
   "# can override arg in OOB conditions"
   with_subscript_data(
     vec_slice(set_names(letters), "foo"),

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -97,7 +97,7 @@ test_that("vec_ptype2() forwards argument tag", {
 })
 
 test_that("stop_incompatible_type() checks for scalars", {
-  expect_error(stop_incompatible_type(NA, foobar()), class = "vctrs_error_scalar_type")
+  expect_error(stop_incompatible_type(NA, foobar(), x_arg = "x", y_arg = "y"), class = "vctrs_error_scalar_type")
   expect_error(vec_ptype_common(NA, foobar()), class = "vctrs_error_scalar_type")
   expect_error(vec_ptype_common(foobar(), list()), class = "vctrs_error_scalar_type")
 })


### PR DESCRIPTION
Closes #1088 

- Fixes the signature of `stop_incompatible_cast(x, y)` by changing `y` to `to`

- Exposes `action = c("combine", "convert")` in `stop_incompatible_type()`.

- Removes a number of internal condition helpers now that `stop_incompatible_type()` takes `action` directly

- `stop_incompatible_cast()` is now a thin wrapper around `stop_incompatible_type()`, but with more intuitive arguments of `to`, `to_arg`, and with `action = "convert"` already set so you don't forget. @lionel- mentioned that we might revisit the need for this wrapper in the future.

- Reworked C condition internals to only use `stop_incompatible_type()` and pass `action` through.