### PR TITLE
Proxy and restore in `vec_rbind()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* `vec_rbind()` now internally calls `vec_proxy()` and `vec_restore()` on
+  the data frame common type that is used to create the output (#1109).
+
 * The documentation of vctrs functions now includes a Dependencies
   section to reference which other vctrs operations are called from
   that function. By following the dependencies links recursively, you

--- a/src/bind.c
+++ b/src/bind.c
@@ -113,8 +113,13 @@ static SEXP vec_rbind(SEXP xs,
     }
   }
 
+  SEXP proxy = PROTECT(vec_proxy(ptype));
+  if (!is_data_frame(proxy)) {
+    Rf_errorcall(R_NilValue, "Can't fill a data frame that doesn't have a data frame proxy.");
+  }
+
   PROTECT_INDEX out_pi;
-  SEXP out = vec_init(ptype, nrow);
+  SEXP out = vec_init(proxy, nrow);
   PROTECT_WITH_INDEX(out, &out_pi);
 
   SEXP idx = PROTECT_N(compact_seq(0, 0, true), &nprot);
@@ -224,8 +229,11 @@ static SEXP vec_rbind(SEXP xs,
     out = df_poke(out, names_to_loc, names_to_col);
   }
 
+  out = vec_restore(out, ptype, r_int(nrow));
+  REPROTECT(out, out_pi);
+
   UNPROTECT(nprot);
-  UNPROTECT(2);
+  UNPROTECT(3);
   return out;
 }
 

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -285,7 +285,7 @@ test_that("vec_rbind() takes the proxy and restores", {
       if (any(is.na(x$x))) {
         new_data_frame(x)
       } else {
-        NextMethod()
+        vec_restore_default(x, to)
       }
     }
   )
@@ -313,7 +313,7 @@ test_that("vec_rbind() proxies before initializing", {
       if (any(is.na(x$x))) {
         abort("`x` can't have NA values.")
       }
-      NextMethod()
+      vec_restore_default(x, to)
     }
   )
 

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -267,6 +267,73 @@ test_that("can assign row names in vec_rbind()", {
   expect_identical(out, exp)
 })
 
+test_that("vec_rbind() takes the proxy and restores", {
+  df <- foobar(data.frame(x = 1))
+
+  # This data frame subclass has an identity proxy and the restore
+  # method falls back to a bare data frame if `$x` has any missing values.
+  # In `vec_rbind()`, the `vec_init()` call will create a bare data frame,
+  # but at the end it is `vec_restore()`d to the right class.
+  local_methods(
+    vec_ptype2.vctrs_foobar.vctrs_foobar = function(x, y, ...) {
+      x
+    },
+    vec_proxy.vctrs_foobar = function(x, ...) {
+      x
+    },
+    vec_restore.vctrs_foobar = function(x, to, ...) {
+      if (any(is.na(x$x))) {
+        new_data_frame(x)
+      } else {
+        NextMethod()
+      }
+    }
+  )
+
+  expect_identical(
+    vec_rbind(df, df),
+    foobar(data.frame(x = c(1, 1)))
+  )
+})
+
+test_that("vec_rbind() proxies before initializing", {
+  df <- foobar(data.frame(x = 1))
+
+  # This data frame subclass doesn't allow `NA`s in columns.
+  # If initialization happened before proxying, it would try to
+  # create `NA` rows with `vec_init()`.
+  local_methods(
+    vec_ptype2.vctrs_foobar.vctrs_foobar = function(x, y, ...) {
+      x
+    },
+    vec_proxy.vctrs_foobar = function(x, ...) {
+      new_data_frame(x)
+    },
+    vec_restore.vctrs_foobar = function(x, to, ...) {
+      if (any(is.na(x$x))) {
+        abort("`x` can't have NA values.")
+      }
+      NextMethod()
+    }
+  )
+
+  expect_identical(
+    vec_rbind(df, df),
+    foobar(data.frame(x = c(1, 1)))
+  )
+})
+
+test_that("vec_rbind() requires a data frame proxy for data frame ptypes", {
+  df <- foobar(data.frame(x = 1))
+
+  local_methods(
+    vec_ptype2.vctrs_foobar.vctrs_foobar = function(x, y, ...) x,
+    vec_proxy.vctrs_foobar = function(x, ...) 1
+  )
+
+  expect_error(vec_rbind(df, df), "doesn't have a data frame proxy")
+})
+
 test_that("monitoring: name repair while rbinding doesn't modify in place", {
   df <- new_data_frame(list(x = 1, x = 1))
   expect <- new_data_frame(list(x = 1, x = 1))


### PR DESCRIPTION
Part of #1107 

This PR ensures that `vec_rbind()` proxies the data frame ptype before initializing it, and then restores after filling it.

The tests are a little long, but I think they capture two important use cases:

1) A data frame subclass might fallback to a bare data frame in `vec_restore()` if certain conditions aren't met. (the dials case)

2) A data frame subclass might error in `vec_restore()` if certain conditions aren't met