### PR TITLE
Remove unneeded arg_match()

### DIFF
--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -172,7 +172,7 @@ vec_as_location2_result <- function(i,
     logical = "error"
   )
 
-  if (!is_null(result$err)) {
+  if (!is.null(result$err)) {
     parent <- result$err
     return(result(err = new_error_location2_type(
       i = i,
@@ -242,7 +242,7 @@ vec_as_location2_result <- function(i,
     i <- -i
   }
 
-  if (is_null(err)) {
+  if (is.null(err)) {
     result(i)
   } else {
     result(err = new_error_location2_type(

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -158,8 +158,13 @@ vec_as_location2_result <- function(i,
                                     missing,
                                     negative,
                                     arg) {
-  allow_missing <- arg_match(missing, c("error", "propagate")) == "propagate"
-  allow_negative <- arg_match(negative, c("error", "ignore")) == "ignore"
+  allow_missing <- (missing == "propagate")
+  if (!allow_missing && missing != "error") {
+    abort('`missing` must be one of "error" or "propagate".')
+  }
+
+  allow_negative <- (negative == "ignore")
+  # checked later, check omitted here for performance
 
   result <- vec_as_subscript2_result(
     i = i,

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -86,7 +86,7 @@ vec_as_subscript2_result <- function(i,
 
   # Return a child of subscript error. The child error messages refer
   # to single subscripts instead of subscript vectors.
-  if (!is_null(result$err)) {
+  if (!is.null(result$err)) {
     parent <- result$err$parent
     if (inherits(parent, "vctrs_error_cast_lossy")) {
       bullets <- new_cnd_bullets_subscript_lossy_cast(parent)
@@ -296,7 +296,7 @@ subscript_actions <- c(
 cnd_subscript_action <- function(cnd, assign_to = TRUE) {
   action <- cnd$subscript_action
 
-  if (is_null(action)) {
+  if (is.null(action)) {
     if (cnd_subscript_scalar(cnd)) {
       action <- "extract"
     } else {

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -75,9 +75,6 @@ vec_as_subscript2_result <- function(i,
                                      logical = "cast",
                                      numeric = "cast",
                                      character = "cast") {
-  logical <- arg_match(logical, c("cast", "error"))
-  numeric <- arg_match(numeric, c("cast", "error"))
-  character <- arg_match(character, c("cast", "error"))
 
   result <- vec_as_subscript_result(
     i,

--- a/tests/testthat/error/test-subscript-loc.txt
+++ b/tests/testthat/error/test-subscript-loc.txt
@@ -1,4 +1,11 @@
 
+vec_as_location() UI
+====================
+
+> vec_as_location(1, 1L, missing = "bogus")
+Error: `missing` must be one of "propagate" or "error".
+
+
 vec_as_location() checks for mix of negative and missing locations
 ==================================================================
 
@@ -25,6 +32,22 @@ i Subscript has a positive value at location 2.
 Error: Must subset elements with a valid subscript vector.
 x Negative and positive locations can't be mixed.
 i Subscript has 10 positive values at locations 2, 3, 4, 5, 6, etc.
+
+
+num_as_location() UI
+====================
+
+> num_as_location(1, 1L, missing = "bogus")
+Error: `missing` must be one of "propagate" or "error".
+
+> num_as_location(1, 1L, negative = "bogus")
+Error: `negative` must be one of "invert", "error", or "ignore".
+
+> num_as_location(1, 1L, oob = "bogus")
+Error: `oob` must be one of "error" or "extend".
+
+> num_as_location(1, 1L, zero = "bogus")
+Error: `zero` must be one of "remove", "error", or "ignore".
 
 
 num_as_location() optionally forbids negative indices
@@ -128,6 +151,13 @@ i It must be logical, numeric, or character.
 > vec_as_location(2.5, 3L, arg = "foo")
 Error: Must subset elements with a valid subscript vector.
 x Can't convert from `foo` <double> to <integer> due to loss of precision.
+
+
+vec_as_location2() UI
+=====================
+
+> vec_as_location2(1, 1L, missing = "bogus")
+Error: `missing` must be one of "error" or "propagate".
 
 
 vec_as_location2() requires integer or character inputs
@@ -302,6 +332,16 @@ x Element `foo` doesn't exist.
 > vec_as_location2("foo", 1L, names = "bar")
 Error: Can't subset elements that don't exist.
 x Element `foo` doesn't exist.
+
+
+num_as_location() UI
+====================
+
+> num_as_location(1, 1L, missing = "bogus")
+Error: `missing` must be one of "propagate" or "error".
+
+> num_as_location(1, 1L, negative = "bogus")
+Error: `negative` must be one of "invert", "error", or "ignore".
 
 
 can optionally extend beyond the end

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -444,6 +444,9 @@ test_that("vec_as_location() works with vectors of dimensionality 1", {
 
 test_that("conversion to locations has informative error messages", {
   verify_output(test_path("error", "test-subscript-loc.txt"), {
+    "# vec_as_location() UI"
+    vec_as_location(1, 1L, missing = "bogus")
+
     "# vec_as_location() checks for mix of negative and missing locations"
     vec_as_location(-c(1L, NA), 30)
     vec_as_location(-c(1L, rep(NA, 10)), 30)
@@ -451,6 +454,12 @@ test_that("conversion to locations has informative error messages", {
     "# vec_as_location() checks for mix of negative and positive locations"
     vec_as_location(c(-1L, 1L), 30)
     vec_as_location(c(-1L, rep(1L, 10)), 30)
+
+    "# num_as_location() UI"
+    num_as_location(1, 1L, missing = "bogus")
+    num_as_location(1, 1L, negative = "bogus")
+    num_as_location(1, 1L, oob = "bogus")
+    num_as_location(1, 1L, zero = "bogus")
 
     "# num_as_location() optionally forbids negative indices"
     num_as_location(dbl(1, -1), 2L, negative = "error")
@@ -477,6 +486,9 @@ test_that("conversion to locations has informative error messages", {
     vec_as_location(env(), 10L, arg = "foo")
     vec_as_location(foobar(), 10L, arg = "foo")
     vec_as_location(2.5, 3L, arg = "foo")
+
+    "# vec_as_location2() UI"
+    vec_as_location2(1, 1L, missing = "bogus")
 
     "# vec_as_location2() requires integer or character inputs"
     vec_as_location2(TRUE, 10L)
@@ -519,6 +531,10 @@ test_that("conversion to locations has informative error messages", {
     "Character subscripts"
     vec_as_location("foo", 1L, names = "bar")
     vec_as_location2("foo", 1L, names = "bar")
+
+    "# num_as_location() UI"
+    num_as_location(1, 1L, missing = "bogus")
+    num_as_location(1, 1L, negative = "bogus")
 
     "# can optionally extend beyond the end"
     num_as_location(c(1, 3), 1, oob = "extend")


### PR DESCRIPTION
With UI tests.

Makes `vec_as_location2()` quite a bit faster, realistically we need to remove that `tryCatch()` and perhaps rewrite in C to make performance comparable with base.

## vctrs main

``` r
library(vctrs)
library(magrittr)

bench::mark(
  vec_as_location2("x", 1L, "x", missing = "propagate", arg = "x"),
  iterations = 1000
) %>%
  dplyr::select(-expression)
#> # A tibble: 1 x 5
#>        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1   78.7µs   88.8µs     9451.     322KB     18.9
```

<sup>Created on 2020-06-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

## This PR

``` r
library(vctrs)
library(magrittr)

bench::mark(
  vec_as_location2("x", 1L, "x", missing = "propagate", arg = "x"),
  iterations = 10000
) %>%
  dplyr::select(-expression)
#> # A tibble: 1 x 5
#>        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1   24.8µs   28.1µs    32548.     174KB     16.3
```

<sup>Created on 2020-06-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>