### PR TITLE
Fix corner case for num_as_location()

### DIFF
--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -184,6 +184,8 @@ static void int_check_consecutive(SEXP subscript, R_len_t n, R_len_t n_extend,
     return;
   }
 
+  // Only the first i_extend entries of the array are populated,
+  // the rest is never touched.
   qsort(extended, i_extend, sizeof(int), &qsort_icmp);
 
   for (R_len_t i = 0; i < i_extend; ++i) {

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -181,6 +181,10 @@ static void int_check_consecutive(SEXP subscript, R_len_t n, R_len_t n_extend,
     }
   }
 
+  if (n_extend != i_extend) {
+    Rf_error("Internal error in `int_check_consecutive()`: n_extend != i_extend.");
+  }
+
   if (i_extend == 0) {
     UNPROTECT(1);
     return;

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -157,7 +157,7 @@ static void int_check_consecutive(SEXP subscript, R_len_t n, R_len_t n_extend,
 
   int extended[n_extend];
   int i_extend = 0;
-  int nn = n;
+  int new_n = n;
 
   int* p_subscript = INTEGER(subscript);
 
@@ -172,8 +172,8 @@ static void int_check_consecutive(SEXP subscript, R_len_t n, R_len_t n_extend,
 
     // Special case: appending in ascending sequence at the end
     // should not require any sorting
-    if (elt - 1 == nn) {
-      ++nn;
+    if (elt - 1 == new_n) {
+      ++new_n;
       --n_extend;
     } else {
       extended[i_extend++] = elt - 1;
@@ -189,7 +189,7 @@ static void int_check_consecutive(SEXP subscript, R_len_t n, R_len_t n_extend,
   for (R_len_t i = 0; i < i_extend; ++i) {
     int elt = extended[i];
 
-    if (elt != nn + i) {
+    if (elt != new_n + i) {
       stop_location_oob_non_consecutive(subscript, n, opts);
     }
   }

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -166,17 +166,17 @@ static void int_check_consecutive(SEXP subscript, R_len_t n, R_len_t n_extend,
     int elt = p_subscript[i];
 
     // Missing value also covered here
-    if (elt < n) {
+    if (elt <= n) {
       continue;
     }
 
     // Special case: appending in ascending sequence at the end
     // should not require any sorting
-    if (elt == nn) {
+    if (elt - 1 == nn) {
       ++nn;
       --n_extend;
     } else {
-      extended[i_extend++] = elt;
+      extended[i_extend++] = elt - 1;
     }
   }
 
@@ -193,8 +193,6 @@ static void int_check_consecutive(SEXP subscript, R_len_t n, R_len_t n_extend,
       stop_location_oob_non_consecutive(subscript, n, opts);
     }
   }
-
-  UNPROTECT(1);
 }
 
 static SEXP dbl_as_location(SEXP subscript, R_len_t n,

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -246,6 +246,10 @@ test_that("can optionally extend beyond the end", {
 
   verify_errors({
     expect_error(
+      num_as_location(3, 1, oob = "extend"),
+      class = "vctrs_error_subscript_oob"
+    )
+    expect_error(
       num_as_location(c(1, 3), 1, oob = "extend"),
       class = "vctrs_error_subscript_oob"
     )

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -237,9 +237,12 @@ test_that("character subscripts require named vectors", {
 
 test_that("can optionally extend beyond the end", {
   expect_error(num_as_location(1:5, 3), class = "vctrs_error_subscript_oob")
+
   expect_identical(num_as_location(1:5, 3, oob = "extend"), 1:5)
+  expect_identical(num_as_location(4:5, 3, oob = "extend"), 4:5)
+  expect_identical(num_as_location(6:4, 3, oob = "extend"), 6:4)
   expect_identical(num_as_location(c(1:5, 7, 6), 3, oob = "extend"), c(1:5, 7L, 6L))
-  expect_identical(num_as_location(c(1, NA, 3), 2, oob = "extend"), c(1L, NA, 3L))
+  expect_identical(num_as_location(c(1, NA, 4, 3), 2, oob = "extend"), c(1L, NA, 4L, 3L))
 
   verify_errors({
     expect_error(

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -240,9 +240,6 @@ test_that("can optionally extend beyond the end", {
 
   expect_identical(num_as_location(1:5, 3, oob = "extend"), 1:5)
   expect_identical(num_as_location(4:5, 3, oob = "extend"), 4:5)
-  expect_identical(num_as_location(6:4, 3, oob = "extend"), 6:4)
-  expect_identical(num_as_location(c(1:5, 7, 6), 3, oob = "extend"), c(1:5, 7L, 6L))
-  expect_identical(num_as_location(c(1, NA, 4, 3), 2, oob = "extend"), c(1L, NA, 4L, 3L))
 
   verify_errors({
     expect_error(
@@ -266,6 +263,12 @@ test_that("can optionally extend beyond the end", {
       num_as_location(c(1:5, 7, 1, 10), 3, oob = "extend")
     )
   })
+})
+
+test_that("can extend beyond the end consecutively but non-monotonically (#1166)", {
+  expect_identical(num_as_location(6:4, 3, oob = "extend"), 6:4)
+  expect_identical(num_as_location(c(1:5, 7, 6), 3, oob = "extend"), c(1:5, 7L, 6L))
+  expect_identical(num_as_location(c(1, NA, 4, 3), 2, oob = "extend"), c(1L, NA, 4L, 3L))
 })
 
 test_that("missing values are supported in error formatters", {


### PR DESCRIPTION
and replace by a simpler and faster implementation, with shortcut if appending in strictly increasing order without gaps.