### PR TITLE
Add coercion methods for sf data frames

### DIFF
--- a/R/type-sf.R
+++ b/R/type-sf.R
@@ -80,6 +80,15 @@ vec_ptype2.data.frame.sf = function(x, y, ...) {
 	sf_ptype2(x, y, ...)
 }
 
+# Maybe we should not have these methods, but they are currently
+# required to avoid the base-df fallback
+vec_ptype2.sf.tbl_df = function(x, y, ...) {
+	new_data_frame(sf_ptype2(x, y, ...))
+}
+vec_ptype2.tbl_df.sf = function(x, y, ...) {
+	new_data_frame(sf_ptype2(x, y, ...))
+}
+
 sf_cast = function(x, to, ...) {
 	data = vctrs::df_cast(x, to, ...)
 

--- a/R/type-sf.R
+++ b/R/type-sf.R
@@ -1,14 +1,20 @@
 
-# Imported at load-time
-st_crs = function(...) NULL
-st_precision = function(...) NULL
-st_as_sf = function(...) NULL
+# Imported at load-time in `sf_env`
+st_crs = function(...) stop_sf()
+st_precision = function(...) stop_sf()
+st_as_sf = function(...) stop_sf()
+stop_sf = function() abort("Internal error: Failed sf import.")
+
 sf_deps = c(
 	"st_crs",
 	"st_precision",
 	"st_as_sf"
 )
+sf_env = env()
 
+
+# sf namespace
+local(envir = sf_env, {
 
 # Registered at load-time (same for all other methods)
 vec_proxy.sf = function(x, ...) {
@@ -142,6 +148,10 @@ common_prec = function(x, y) {
 
 	lhs
 }
+
+}) # local(envir = sf_env)
+
+env_bind(ns_env("vctrs"), !!!as.list(sf_env))
 
 # Local Variables:
 # indent-tabs-mode: t

--- a/R/type-sf.R
+++ b/R/type-sf.R
@@ -99,12 +99,9 @@ sf_cast = function(x, to, ...) {
 		return(data)
 	}
 
-	# Take active geometry from target type
 	sfc_name = attr(to, "sf_column")
-
-	# CRS and precision must match
-	crs = common_crs(x, to)
-	prec = common_prec(x, to)
+	crs = st_crs(to)
+	prec = st_precision(to)
 
 	st_as_sf(
 		data,
@@ -117,6 +114,12 @@ sf_cast = function(x, to, ...) {
 
 vec_cast.sf.sf = function(x, to, ...) {
 	sf_cast(x, to, ...)
+}
+vec_cast.sf.data.frame = function(x, to, ...) {
+	sf_cast(x, to, ...)
+}
+vec_cast.data.frame.sf = function(x, to, ...) {
+	df_cast(x, to, ...)
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -207,3 +207,8 @@ vec_common_suffix <- function(x, y) {
     x
   }
 }
+
+import_from <- function(ns, names, env = caller_env()) {
+  objs <- env_get_list(ns_env(ns), names)
+  env_bind(env, !!!objs)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -80,7 +80,7 @@ on_package_load <- function(pkg, expr) {
   })
 
   on_package_load("sf", {
-    import_from("sf", sf_deps, env = ns)
+    import_from("sf", sf_deps, env = sf_env)
 
     if (!env_has(ns_env("sf"), "vec_restore.sf")) {
       s3_register("vctrs::vec_proxy", "sf")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -93,6 +93,8 @@ on_package_load <- function(pkg, expr) {
       s3_register("vctrs::vec_ptype2", "sf.tbl_df")
       s3_register("vctrs::vec_ptype2", "tbl_df.sf")
       s3_register("vctrs::vec_cast", "sf.sf")
+      s3_register("vctrs::vec_cast", "sf.data.frame")
+      s3_register("vctrs::vec_cast", "data.frame.sf")
     }
   })
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -90,6 +90,8 @@ on_package_load <- function(pkg, expr) {
       s3_register("vctrs::vec_ptype2", "sf.sf")
       s3_register("vctrs::vec_ptype2", "sf.data.frame")
       s3_register("vctrs::vec_ptype2", "data.frame.sf")
+      s3_register("vctrs::vec_ptype2", "sf.tbl_df")
+      s3_register("vctrs::vec_ptype2", "tbl_df.sf")
       s3_register("vctrs::vec_cast", "sf.sf")
     }
   })

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,6 +11,7 @@ on_package_load <- function(pkg, expr) {
 
 .onLoad <- function(libname, pkgname) {
   check_linked_version(pkgname)
+  ns <- ns_env("vctrs")
 
   on_package_load("testthat", {
     s3_register("testthat::is_informative_error", "vctrs_error_cast_lossy")
@@ -78,6 +79,21 @@ on_package_load <- function(pkg, expr) {
     }
   })
 
+  on_package_load("sf", {
+    import_from("sf", sf_deps, env = ns)
+
+    if (!env_has(ns_env("sf"), "vec_restore.sf")) {
+      s3_register("vctrs::vec_proxy", "sf")
+      s3_register("vctrs::vec_restore", "sf")
+    }
+    if (!env_has(ns_env("sf"), "vec_ptype2.sf.sf")) {
+      s3_register("vctrs::vec_ptype2", "sf.sf")
+      s3_register("vctrs::vec_ptype2", "sf.data.frame")
+      s3_register("vctrs::vec_ptype2", "data.frame.sf")
+      s3_register("vctrs::vec_cast", "sf.sf")
+    }
+  })
+
   utils::globalVariables("vec_set_attributes")
 
   # Prevent two copies from being made by `attributes(x) <- attrib` on R < 3.6.0
@@ -92,7 +108,6 @@ on_package_load <- function(pkg, expr) {
     }
   }
 
-  ns <- ns_env("vctrs")
   env_bind(ns, vec_set_attributes = vec_set_attributes)
 
   .Call(vctrs_init_library, ns_env())

--- a/tests/testthat/helper-vctrs.R
+++ b/tests/testthat/helper-vctrs.R
@@ -1,8 +1,7 @@
 
-import_from <- function(ns, names, env = caller_env()) {
+testthat_import_from <- function(ns, names, env = caller_env()) {
   skip_if_not_installed(ns)
-  objs <- env_get_list(ns_env(ns), names)
-  env_bind(env, !!!objs)
+  import_from(ns, names, env = env)
 }
 
 vec_ptype2_fallback <- function(x, y, ...) {

--- a/tests/testthat/test-type-misc.R
+++ b/tests/testthat/test-type-misc.R
@@ -32,7 +32,7 @@ test_that("`numeric_version` falls back to base methods", {
 test_that("common type of data.table and data.frame is data.table", {
   # As data.table is not in Suggests, these checks are only run on the
   # devs' machines
-  import_from("data.table", "data.table")
+  testthat_import_from("data.table", "data.table")
 
   expect_identical(
     vec_ptype2(data.table(x = TRUE), data.table(y = 2)),
@@ -62,7 +62,7 @@ test_that("common type of data.table and data.frame is data.table", {
 })
 
 test_that("data.table and tibble do not have a common type", {
-  import_from("data.table", "data.table")
+  testthat_import_from("data.table", "data.table")
 
   expect_incompatible_df(
     vec_ptype_common(data.table(x = TRUE), tibble(y = 2)),

--- a/tests/testthat/test-type-sf.R
+++ b/tests/testthat/test-type-sf.R
@@ -75,6 +75,12 @@ test_that("sf has a cast method", {
 	)
 	expect_identical(out, exp)
 
+	out = vctrs::vec_cast(new_data_frame(sf1), common)
+	expect_identical(out, exp)
+
+	out = vctrs::vec_cast(sf1, new_data_frame(common))
+	expect_identical(out, new_data_frame(exp))
+
 	out = vctrs::vec_cast(sf2, common)
 	exp = st_sf(
 		x = 0,

--- a/tests/testthat/test-type-sf.R
+++ b/tests/testthat/test-type-sf.R
@@ -1,6 +1,6 @@
 
 # Avoids adding `sf` to Suggests
-import_from("sf", c(
+testthat_import_from("sf", c(
   "st_sfc",
   "st_point",
   "st_bbox",

--- a/tests/testthat/test-type-sf.R
+++ b/tests/testthat/test-type-sf.R
@@ -119,6 +119,33 @@ test_that("can combine sf data frames", {
 	expect_identical(bind_rows(sf2, sf1, sf2), st_as_sf(exp))
 })
 
+test_that("can combine sf and tibble", {
+	sfc1 = st_sfc(st_point(1:2), st_point(3:4))
+	sfc2 = st_sfc(st_linestring(matrix(1:4, 2)))
+
+	sf1 = st_sf(x = c(TRUE, FALSE), geo1 = sfc1)
+	sf2 = st_sf(y = "", geo2 = sfc2, x = 0, stringsAsFactors = FALSE)
+
+	out = vctrs::vec_rbind(sf2, data.frame(x = 1))
+	exp = data_frame(
+		y = c("", NA),
+		x = c(0, 1),
+		geo2 = sfc2[c(1L, NA)]
+	)
+	expect_identical(out, exp)
+
+	out = vctrs::vec_rbind(sf2, tibble::tibble(x = 1))
+	expect_identical(out, exp)
+
+	out = vctrs::vec_rbind(tibble::tibble(x = 1), sf2)
+	exp = data_frame(
+		x = c(1, 0),
+		y = c(NA, ""),
+		geo2 = sfc2[c(NA, 1L)]
+	)
+	expect_identical(out, exp)
+})
+
 # https://github.com/r-spatial/sf/issues/1390
 test_that("can combine sfc lists", {
   ls <- st_linestring(matrix(1:3, ncol = 3))


### PR DESCRIPTION
Closes #1136.

Methods can't be included downstream yet because of workarounds to fix the bad interactions between ptype2 and the `c()` fallback in `vec_rbind()` on which we count to combine geometry columns. When the `c()` fallback is enabled, we return a bare data frame instead of an sf one. This is a stopgap to make dplyr work (via `dplyr_reconstruct()`).

Requires r-spatial/sf#1414.