### PR TITLE
Fall back to `c()` in `vec_unchop()`

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -535,10 +535,14 @@ SEXP s4_find_method(SEXP x, SEXP table) {
   }
 
   SEXP class = PROTECT(Rf_getAttrib(x, R_ClassSymbol));
+  SEXP out = s4_class_find_method(class, table);
 
+  UNPROTECT(1);
+  return out;
+}
+SEXP s4_class_find_method(SEXP class, SEXP table) {
   // Avoid corrupt objects where `x` is an OBJECT(), but the class is NULL
   if (class == R_NilValue) {
-    UNPROTECT(1);
     return R_NilValue;
   }
 
@@ -548,12 +552,10 @@ SEXP s4_find_method(SEXP x, SEXP table) {
   for (int i = 0; i < n_class; ++i) {
     SEXP method = s4_get_method(CHAR(p_class[i]), table);
     if (method != R_NilValue) {
-      UNPROTECT(1);
       return method;
     }
   }
 
-  UNPROTECT(1);
   return R_NilValue;
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -133,6 +133,7 @@ SEXP s3_find_method2(const char* generic,
 SEXP s3_paste_method_sym(const char* generic, const char* cls);
 SEXP s3_bare_class(SEXP x);
 SEXP s4_find_method(SEXP x, SEXP table);
+SEXP s4_class_find_method(SEXP class, SEXP table);
 bool vec_implements_ptype2(SEXP x);
 
 SEXP r_env_get(SEXP env, SEXP sym);

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -718,6 +718,32 @@ test_that("can ignore names in `vec_unchop()` by providing a `zap()` name-spec (
   })
 })
 
+test_that("vec_unchop() falls back to c() methods (#1120)", {
+  expect_error(
+    vec_unchop(list(foobar(1), foobar(2, class = "foo"))),
+    class = "vctrs_error_incompatible_type"
+  )
+
+  local_methods(
+    c.vctrs_foobar = function(...) {
+      inputs <- list(...)
+      paste0(rep_along(inputs, "dispatched"), seq_along(inputs))
+    }
+  )
+
+  # Different subclasses
+  xs <- list(foobar(1), foobar(2, class = "foo"))
+
+  expect_identical(
+    vec_unchop(xs),
+    c("dispatched1", "dispatched2")
+  )
+  expect_identical(
+    vec_unchop(xs, indices = list(2, 1)),
+    c("dispatched2", "dispatched1")
+  )
+})
+
 test_that("vec_unchop() has informative error messages", {
   verify_output(test_path("error", "test-unchop.txt"), {
     "# vec_unchop() errors on unsupported location values"


### PR DESCRIPTION
Branched from #1125.
Closes #1120.