### PR TITLE
Remove experimental callables no longer used by slider

### DIFF
--- a/src/callables.c
+++ b/src/callables.c
@@ -19,20 +19,8 @@ SEXP exp_vec_cast(SEXP x, SEXP to) {
   return vec_cast(x, to, args_empty, args_empty);
 }
 
-SEXP exp_vec_restore(SEXP x, SEXP to) {
-  return vec_restore(x, to, R_NilValue);
-}
-
-SEXP exp_vec_proxy(SEXP x) {
-  return vec_proxy(x);
-}
-
 SEXP exp_vec_chop(SEXP x, SEXP indices) {
   return vec_chop(x, indices);
-}
-
-SEXP exp_vec_proxy_assign(SEXP proxy, SEXP index, SEXP value) {
-  return vec_proxy_assign(proxy, index, value);
 }
 
 SEXP exp_vec_slice_impl(SEXP x, SEXP subscript) {
@@ -45,10 +33,6 @@ SEXP exp_vec_names(SEXP x) {
 
 SEXP exp_vec_set_names(SEXP x, SEXP names) {
   return vec_set_names(x, names);
-}
-
-SEXP exp_short_vec_init(SEXP x, R_len_t size) {
-  return vec_init(x, size);
 }
 
 SEXP exp_short_compact_seq(R_len_t start, R_len_t size, bool increasing) {

--- a/src/init.c
+++ b/src/init.c
@@ -128,14 +128,10 @@ extern SEXP short_vec_recycle(SEXP, R_len_t);
 // Experimental
 // Exported but not available in the public header
 extern SEXP exp_vec_cast(SEXP, SEXP);
-extern SEXP exp_vec_restore(SEXP, SEXP);
-extern SEXP exp_vec_proxy(SEXP);
 extern SEXP exp_vec_chop(SEXP, SEXP);
-extern SEXP exp_vec_proxy_assign(SEXP, SEXP, SEXP);
 extern SEXP exp_vec_slice_impl(SEXP, SEXP);
 extern SEXP exp_vec_names(SEXP);
 extern SEXP exp_vec_set_names(SEXP, SEXP);
-extern SEXP exp_short_vec_init(SEXP, R_len_t);
 extern SEXP exp_short_compact_seq(R_len_t, R_len_t, bool);
 extern SEXP exp_short_init_compact_seq(int*, R_len_t, R_len_t, bool);
 
@@ -297,14 +293,10 @@ export void R_init_vctrs(DllInfo *dll)
     // Experimental
     // Exported but not available in the public header
     R_RegisterCCallable("vctrs", "exp_vec_cast",                (DL_FUNC) &exp_vec_cast);
-    R_RegisterCCallable("vctrs", "exp_vec_restore",             (DL_FUNC) &exp_vec_restore);
-    R_RegisterCCallable("vctrs", "exp_vec_proxy",               (DL_FUNC) &exp_vec_proxy);
     R_RegisterCCallable("vctrs", "exp_vec_chop",                (DL_FUNC) &exp_vec_chop);
-    R_RegisterCCallable("vctrs", "exp_vec_proxy_assign",        (DL_FUNC) &exp_vec_proxy_assign);
     R_RegisterCCallable("vctrs", "exp_vec_slice_impl",          (DL_FUNC) &exp_vec_slice_impl);
     R_RegisterCCallable("vctrs", "exp_vec_names",               (DL_FUNC) &exp_vec_names);
     R_RegisterCCallable("vctrs", "exp_vec_set_names",           (DL_FUNC) &exp_vec_set_names);
-    R_RegisterCCallable("vctrs", "exp_short_vec_init",          (DL_FUNC) &exp_short_vec_init);
     R_RegisterCCallable("vctrs", "exp_short_compact_seq",       (DL_FUNC) &exp_short_compact_seq);
     R_RegisterCCallable("vctrs", "exp_short_init_compact_seq",  (DL_FUNC) &exp_short_init_compact_seq);
 


### PR DESCRIPTION
Removes the following experimental callables from the exported API now that slider no longer uses them

- `exp_vec_proxy()`
- `exp_vec_restore()`
- `exp_vec_proxy_assign()`
- `exp_short_vec_init()`

Mainly I'm happy to remove `exp_vec_proxy_assign()` since it is so internal facing