### PR TITLE
Avoid concatenation of class vector if already contains data.frame

### DIFF
--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -174,6 +174,9 @@ static SEXP c_data_frame_class(SEXP cls) {
   if (Rf_length(cls) == 0) {
     return classes_data_frame;
   }
+  if (STRING_ELT(cls, Rf_length(cls) - 1) == strings_data_frame) {
+    return cls;
+  }
 
   SEXP args = PROTECT(Rf_allocVector(VECSXP, 2));
   SET_VECTOR_ELT(args, 0, cls);

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -288,7 +288,7 @@ test_that("class attribute", {
   )
   expect_identical(
     class(new_data_frame(list(a = 1), class = c("tbl_df", "tbl", "data.frame"))),
-    c("tbl_df", "tbl", "data.frame", "data.frame")
+    c("tbl_df", "tbl", "data.frame")
   )
   expect_identical(
     class(new_data_frame(list(a = 1), class = "foo_frame")),
@@ -296,11 +296,11 @@ test_that("class attribute", {
   )
   expect_identical(
     class(exec(new_data_frame, list(a = 1), !!!attributes(new_data_frame(list(), class = "tbl_df")))),
-    c("tbl_df", "data.frame", "data.frame")
+    c("tbl_df", "data.frame")
   )
   expect_identical(
     class(exec(new_data_frame, list(a = 1), !!!attributes(new_data_frame(list(b = 1), class = "tbl_df")))),
-    c("tbl_df", "data.frame", "data.frame")
+    c("tbl_df", "data.frame")
   )
 })
 


### PR DESCRIPTION
I'd like to use `new_data_frame()` in tibble, it's much easier to create correct classes if callers are allowed to pass `class = c(..., "data.frame")` . Can provide timings if required.