### PR TITLE
Fix performance of class concatenation in `new_data_frame()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # vctrs (development version)
 
+* `new_data_frame()` is now twice as fast when `class` is supplied.
+
 * New `vec_names2()`, `vec_names()` and `vec_set_names()` (#1173).
 
 * New `vec_proxy_order()` that provides an ordering proxy for use in

--- a/R/utils.R
+++ b/R/utils.R
@@ -212,3 +212,7 @@ import_from <- function(ns, names, env = caller_env()) {
   objs <- env_get_list(ns_env(ns), names)
   env_bind(env, !!!objs)
 }
+
+fast_c <- function(x, y) {
+  .Call(vctrs_fast_c, x, y)
+}

--- a/src/init.c
+++ b/src/init.c
@@ -121,6 +121,7 @@ extern SEXP vctrs_s3_find_method(SEXP, SEXP, SEXP);
 extern SEXP vctrs_implements_ptype2(SEXP);
 extern SEXP vctrs_ptype2_dispatch_native(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_cast_dispatch_native(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_fast_c(SEXP, SEXP);
 
 
 // Maturing
@@ -259,6 +260,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_implements_ptype2",          (DL_FUNC) &vctrs_implements_ptype2, 1},
   {"vctrs_ptype2_dispatch_native",     (DL_FUNC) &vctrs_ptype2_dispatch_native, 5},
   {"vctrs_cast_dispatch_native",       (DL_FUNC) &vctrs_cast_dispatch_native, 5},
+  {"vctrs_fast_c",                     (DL_FUNC) &vctrs_fast_c, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -171,23 +171,7 @@ static SEXP c_data_frame_class(SEXP cls) {
   if (TYPEOF(cls) != STRSXP) {
     Rf_errorcall(R_NilValue, "`class` must be NULL or a character vector");
   }
-  if (Rf_length(cls) == 0) {
-    return classes_data_frame;
-  }
-
-  SEXP args = PROTECT(Rf_allocVector(VECSXP, 2));
-  SET_VECTOR_ELT(args, 0, cls);
-  SET_VECTOR_ELT(args, 1, classes_data_frame);
-
-  SEXP out = vec_c(
-    args,
-    vctrs_shared_empty_chr,
-    R_NilValue,
-    NULL
-  );
-
-  UNPROTECT(1);
-  return out;
+  return chr_c(cls, classes_data_frame);
 }
 
 // [[ include("type-data-frame.h") ]]

--- a/src/utils.c
+++ b/src/utils.c
@@ -1489,6 +1489,51 @@ ERR r_try_catch(void (*fn)(void*),
 SEXP (*rlang_sym_as_character)(SEXP x);
 
 
+// [[ include("utils.h") ]]
+SEXP chr_c(SEXP x, SEXP y) {
+  r_ssize x_n = r_length(x);
+  r_ssize y_n = r_length(y);
+
+  if (x_n == 0) {
+    return y;
+  }
+  if (y_n == 0) {
+    return x;
+  }
+
+  r_ssize out_n = r_ssize_add(x_n, y_n);
+  SEXP out = PROTECT(r_new_vector(STRSXP, out_n));
+
+  SEXP* p_out = STRING_PTR(out);
+  const SEXP* p_x = STRING_PTR_RO(x);
+  const SEXP* p_y = STRING_PTR_RO(y);
+
+  for (r_ssize i = 0; i < x_n; ++i) {
+    p_out[i] = p_x[i];
+  }
+  for (r_ssize i = 0, j = x_n; i < y_n; ++i, ++j) {
+    p_out[j] = p_y[i];
+  }
+
+  UNPROTECT(1);
+  return out;
+}
+
+// [[ register() ]]
+SEXP vctrs_fast_c(SEXP x, SEXP y) {
+  SEXPTYPE x_type = TYPEOF(x);
+
+  if (x_type != TYPEOF(y)) {
+    Rf_error("`x` and `y` must have the same types.");
+  }
+
+  switch (x_type) {
+  case STRSXP: return chr_c(x, y);
+  default: Rf_error("Unimplemented type `%s` in `base_c()`.", x_type);
+  }
+}
+
+
 bool vctrs_debug_verbose = false;
 
 SEXP vctrs_ns_env = NULL;

--- a/src/utils.c
+++ b/src/utils.c
@@ -1529,7 +1529,7 @@ SEXP vctrs_fast_c(SEXP x, SEXP y) {
 
   switch (x_type) {
   case STRSXP: return chr_c(x, y);
-  default: Rf_error("Unimplemented type `%s` in `base_c()`.", x_type);
+  default: Rf_error("Unimplemented type `%s` in `fast_c()`.", x_type);
   }
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -444,10 +444,6 @@ void r_browse(SEXP x);
 // Adapted from CERT C coding standards
 static inline
 intmax_t intmax_add(intmax_t x, intmax_t y) {
-  if (x == NA_INTEGER || y == NA_INTEGER) {
-    Rf_error("Internal error in `intmax_add()`: Unhandled missing values.");
-  }
-
   if ((y > 0 && x > (INTMAX_MAX - y)) ||
       (y < 0 && x < (INTMAX_MIN - y))) {
     Rf_error("Internal error in `intmax_add()`: Values too large to be added.");

--- a/src/utils.h
+++ b/src/utils.h
@@ -201,11 +201,6 @@ extern SEXP (*rlang_unbox)(SEXP);
 extern SEXP (*rlang_env_dots_values)(SEXP);
 extern SEXP (*rlang_env_dots_list)(SEXP);
 
-static inline
-R_len_t r_length(SEXP x) {
-  return Rf_length(x);
-}
-
 void* r_vec_deref(SEXP x);
 const void* r_vec_const_deref(SEXP x);
 
@@ -444,6 +439,35 @@ static inline const void* vec_type_missing_value(enum vctrs_type type) {
 
 void c_print_backtrace();
 void r_browse(SEXP x);
+
+
+// Adapted from CERT C coding standards
+static inline
+intmax_t intmax_add(intmax_t x, intmax_t y) {
+  if (x == NA_INTEGER || y == NA_INTEGER) {
+    Rf_error("Internal error in `intmax_add()`: Unhandled missing values.");
+  }
+
+  if ((y > 0 && x > (INTMAX_MAX - y)) ||
+      (y < 0 && x < (INTMAX_MIN - y))) {
+    Rf_error("Internal error in `intmax_add()`: Values too large to be added.");
+  }
+
+  return x + y;
+}
+
+static inline
+r_ssize r_ssize_add(r_ssize x, r_ssize y) {
+  intmax_t out = intmax_add(x, y);
+
+  if (out > R_SSIZE_MAX) {
+    Rf_error("Internal error in `r_ssize_safe_add()`: Result too large for an `r_ssize`.");
+  }
+
+  return (r_ssize) out;
+}
+
+SEXP chr_c(SEXP x, SEXP y);
 
 
 extern SEXP vctrs_ns_env;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -19,7 +19,7 @@ extern bool vctrs_debug_verbose;
 typedef R_xlen_t r_ssize;
 #define R_SSIZE_MAX R_XLEN_T_MAX
 
-#define r_length Rf_length
+#define r_length Rf_xlength
 #define r_new_vector Rf_allocVector
 
 // An ERR indicates either a C NULL in case of no error, or a

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -17,6 +17,10 @@ extern bool vctrs_debug_verbose;
 
 
 typedef R_xlen_t r_ssize;
+#define R_SSIZE_MAX R_XLEN_T_MAX
+
+#define r_length Rf_length
+#define r_new_vector Rf_allocVector
 
 // An ERR indicates either a C NULL in case of no error, or a
 // condition object otherwise

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -68,3 +68,10 @@ test_that("vec_common_suffix() finds common suffix", {
   exp <- data.frame(x = 2:3, y = c("bar", "baz"))
   expect_identical(vec_common_suffix(x, y), exp)
 })
+
+test_that("fast_c() concatenates", {
+  expect_identical(fast_c(character(), "foo"), "foo")
+  expect_identical(fast_c("foo", character()), "foo")
+  expect_identical(fast_c("foo", c("bar", "baz")), c("foo", "bar", "baz"))
+  expect_identical(fast_c(c("bar", "baz"), "foo"), c("bar", "baz", "foo"))
+})


### PR DESCRIPTION
Closes #1174.

```r
sc <- c("tbl_df", "tbl")
c <- c("tbl_df", "tbl", "data.frame")

bench::mark(
  new_data_frame(class = sc),
  new_data_frame(class = c),
  new_data_frame(),
  iterations = 1e6,
  check = FALSE
)
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`  n_itr  n_gc
#>   <bch:expr>                 <bch> <bch:tm>     <dbl> <bch:byt>    <dbl>  <int> <dbl>
#> 1 new_data_frame(class = sc) 834ns   1.06µs   824160.        0B     33.8 999959    41
#> 2 new_data_frame(class = c)  834ns   1.05µs   836700.        0B     34.3 999959    41
#> 3 new_data_frame()           719ns    881ns  1004085.        0B     35.1 999965    35
```