### PR TITLE
Fix UBSAN error

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,5 @@
 
-* The UBSAN error is fixed.
-* The r-devel warning is fixed.
+This is a resubmission to fix the SAN error.
 
 
 ## Test environments

--- a/src/subscript.c
+++ b/src/subscript.c
@@ -165,17 +165,21 @@ static SEXP dbl_cast_subscript(SEXP subscript,
       continue;
     }
 
-    int out_elt = (int) elt;
-
-    // Detect out-of-bounds and fractional numbers
-    if (elt > INT_MAX || out_elt != elt) {
+    if (!isfinite(elt) || elt > INT_MAX) {
       // Once we throw lazy errors from the cast method, we should
       // throw the error here as well
       UNPROTECT(1);
       return dbl_cast_subscript_fallback(subscript, opts, err);
     }
 
-    out_p[i] = out_elt;
+    int elt_int = (int) elt;
+
+    if (elt != elt_int) {
+      UNPROTECT(1);
+      return dbl_cast_subscript_fallback(subscript, opts, err);
+    }
+
+    out_p[i] = elt_int;
   }
 
   UNPROTECT(1);

--- a/src/subscript.c
+++ b/src/subscript.c
@@ -165,7 +165,7 @@ static SEXP dbl_cast_subscript(SEXP subscript,
       continue;
     }
 
-    if (!isfinite(elt) || elt > INT_MAX) {
+    if (!isfinite(elt) || elt <= INT_MIN || elt > INT_MAX) {
       // Once we throw lazy errors from the cast method, we should
       // throw the error here as well
       UNPROTECT(1);

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -169,6 +169,14 @@ i It must be numeric or character.
 Error: Must extract element with a single valid subscript.
 x Can't convert from <double> to <integer> due to loss of precision.
 
+> vec_as_location2(Inf, 10L)
+Error: Must extract element with a single valid subscript.
+x Can't convert from <double> to <integer> due to loss of precision.
+
+> vec_as_location2(-Inf, 10L)
+Error: Must extract element with a single valid subscript.
+x Can't convert from <double> to <integer> due to loss of precision.
+
 > # Idem with custom `arg`
 > vec_as_location2(foobar(), 10L, arg = "foo")
 Error: Must extract element with a single valid subscript.

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -11,6 +11,8 @@ test_that("vec_as_location2() requires integer or character inputs", {
     expect_error(vec_as_location2(env(), 10L), class = "vctrs_error_subscript_type")
     expect_error(vec_as_location2(foobar(), 10L), class = "vctrs_error_subscript_type")
     expect_error(vec_as_location2(2.5, 10L), class = "vctrs_error_subscript_type")
+    expect_error(vec_as_location2(Inf, 10L), class = "vctrs_error_subscript_type")
+    expect_error(vec_as_location2(-Inf, 10L), class = "vctrs_error_subscript_type")
 
     "Idem with custom `arg`"
     expect_error(vec_as_location2(foobar(), 10L, arg = "foo"), class = "vctrs_error_subscript_type")
@@ -481,6 +483,8 @@ test_that("conversion to locations has informative error messages", {
     vec_as_location2(env(), 10L)
     vec_as_location2(foobar(), 10L)
     vec_as_location2(2.5, 3L)
+    vec_as_location2(Inf, 10L)
+    vec_as_location2(-Inf, 10L)
     "Idem with custom `arg`"
     vec_as_location2(foobar(), 10L, arg = "foo")
     vec_as_location2(2.5, 3L, arg = "foo")


### PR DESCRIPTION

```
vctrs.Rcheck/tests/testthat.Rout:subscript.c:168:19: runtime error: 2.14748e+09 is outside the range of representable values of type 'int'
    #0 0x7f21c83e0d08 in dbl_cast_subscript /data/gannet/ripley/R/packages/incoming/vctrs.Rcheck/00_pkg_src/vctrs/src/subscript.c:168:19
    #1 0x7f21c83e0d08 in vec_as_subscript_opts /data/gannet/ripley/R/packages/incoming/vctrs.Rcheck/00_pkg_src/vctrs/src/subscript.c:61:17
    #2 0x7f21c83dc678 in vec_as_location_opts /data/gannet/ripley/R/packages/incoming/vctrs.Rcheck/00_pkg_src/vctrs/src/subscript-loc.c:292:15
    #3 0x7f21c83deba1 in vctrs_as_location /data/gannet/ripley/R/packages/incoming/vctrs.Rcheck/00_pkg_src/vctrs/src/subscript-loc.c:418:10 
```

Can't reproduce these warnings, but hopefully this fixes it:

* Check for all non-finite values.
* Check for range before coercion.