### PR TITLE
Add `.name_spec` argument to `vec_rbind()`

### DIFF
--- a/R/bind.R
+++ b/R/bind.R
@@ -142,12 +142,18 @@
 NULL
 
 #' @export
+#' @param .name_spec A name specification (as documented in [vec_c()])
+#'   for combining the outer inputs names in `...` and the inner row
+#'   names of the inputs. This only has an effect when `.names_to` is
+#'   set to `NULL`, which causes the input names to be assigned as row
+#'   names.
 #' @rdname vec_bind
 vec_rbind <- function(...,
                       .ptype = NULL,
                       .names_to = rlang::zap(),
-                      .name_repair = c("unique", "universal", "check_unique")) {
-  .External2(vctrs_rbind, .ptype, .names_to, .name_repair)
+                      .name_repair = c("unique", "universal", "check_unique"),
+                      .name_spec = NULL) {
+  .External2(vctrs_rbind, .ptype, .names_to, .name_repair, .name_spec)
 }
 vec_rbind <- fn_inline_formals(vec_rbind, ".name_repair")
 

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -10,7 +10,8 @@ vec_rbind(
   ...,
   .ptype = NULL,
   .names_to = rlang::zap(),
-  .name_repair = c("unique", "universal", "check_unique")
+  .name_repair = c("unique", "universal", "check_unique"),
+  .name_spec = NULL
 )
 
 vec_cbind(
@@ -64,6 +65,12 @@ have unique names. On the other hand, \code{vec_cbind()} applies the
 repair function after all inputs have been concatenated together
 in a final data frame. Hence \code{vec_cbind()} allows the more
 permissive minimal names repair.}
+
+\item{.name_spec}{A name specification (as documented in \code{\link[=vec_c]{vec_c()}})
+for combining the outer inputs names in \code{...} and the inner row
+names of the inputs. This only has an effect when \code{.names_to} is
+set to \code{NULL}, which causes the input names to be assigned as row
+names.}
 
 \item{.size}{If, \code{NULL}, the default, will determine the number of
 rows in \code{vec_cbind()} output by using the standard recycling rules.

--- a/src/init.c
+++ b/src/init.c
@@ -264,7 +264,7 @@ extern SEXP vctrs_size_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_recycle_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cast_common(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cast_common_params(SEXP, SEXP, SEXP, SEXP);
-extern SEXP vctrs_rbind(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_rbind(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cbind(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_c(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_new_data_frame(SEXP);
@@ -276,7 +276,7 @@ static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_recycle_common",             (DL_FUNC) &vctrs_recycle_common, 1},
   {"vctrs_cast_common",                (DL_FUNC) &vctrs_cast_common, 1},
   {"vctrs_cast_common_params",         (DL_FUNC) &vctrs_cast_common_params, 2},
-  {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 3},
+  {"vctrs_rbind",                      (DL_FUNC) &vctrs_rbind, 4},
   {"vctrs_cbind",                      (DL_FUNC) &vctrs_cbind, 3},
   {"vctrs_c",                          (DL_FUNC) &vctrs_c, 3},
   {"vctrs_new_data_frame",             (DL_FUNC) &vctrs_new_data_frame, -1},

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -219,14 +219,24 @@ test_that("can assign row names in vec_rbind()", {
   df1 <- mtcars[1:3, ]
   df2 <- mtcars[4:5, ]
 
+  expect_error(
+    vec_rbind(
+      foo = df1,
+      df2,
+      .names_to = NULL
+    ),
+    "specification"
+  )
+
   # Combination
   out <- vec_rbind(
     foo = df1,
     df2,
-    .names_to = NULL
+    .names_to = NULL,
+    .name_spec = "{outer}_{inner}"
   )
   exp <- mtcars[1:5, ]
-  row.names(exp) <- c(paste0("foo...", row.names(df1)), row.names(df2))
+  row.names(exp) <- c(paste0("foo_", row.names(df1)), row.names(df2))
   expect_identical(out, exp)
 
   out <- vec_rbind(foo = df1, df2, .names_to = "id")


### PR DESCRIPTION
For consistency with `vec_c()`.
Closes #966.