### PR TITLE
Reprotect after calling `init_dictionary_df()`

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -272,6 +272,10 @@ static struct dictionary* new_dictionary_opts(SEXP x, struct dictionary_opts* op
   default: Rf_error("Internal error: Unimplemented type in `new_dictionary()`.");
   }
 
+  // Reprotect `d->protect` for the case of `init_dictionary_df()`,
+  // which allocates a new handle and assigns it to `d->protect`.
+  PROTECT(d->protect);
+
   d->used = 0;
 
   if (opts->partial) {
@@ -305,7 +309,7 @@ static struct dictionary* new_dictionary_opts(SEXP x, struct dictionary_opts* op
     d->hash = NULL;
   }
 
-  UNPROTECT(1);
+  UNPROTECT(2);
   return d;
 }
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -272,8 +272,7 @@ static struct dictionary* new_dictionary_opts(SEXP x, struct dictionary_opts* op
   default: Rf_error("Internal error: Unimplemented type in `new_dictionary()`.");
   }
 
-  // Reprotect `d->protect` for the case of `init_dictionary_df()`,
-  // which allocates a new handle and assigns it to `d->protect`.
+  // `init_dictionary_*()` functions may allocate
   PROTECT(d->protect);
 
   d->used = 0;


### PR DESCRIPTION
Possibly fixes https://github.com/r-lib/vctrs/issues/1165

It seems to not crash for me now? It was pretty random though, so it is hard to say for certain