### PR TITLE
Fix default `vec_proxy_compare()` method

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -49,7 +49,7 @@ vec_proxy_compare_default <- function(x, relax = FALSE) {
       stop_unsupported(x, "vec_proxy_compare")
     }
   } else {
-    vec_data(x)
+    vec_proxy_equal(x)
   }
 }
 

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -449,7 +449,11 @@ xtfrm.vctrs_vctr <- function(x) {
 
   # order(order(x)) ~= rank(x)
   if (is_integer(proxy) || is_double(proxy)) {
-    proxy
+    if (is.object(proxy)) {
+      unstructure(proxy)
+    } else {
+      proxy
+    }
   } else {
     order(order_proxy(proxy))
   }
@@ -673,14 +677,12 @@ format.hidden <- function(x, ...) rep("xxx", length(x))
 
 local_hidden <- function(frame = caller_env()) {
   local_bindings(.env = global_env(), .frame = frame,
-    vec_ptype2.hidden         = function(x, y, ...) UseMethod("vec_ptype2.hidden"),
     vec_ptype2.hidden.hidden  = function(x, y, ...) new_hidden(),
     vec_ptype2.hidden.double  = function(x, y, ...) new_hidden(),
     vec_ptype2.double.hidden  = function(x, y, ...) new_hidden(),
     vec_ptype2.hidden.logical = function(x, y, ...) new_hidden(),
     vec_ptype2.logical.hidden = function(x, y, ...) new_hidden(),
 
-    vec_cast.hidden          = function(x, to, ...) UseMethod("vec_cast.hidden"),
     vec_cast.hidden.hidden   = function(x, to, ...) x,
     vec_cast.hidden.double   = function(x, to, ...) new_hidden(vec_data(x)),
     vec_cast.double.hidden   = function(x, to, ...) vec_data(x),

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -149,9 +149,14 @@ SEXP vctrs_new_data_frame(SEXP args) {
 
 static R_len_t df_size_from_list(SEXP x, SEXP n) {
   if (n == R_NilValue) {
-    return df_raw_size_from_list(x);
+    if (is_data_frame(x)) {
+      return df_size(x);
+    } else {
+      return df_raw_size_from_list(x);
+    }
+  } else {
+    return df_size_from_n(n);
   }
-  return df_size_from_n(n);
 }
 
 static R_len_t df_size_from_n(SEXP n) {

--- a/tests/testthat/test-proxy.R
+++ b/tests/testthat/test-proxy.R
@@ -94,3 +94,19 @@ test_that("vec_proxy_equal() returns a POSIXct for POSIXlt objects (#901)", {
   x <- as.POSIXlt(new_date(0), tz = "UTC")
   expect_s3_class(vec_proxy_equal(x), "POSIXct")
 })
+
+test_that("vec_proxy_equal() defaults to vec_proxy() and vec_proxy_compare() defaults to vec_proxy_equal() (#1140)", {
+  foobar_proxy <- function(x, ...) data_frame(x = unclass(x), y = seq_along(x))
+
+  local_methods(vec_proxy.vctrs_foobar = foobar_proxy)
+
+  x <- foobar(3:1)
+  expect_identical(vec_proxy(x), foobar_proxy(x))
+  expect_identical(vec_proxy_equal(x), foobar_proxy(x))
+  expect_identical(vec_proxy_compare(x), foobar_proxy(x))
+
+  local_methods(vec_proxy_equal.vctrs_foobar = function(x, ...) foobar_proxy(letters[x]))
+
+  expect_identical(vec_proxy_equal(x), data_frame(x = letters[3:1], y = 1:3))
+  expect_identical(vec_proxy_compare(x), data_frame(x = letters[3:1], y = 1:3))
+})

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -579,3 +579,7 @@ test_that("generic predicates return logical vectors (#251)", {
   expect_identical(any(x), TRUE)
   expect_identical(all(x), TRUE)
 })
+
+test_that("xtfrm() returns a bare vector", {
+  expect_identical(xtfrm(new_vctr(1:3, foo = "bar")), 1:3)
+})


### PR DESCRIPTION
* Defaults to `vec_proxy_equal()` instead of `vec_data()`. Closes #1140.

* Update `xtfrm.vctrs_vctr()` to return an unclassed integer vector even when the comparison proxy is classed.