### PR TITLE
Fix unspecified fallback

### DIFF
--- a/R/c.R
+++ b/R/c.R
@@ -81,7 +81,7 @@ base_c_invoke <- function(xs) {
   # position and might not be handled correctly by methods
   xs <- compact(xs)
 
-  unspecified <- map_lgl(xs, is_unspecified)
+  unspecified <- map_lgl(xs, fallback_is_unspecified)
   if (!any(unspecified)) {
     return(base_c(xs))
   }
@@ -100,6 +100,15 @@ base_c_invoke <- function(xs) {
 
   # Expand the concatenated vector with unspecified chunks
   out[locs]
+}
+
+# FIXME: Should be unnecessary in the future. We currently attach an
+# attribute to unspecified columns initialised in `df_cast()`. We
+# can't use an unspecified vector because we (unnecessarily but for
+# convenience) go through `vec_assign()` before falling back in
+# `vec_rbind()`.
+fallback_is_unspecified <- function(x) {
+  is_unspecified(x) || is_true(attr(x, "vctrs:::unspecified"))
 }
 
 c_locs <- function(xs) {

--- a/R/cast.R
+++ b/R/cast.R
@@ -97,6 +97,9 @@ vec_cast_common_params <- function(...,
   )
   vec_cast_common_opts(..., .to = .to, .opts = opts)
 }
+vec_cast_common_fallback <- function(..., .to = NULL) {
+  vec_cast_common_opts(..., .to = .to, .opts = fallback_ptype2_opts())
+}
 
 #' @rdname vec_default_ptype2
 #' @inheritParams vec_cast

--- a/src/c.c
+++ b/src/c.c
@@ -291,15 +291,10 @@ SEXP vec_c_fallback_invoke(SEXP xs, SEXP name_spec) {
     stop_vec_c_fallback(xs, err_type);
   }
 
-  SEXP args = PROTECT(Rf_coerceVector(xs, LISTSXP));
-  args = PROTECT(node_compact_d(args));
+  SEXP call = PROTECT(Rf_lang2(Rf_install("base_c_invoke"), xs));
+  SEXP out = Rf_eval(call, vctrs_ns_env);
 
-  SEXP call = PROTECT(Rf_lcons(Rf_install("c"), args));
-
-  // Dispatch in the base namespace which inherits from the global env
-  SEXP out = Rf_eval(call, R_BaseNamespace);
-
-  UNPROTECT(3);
+  UNPROTECT(1);
   return out;
 }
 

--- a/src/ptype2.h
+++ b/src/ptype2.h
@@ -95,5 +95,10 @@ SEXP vec_invoke_coerce_method(SEXP method_sym,
                               SEXP y_arg,
                               const struct fallback_opts* opts);
 
+SEXP vec_ptype2_from_unspecified(const struct ptype2_opts* opts,
+                                 enum vctrs_type other_type,
+                                 SEXP other,
+                                 struct vctrs_arg* other_arg);
+
 
 #endif

