### PR TITLE
Pass `ownership` through to `vec_restore()`

### DIFF
--- a/src/bind.c
+++ b/src/bind.c
@@ -181,7 +181,7 @@ static SEXP vec_rbind(SEXP xs,
     init_compact_seq(idx_ptr, counter, size, true);
 
     // Total ownership of `out` because it was freshly created with `vec_init()`
-    out = df_assign(out, idx, x, vctrs_ownership_total, &bind_assign_opts);
+    out = df_assign(out, idx, x, VCTRS_OWNERSHIP_total, &bind_assign_opts);
     REPROTECT(out, out_pi);
 
     if (has_rownames) {
@@ -199,7 +199,7 @@ static SEXP vec_rbind(SEXP xs,
       PROTECT(rn);
 
       if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
-        rownames = chr_assign(rownames, idx, rn, vctrs_ownership_total);
+        rownames = chr_assign(rownames, idx, rn, VCTRS_OWNERSHIP_total);
         REPROTECT(rownames, rownames_pi);
       }
 
@@ -247,7 +247,7 @@ static SEXP vec_rbind(SEXP xs,
     }
   }
 
-  out = vec_restore(out, ptype, r_int(n_rows), vctrs_ownership_total);
+  out = vec_restore(out, ptype, r_int(n_rows), VCTRS_OWNERSHIP_total);
   REPROTECT(out, out_pi);
 
   UNPROTECT(n_prot);
@@ -461,12 +461,12 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
     init_compact_seq(idx_ptr, counter, xn, true);
 
     // Total ownership of `out` because it was freshly created with `Rf_allocVector()`
-    out = list_assign(out, idx, x, vctrs_ownership_total);
+    out = list_assign(out, idx, x, VCTRS_OWNERSHIP_total);
     REPROTECT(out, out_pi);
 
     SEXP xnms = PROTECT(r_names(x));
     if (xnms != R_NilValue) {
-      names = chr_assign(names, idx, xnms, vctrs_ownership_total);
+      names = chr_assign(names, idx, xnms, VCTRS_OWNERSHIP_total);
       REPROTECT(names, names_pi);
     }
     UNPROTECT(1);
@@ -481,7 +481,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
     Rf_setAttrib(out, R_RowNamesSymbol, rownames);
   }
 
-  out = vec_restore(out, type, R_NilValue, vctrs_ownership_total);
+  out = vec_restore(out, type, R_NilValue, VCTRS_OWNERSHIP_total);
 
   UNPROTECT(9);
   return out;

--- a/src/bind.c
+++ b/src/bind.c
@@ -3,6 +3,7 @@
 #include "dim.h"
 #include "ptype-common.h"
 #include "slice-assign.h"
+#include "ownership.h"
 #include "type-data-frame.h"
 #include "utils.h"
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -247,7 +247,7 @@ static SEXP vec_rbind(SEXP xs,
     }
   }
 
-  out = vec_restore(out, ptype, r_int(n_rows));
+  out = vec_restore(out, ptype, r_int(n_rows), vctrs_ownership_total);
   REPROTECT(out, out_pi);
 
   UNPROTECT(n_prot);
@@ -481,7 +481,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
     Rf_setAttrib(out, R_RowNamesSymbol, rownames);
   }
 
-  out = vec_restore(out, type, R_NilValue);
+  out = vec_restore(out, type, R_NilValue, vctrs_ownership_total);
 
   UNPROTECT(9);
   return out;

