### PR TITLE
Revert to a simpler ownership model - but always duplicate ALTREP

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,6 +29,7 @@ jobs:
           - {os: ubuntu-16.04,   r: '3.2',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
+      VCTRS_TEST_PERFORMANCE: true
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/src/bind.c
+++ b/src/bind.c
@@ -4,6 +4,7 @@
 #include "ptype-common.h"
 #include "slice-assign.h"
 #include "type-data-frame.h"
+#include "owned.h"
 #include "utils.h"
 
 
@@ -180,7 +181,7 @@ static SEXP vec_rbind(SEXP xs,
     init_compact_seq(idx_ptr, counter, size, true);
 
     // Total ownership of `out` because it was freshly created with `vec_init()`
-    out = df_assign(out, idx, x, vctrs_ownership_total, &bind_assign_opts);
+    out = df_assign(out, idx, x, vctrs_owned_TRUE, &bind_assign_opts);
     REPROTECT(out, out_pi);
 
     if (has_rownames) {
@@ -198,7 +199,7 @@ static SEXP vec_rbind(SEXP xs,
       PROTECT(rn);
 
       if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
-        rownames = chr_assign(rownames, idx, rn, vctrs_ownership_total);
+        rownames = chr_assign(rownames, idx, rn, vctrs_owned_TRUE);
         REPROTECT(rownames, rownames_pi);
       }
 
@@ -460,12 +461,12 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
     init_compact_seq(idx_ptr, counter, xn, true);
 
     // Total ownership of `out` because it was freshly created with `Rf_allocVector()`
-    out = list_assign(out, idx, x, vctrs_ownership_total);
+    out = list_assign(out, idx, x, vctrs_owned_TRUE);
     REPROTECT(out, out_pi);
 
     SEXP xnms = PROTECT(r_names(x));
     if (xnms != R_NilValue) {
-      names = chr_assign(names, idx, xnms, vctrs_ownership_total);
+      names = chr_assign(names, idx, xnms, vctrs_owned_TRUE);
       REPROTECT(names, names_pi);
     }
     UNPROTECT(1);

--- a/src/bind.c
+++ b/src/bind.c
@@ -248,7 +248,7 @@ static SEXP vec_rbind(SEXP xs,
     }
   }
 
-  out = vec_restore(out, ptype, PROTECT(r_int(n_rows)));
+  out = vec_restore(out, ptype, PROTECT(r_int(n_rows)), VCTRS_OWNED_true);
 
   UNPROTECT(n_prot);
   UNPROTECT(4);
@@ -481,7 +481,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
     Rf_setAttrib(out, R_RowNamesSymbol, rownames);
   }
 
-  out = vec_restore(out, type, R_NilValue);
+  out = vec_restore(out, type, R_NilValue, VCTRS_OWNED_true);
 
   UNPROTECT(9);
   return out;

--- a/src/bind.c
+++ b/src/bind.c
@@ -181,7 +181,7 @@ static SEXP vec_rbind(SEXP xs,
     init_compact_seq(idx_ptr, counter, size, true);
 
     // Total ownership of `out` because it was freshly created with `vec_init()`
-    out = df_assign(out, idx, x, vctrs_owned_TRUE, &bind_assign_opts);
+    out = df_assign(out, idx, x, VCTRS_OWNED_true, &bind_assign_opts);
     REPROTECT(out, out_pi);
 
     if (has_rownames) {
@@ -199,7 +199,7 @@ static SEXP vec_rbind(SEXP xs,
       PROTECT(rn);
 
       if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
-        rownames = chr_assign(rownames, idx, rn, vctrs_owned_TRUE);
+        rownames = chr_assign(rownames, idx, rn, VCTRS_OWNED_true);
         REPROTECT(rownames, rownames_pi);
       }
 
@@ -461,12 +461,12 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
     init_compact_seq(idx_ptr, counter, xn, true);
 
     // Total ownership of `out` because it was freshly created with `Rf_allocVector()`
-    out = list_assign(out, idx, x, vctrs_owned_TRUE);
+    out = list_assign(out, idx, x, VCTRS_OWNED_true);
     REPROTECT(out, out_pi);
 
     SEXP xnms = PROTECT(r_names(x));
     if (xnms != R_NilValue) {
-      names = chr_assign(names, idx, xnms, vctrs_owned_TRUE);
+      names = chr_assign(names, idx, xnms, VCTRS_OWNED_true);
       REPROTECT(names, names_pi);
     }
     UNPROTECT(1);

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -3,6 +3,7 @@
 #include "ptype-common.h"
 #include "slice.h"
 #include "slice-assign.h"
+#include "owned.h"
 #include "utils.h"
 
 // Defined in slice-chop.c
@@ -151,7 +152,7 @@ static SEXP vec_unchop(SEXP x,
     SEXP index = VECTOR_ELT(indices, i);
 
     // Total ownership of `proxy` because it was freshly created with `vec_init()`
-    proxy = vec_proxy_assign_opts(proxy, index, elt, vctrs_ownership_total, &unchop_assign_opts);
+    proxy = vec_proxy_assign_opts(proxy, index, elt, vctrs_owned_TRUE, &unchop_assign_opts);
     REPROTECT(proxy, proxy_pi);
 
     if (has_names) {
@@ -160,7 +161,7 @@ static SEXP vec_unchop(SEXP x,
       SEXP inner = PROTECT(vec_names(elt));
       SEXP elt_names = PROTECT(apply_name_spec(name_spec, outer, inner, size));
       if (elt_names != R_NilValue) {
-        out_names = chr_assign(out_names, index, elt_names, vctrs_ownership_total);
+        out_names = chr_assign(out_names, index, elt_names, vctrs_owned_TRUE);
         REPROTECT(out_names, out_names_pi);
       }
       UNPROTECT(2);

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -170,7 +170,7 @@ static SEXP vec_unchop(SEXP x,
 
   SEXP out_size_sexp = PROTECT(r_int(out_size));
 
-  SEXP out = PROTECT(vec_restore(proxy, ptype, out_size_sexp));
+  SEXP out = PROTECT(vec_restore(proxy, ptype, out_size_sexp, VCTRS_OWNED_true));
 
   if (has_names) {
     out_names = vec_as_names(out_names, name_repair);

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -152,7 +152,7 @@ static SEXP vec_unchop(SEXP x,
     SEXP index = VECTOR_ELT(indices, i);
 
     // Total ownership of `proxy` because it was freshly created with `vec_init()`
-    proxy = vec_proxy_assign_opts(proxy, index, elt, vctrs_owned_TRUE, &unchop_assign_opts);
+    proxy = vec_proxy_assign_opts(proxy, index, elt, VCTRS_OWNED_true, &unchop_assign_opts);
     REPROTECT(proxy, proxy_pi);
 
     if (has_names) {
@@ -161,7 +161,7 @@ static SEXP vec_unchop(SEXP x,
       SEXP inner = PROTECT(vec_names(elt));
       SEXP elt_names = PROTECT(apply_name_spec(name_spec, outer, inner, size));
       if (elt_names != R_NilValue) {
-        out_names = chr_assign(out_names, index, elt_names, vctrs_owned_TRUE);
+        out_names = chr_assign(out_names, index, elt_names, VCTRS_OWNED_true);
         REPROTECT(out_names, out_names_pi);
       }
       UNPROTECT(2);

--- a/src/c.c
+++ b/src/c.c
@@ -134,7 +134,7 @@ SEXP vec_c_opts(SEXP xs,
     init_compact_seq(idx_ptr, counter, size, true);
 
     // Total ownership of `out` because it was freshly created with `vec_init()`
-    out = vec_proxy_assign_opts(out, idx, x, vctrs_owned_TRUE, &c_assign_opts);
+    out = vec_proxy_assign_opts(out, idx, x, VCTRS_OWNED_true, &c_assign_opts);
     REPROTECT(out, out_pi);
 
     if (has_names) {
@@ -143,7 +143,7 @@ SEXP vec_c_opts(SEXP xs,
       SEXP x_nms = PROTECT(apply_name_spec(name_spec, outer, inner, size));
 
       if (x_nms != R_NilValue) {
-        out_names = chr_assign(out_names, idx, x_nms, vctrs_owned_TRUE);
+        out_names = chr_assign(out_names, idx, x_nms, VCTRS_OWNED_true);
         REPROTECT(out_names, out_names_pi);
       }
 

--- a/src/c.c
+++ b/src/c.c
@@ -153,7 +153,7 @@ SEXP vec_c_opts(SEXP xs,
     counter += size;
   }
 
-  out = PROTECT(vec_restore(out, ptype, R_NilValue));
+  out = PROTECT(vec_restore(out, ptype, R_NilValue, VCTRS_OWNED_true));
 
   if (has_names) {
     out_names = PROTECT(vec_as_names(out_names, name_repair));

--- a/src/c.c
+++ b/src/c.c
@@ -2,6 +2,7 @@
 #include "c.h"
 #include "ptype-common.h"
 #include "slice-assign.h"
+#include "owned.h"
 #include "utils.h"
 
 
@@ -133,7 +134,7 @@ SEXP vec_c_opts(SEXP xs,
     init_compact_seq(idx_ptr, counter, size, true);
 
     // Total ownership of `out` because it was freshly created with `vec_init()`
-    out = vec_proxy_assign_opts(out, idx, x, vctrs_ownership_total, &c_assign_opts);
+    out = vec_proxy_assign_opts(out, idx, x, vctrs_owned_TRUE, &c_assign_opts);
     REPROTECT(out, out_pi);
 
     if (has_names) {
@@ -142,7 +143,7 @@ SEXP vec_c_opts(SEXP xs,
       SEXP x_nms = PROTECT(apply_name_spec(name_spec, outer, inner, size));
 
       if (x_nms != R_NilValue) {
-        out_names = chr_assign(out_names, idx, x_nms, vctrs_ownership_total);
+        out_names = chr_assign(out_names, idx, x_nms, vctrs_owned_TRUE);
         REPROTECT(out_names, out_names_pi);
       }
 

--- a/src/init.c
+++ b/src/init.c
@@ -54,8 +54,8 @@ extern SEXP vctrs_unchop(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_chop_seq(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_slice_seq(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_slice_rep(SEXP, SEXP, SEXP);
-extern SEXP vec_restore(SEXP, SEXP, SEXP);
-extern SEXP vec_restore_default(SEXP, SEXP);
+extern SEXP vctrs_restore(SEXP, SEXP, SEXP);
+extern SEXP vctrs_restore_default(SEXP, SEXP);
 extern SEXP vec_proxy(SEXP);
 extern SEXP vec_proxy_equal(SEXP);
 extern SEXP vec_proxy_compare(SEXP);
@@ -76,7 +76,7 @@ extern SEXP vctrs_df_ptype2_opts(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_type_info(SEXP);
 extern SEXP vctrs_proxy_info(SEXP);
 extern SEXP vctrs_class_type(SEXP);
-extern SEXP vec_bare_df_restore(SEXP, SEXP, SEXP);
+extern SEXP vctrs_bare_df_restore(SEXP, SEXP, SEXP);
 extern SEXP vctrs_recycle(SEXP, SEXP, SEXP);
 extern SEXP vctrs_assign(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_assign_seq(SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -191,8 +191,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_chop_seq",                   (DL_FUNC) &vctrs_chop_seq, 4},
   {"vctrs_slice_seq",                  (DL_FUNC) &vec_slice_seq, 4},
   {"vctrs_slice_rep",                  (DL_FUNC) &vec_slice_rep, 3},
-  {"vctrs_restore",                    (DL_FUNC) &vec_restore, 3},
-  {"vctrs_restore_default",            (DL_FUNC) &vec_restore_default, 2},
+  {"vctrs_restore",                    (DL_FUNC) &vctrs_restore, 3},
+  {"vctrs_restore_default",            (DL_FUNC) &vctrs_restore_default, 2},
   {"vctrs_proxy",                      (DL_FUNC) &vec_proxy, 1},
   {"vctrs_proxy_equal",                (DL_FUNC) &vec_proxy_equal, 1},
   {"vctrs_proxy_compare",              (DL_FUNC) &vec_proxy_compare, 1},
@@ -213,7 +213,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_type_info",                  (DL_FUNC) &vctrs_type_info, 1},
   {"vctrs_proxy_info",                 (DL_FUNC) &vctrs_proxy_info, 1},
   {"vctrs_class_type",                 (DL_FUNC) &vctrs_class_type, 1},
-  {"vctrs_bare_df_restore",            (DL_FUNC) &vec_bare_df_restore, 3},
+  {"vctrs_bare_df_restore",            (DL_FUNC) &vctrs_bare_df_restore, 3},
   {"vctrs_recycle",                    (DL_FUNC) &vctrs_recycle, 3},
   {"vctrs_assign",                     (DL_FUNC) &vctrs_assign, 5},
   {"vctrs_assign_seq",                 (DL_FUNC) &vctrs_assign_seq, 5},

--- a/src/owned.h
+++ b/src/owned.h
@@ -17,12 +17,16 @@ static inline enum vctrs_owned vec_owned(SEXP x) {
 }
 
 // Wrapper around `r_clone_referenced()` that only attempts to clone if
-// we indicate that we don't own `x`, or if we do own `x` but it is ALTREP.
-// If `x` is ALTREP, we must clone it before dereferencing, otherwise we get
-// a pointer into the ALTREP internals rather than into the object it
-// truly represents.
+// we indicate that we don't own `x`, or if `x` is ALTREP.
+// If `x` is ALTREP, we must unconditionally clone it before dereferencing,
+// otherwise we get a pointer into the ALTREP internals rather than into the
+// object it truly represents.
 static inline SEXP vec_clone_referenced(SEXP x, const enum vctrs_owned owned) {
-  if (owned == VCTRS_OWNED_false || ALTREP(x)) {
+  if (ALTREP(x)) {
+    return r_clone_referenced(x);
+  }
+
+  if (owned == VCTRS_OWNED_false) {
     return r_clone_referenced(x);
   } else {
     return x;

--- a/src/owned.h
+++ b/src/owned.h
@@ -1,0 +1,32 @@
+#ifndef VCTRS_OWNED_H
+#define VCTRS_OWNED_H
+
+#include "altrep.h"
+#include "utils.h"
+
+
+// Ownership is recursive
+enum vctrs_owned {
+  vctrs_owned_FALSE = 0,
+  vctrs_owned_TRUE
+};
+
+
+static inline enum vctrs_owned vec_owned(SEXP x) {
+  return NO_REFERENCES(x) ? vctrs_owned_TRUE : vctrs_owned_FALSE;
+}
+
+// Wrapper around `r_clone_referenced()` that only attempts to clone if
+// we indicate that we don't own `x`, or if we do own `x` but it is ALTREP.
+// If `x` is ALTREP, we must clone it before dereferencing, otherwise we get
+// a pointer into the ALTREP internals rather than into the object it
+// truly represents.
+static inline SEXP vec_clone_referenced(SEXP x, const enum vctrs_owned owned) {
+  if (owned == vctrs_owned_FALSE || ALTREP(x)) {
+    return r_clone_referenced(x);
+  } else {
+    return x;
+  }
+}
+
+#endif

--- a/src/owned.h
+++ b/src/owned.h
@@ -7,13 +7,13 @@
 
 // Ownership is recursive
 enum vctrs_owned {
-  vctrs_owned_FALSE = 0,
-  vctrs_owned_TRUE
+  VCTRS_OWNED_false = 0,
+  VCTRS_OWNED_true
 };
 
 
 static inline enum vctrs_owned vec_owned(SEXP x) {
-  return NO_REFERENCES(x) ? vctrs_owned_TRUE : vctrs_owned_FALSE;
+  return NO_REFERENCES(x) ? VCTRS_OWNED_true : VCTRS_OWNED_false;
 }
 
 // Wrapper around `r_clone_referenced()` that only attempts to clone if
@@ -22,7 +22,7 @@ static inline enum vctrs_owned vec_owned(SEXP x) {
 // a pointer into the ALTREP internals rather than into the object it
 // truly represents.
 static inline SEXP vec_clone_referenced(SEXP x, const enum vctrs_owned owned) {
-  if (owned == vctrs_owned_FALSE || ALTREP(x)) {
+  if (owned == VCTRS_OWNED_false || ALTREP(x)) {
     return r_clone_referenced(x);
   } else {
     return x;

--- a/src/slice-assign-array.c
+++ b/src/slice-assign-array.c
@@ -2,79 +2,68 @@
 #include "utils.h"
 #include "strides.h"
 #include "slice-assign.h"
+#include "owned.h"
 
-#define ASSIGN_SHAPED_INDEX(CTYPE, DEREF, CONST_DEREF)   \
-  SEXP out;                                              \
-  if (ownership == vctrs_ownership_total) {              \
-    out = PROTECT(r_clone_shared(proxy));                \
-  } else {                                               \
-    out = PROTECT(r_clone_referenced(proxy));            \
-  }                                                      \
-                                                         \
-  CTYPE* p_out = DEREF(out);                             \
-                                                         \
-  const CTYPE* p_value = CONST_DEREF(value);             \
-  R_len_t k = 0;                                         \
-                                                         \
-  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {   \
-    R_len_t loc = vec_strided_loc(                       \
-      p_info->p_shape_index,                             \
-      p_info->p_strides,                                 \
-      p_info->shape_n                                    \
-    );                                                   \
-                                                         \
-    for (R_len_t j = 0; j < p_info->index_n; ++j, ++k) { \
-      const int step = p_info->p_steps[j];               \
-                                                         \
-      if (step == NA_INTEGER) {                          \
-        continue;                                        \
-      }                                                  \
-                                                         \
-      loc += step;                                       \
-                                                         \
-      p_out[loc] = p_value[k];                           \
-    }                                                    \
-                                                         \
-    vec_shape_index_increment(p_info);                   \
-  }                                                      \
-                                                         \
-  UNPROTECT(1);                                          \
+#define ASSIGN_SHAPED_INDEX(CTYPE, DEREF, CONST_DEREF)    \
+  SEXP out = PROTECT(vec_clone_referenced(proxy, owned)); \
+  CTYPE* p_out = DEREF(out);                              \
+                                                          \
+  const CTYPE* p_value = CONST_DEREF(value);              \
+  R_len_t k = 0;                                          \
+                                                          \
+  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {    \
+    R_len_t loc = vec_strided_loc(                        \
+      p_info->p_shape_index,                              \
+      p_info->p_strides,                                  \
+      p_info->shape_n                                     \
+    );                                                    \
+                                                          \
+    for (R_len_t j = 0; j < p_info->index_n; ++j, ++k) {  \
+      const int step = p_info->p_steps[j];                \
+                                                          \
+      if (step == NA_INTEGER) {                           \
+        continue;                                         \
+      }                                                   \
+                                                          \
+      loc += step;                                        \
+                                                          \
+      p_out[loc] = p_value[k];                            \
+    }                                                     \
+                                                          \
+    vec_shape_index_increment(p_info);                    \
+  }                                                       \
+                                                          \
+  UNPROTECT(1);                                           \
   return out
 
-#define ASSIGN_SHAPED_COMPACT(CTYPE, DEREF, CONST_DEREF) \
-  SEXP out;                                              \
-  if (ownership == vctrs_ownership_total) {              \
-    out = PROTECT(r_clone_shared(proxy));                \
-  } else {                                               \
-    out = PROTECT(r_clone_referenced(proxy));            \
-  }                                                      \
-                                                         \
-  CTYPE* p_out = DEREF(out);                             \
-                                                         \
-  const R_len_t start = p_info->p_index[0];              \
-  const R_len_t n = p_info->p_index[1];                  \
-  const R_len_t step = p_info->p_index[2];               \
-                                                         \
-  const CTYPE* p_value = CONST_DEREF(value);             \
-  R_len_t k = 0;                                         \
-                                                         \
-  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {   \
-    R_len_t loc = vec_strided_loc(                       \
-      p_info->p_shape_index,                             \
-      p_info->p_strides,                                 \
-      p_info->shape_n                                    \
-    );                                                   \
-                                                         \
-    loc += start;                                        \
-                                                         \
-    for (R_len_t j = 0; j < n; ++j, ++k, loc += step) {  \
-      p_out[loc] = p_value[k];                           \
-    }                                                    \
-                                                         \
-    vec_shape_index_increment(p_info);                   \
-  }                                                      \
-                                                         \
-  UNPROTECT(1);                                          \
+#define ASSIGN_SHAPED_COMPACT(CTYPE, DEREF, CONST_DEREF)  \
+  SEXP out = PROTECT(vec_clone_referenced(proxy, owned)); \
+  CTYPE* p_out = DEREF(out);                              \
+                                                          \
+  const R_len_t start = p_info->p_index[0];               \
+  const R_len_t n = p_info->p_index[1];                   \
+  const R_len_t step = p_info->p_index[2];                \
+                                                          \
+  const CTYPE* p_value = CONST_DEREF(value);              \
+  R_len_t k = 0;                                          \
+                                                          \
+  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {    \
+    R_len_t loc = vec_strided_loc(                        \
+      p_info->p_shape_index,                              \
+      p_info->p_strides,                                  \
+      p_info->shape_n                                     \
+    );                                                    \
+                                                          \
+    loc += start;                                         \
+                                                          \
+    for (R_len_t j = 0; j < n; ++j, ++k, loc += step) {   \
+      p_out[loc] = p_value[k];                            \
+    }                                                     \
+                                                          \
+    vec_shape_index_increment(p_info);                    \
+  }                                                       \
+                                                          \
+  UNPROTECT(1);                                           \
   return out
 
 // -----------------------------------------------------------------------------
@@ -87,32 +76,32 @@
   }
 
 static inline SEXP lgl_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     const enum vctrs_ownership ownership,
+                                     const enum vctrs_owned owned,
                                      struct strides_info* p_info) {
   ASSIGN_SHAPED(int, LOGICAL, LOGICAL_RO);
 }
 static inline SEXP int_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     const enum vctrs_ownership ownership,
+                                     const enum vctrs_owned owned,
                                      struct strides_info* p_info) {
   ASSIGN_SHAPED(int, INTEGER, INTEGER_RO);
 }
 static inline SEXP dbl_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     const enum vctrs_ownership ownership,
+                                     const enum vctrs_owned owned,
                                      struct strides_info* p_info) {
   ASSIGN_SHAPED(double, REAL, REAL_RO);
 }
 static inline SEXP cpl_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     const enum vctrs_ownership ownership,
+                                     const enum vctrs_owned owned,
                                      struct strides_info* p_info) {
   ASSIGN_SHAPED(Rcomplex, COMPLEX, COMPLEX_RO);
 }
 static inline SEXP chr_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     const enum vctrs_ownership ownership,
+                                     const enum vctrs_owned owned,
                                      struct strides_info* p_info) {
   ASSIGN_SHAPED(SEXP, STRING_PTR, STRING_PTR_RO);
 }
 static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     const enum vctrs_ownership ownership,
+                                     const enum vctrs_owned owned,
                                      struct strides_info* p_info) {
   ASSIGN_SHAPED(Rbyte, RAW, RAW_RO);
 }
@@ -123,74 +112,64 @@ static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value,
 
 // -----------------------------------------------------------------------------
 
-#define ASSIGN_BARRIER_SHAPED_INDEX(GET, SET)            \
-  SEXP out;                                              \
-  if (ownership == vctrs_ownership_total) {              \
-    out = PROTECT(r_clone_shared(proxy));                \
-  } else {                                               \
-    out = PROTECT(r_clone_referenced(proxy));            \
-  }                                                      \
-                                                         \
-  R_len_t k = 0;                                         \
-                                                         \
-  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {   \
-    R_len_t loc = vec_strided_loc(                       \
-      p_info->p_shape_index,                             \
-      p_info->p_strides,                                 \
-      p_info->shape_n                                    \
-    );                                                   \
-                                                         \
-    for (R_len_t j = 0; j < p_info->index_n; ++j, ++k) { \
-      const int step = p_info->p_steps[j];               \
-                                                         \
-      if (step == NA_INTEGER) {                          \
-        continue;                                        \
-      }                                                  \
-                                                         \
-      loc += step;                                       \
-                                                         \
-      SEXP elt = GET(value, k);                          \
-      SET(out, loc, elt);                                \
-    }                                                    \
-                                                         \
-    vec_shape_index_increment(p_info);                   \
-  }                                                      \
-                                                         \
-  UNPROTECT(1);                                          \
+#define ASSIGN_BARRIER_SHAPED_INDEX(GET, SET)             \
+  SEXP out = PROTECT(vec_clone_referenced(proxy, owned)); \
+                                                          \
+  R_len_t k = 0;                                          \
+                                                          \
+  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {    \
+    R_len_t loc = vec_strided_loc(                        \
+      p_info->p_shape_index,                              \
+      p_info->p_strides,                                  \
+      p_info->shape_n                                     \
+    );                                                    \
+                                                          \
+    for (R_len_t j = 0; j < p_info->index_n; ++j, ++k) {  \
+      const int step = p_info->p_steps[j];                \
+                                                          \
+      if (step == NA_INTEGER) {                           \
+        continue;                                         \
+      }                                                   \
+                                                          \
+      loc += step;                                        \
+                                                          \
+      SEXP elt = GET(value, k);                           \
+      SET(out, loc, elt);                                 \
+    }                                                     \
+                                                          \
+    vec_shape_index_increment(p_info);                    \
+  }                                                       \
+                                                          \
+  UNPROTECT(1);                                           \
   return out
 
-#define ASSIGN_BARRIER_SHAPED_COMPACT(GET, SET)         \
-  SEXP out;                                             \
-  if (ownership == vctrs_ownership_total) {             \
-    out = PROTECT(r_clone_shared(proxy));               \
-  } else {                                              \
-    out = PROTECT(r_clone_referenced(proxy));           \
-  }                                                     \
-                                                        \
-  const R_len_t start = p_info->p_index[0];             \
-  const R_len_t n = p_info->p_index[1];                 \
-  const R_len_t step = p_info->p_index[2];              \
-                                                        \
-  R_len_t k = 0;                                        \
-                                                        \
-  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {  \
-    R_len_t loc = vec_strided_loc(                      \
-      p_info->p_shape_index,                            \
-      p_info->p_strides,                                \
-      p_info->shape_n                                   \
-    );                                                  \
-                                                        \
-    loc += start;                                       \
-                                                        \
-    for (R_len_t j = 0; j < n; ++j, ++k, loc += step) { \
-      SEXP elt = GET(value, k);                         \
-      SET(out, loc, elt);                               \
-    }                                                   \
-                                                        \
-    vec_shape_index_increment(p_info);                  \
-  }                                                     \
-                                                        \
-  UNPROTECT(1);                                         \
+#define ASSIGN_BARRIER_SHAPED_COMPACT(GET, SET)           \
+  SEXP out = PROTECT(vec_clone_referenced(proxy, owned)); \
+                                                          \
+  const R_len_t start = p_info->p_index[0];               \
+  const R_len_t n = p_info->p_index[1];                   \
+  const R_len_t step = p_info->p_index[2];                \
+                                                          \
+  R_len_t k = 0;                                          \
+                                                          \
+  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {    \
+    R_len_t loc = vec_strided_loc(                        \
+      p_info->p_shape_index,                              \
+      p_info->p_strides,                                  \
+      p_info->shape_n                                     \
+    );                                                    \
+                                                          \
+    loc += start;                                         \
+                                                          \
+    for (R_len_t j = 0; j < n; ++j, ++k, loc += step) {   \
+      SEXP elt = GET(value, k);                           \
+      SET(out, loc, elt);                                 \
+    }                                                     \
+                                                          \
+    vec_shape_index_increment(p_info);                    \
+  }                                                       \
+                                                          \
+  UNPROTECT(1);                                           \
   return out
 
 // -----------------------------------------------------------------------------
@@ -203,7 +182,7 @@ static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value,
   }
 
 static SEXP list_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                               const enum vctrs_ownership ownership,
+                               const enum vctrs_owned owned,
                                struct strides_info* p_info) {
   ASSIGN_BARRIER_SHAPED(VECTOR_ELT, SET_VECTOR_ELT);
 }
@@ -217,16 +196,16 @@ static SEXP list_assign_shaped(SEXP proxy, SEXP index, SEXP value,
 static inline SEXP vec_assign_shaped_switch(SEXP proxy,
                                             SEXP index,
                                             SEXP value,
-                                            const enum vctrs_ownership ownership,
+                                            const enum vctrs_owned owned,
                                             struct strides_info* p_info) {
   switch (vec_proxy_typeof(proxy)) {
-  case vctrs_type_logical:   return lgl_assign_shaped(proxy, index, value, ownership, p_info);
-  case vctrs_type_integer:   return int_assign_shaped(proxy, index, value, ownership, p_info);
-  case vctrs_type_double:    return dbl_assign_shaped(proxy, index, value, ownership, p_info);
-  case vctrs_type_complex:   return cpl_assign_shaped(proxy, index, value, ownership, p_info);
-  case vctrs_type_character: return chr_assign_shaped(proxy, index, value, ownership, p_info);
-  case vctrs_type_raw:       return raw_assign_shaped(proxy, index, value, ownership, p_info);
-  case vctrs_type_list:      return list_assign_shaped(proxy, index, value, ownership, p_info);
+  case vctrs_type_logical:   return lgl_assign_shaped(proxy, index, value, owned, p_info);
+  case vctrs_type_integer:   return int_assign_shaped(proxy, index, value, owned, p_info);
+  case vctrs_type_double:    return dbl_assign_shaped(proxy, index, value, owned, p_info);
+  case vctrs_type_complex:   return cpl_assign_shaped(proxy, index, value, owned, p_info);
+  case vctrs_type_character: return chr_assign_shaped(proxy, index, value, owned, p_info);
+  case vctrs_type_raw:       return raw_assign_shaped(proxy, index, value, owned, p_info);
+  case vctrs_type_list:      return list_assign_shaped(proxy, index, value, owned, p_info);
   default: Rf_error("Internal error: Non-vector type `%s` in `vec_assign_shaped_switch()`",
                     vec_type_as_str(vec_proxy_typeof(proxy)));
   }
@@ -236,14 +215,14 @@ static inline SEXP vec_assign_shaped_switch(SEXP proxy,
 
 // [[ include("vctrs.h") ]]
 SEXP vec_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                       const enum vctrs_ownership ownership,
+                       const enum vctrs_owned owned,
                        const struct vec_assign_opts* opts) {
   int n_protect = 0;
 
   struct strides_info info = new_strides_info(proxy, index);
   PROTECT_STRIDES_INFO(&info, &n_protect);
 
-  SEXP out = vec_assign_shaped_switch(proxy, index, value, ownership, &info);
+  SEXP out = vec_assign_shaped_switch(proxy, index, value, owned, &info);
 
   UNPROTECT(n_protect);
   return out;

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -98,28 +98,28 @@ static SEXP vec_assign_switch(SEXP proxy, SEXP index, SEXP value,
 // on a number of factors.
 //
 // - If a fallback is required, the `proxy` is duplicated at the R level.
-// - If `owned` is `vctrs_owned_TRUE`, the `proxy` is typically not duplicated.
+// - If `owned` is `VCTRS_OWNED_true`, the `proxy` is typically not duplicated.
 //   However, if it is an ALTREP object, it is duplicated because we need to be
 //   able to assign into the object it represents, not the ALTREP SEXP itself.
-// - If `owned` is `vctrs_owned_FALSE`, the `proxy` is only
+// - If `owned` is `VCTRS_OWNED_false`, the `proxy` is only
 //   duplicated if it is referenced, i.e. `MAYBE_REFERENCED()` returns `true`.
 //
 // In `vec_proxy_assign()`, which is part of the experimental public API,
 // ownership is determined with a call to `NO_REFERENCES()`. If there are no
-// references, then `vctrs_owned_TRUE` is used, else
-// `vctrs_owned_FALSE` is used.
+// references, then `VCTRS_OWNED_true` is used, else
+// `VCTRS_OWNED_false` is used.
 //
 // Ownership of the `proxy` must be recursive. For data frames, the `owned`
 // argument is passed along to each column.
 //
-// Practically, we only set `vctrs_owned_TRUE` when we create a fresh data
+// Practically, we only set `VCTRS_OWNED_true` when we create a fresh data
 // structure at the C level and then assign into it to fill it. This happens
 // in `vec_c()` and `vec_rbind()`. For data frames, this `owned` parameter
 // is particularly important for R 4.0.0 where references are tracked more
 // precisely. In R 4.0.0, a freshly created data frame's columns all have a
 // refcount of 1 because of the `SET_VECTOR_ELT()` call that set them in the
 // data frame. This makes them referenced, but not shared. If
-// `vctrs_owned_FALSE` was set and `df_assign()` was used in a loop
+// `VCTRS_OWNED_false` was set and `df_assign()` was used in a loop
 // (as it is in `vec_rbind()`), then a copy of each column would be made at
 // each iteration of the loop (any time a new set of rows is assigned
 // into the output object).
@@ -398,7 +398,7 @@ SEXP vec_proxy_assign_names(SEXP proxy, SEXP index, SEXP value) {
     proxy_nms = PROTECT(r_clone_referenced(proxy_nms));
   }
 
-  proxy_nms = PROTECT(chr_assign(proxy_nms, index, value_nms, vctrs_owned_TRUE));
+  proxy_nms = PROTECT(chr_assign(proxy_nms, index, value_nms, VCTRS_OWNED_true));
 
   proxy = PROTECT(r_clone_referenced(proxy));
   proxy = vec_set_names(proxy, proxy_nms);

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -47,7 +47,7 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
   const enum vctrs_owned owned = vec_owned(proxy);
   proxy = PROTECT(vec_proxy_assign_opts(proxy, index, value, owned, opts));
 
-  SEXP out = vec_restore(proxy, x, R_NilValue);
+  SEXP out = vec_restore(proxy, x, R_NilValue, owned);
 
   UNPROTECT(6);
   return out;
@@ -365,7 +365,7 @@ SEXP df_assign(SEXP x, SEXP index, SEXP value,
     SEXP proxy_elt = PROTECT(vec_proxy(out_elt));
 
     SEXP assigned = PROTECT(vec_proxy_assign_opts(proxy_elt, index, value_elt, owned, opts));
-    assigned = vec_restore(assigned, out_elt, R_NilValue);
+    assigned = vec_restore(assigned, out_elt, R_NilValue, owned);
 
     SET_VECTOR_ELT(out, i, assigned);
     UNPROTECT(2);
@@ -427,7 +427,7 @@ SEXP vctrs_assign_seq(SEXP x, SEXP value, SEXP start, SEXP size, SEXP increasing
   const enum vctrs_owned owned = vec_owned(proxy);
   proxy = PROTECT(vec_proxy_assign_opts(proxy, index, value, owned, opts));
 
-  SEXP out = vec_restore(proxy, x, R_NilValue);
+  SEXP out = vec_restore(proxy, x, R_NilValue, owned);
 
   UNPROTECT(5);
   return out;

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -1,11 +1,7 @@
 #ifndef VCTRS_SLICE_ASSIGN_H
 #define VCTRS_SLICE_ASSIGN_H
 
-// Ownership is recursive
-enum vctrs_ownership {
-  vctrs_ownership_shared,
-  vctrs_ownership_total
-};
+#include "owned.h"
 
 struct vec_assign_opts {
   bool assign_names;
@@ -17,17 +13,17 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
                      const struct vec_assign_opts* opts);
 
 SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
-                           const enum vctrs_ownership ownership,
+                           const enum vctrs_owned owned,
                            const struct vec_assign_opts* opts);
 
-SEXP chr_assign(SEXP out, SEXP index, SEXP value, const enum vctrs_ownership ownership);
-SEXP list_assign(SEXP out, SEXP index, SEXP value, const enum vctrs_ownership ownership);
+SEXP chr_assign(SEXP out, SEXP index, SEXP value, const enum vctrs_owned owned);
+SEXP list_assign(SEXP out, SEXP index, SEXP value, const enum vctrs_owned owned);
 SEXP df_assign(SEXP x, SEXP index, SEXP value,
-               const enum vctrs_ownership ownership,
+               const enum vctrs_owned owned,
                const struct vec_assign_opts* opts);
 
 SEXP vec_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                       const enum vctrs_ownership ownership,
+                       const enum vctrs_owned owned,
                        const struct vec_assign_opts* opts);
 
 #endif

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -3,6 +3,7 @@
 #include "slice.h"
 #include "subscript-loc.h"
 #include "type-data-frame.h"
+#include "owned.h"
 #include "utils.h"
 
 /*
@@ -199,7 +200,7 @@ static SEXP chop(SEXP x, SEXP indices, struct vctrs_chop_info info) {
       UNPROTECT(1);
     }
 
-    elt = vec_restore(elt, x, info.restore_size);
+    elt = vec_restore(elt, x, info.restore_size, vec_owned(elt));
 
     SET_VECTOR_ELT(info.out, i, elt);
     UNPROTECT(1);
@@ -260,7 +261,7 @@ static SEXP chop_df(SEXP x, SEXP indices, struct vctrs_chop_info info) {
     }
 
     SEXP elt = VECTOR_ELT(info.out, i);
-    elt = vec_restore(elt, x, info.restore_size);
+    elt = vec_restore(elt, x, info.restore_size, vec_owned(elt));
     SET_VECTOR_ELT(info.out, i, elt);
   }
 
@@ -300,7 +301,7 @@ static SEXP chop_shaped(SEXP x, SEXP indices, struct vctrs_chop_info info) {
       }
     }
 
-    elt = vec_restore(elt, x, info.restore_size);
+    elt = vec_restore(elt, x, info.restore_size, vec_owned(elt));
 
     SET_VECTOR_ELT(info.out, i, elt);
     UNPROTECT(1);
@@ -346,7 +347,7 @@ static SEXP chop_fallback(SEXP x, SEXP indices, struct vctrs_chop_info info) {
     SEXP elt = PROTECT(Rf_eval(call, env));
 
     if (!vec_is_restored(elt, x)) {
-      elt = vec_restore(elt, x, info.restore_size);
+      elt = vec_restore(elt, x, info.restore_size, vec_owned(elt));
     }
 
     SET_VECTOR_ELT(info.out, i, elt);

--- a/src/slice.c
+++ b/src/slice.c
@@ -3,6 +3,7 @@
 #include "slice.h"
 #include "subscript-loc.h"
 #include "type-data-frame.h"
+#include "owned.h"
 #include "utils.h"
 #include "dim.h"
 
@@ -351,7 +352,7 @@ SEXP vec_slice_impl(SEXP x, SEXP subscript) {
 
     // Take over attribute restoration only if there is no `[` method
     if (!vec_is_restored(out, x)) {
-      out = vec_restore(out, x, restore_size);
+      out = vec_restore(out, x, restore_size, vec_owned(out));
     }
 
     UNPROTECT(nprot);
@@ -390,7 +391,7 @@ SEXP vec_slice_impl(SEXP x, SEXP subscript) {
       Rf_setAttrib(out, R_NamesSymbol, names);
     }
 
-    out = vec_restore(out, x, restore_size);
+    out = vec_restore(out, x, restore_size, vec_owned(out));
 
     UNPROTECT(nprot);
     return out;
@@ -398,7 +399,7 @@ SEXP vec_slice_impl(SEXP x, SEXP subscript) {
 
   case vctrs_type_dataframe: {
     SEXP out = PROTECT_N(df_slice(data, subscript), &nprot);
-    out = vec_restore(out, x, restore_size);
+    out = vec_restore(out, x, restore_size, vec_owned(out));
     UNPROTECT(nprot);
     return out;
   }

--- a/src/type-date-time.c
+++ b/src/type-date-time.c
@@ -1,4 +1,5 @@
 #include "vctrs.h"
+#include "owned.h"
 #include "utils.h"
 
 
@@ -238,24 +239,24 @@ SEXP posixlt_as_posixlt(SEXP x, SEXP to) {
 // restore
 
 // [[ include("vctrs.h") ]]
-SEXP vec_date_restore(SEXP x, SEXP to) {
-  SEXP out = PROTECT(vec_restore_default(x, to));
+SEXP vec_date_restore(SEXP x, SEXP to, const enum vctrs_owned owned) {
+  SEXP out = PROTECT(vec_restore_default(x, to, owned));
   out = date_validate(out);
   UNPROTECT(1);
   return out;
 }
 
 // [[ include("vctrs.h") ]]
-SEXP vec_posixct_restore(SEXP x, SEXP to) {
-  SEXP out = PROTECT(vec_restore_default(x, to));
+SEXP vec_posixct_restore(SEXP x, SEXP to, const enum vctrs_owned owned) {
+  SEXP out = PROTECT(vec_restore_default(x, to, owned));
   out = datetime_validate(out);
   UNPROTECT(1);
   return out;
 }
 
 // [[ include("vctrs.h") ]]
-SEXP vec_posixlt_restore(SEXP x, SEXP to) {
-  SEXP out = PROTECT(vec_restore_default(x, to));
+SEXP vec_posixlt_restore(SEXP x, SEXP to, const enum vctrs_owned owned) {
+  SEXP out = PROTECT(vec_restore_default(x, to, owned));
   out = datetime_validate_tzone(out);
   UNPROTECT(1);
   return out;

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,6 +1,7 @@
 #include "vctrs.h"
 #include "utils.h"
 #include "type-data-frame.h"
+#include "owned.h"
 
 #include <R_ext/Rdynload.h>
 
@@ -336,7 +337,9 @@ SEXP map_with_data(SEXP x, SEXP (*fn)(SEXP, void*), void* data) {
 // [[ include("utils.h") ]]
 SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
-  out = vec_bare_df_restore(out, df, vctrs_shared_zero_int);
+
+  // Total ownership because `map()` generates a fresh list
+  out = vec_bare_df_restore(out, df, vctrs_shared_zero_int, VCTRS_OWNED_true);
 
   UNPROTECT(1);
   return out;
@@ -345,7 +348,9 @@ SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP)) {
 // [[ include("utils.h") ]]
 SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
-  out = vec_df_restore(out, df, vctrs_shared_zero_int);
+
+  // Total ownership because `map()` generates a fresh list
+  out = vec_df_restore(out, df, vctrs_shared_zero_int, VCTRS_OWNED_true);
 
   UNPROTECT(1);
   return out;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -349,6 +349,7 @@ bool vec_is_unspecified(SEXP x);
 
 #include "arg.h"
 #include "names.h"
+#include "owned.h"
 
 enum vctrs_proxy_kind {
   VCTRS_PROXY_KIND_default,
@@ -361,8 +362,8 @@ SEXP vec_proxy(SEXP x);
 SEXP vec_proxy_equal(SEXP x);
 SEXP vec_proxy_compare(SEXP x);
 SEXP vec_proxy_order(SEXP x);
-SEXP vec_restore(SEXP x, SEXP to, SEXP i);
-SEXP vec_restore_default(SEXP x, SEXP to);
+SEXP vec_restore(SEXP x, SEXP to, SEXP n, const enum vctrs_owned owned);
+SEXP vec_restore_default(SEXP x, SEXP to, const enum vctrs_owned owned);
 R_len_t vec_size(SEXP x);
 R_len_t vec_size_common(SEXP xs, R_len_t absent);
 SEXP vec_cast_common(SEXP xs, SEXP to);
@@ -411,8 +412,8 @@ R_len_t df_size(SEXP x);
 R_len_t df_rownames_size(SEXP x);
 R_len_t df_raw_size(SEXP x);
 R_len_t df_raw_size_from_list(SEXP x);
-SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n);
-SEXP vec_df_restore(SEXP x, SEXP to, SEXP n);
+SEXP vec_bare_df_restore(SEXP x, SEXP to, SEXP n, const enum vctrs_owned owned);
+SEXP vec_df_restore(SEXP x, SEXP to, SEXP n, const enum vctrs_owned owned);
 
 // equal_object() never propagates missingness, so
 // it can return a `bool`
@@ -551,9 +552,9 @@ SEXP posixlt_as_posixct(SEXP x, SEXP to);
 SEXP posixct_as_posixlt(SEXP x, SEXP to);
 SEXP posixlt_as_posixlt(SEXP x, SEXP to);
 
-SEXP vec_date_restore(SEXP x, SEXP to);
-SEXP vec_posixct_restore(SEXP x, SEXP to);
-SEXP vec_posixlt_restore(SEXP x, SEXP to);
+SEXP vec_date_restore(SEXP x, SEXP to, const enum vctrs_owned owned);
+SEXP vec_posixct_restore(SEXP x, SEXP to, const enum vctrs_owned owned);
+SEXP vec_posixlt_restore(SEXP x, SEXP to, const enum vctrs_owned owned);
 
 SEXP date_datetime_ptype2(SEXP x, SEXP y);
 SEXP datetime_datetime_ptype2(SEXP x, SEXP y);

--- a/tests/testthat/helper-performance.R
+++ b/tests/testthat/helper-performance.R
@@ -1,0 +1,21 @@
+skip_if_not_testing_performance <- function(x) {
+  opt <- Sys.getenv("VCTRS_TEST_PERFORMANCE", unset = "false")
+  testing <- identical(opt, "true")
+
+  if (testing) {
+    return()
+  }
+
+  skip("Not testing performance")
+}
+
+expect_time_lt <- function(expr, expect) {
+  time <- time_expr({{ expr }})
+  expect_lt(time, expect)
+}
+
+time_expr <- function(expr) {
+  expr <- enquo(expr)
+  time <- system.time(eval_tidy(expr))
+  unclass(time)[["elapsed"]]
+}

--- a/tests/testthat/helper-performance.R
+++ b/tests/testthat/helper-performance.R
@@ -10,11 +10,11 @@ skip_if_not_testing_performance <- function(x) {
 }
 
 expect_time_lt <- function(expr, expect) {
-  time <- time_expr({{ expr }})
+  time <- time_of({{ expr }})
   expect_lt(time, expect)
 }
 
-time_expr <- function(expr) {
+time_of <- function(expr) {
   expr <- enquo(expr)
   time <- system.time(eval_tidy(expr))
   unclass(time)[["elapsed"]]

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -345,6 +345,28 @@ test_that("monitoring: name repair while rbinding doesn't modify in place", {
   expect_identical(df, expect)
 })
 
+test_that("performance: Row binding with S3 columns doesn't duplicate on every assignment (#1151)", {
+  skip_if_not_testing_performance()
+
+  x <- as.Date("2000-01-01")
+  x <- rep(x, 100)
+  df <- data.frame(x = x)
+  lst <- rep_len(list(df), 10000)
+
+  expect_time_lt(vec_rbind(!!!lst), 5)
+})
+
+test_that("performance: Row binding with df-cols doesn't duplicate on every assignment (#1122)", {
+  skip_if_not_testing_performance()
+
+  df_col <- new_data_frame(list(x = 1:1000))
+  df <- new_data_frame(list(y = df_col))
+
+  lst <- rep_len(list(df), 10000)
+
+  expect_time_lt(vec_rbind(!!!lst), 5)
+})
+
 # cols --------------------------------------------------------------------
 
 test_that("empty inputs give data frame", {


### PR DESCRIPTION
Closes tidyverse/dplyr#5327
Closes #1124
Closes #1122 

Reverts back to a slightly simpler ownership model of `VCTRS_OWNED_true` and `VCTRS_OWNED_false`.

When we own the object, we only ever attempt to duplicate it if it is ALTREP. If `vec_init()` ever creates ALTREP objects in the future (https://github.com/r-lib/vctrs/pull/837), this will be required. When doing assignment, we have to duplicate ALTREP objects before dereferencing even if we own them, because we need access to the actual data that it is representing, not the ALTREP object's internals.

When we don't own the object, we use `r_clone_referenced()` to determine if we need to duplicate or not.

This fixed the repeated duplication that was occurring in `df_assign()`'s calls to `vec_proxy_assign_opts()`, but I then discovered that we still had repeated duplication in `vec_restore()`. To fix that, I had to borrow from the ideas in #1124 and pass through `owned` to `vec_restore()` as well. This allows us to avoid attempting duplication here as well.

With both of those in place, tidyverse/dplyr#5327 is fixed:

```r
library(dplyr)

date_frame <- tibble(date = rep(lubridate::date("2020-01-01"), 100))
date_frames_to_bind <- rep(list(date_frame), 10000)
bench::mark(bind_rows(date_frames_to_bind))
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 bind_rows(date_frames_to_bind)    133ms    142ms      6.87    8.39MB     25.8
```

---

It is worth noting that @lionel- and I both think that eventually we should probably have recursive proxy and restore functions (https://github.com/r-lib/vctrs/issues/1107). This would allow `df_assign()` to not have to proxy and restore the output columns repeatedly, which is where many of these duplication issues arise. That would also allow us to remove the `owned` argument from `vec_restore()` again, which I am currently viewing as a temporary fix.

---

This also closes #1124, because it fixes the original problem there where columns of df-cols were being duplicated.