--- a/src/type2.c
+++ b/src/type2.c
@@ -120,7 +120,7 @@ SEXP vec_ptype2_switch_native(const struct ptype2_opts* opts,
  *
  * This is normally the `vec_ptype()` of the other input, but if the
  * common class fallback is enabled we return the `vec_ptype2()` of
- * this input. This way we may return a fallback sentinel which can be
+ * this input with itself. This way we may return a fallback sentinel which can be
  * treated specially, for instance in `vec_c(NA, x, NA)`.
  */
 SEXP vec_ptype2_from_unspecified(const struct ptype2_opts* opts,

--- a/src/utils.c
+++ b/src/utils.c
@@ -1620,6 +1620,19 @@ void c_print_backtrace() {
 #endif
 }
 
+void r_browse(SEXP x) {
+  r_env_poke(R_GlobalEnv, Rf_install(".debug"), x);
+
+  Rprintf("Object saved in `.debug`:\n");
+  Rf_PrintValue(x);
+
+  // `browser()` can't be trailing due to ESS limitations
+  SEXP call = PROTECT(r_parse("{ base::browser(); NULL }"));
+  Rf_eval(call, R_GlobalEnv);
+
+  UNPROTECT(1);
+}
+
 void vctrs_init_utils(SEXP ns) {
   vctrs_ns_env = ns;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -137,6 +137,11 @@ bool vec_implements_ptype2(SEXP x);
 
 SEXP r_env_get(SEXP env, SEXP sym);
 
+static inline
+void r_env_poke(SEXP env, SEXP sym, SEXP value) {
+  Rf_defineVar(sym, value, env);
+}
+
 extern SEXP syms_s3_methods_table;
 static inline SEXP s3_get_table(SEXP env) {
   return r_env_get(env, syms_s3_methods_table);
@@ -436,6 +441,7 @@ static inline const void* vec_type_missing_value(enum vctrs_type type) {
 }
 
 void c_print_backtrace();
+void r_browse(SEXP x);
 
 
 extern SEXP vctrs_ns_env;

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -757,7 +757,19 @@ test_that("vec_rbind() falls back to c() if S3 method is available", {
 })
 
 test_that("c() fallback works with unspecified columns", {
-  skip("FIXME: c() fallback with unspecified columns")
+  local_methods(
+    c.vctrs_foobar = function(...) foobar(NextMethod()),
+    `[.vctrs_foobar` = function(x, i, ...) foobar(NextMethod(), dispatched = TRUE)
+  )
+
+  out <- vec_rbind(
+    data_frame(x = foobar(1)),
+    data_frame(y = foobar(2))
+  )
+  expect_identical(out, data_frame(
+    x = foobar(c(1, NA), dispatched = TRUE),
+    y = foobar(c(NA, 2), dispatched = TRUE)
+  ))
 })
 
 test_that("vec_rbind() falls back to c() if S3 method is available for S4 class", {

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -213,6 +213,12 @@ test_that("vec_ptype_common_fallback() collects common type", {
   )
 })
 
+test_that("fallback sentinel is returned with unspecified inputs", {
+  fallback <- vec_ptype_common_fallback(foobar(1), foobar(1))
+  expect_identical(vec_ptype_common_fallback(NA, foobar(1)), fallback)
+  expect_identical(vec_ptype_common_fallback(foobar(1), NA), fallback)
+})
+
 test_that("vec_ptype_common() supports subclasses of list", {
   x <- structure(list(1), class = c("vctrs_foo", "list"))
   y <- structure(list(2), class = c("bar", "vctrs_foo", "list"))

--- a/tests/testthat/test-type-sf.R
+++ b/tests/testthat/test-type-sf.R
@@ -7,7 +7,8 @@ import_from("sf", c(
   "st_precision",
   "st_crs",
   "st_linestring",
-  "st_as_sf"
+  "st_as_sf",
+  "st_multipoint"
 ))
 
 # https://github.com/r-spatial/sf/issues/1390
@@ -25,6 +26,18 @@ test_that("can combine sfc lists with unspecified chunks", {
   point <- st_point(1:2)
   out <- vec_c(c(NA, NA), st_sfc(point), NA)
   expect_identical(out, st_sfc(NA, NA, point, NA))
+
+  multipoint <- st_multipoint(matrix(1:4, 2))
+  x <- st_sfc(point)
+  y <- st_sfc(multipoint, multipoint)
+  out <- vec_rbind(
+    data_frame(x = x),
+    data_frame(y = y)
+  )
+  expect_identical(out, data_frame(
+    x = st_sfc(point, NA, NA),
+    y = st_sfc(NA, multipoint, multipoint)
+  ))
 })
 
 test_that("`n_empty` attribute of `sfc` vectors is restored", {

--- a/tests/testthat/test-type-sf.R
+++ b/tests/testthat/test-type-sf.R
@@ -21,6 +21,12 @@ test_that("can combine sfc lists", {
   expect_identical(vec_rbind(sf, sf), rbind(sf, sf))
 })
 
+test_that("can combine sfc lists with unspecified chunks", {
+  point <- st_point(1:2)
+  out <- vec_c(c(NA, NA), st_sfc(point), NA)
+  expect_identical(out, st_sfc(NA, NA, point, NA))
+})
+
 test_that("`n_empty` attribute of `sfc` vectors is restored", {
 	pt1 = st_sfc(st_point(c(NA_real_, NA_real_)))
 	pt2 = st_sfc(st_point(0:1))


### PR DESCRIPTION
Branched from #1111.

This adds support for combining unspecified chunks to the `base::c()` fallback. We can't rely on `c()` for this because implementations might not handle unspecified inputs, and if unspecified is the first input this would prevent dispatch from reaching the expected method. Instead, we first combine non-unspecified chunks, then use `[` with `NA` integer locations to expand the result with missing values.

With this change, the fallback is now consistent when disjoint data frames are binded: 

```r
x <- sf::st_sfc(sf::st_point(1:2))
y <- sf::st_sfc(sf::st_multipoint(matrix(1:4, 2)), sf::st_multipoint(matrix(5:8, 2)))

vec_rbind(
  data_frame(x = x),
  data_frame(y = y)
)
#>             x                         y
#> 1 POINT (1 2)          MULTIPOINT EMPTY
#> 2 POINT EMPTY MULTIPOINT ((1 3), (2 4))
#> 3 POINT EMPTY MULTIPOINT ((5 7), (6 8))
```