--- a/src/c.c
+++ b/src/c.c
@@ -134,7 +134,7 @@ SEXP vec_c_opts(SEXP xs,
     init_compact_seq(idx_ptr, counter, size, true);
 
     // Total ownership of `out` because it was freshly created with `vec_init()`
-    out = vec_proxy_assign_opts(out, idx, x, vctrs_ownership_total, &c_assign_opts);
+    out = vec_proxy_assign_opts(out, idx, x, VCTRS_OWNERSHIP_total, &c_assign_opts);
     REPROTECT(out, out_pi);
 
     if (has_names) {
@@ -143,7 +143,7 @@ SEXP vec_c_opts(SEXP xs,
       SEXP x_nms = PROTECT(apply_name_spec(name_spec, outer, inner, size));
 
       if (x_nms != R_NilValue) {
-        out_names = chr_assign(out_names, idx, x_nms, vctrs_ownership_total);
+        out_names = chr_assign(out_names, idx, x_nms, VCTRS_OWNERSHIP_total);
         REPROTECT(out_names, out_names_pi);
       }
 
@@ -153,7 +153,7 @@ SEXP vec_c_opts(SEXP xs,
     counter += size;
   }
 
-  out = PROTECT(vec_restore(out, ptype, R_NilValue, vctrs_ownership_total));
+  out = PROTECT(vec_restore(out, ptype, R_NilValue, VCTRS_OWNERSHIP_total));
 
   if (has_names) {
     out_names = PROTECT(vec_as_names(out_names, name_repair));

--- a/src/c.c
+++ b/src/c.c
@@ -2,6 +2,7 @@
 #include "c.h"
 #include "ptype-common.h"
 #include "slice-assign.h"
+#include "ownership.h"
 #include "utils.h"
 
 

--- a/src/c.c
+++ b/src/c.c
@@ -153,7 +153,7 @@ SEXP vec_c_opts(SEXP xs,
     counter += size;
   }
 
-  out = PROTECT(vec_restore(out, ptype, R_NilValue));
+  out = PROTECT(vec_restore(out, ptype, R_NilValue, vctrs_ownership_total));
 
   if (has_names) {
     out_names = PROTECT(vec_as_names(out_names, name_repair));

--- a/src/init.c
+++ b/src/init.c
@@ -54,8 +54,8 @@ extern SEXP vctrs_unchop(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_chop_seq(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_slice_seq(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_slice_rep(SEXP, SEXP, SEXP);
-extern SEXP vec_restore(SEXP, SEXP, SEXP);
-extern SEXP vec_restore_default(SEXP, SEXP);
+extern SEXP vctrs_restore(SEXP, SEXP, SEXP);
+extern SEXP vctrs_restore_default(SEXP, SEXP);
 extern SEXP vec_proxy(SEXP);
 extern SEXP vec_proxy_equal(SEXP);
 extern SEXP vctrs_unspecified(SEXP);
@@ -73,7 +73,7 @@ extern SEXP vctrs_df_ptype2_opts(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_type_info(SEXP);
 extern SEXP vctrs_proxy_info(SEXP);
 extern SEXP vctrs_class_type(SEXP);
-extern SEXP vec_bare_df_restore(SEXP, SEXP, SEXP);
+extern SEXP vctrs_bare_df_restore(SEXP, SEXP, SEXP);
 extern SEXP vctrs_recycle(SEXP, SEXP, SEXP);
 extern SEXP vctrs_assign(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_assign_seq(SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -187,8 +187,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_chop_seq",                   (DL_FUNC) &vctrs_chop_seq, 4},
   {"vctrs_slice_seq",                  (DL_FUNC) &vec_slice_seq, 4},
   {"vctrs_slice_rep",                  (DL_FUNC) &vec_slice_rep, 3},
-  {"vctrs_restore",                    (DL_FUNC) &vec_restore, 3},
-  {"vctrs_restore_default",            (DL_FUNC) &vec_restore_default, 2},
+  {"vctrs_restore",                    (DL_FUNC) &vctrs_restore, 3},
+  {"vctrs_restore_default",            (DL_FUNC) &vctrs_restore_default, 2},
   {"vctrs_proxy",                      (DL_FUNC) &vec_proxy, 1},
   {"vctrs_proxy_equal",                (DL_FUNC) &vec_proxy_equal, 1},
   {"vctrs_unspecified",                (DL_FUNC) &vctrs_unspecified, 1},
@@ -206,7 +206,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_type_info",                  (DL_FUNC) &vctrs_type_info, 1},
   {"vctrs_proxy_info",                 (DL_FUNC) &vctrs_proxy_info, 1},
   {"vctrs_class_type",                 (DL_FUNC) &vctrs_class_type, 1},
-  {"vctrs_bare_df_restore",            (DL_FUNC) &vec_bare_df_restore, 3},
+  {"vctrs_bare_df_restore",            (DL_FUNC) &vctrs_bare_df_restore, 3},
   {"vctrs_recycle",                    (DL_FUNC) &vctrs_recycle, 3},
   {"vctrs_assign",                     (DL_FUNC) &vctrs_assign, 5},
   {"vctrs_assign_seq",                 (DL_FUNC) &vctrs_assign_seq, 5},

--- a/src/ownership.h
+++ b/src/ownership.h
@@ -7,7 +7,7 @@ enum vctrs_ownership {
   vctrs_ownership_total
 };
 
-static inline const enum vctrs_ownership proxy_ownership(SEXP x) {
+static inline const enum vctrs_ownership vec_ownership(SEXP x) {
   return NO_REFERENCES(x) ? vctrs_ownership_total : vctrs_ownership_shared;
 }
 

--- a/src/ownership.h
+++ b/src/ownership.h
@@ -1,0 +1,14 @@
+#ifndef VCTRS_OWNERSHIP_H
+#define VCTRS_OWNERSHIP_H
+
+// Ownership is recursive
+enum vctrs_ownership {
+  vctrs_ownership_shared,
+  vctrs_ownership_total
+};
+
+static inline const enum vctrs_ownership proxy_ownership(SEXP x) {
+  return NO_REFERENCES(x) ? vctrs_ownership_total : vctrs_ownership_shared;
+}
+
+#endif

--- a/src/ownership.h
+++ b/src/ownership.h
@@ -3,12 +3,12 @@
 
 // Ownership is recursive
 enum vctrs_ownership {
-  vctrs_ownership_shared,
-  vctrs_ownership_total
+  VCTRS_OWNERSHIP_shared,
+  VCTRS_OWNERSHIP_total
 };
 
 static inline const enum vctrs_ownership vec_ownership(SEXP x) {
-  return NO_REFERENCES(x) ? vctrs_ownership_total : vctrs_ownership_shared;
+  return NO_REFERENCES(x) ? VCTRS_OWNERSHIP_total : VCTRS_OWNERSHIP_shared;
 }
 
 #endif

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -1,15 +1,20 @@
 #include "vctrs.h"
 #include "type-data-frame.h"
+#include "ownership.h"
 #include "utils.h"
 
 // Initialised at load time
 static SEXP syms_vec_restore_dispatch = NULL;
 static SEXP fns_vec_restore_dispatch = NULL;
 
+// [[ register() ]]
+SEXP vctrs_restore_default(SEXP x, SEXP to) {
+  return vec_restore_default(x, to, vec_ownership(x));
+}
 
 // Copy attributes except names and dim. This duplicates `x` if needed.
 // [[ include("vctrs.h") ]]
-SEXP vec_restore_default(SEXP x, SEXP to) {
+SEXP vec_restore_default(SEXP x, SEXP to, const enum vctrs_ownership ownership) {
   SEXP attrib = ATTRIB(to);
 
   const bool is_s4 = IS_S4_OBJECT(to);
@@ -23,7 +28,11 @@ SEXP vec_restore_default(SEXP x, SEXP to) {
   attrib = PROTECT(Rf_shallow_duplicate(attrib));
   ++n_protect;
 
-  x = PROTECT(r_clone_referenced(x));
+  if (ownership == vctrs_ownership_total) {
+    x = PROTECT(r_clone_shared(x));
+  } else {
+    x = PROTECT(r_clone_referenced(x));
+  }
   ++n_protect;
 
   // Remove vectorised attributes which might be incongruent after reshaping.
@@ -113,8 +122,9 @@ static SEXP vec_restore_dispatch(SEXP x, SEXP to, SEXP n) {
                          syms_n, n);
 }
 
-static SEXP vec_bare_df_restore_impl(SEXP x, SEXP to, R_len_t size) {
-  x = PROTECT(vec_restore_default(x, to));
+static SEXP vec_bare_df_restore_impl(SEXP x, SEXP to, R_len_t size,
+                                     const enum vctrs_ownership ownership) {
+  x = PROTECT(vec_restore_default(x, to, ownership));
 
   if (Rf_getAttrib(x, R_NamesSymbol) == R_NilValue) {
     Rf_setAttrib(x, R_NamesSymbol, vctrs_shared_empty_chr);
@@ -129,40 +139,51 @@ static SEXP vec_bare_df_restore_impl(SEXP x, SEXP to, R_len_t size) {
   return x;
 }
 
-// [[ include("vctrs.h"); register() ]]
-SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n) {
+// [[ register() ]]
+SEXP vctrs_bare_df_restore(SEXP x, SEXP to, SEXP n) {
+  return vec_bare_df_restore(x, to, n, vec_ownership(x));
+}
+
+// [[ include("vctrs.h") ]]
+SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n, const enum vctrs_ownership ownership) {
   if (TYPEOF(x) != VECSXP) {
     Rf_errorcall(R_NilValue, "Internal error: Attempt to restore data frame from a %s.",
                  Rf_type2char(TYPEOF(x)));
   }
 
   R_len_t size = (n == R_NilValue) ? df_raw_size(x) : r_int_get(n, 0);
-  return vec_bare_df_restore_impl(x, to, size);
+  return vec_bare_df_restore_impl(x, to, size, ownership);
 }
 
 // Restore methods are passed the original atomic type back, so we
 // first restore data frames as such before calling the restore
 // method, if any
 // [[ include("vctrs.h") ]]
-SEXP vec_df_restore(SEXP x, SEXP to, SEXP n) {
-  SEXP out = PROTECT(vec_bare_df_restore(x, to, n));
+SEXP vec_df_restore(SEXP x, SEXP to, SEXP n, const enum vctrs_ownership ownership) {
+  SEXP out = PROTECT(vec_bare_df_restore(x, to, n, ownership));
   out = vec_restore_dispatch(out, to, n);
   UNPROTECT(1);
   return out;
 }
 
-SEXP vec_restore(SEXP x, SEXP to, SEXP n) {
+// [[ register() ]]
+SEXP vctrs_restore(SEXP x, SEXP to, SEXP n) {
+  return vec_restore(x, to, n, vec_ownership(x));
+}
+
+// [[ include("vctrs.h") ]]
+SEXP vec_restore(SEXP x, SEXP to, SEXP n, const enum vctrs_ownership ownership) {
   switch (class_type(to)) {
   default: return vec_restore_dispatch(x, to, n);
   case vctrs_class_bare_factor:
   case vctrs_class_bare_ordered:
-  case vctrs_class_none: return vec_restore_default(x, to);
-  case vctrs_class_bare_date: return vec_date_restore(x, to);
-  case vctrs_class_bare_posixct: return vec_posixct_restore(x, to);
-  case vctrs_class_bare_posixlt: return vec_posixlt_restore(x, to);
+  case vctrs_class_none: return vec_restore_default(x, to, ownership);
+  case vctrs_class_bare_date: return vec_date_restore(x, to, ownership);
+  case vctrs_class_bare_posixct: return vec_posixct_restore(x, to, ownership);
+  case vctrs_class_bare_posixlt: return vec_posixlt_restore(x, to, ownership);
   case vctrs_class_bare_data_frame:
-  case vctrs_class_bare_tibble: return vec_bare_df_restore(x, to, n);
-  case vctrs_class_data_frame: return vec_df_restore(x, to, n);
+  case vctrs_class_bare_tibble: return vec_bare_df_restore(x, to, n, ownership);
+  case vctrs_class_data_frame: return vec_df_restore(x, to, n, ownership);
   }
 }
 

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -113,7 +113,7 @@ static SEXP vec_restore_dispatch(SEXP x, SEXP to, SEXP n) {
                          syms_n, n);
 }
 
-static SEXP bare_df_restore_impl(SEXP x, SEXP to, R_len_t size) {
+static SEXP vec_bare_df_restore_impl(SEXP x, SEXP to, R_len_t size) {
   x = PROTECT(r_clone_referenced(x));
   x = PROTECT(vec_restore_default(x, to));
 
@@ -138,7 +138,7 @@ SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n) {
   }
 
   R_len_t size = (n == R_NilValue) ? df_raw_size(x) : r_int_get(n, 0);
-  return bare_df_restore_impl(x, to, size);
+  return vec_bare_df_restore_impl(x, to, size);
 }
 
 // Restore methods are passed the original atomic type back, so we

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -28,7 +28,7 @@ SEXP vec_restore_default(SEXP x, SEXP to, const enum vctrs_ownership ownership) 
   attrib = PROTECT(Rf_shallow_duplicate(attrib));
   ++n_protect;
 
-  if (ownership == vctrs_ownership_total) {
+  if (ownership == VCTRS_OWNERSHIP_total) {
     x = PROTECT(r_clone_shared(x));
   } else {
     x = PROTECT(r_clone_referenced(x));

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -114,7 +114,6 @@ static SEXP vec_restore_dispatch(SEXP x, SEXP to, SEXP n) {
 }
 
 static SEXP vec_bare_df_restore_impl(SEXP x, SEXP to, R_len_t size) {
-  x = PROTECT(r_clone_referenced(x));
   x = PROTECT(vec_restore_default(x, to));
 
   if (Rf_getAttrib(x, R_NamesSymbol) == R_NilValue) {
@@ -126,7 +125,7 @@ static SEXP vec_bare_df_restore_impl(SEXP x, SEXP to, R_len_t size) {
     init_compact_rownames(x, size);
   }
 
-  UNPROTECT(3);
+  UNPROTECT(2);
   return x;
 }
 

--- a/src/slice-assign-array.c
+++ b/src/slice-assign-array.c
@@ -6,7 +6,7 @@
 
 #define ASSIGN_SHAPED_INDEX(CTYPE, DEREF, CONST_DEREF)   \
   SEXP out;                                              \
-  if (ownership == vctrs_ownership_total) {              \
+  if (ownership == VCTRS_OWNERSHIP_total) {              \
     out = PROTECT(r_clone_shared(proxy));                \
   } else {                                               \
     out = PROTECT(r_clone_referenced(proxy));            \
@@ -44,7 +44,7 @@
 
 #define ASSIGN_SHAPED_COMPACT(CTYPE, DEREF, CONST_DEREF) \
   SEXP out;                                              \
-  if (ownership == vctrs_ownership_total) {              \
+  if (ownership == VCTRS_OWNERSHIP_total) {              \
     out = PROTECT(r_clone_shared(proxy));                \
   } else {                                               \
     out = PROTECT(r_clone_referenced(proxy));            \
@@ -126,7 +126,7 @@ static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value,
 
 #define ASSIGN_BARRIER_SHAPED_INDEX(GET, SET)            \
   SEXP out;                                              \
-  if (ownership == vctrs_ownership_total) {              \
+  if (ownership == VCTRS_OWNERSHIP_total) {              \
     out = PROTECT(r_clone_shared(proxy));                \
   } else {                                               \
     out = PROTECT(r_clone_referenced(proxy));            \
@@ -162,7 +162,7 @@ static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value,
 
 #define ASSIGN_BARRIER_SHAPED_COMPACT(GET, SET)         \
   SEXP out;                                             \
-  if (ownership == vctrs_ownership_total) {             \
+  if (ownership == VCTRS_OWNERSHIP_total) {             \
     out = PROTECT(r_clone_shared(proxy));               \
   } else {                                              \
     out = PROTECT(r_clone_referenced(proxy));           \

--- a/src/slice-assign-array.c
+++ b/src/slice-assign-array.c
@@ -2,6 +2,7 @@
 #include "utils.h"
 #include "strides.h"
 #include "slice-assign.h"
+#include "ownership.h"
 
 #define ASSIGN_SHAPED_INDEX(CTYPE, DEREF, CONST_DEREF)   \
   SEXP out;                                              \

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -1,6 +1,7 @@
 #include "vctrs.h"
 #include "slice-assign.h"
 #include "subscript-loc.h"
+#include "ownership.h"
 #include "utils.h"
 #include "dim.h"
 
@@ -11,8 +12,6 @@ SEXP fns_vec_assign_fallback = NULL;
 const struct vec_assign_opts vec_assign_default_opts = {
   .assign_names = false
 };
-
-static const enum vctrs_ownership proxy_ownership(SEXP x);
 
 static SEXP vec_assign_fallback(SEXP x, SEXP index, SEXP value);
 static SEXP vec_proxy_assign_names(SEXP proxy, SEXP index, SEXP value);
@@ -407,10 +406,6 @@ static SEXP vec_assign_fallback(SEXP x, SEXP index, SEXP value) {
                          syms_x, x,
                          syms_i, index,
                          syms_value, value);
-}
-
-static const enum vctrs_ownership proxy_ownership(SEXP proxy) {
-  return NO_REFERENCES(proxy) ? vctrs_ownership_total : vctrs_ownership_shared;
 }
 
 static

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -47,7 +47,7 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
   const enum vctrs_ownership ownership = vec_ownership(proxy);
   proxy = PROTECT(vec_proxy_assign_opts(proxy, index, value, ownership, opts));
 
-  SEXP out = vec_restore(proxy, x, R_NilValue);
+  SEXP out = vec_restore(proxy, x, R_NilValue, ownership);
 
   UNPROTECT(6);
   return out;
@@ -391,7 +391,7 @@ SEXP df_assign(SEXP x, SEXP index, SEXP value,
     SEXP proxy_elt = PROTECT(vec_proxy(out_elt));
 
     SEXP assigned = PROTECT(vec_proxy_assign_opts(proxy_elt, index, value_elt, ownership, opts));
-    assigned = vec_restore(assigned, out_elt, R_NilValue);
+    assigned = vec_restore(assigned, out_elt, R_NilValue, ownership);
 
     SET_VECTOR_ELT(out, i, assigned);
     UNPROTECT(2);
@@ -453,7 +453,7 @@ SEXP vctrs_assign_seq(SEXP x, SEXP value, SEXP start, SEXP size, SEXP increasing
   const enum vctrs_ownership ownership = vec_ownership(proxy);
   proxy = PROTECT(vec_proxy_assign_opts(proxy, index, value, ownership, opts));
 
-  SEXP out = vec_restore(proxy, x, R_NilValue);
+  SEXP out = vec_restore(proxy, x, R_NilValue, ownership);
 
   UNPROTECT(5);
   return out;

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -44,7 +44,7 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
   value = PROTECT(vec_recycle(value, vec_size(index), opts->value_arg));
 
   SEXP proxy = PROTECT(vec_proxy(x));
-  const enum vctrs_ownership ownership = proxy_ownership(proxy);
+  const enum vctrs_ownership ownership = vec_ownership(proxy);
   proxy = PROTECT(vec_proxy_assign_opts(proxy, index, value, ownership, opts));
 
   SEXP out = vec_restore(proxy, x, R_NilValue);
@@ -137,7 +137,7 @@ static SEXP vec_assign_switch(SEXP proxy, SEXP index, SEXP value,
  */
 SEXP vec_proxy_assign(SEXP proxy, SEXP index, SEXP value) {
   return vec_proxy_assign_opts(proxy, index, value,
-                               proxy_ownership(proxy),
+                               vec_ownership(proxy),
                                &vec_assign_default_opts);
 }
 SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
@@ -450,7 +450,7 @@ SEXP vctrs_assign_seq(SEXP x, SEXP value, SEXP start, SEXP size, SEXP increasing
   value = PROTECT(vec_recycle(value, vec_subscript_size(index), opts->value_arg));
 
   SEXP proxy = PROTECT(vec_proxy(x));
-  const enum vctrs_ownership ownership = proxy_ownership(proxy);
+  const enum vctrs_ownership ownership = vec_ownership(proxy);
   proxy = PROTECT(vec_proxy_assign_opts(proxy, index, value, ownership, opts));
 
   SEXP out = vec_restore(proxy, x, R_NilValue);

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -98,27 +98,27 @@ static SEXP vec_assign_switch(SEXP proxy, SEXP index, SEXP value,
 // on a number of factors.
 //
 // - If a fallback is required, the `proxy` is duplicated at the R level.
-// - If `opts->ownership` is `vctrs_ownership_total`, the `proxy` is only
+// - If `opts->ownership` is `VCTRS_OWNERSHIP_total`, the `proxy` is only
 //   duplicated if it is shared, i.e. `MAYBE_SHARED()` returns `true`.
-// - If `opts->ownership` is `vctrs_ownership_shared`, the `proxy` is only
+// - If `opts->ownership` is `VCTRS_OWNERSHIP_shared`, the `proxy` is only
 //   duplicated if it is referenced, i.e. `MAYBE_REFERENCED()` returns `true`.
 //
 // In `vec_proxy_assign()`, which is part of the experimental public API,
 // ownership is determined with a call to `NO_REFERENCES()`. If there are no
-// references, then `vctrs_ownership_total` is used, else
-// `vctrs_ownership_shared` is used.
+// references, then `VCTRS_OWNERSHIP_total` is used, else
+// `VCTRS_OWNERSHIP_shared` is used.
 //
 // Ownership of the `proxy` must be recursive. For data frames, the `ownership`
 // argument is passed along to each column.
 //
-// Practically, we only set `vctrs_ownership_total` when we create a fresh data
+// Practically, we only set `VCTRS_OWNERSHIP_total` when we create a fresh data
 // structure at the C level and then assign into it to fill it. This happens
 // in `vec_c()` and `vec_rbind()`. For data frames, this `ownership` parameter
 // is particularly important for R 4.0.0 where references are tracked more
 // precisely. In R 4.0.0, a freshly created data frame's columns all have a
 // refcount of 1 because of the `SET_VECTOR_ELT()` call that set them in the
 // data frame. This makes them referenced, but not shared. If
-// `vctrs_ownership_shared` was set and `df_assign()` was used in a loop
+// `VCTRS_OWNERSHIP_shared` was set and `df_assign()` was used in a loop
 // (as it is in `vec_rbind()`), then a copy of each column would be made at
 // each iteration of the loop (any time a new set of rows is assigned
 // into the output object).
@@ -196,7 +196,7 @@ SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
   const CTYPE* value_data = CONST_DEREF(value);                 \
                                                                 \
   SEXP out;                                                     \
-  if (ownership == vctrs_ownership_total) {                     \
+  if (ownership == VCTRS_OWNERSHIP_total) {                     \
     out = PROTECT(r_clone_shared(x));                           \
   } else {                                                      \
     out = PROTECT(r_clone_referenced(x));                       \
@@ -228,7 +228,7 @@ SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
   const CTYPE* value_data = CONST_DEREF(value);                 \
                                                                 \
   SEXP out;                                                     \
-  if (ownership == vctrs_ownership_total) {                     \
+  if (ownership == VCTRS_OWNERSHIP_total) {                     \
     out = PROTECT(r_clone_shared(x));                           \
   } else {                                                      \
     out = PROTECT(r_clone_referenced(x));                       \
@@ -284,7 +284,7 @@ static SEXP raw_assign(SEXP x, SEXP index, SEXP value, const enum vctrs_ownershi
   }                                                             \
                                                                 \
   SEXP out;                                                     \
-  if (ownership == vctrs_ownership_total) {                     \
+  if (ownership == VCTRS_OWNERSHIP_total) {                     \
     out = PROTECT(r_clone_shared(x));                           \
   } else {                                                      \
     out = PROTECT(r_clone_referenced(x));                       \
@@ -312,7 +312,7 @@ static SEXP raw_assign(SEXP x, SEXP index, SEXP value, const enum vctrs_ownershi
   }                                                             \
                                                                 \
   SEXP out;                                                     \
-  if (ownership == vctrs_ownership_total) {                     \
+  if (ownership == VCTRS_OWNERSHIP_total) {                     \
     out = PROTECT(r_clone_shared(x));                           \
   } else {                                                      \
     out = PROTECT(r_clone_referenced(x));                       \
@@ -366,7 +366,7 @@ SEXP df_assign(SEXP x, SEXP index, SEXP value,
                const enum vctrs_ownership ownership,
                const struct vec_assign_opts* opts) {
   SEXP out;
-  if (ownership == vctrs_ownership_total) {
+  if (ownership == VCTRS_OWNERSHIP_total) {
     out = PROTECT(r_clone_shared(x));
   } else {
     out = PROTECT(r_clone_referenced(x));
@@ -424,7 +424,7 @@ SEXP vec_proxy_assign_names(SEXP proxy, SEXP index, SEXP value) {
     proxy_nms = PROTECT(r_clone_referenced(proxy_nms));
   }
 
-  proxy_nms = PROTECT(chr_assign(proxy_nms, index, value_nms, vctrs_ownership_total));
+  proxy_nms = PROTECT(chr_assign(proxy_nms, index, value_nms, VCTRS_OWNERSHIP_total));
 
   proxy = PROTECT(r_clone_referenced(proxy));
   proxy = vec_set_names(proxy, proxy_nms);

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -44,7 +44,7 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
   value = PROTECT(vec_recycle(value, vec_size(index), opts->value_arg));
 
   SEXP proxy = PROTECT(vec_proxy(x));
-  const enum vctrs_ownership ownership = vec_ownership(proxy);
+  enum vctrs_ownership ownership = vec_ownership(proxy);
   proxy = PROTECT(vec_proxy_assign_opts(proxy, index, value, ownership, opts));
 
   SEXP out = vec_restore(proxy, x, R_NilValue, ownership);
@@ -450,7 +450,7 @@ SEXP vctrs_assign_seq(SEXP x, SEXP value, SEXP start, SEXP size, SEXP increasing
   value = PROTECT(vec_recycle(value, vec_subscript_size(index), opts->value_arg));
 
   SEXP proxy = PROTECT(vec_proxy(x));
-  const enum vctrs_ownership ownership = vec_ownership(proxy);
+  enum vctrs_ownership ownership = vec_ownership(proxy);
   proxy = PROTECT(vec_proxy_assign_opts(proxy, index, value, ownership, opts));
 
   SEXP out = vec_restore(proxy, x, R_NilValue, ownership);

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -1,11 +1,7 @@
 #ifndef VCTRS_SLICE_ASSIGN_H
 #define VCTRS_SLICE_ASSIGN_H
 
-// Ownership is recursive
-enum vctrs_ownership {
-  vctrs_ownership_shared,
-  vctrs_ownership_total
-};
+#include "ownership.h"
 
 struct vec_assign_opts {
   bool assign_names;

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -203,7 +203,8 @@ static SEXP chop(SEXP x, SEXP indices, struct vctrs_chop_info info) {
       UNPROTECT(1);
     }
 
-    elt = vec_restore(elt, x, info.restore_size);
+    const enum vctrs_ownership ownership = vec_ownership(elt);
+    elt = vec_restore(elt, x, info.restore_size, ownership);
 
     SET_VECTOR_ELT(info.out, i, elt);
     UNPROTECT(1);
@@ -264,7 +265,8 @@ static SEXP chop_df(SEXP x, SEXP indices, struct vctrs_chop_info info) {
     }
 
     SEXP elt = VECTOR_ELT(info.out, i);
-    elt = vec_restore(elt, x, info.restore_size);
+    const enum vctrs_ownership ownership = vec_ownership(elt);
+    elt = vec_restore(elt, x, info.restore_size, ownership);
     SET_VECTOR_ELT(info.out, i, elt);
   }
 
@@ -304,7 +306,8 @@ static SEXP chop_shaped(SEXP x, SEXP indices, struct vctrs_chop_info info) {
       }
     }
 
-    elt = vec_restore(elt, x, info.restore_size);
+    const enum vctrs_ownership ownership = vec_ownership(elt);
+    elt = vec_restore(elt, x, info.restore_size, ownership);
 
     SET_VECTOR_ELT(info.out, i, elt);
     UNPROTECT(1);
@@ -351,7 +354,8 @@ static SEXP chop_fallback(SEXP x, SEXP indices, struct vctrs_chop_info info) {
 
     // Restore attributes only if `[` fallback doesn't
     if (ATTRIB(elt) == R_NilValue) {
-      elt = vec_restore(elt, x, info.restore_size);
+      const enum vctrs_ownership ownership = vec_ownership(elt);
+      elt = vec_restore(elt, x, info.restore_size, ownership);
     }
 
     SET_VECTOR_ELT(info.out, i, elt);
@@ -525,8 +529,9 @@ static SEXP vec_unchop(SEXP x,
   }
 
   SEXP out_size_sexp = PROTECT(r_int(out_size));
+  const enum vctrs_ownership ownership = vec_ownership(proxy);
 
-  SEXP out = PROTECT(vec_restore(proxy, ptype, out_size_sexp));
+  SEXP out = PROTECT(vec_restore(proxy, ptype, out_size_sexp, ownership));
 
   if (has_names) {
     out_names = vec_as_names(out_names, name_repair);

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -203,8 +203,7 @@ static SEXP chop(SEXP x, SEXP indices, struct vctrs_chop_info info) {
       UNPROTECT(1);
     }
 
-    const enum vctrs_ownership ownership = vec_ownership(elt);
-    elt = vec_restore(elt, x, info.restore_size, ownership);
+    elt = vec_restore(elt, x, info.restore_size, vec_ownership(elt));
 
     SET_VECTOR_ELT(info.out, i, elt);
     UNPROTECT(1);
@@ -265,8 +264,7 @@ static SEXP chop_df(SEXP x, SEXP indices, struct vctrs_chop_info info) {
     }
 
     SEXP elt = VECTOR_ELT(info.out, i);
-    const enum vctrs_ownership ownership = vec_ownership(elt);
-    elt = vec_restore(elt, x, info.restore_size, ownership);
+    elt = vec_restore(elt, x, info.restore_size, vec_ownership(elt));
     SET_VECTOR_ELT(info.out, i, elt);
   }
 
@@ -306,8 +304,7 @@ static SEXP chop_shaped(SEXP x, SEXP indices, struct vctrs_chop_info info) {
       }
     }
 
-    const enum vctrs_ownership ownership = vec_ownership(elt);
-    elt = vec_restore(elt, x, info.restore_size, ownership);
+    elt = vec_restore(elt, x, info.restore_size, vec_ownership(elt));
 
     SET_VECTOR_ELT(info.out, i, elt);
     UNPROTECT(1);
@@ -354,8 +351,7 @@ static SEXP chop_fallback(SEXP x, SEXP indices, struct vctrs_chop_info info) {
 
     // Restore attributes only if `[` fallback doesn't
     if (ATTRIB(elt) == R_NilValue) {
-      const enum vctrs_ownership ownership = vec_ownership(elt);
-      elt = vec_restore(elt, x, info.restore_size, ownership);
+      elt = vec_restore(elt, x, info.restore_size, vec_ownership(elt));
     }
 
     SET_VECTOR_ELT(info.out, i, elt);
@@ -529,7 +525,7 @@ static SEXP vec_unchop(SEXP x,
   }
 
   SEXP out_size_sexp = PROTECT(r_int(out_size));
-  const enum vctrs_ownership ownership = vec_ownership(proxy);
+  enum vctrs_ownership ownership = vec_ownership(proxy);
 
   SEXP out = PROTECT(vec_restore(proxy, ptype, out_size_sexp, ownership));
 

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -2,6 +2,7 @@
 #include "c.h"
 #include "slice.h"
 #include "slice-assign.h"
+#include "ownership.h"
 #include "subscript-loc.h"
 #include "ptype-common.h"
 #include "type-data-frame.h"

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -512,7 +512,7 @@ static SEXP vec_unchop(SEXP x,
     SEXP index = VECTOR_ELT(indices, i);
 
     // Total ownership of `proxy` because it was freshly created with `vec_init()`
-    proxy = vec_proxy_assign_opts(proxy, index, elt, vctrs_ownership_total, &unchop_assign_opts);
+    proxy = vec_proxy_assign_opts(proxy, index, elt, VCTRS_OWNERSHIP_total, &unchop_assign_opts);
     REPROTECT(proxy, proxy_pi);
 
     if (has_names) {
@@ -521,7 +521,7 @@ static SEXP vec_unchop(SEXP x,
       SEXP inner = PROTECT(vec_names(elt));
       SEXP elt_names = PROTECT(apply_name_spec(name_spec, outer, inner, size));
       if (elt_names != R_NilValue) {
-        out_names = chr_assign(out_names, index, elt_names, vctrs_ownership_total);
+        out_names = chr_assign(out_names, index, elt_names, VCTRS_OWNERSHIP_total);
         REPROTECT(out_names, out_names_pi);
       }
       UNPROTECT(2);

--- a/src/slice.c
+++ b/src/slice.c
@@ -352,8 +352,7 @@ SEXP vec_slice_impl(SEXP x, SEXP subscript) {
     // Take over attribute restoration only if the `[` method did not
     // restore itself
     if (ATTRIB(out) == R_NilValue) {
-      const enum vctrs_ownership ownership = vec_ownership(out);
-      out = vec_restore(out, x, restore_size, ownership);
+      out = vec_restore(out, x, restore_size, vec_ownership(out));
     }
 
     UNPROTECT(nprot);
@@ -392,8 +391,7 @@ SEXP vec_slice_impl(SEXP x, SEXP subscript) {
       Rf_setAttrib(out, R_NamesSymbol, names);
     }
 
-    const enum vctrs_ownership ownership = vec_ownership(out);
-    out = vec_restore(out, x, restore_size, ownership);
+    out = vec_restore(out, x, restore_size, vec_ownership(out));
 
     UNPROTECT(nprot);
     return out;
@@ -401,8 +399,7 @@ SEXP vec_slice_impl(SEXP x, SEXP subscript) {
 
   case vctrs_type_dataframe: {
     SEXP out = PROTECT_N(df_slice(data, subscript), &nprot);
-    const enum vctrs_ownership ownership = vec_ownership(out);
-    out = vec_restore(out, x, restore_size, ownership);
+    out = vec_restore(out, x, restore_size, vec_ownership(out));
     UNPROTECT(nprot);
     return out;
   }

--- a/src/slice.c
+++ b/src/slice.c
@@ -352,7 +352,8 @@ SEXP vec_slice_impl(SEXP x, SEXP subscript) {
     // Take over attribute restoration only if the `[` method did not
     // restore itself
     if (ATTRIB(out) == R_NilValue) {
-      out = vec_restore(out, x, restore_size);
+      const enum vctrs_ownership ownership = vec_ownership(out);
+      out = vec_restore(out, x, restore_size, ownership);
     }
 
     UNPROTECT(nprot);
@@ -391,7 +392,8 @@ SEXP vec_slice_impl(SEXP x, SEXP subscript) {
       Rf_setAttrib(out, R_NamesSymbol, names);
     }
 
-    out = vec_restore(out, x, restore_size);
+    const enum vctrs_ownership ownership = vec_ownership(out);
+    out = vec_restore(out, x, restore_size, ownership);
 
     UNPROTECT(nprot);
     return out;
@@ -399,7 +401,8 @@ SEXP vec_slice_impl(SEXP x, SEXP subscript) {
 
   case vctrs_type_dataframe: {
     SEXP out = PROTECT_N(df_slice(data, subscript), &nprot);
-    out = vec_restore(out, x, restore_size);
+    const enum vctrs_ownership ownership = vec_ownership(out);
+    out = vec_restore(out, x, restore_size, ownership);
     UNPROTECT(nprot);
     return out;
   }

--- a/src/type-date-time.c
+++ b/src/type-date-time.c
@@ -1,4 +1,5 @@
 #include "vctrs.h"
+#include "ownership.h"
 #include "utils.h"
 
 
@@ -238,24 +239,24 @@ SEXP posixlt_as_posixlt(SEXP x, SEXP to) {
 // restore
 
 // [[ include("vctrs.h") ]]
-SEXP vec_date_restore(SEXP x, SEXP to) {
-  SEXP out = PROTECT(vec_restore_default(x, to));
+SEXP vec_date_restore(SEXP x, SEXP to, const enum vctrs_ownership ownership) {
+  SEXP out = PROTECT(vec_restore_default(x, to, ownership));
   out = date_validate(out);
   UNPROTECT(1);
   return out;
 }
 
 // [[ include("vctrs.h") ]]
-SEXP vec_posixct_restore(SEXP x, SEXP to) {
-  SEXP out = PROTECT(vec_restore_default(x, to));
+SEXP vec_posixct_restore(SEXP x, SEXP to, const enum vctrs_ownership ownership) {
+  SEXP out = PROTECT(vec_restore_default(x, to, ownership));
   out = datetime_validate(out);
   UNPROTECT(1);
   return out;
 }
 
 // [[ include("vctrs.h") ]]
-SEXP vec_posixlt_restore(SEXP x, SEXP to) {
-  SEXP out = PROTECT(vec_restore_default(x, to));
+SEXP vec_posixlt_restore(SEXP x, SEXP to, const enum vctrs_ownership ownership) {
+  SEXP out = PROTECT(vec_restore_default(x, to, ownership));
   out = datetime_validate_tzone(out);
   UNPROTECT(1);
   return out;

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,6 +1,7 @@
 #include "vctrs.h"
 #include "utils.h"
 #include "type-data-frame.h"
+#include "ownership.h"
 
 #include <R_ext/Rdynload.h>
 
@@ -336,7 +337,9 @@ SEXP map_with_data(SEXP x, SEXP (*fn)(SEXP, void*), void* data) {
 // [[ include("utils.h") ]]
 SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
-  out = vec_bare_df_restore(out, df, vctrs_shared_zero_int);
+
+  // Total ownership because `map()` generates a fresh list
+  out = vec_bare_df_restore(out, df, vctrs_shared_zero_int, vctrs_ownership_total);
 
   UNPROTECT(1);
   return out;
@@ -345,7 +348,9 @@ SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP)) {
 // [[ include("utils.h") ]]
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
-  out = vec_df_restore(out, df, vctrs_shared_zero_int);
+
+  // Total ownership because `map()` generates a fresh list
+  out = vec_df_restore(out, df, vctrs_shared_zero_int, vctrs_ownership_total);
 
   UNPROTECT(1);
   return out;

--- a/src/utils.c
+++ b/src/utils.c
@@ -339,7 +339,7 @@ SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
 
   // Total ownership because `map()` generates a fresh list
-  out = vec_bare_df_restore(out, df, vctrs_shared_zero_int, vctrs_ownership_total);
+  out = vec_bare_df_restore(out, df, vctrs_shared_zero_int, VCTRS_OWNERSHIP_total);
 
   UNPROTECT(1);
   return out;
@@ -350,7 +350,7 @@ SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
 
   // Total ownership because `map()` generates a fresh list
-  out = vec_df_restore(out, df, vctrs_shared_zero_int, vctrs_ownership_total);
+  out = vec_df_restore(out, df, vctrs_shared_zero_int, VCTRS_OWNERSHIP_total);
 
   UNPROTECT(1);
   return out;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -349,6 +349,7 @@ bool vec_is_unspecified(SEXP x);
 
 #include "arg.h"
 #include "names.h"
+#include "ownership.h"
 
 enum vctrs_proxy_kind {
   vctrs_proxy_default,
@@ -359,8 +360,8 @@ enum vctrs_proxy_kind {
 SEXP vec_proxy(SEXP x);
 SEXP vec_proxy_equal(SEXP x);
 SEXP vec_proxy_recursive(SEXP x, enum vctrs_proxy_kind kind);
-SEXP vec_restore(SEXP x, SEXP to, SEXP i);
-SEXP vec_restore_default(SEXP x, SEXP to);
+SEXP vec_restore(SEXP x, SEXP to, SEXP i, const enum vctrs_ownership ownership);
+SEXP vec_restore_default(SEXP x, SEXP to, const enum vctrs_ownership ownership);
 R_len_t vec_size(SEXP x);
 R_len_t vec_size_common(SEXP xs, R_len_t absent);
 SEXP vec_cast_common(SEXP xs, SEXP to);
@@ -409,8 +410,8 @@ R_len_t df_size(SEXP x);
 R_len_t df_rownames_size(SEXP x);
 R_len_t df_raw_size(SEXP x);
 R_len_t df_raw_size_from_list(SEXP x);
-SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n);
-SEXP vec_df_restore(SEXP x, SEXP to, SEXP n);
+SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n, const enum vctrs_ownership ownership);
+SEXP vec_df_restore(SEXP x, SEXP to, SEXP n, const enum vctrs_ownership ownership);
 
 // equal_object() never propagates missingness, so
 // it can return a `bool`
@@ -549,9 +550,9 @@ SEXP posixlt_as_posixct(SEXP x, SEXP to);
 SEXP posixct_as_posixlt(SEXP x, SEXP to);
 SEXP posixlt_as_posixlt(SEXP x, SEXP to);
 
-SEXP vec_date_restore(SEXP x, SEXP to);
-SEXP vec_posixct_restore(SEXP x, SEXP to);
-SEXP vec_posixlt_restore(SEXP x, SEXP to);
+SEXP vec_date_restore(SEXP x, SEXP to, const enum vctrs_ownership ownership);
+SEXP vec_posixct_restore(SEXP x, SEXP to, const enum vctrs_ownership ownership);
+SEXP vec_posixlt_restore(SEXP x, SEXP to, const enum vctrs_ownership ownership);
 
 SEXP date_datetime_ptype2(SEXP x, SEXP y);
 SEXP datetime_datetime_ptype2(SEXP x, SEXP y);


### PR DESCRIPTION
Closes #1122 

This PR fixes the `vec_rbind()` performance regression seen in #1122 by passing along the ownership parameter to `vec_restore()`. The sole purpose of this is to allow us to swap between `r_clone_shared()` and `r_clone_referenced()` here:

https://github.com/r-lib/vctrs/pull/1124/files#diff-90e5f87281649d48864c579abd8649c3R31-R35

The problem in #1122 is that df-cols created by `vec_init()` automatically get a refcount of 1 due to the `SET_VECTOR_ELT()` call that places them in the outer data frame. When `vec_restore()` is called from `df_assign()` on those inner df-cols it eventually hands off to `vec_bare_df_restore_impl()` which unconditionally called `r_clone_referenced()`. Because our df-col _was_ referenced, it makes a shallow duplicate of it even though it is the freshly created output object. The problem with this is that by shallow duplicating the df-col, the refcount of all the columns in the df-col gets bumped from 1 to 2. So on the next iteration of `vec_rbind()`, those columns get shallow duplicated (which is really a full duplication for non-lists). That was where the performance really suffered.

By passing the ownership parameter through, we can correctly switch to `r_clone_shared()` when restoring, which allows in place modification of the case where the refcount is 1. Since the df-col's refcount is 1, it doesn't get shallow duplicated and the inner columns of that df-col don't have their refcount bumped.

This is on R 4.0 with this PR. We now match R 3.6 performance 

```r
library(vctrs)

df_col <- new_data_frame(list(x = 1:2))
df <- new_data_frame(list(y = df_col))

x <- rep_len(list(df), 10000)
y <- rep_len(list(df_col), 10000)

lst_rbind <- function(x) {
    vec_rbind(!!!x)
}

bench::mark(lst_rbind(x))
#> # A tibble: 1 x 6
#>   expression        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 lst_rbind(x)   37.8ms   39.1ms      25.6     278KB     44.7
```

---

In theory this needs a test, but I'm not really sure how to design one for this pathological case