### PR TITLE
R 3.5 doesn't support ALTREP on Windows

### DIFF
--- a/src/altrep.h
+++ b/src/altrep.h
@@ -3,7 +3,8 @@
 
 #include "Rversion.h"
 
-#if (R_VERSION < R_Version(3, 5, 0))
+#if (R_VERSION < R_Version(3, 5, 0)) ||                 \
+    (defined(_WIN32) && R_VERSION == R_Version(3, 5, 0))
 
 # define ALTREP(x) false
 # define ALTVEC_EXTRACT_SUBSET_PROXY(x, indx, call) NULL


### PR DESCRIPTION
Closes #1153

Technically we could include the relevant .h file in the package, but this doesn't seem worth it.