### PR TITLE
Restore after slice fallback when result is named

### DIFF
--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -346,7 +346,7 @@ static SEXP chop_fallback(SEXP x, SEXP indices, struct vctrs_chop_info info) {
     SEXP elt = PROTECT(Rf_eval(call, env));
 
     // Restore attributes only if `[` fallback doesn't
-    if (ATTRIB(elt) == R_NilValue) {
+    if (!vec_is_restored(elt)) {
       elt = vec_restore(elt, x, info.restore_size);
     }
 

--- a/src/slice.c
+++ b/src/slice.c
@@ -15,9 +15,6 @@ SEXP fns_vec_slice_fallback_integer64 = NULL;
 SEXP syms_vec_slice_dispatch_integer64 = NULL;
 SEXP fns_vec_slice_dispatch_integer64 = NULL;
 
-// Defined below
-static bool vec_is_restored(SEXP x);
-
 
 #define SLICE_SUBSCRIPT(RTYPE, CTYPE, DEREF, CONST_DEREF, NA_VALUE)     \
   const CTYPE* data = CONST_DEREF(x);                                   \
@@ -413,7 +410,6 @@ SEXP vec_slice_impl(SEXP x, SEXP subscript) {
   }
 }
 
-static
 bool vec_is_restored(SEXP x) {
   SEXP attrib = ATTRIB(x);
 

--- a/src/slice.h
+++ b/src/slice.h
@@ -9,5 +9,7 @@ SEXP slice_rownames(SEXP names, SEXP subscript);
 SEXP vec_slice_base(enum vctrs_type type, SEXP x, SEXP subscript);
 SEXP vec_slice_fallback(SEXP x, SEXP subscript);
 
+bool vec_is_restored(SEXP x);
+
 
 #endif

--- a/tests/testthat/test-proxy-restore.R
+++ b/tests/testthat/test-proxy-restore.R
@@ -41,6 +41,7 @@ test_that("can use vctrs primitives from vec_restore() without inflooping", {
 
 test_that("vec_restore() passes `n` argument to methods", {
   local_methods(
+    vec_proxy.vctrs_foobar = identity,
     vec_restore.vctrs_foobar = function(x, to, ..., n) n
   )
   expect_identical(vec_slice(foobar(1:3), 2), 1L)

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -678,6 +678,8 @@ test_that("vec_slice() restores unrestored but named foreign classes", {
   x <- foobar(c(x = 1))
 
   expect_identical(vec_slice(x, 1), x)
+  expect_identical(vec_chop(x), list(x))
+  expect_identical(vec_chop(x, list(1)), list(x))
   expect_identical(vec_ptype(x), foobar(named(dbl())))
   expect_identical(vec_ptype(x), foobar(named(dbl())))
   expect_identical(vec_ptype_common(x, x), foobar(named(dbl())))

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -217,15 +217,27 @@ test_that("vec_slice() is proxied", {
 })
 
 test_that("dimensions are preserved by vec_slice()", {
-  attrib <- NULL
-
-  local_methods(
-    vec_restore.vctrs_foobar = function(x, ...) attrib <<- attributes(x)
-  )
-
+  # Fallback case
   x <- foobar(1:4)
   dim(x) <- c(2, 2)
   dimnames(x) <- list(a = c("foo", "bar"), b = c("quux", "hunoz"))
+
+  out <- vec_slice(x, 1)
+  exp <- foobar(
+    c(1L, 3L),
+    dim = c(1, 2),
+    dimnames = list(a = "foo", b = c("quux", "hunoz")
+  ))
+  expect_identical(out, exp)
+
+
+  # Native case
+  attrib <- NULL
+
+  local_methods(
+    vec_proxy.vctrs_foobar = identity,
+    vec_restore.vctrs_foobar = function(x, to, ...) attrib <<- attributes(x)
+  )
 
   vec_slice(x, 1)
 
@@ -660,4 +672,17 @@ test_that("vec_init() handles names in columns", {
     vec_init(data_frame(x = c(1, 2)))$x,
     na_dbl
   )
+})
+
+test_that("vec_slice() restores unrestored but named foreign classes", {
+  x <- foobar(c(x = 1))
+
+  expect_identical(vec_slice(x, 1), x)
+  expect_identical(vec_ptype(x), foobar(named(dbl())))
+  expect_identical(vec_ptype(x), foobar(named(dbl())))
+  expect_identical(vec_ptype_common(x, x), foobar(named(dbl())))
+
+  out <- vec_ptype_common_fallback(x, x)
+  expect_true(is_common_class_fallback(out))
+  expect_identical(fallback_class(out), "vctrs_foobar")
 })


### PR DESCRIPTION
Fixes

```r
vec_ptype_common(foobar(c(x = 1, y = 2)), foobar(c(x = 1)))
#> Error: `vec_ptype2.double.double()` is implemented at C level.
#> This R function is purely indicative and should never be called.
```

Caused by `vec_ptype()` losing the foreign class after a fallback slice, in the case of a named vector. We now also restore when the attributes only contain names.

Worth noting that after we'll have fixed the native dispatch after taking the ptype of inputs, this sort of problems will become harder to detect. Maybe we should add a check in the atomic ptype2 methods for OBJECT or ATTRIB.