### PR TITLE
vec_ptype_abbr(check_named = , shape = )

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # vctrs (development version)
 
+* `vec_ptype_abbr()` gains arguments to control whether to indicate
+  named vectors with a prefix (`prefix_named`) and indicate shaped
+  vectors with a suffix (`suffix_shape`) (#781, @krlmlr).
+
 * `vec_ptype()` is now an optional _performance_ generic. It is not necessary
   to implement, but if your class has a static prototype, you might consider
   implementing a custom `vec_ptype()` method that returns a constant to

--- a/R/ptype-abbr-full.R
+++ b/R/ptype-abbr-full.R
@@ -13,8 +13,12 @@
 #' characters where possible.
 #'
 #' @param x A vector.
-#' @param prefix_named If `TRUE`, to add a prefix for named vectors.
-#' @param suffix_shape If `TRUE` (the default), append the shape of the vector.
+#' @param prefix_named
+#'   If `TRUE`, to add a prefix for named vectors.
+#'   This argument is handled by the generic and will not be passed on to methods.
+#' @param suffix_shape
+#'   If `TRUE` (the default), append the shape of the vector.
+#'   This argument is handled by the generic and will not be passed on to methods.
 #' @inheritParams ellipsis::dots_empty
 #'
 #' @keywords internal
@@ -39,16 +43,16 @@ vec_ptype_abbr <- function(x, ..., prefix_named = FALSE, suffix_shape = TRUE) {
     ellipsis::check_dots_empty()
   }
 
-  abbr <- vec_ptype_abbr_(x, prefix_named = prefix_named, suffix_shape = suffix_shape)
+  abbr <- vec_ptype_abbr_dispatch(x)
 
   return(paste0(
-    if (prefix_named && !is.null(vec_names(x))) "named ",
+    if ((prefix_named || is_bare_list(x)) && !is.null(vec_names(x))) "named ",
     abbr,
     if (suffix_shape) vec_ptype_shape(x)
   ))
   UseMethod("vec_ptype_abbr")
 }
-vec_ptype_abbr_ <- function(x, ..., prefix_named = FALSE, suffix_shape = TRUE) {
+vec_ptype_abbr_dispatch <- function(x, ...) {
   UseMethod("vec_ptype_abbr")
 }
 
@@ -72,15 +76,12 @@ vec_ptype_full.default <- function(x, ...) {
 }
 
 #' @export
-vec_ptype_abbr.default <- function(x, ..., prefix_named = FALSE) {
+vec_ptype_abbr.default <- function(x, ...) {
   if (is.object(x)) {
     unname(abbreviate(vec_ptype_full(x), 8))
-  } else if (is_list(x)) {
-    named <- is_character(names(x))
-    # Always print "named" even if !prefix_named, for compatibility
-    paste0(if (named && !prefix_named) "named ", "list")
   } else if (is_vector(x)) {
     switch(typeof(x),
+      list = "list",
       logical = "lgl",
       integer = "int",
       double = "dbl",

--- a/R/ptype-abbr-full.R
+++ b/R/ptype-abbr-full.R
@@ -13,8 +13,8 @@
 #' characters where possible.
 #'
 #' @param x A vector.
-#' @param prefix_named Add a prefix for named vectors.
-#' @param shape Include the shape of the vector.
+#' @param prefix_named If `TRUE`, to add a prefix for named vectors.
+#' @param suffix_shape If `TRUE` (the default), append the shape of the vector.
 #' @inheritParams ellipsis::dots_empty
 #'
 #' @keywords internal
@@ -34,7 +34,7 @@ vec_ptype_full <- function(x, ...) {
 
 #' @export
 #' @rdname vec_ptype_full
-vec_ptype_abbr <- function(x, ..., prefix_named = FALSE, shape = TRUE) {
+vec_ptype_abbr <- function(x, ..., prefix_named = FALSE, suffix_shape = TRUE) {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
@@ -61,7 +61,7 @@ vec_ptype_full.default <- function(x, ...) {
 }
 
 #' @export
-vec_ptype_abbr.default <- function(x, ..., prefix_named = FALSE, shape = TRUE) {
+vec_ptype_abbr.default <- function(x, ..., prefix_named = FALSE, suffix_shape = TRUE) {
   if (is.object(x)) {
     unname(abbreviate(vec_ptype_full(x), 8))
   } else if (is_list(x)) {
@@ -83,7 +83,7 @@ vec_ptype_abbr.default <- function(x, ..., prefix_named = FALSE, shape = TRUE) {
     paste0(
       if (prefix_named && !is.null(x) && !is.null(vec_names(x))) "named ",
       abbr,
-      if (shape) vec_ptype_shape(x)
+      if (suffix_shape) vec_ptype_shape(x)
     )
   } else {
     abort("Not a vector.")

--- a/R/ptype-abbr-full.R
+++ b/R/ptype-abbr-full.R
@@ -13,7 +13,7 @@
 #' characters where possible.
 #'
 #' @param x A vector.
-#' @param check_named Add a prefix for named vectors.
+#' @param prefix_named Add a prefix for named vectors.
 #' @param shape Include the shape of the vector.
 #' @inheritParams ellipsis::dots_empty
 #'
@@ -34,7 +34,7 @@ vec_ptype_full <- function(x, ...) {
 
 #' @export
 #' @rdname vec_ptype_full
-vec_ptype_abbr <- function(x, ..., check_named = FALSE, shape = TRUE) {
+vec_ptype_abbr <- function(x, ..., prefix_named = FALSE, shape = TRUE) {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
@@ -61,12 +61,12 @@ vec_ptype_full.default <- function(x, ...) {
 }
 
 #' @export
-vec_ptype_abbr.default <- function(x, ..., check_named = FALSE, shape = TRUE) {
+vec_ptype_abbr.default <- function(x, ..., prefix_named = FALSE, shape = TRUE) {
   if (is.object(x)) {
     unname(abbreviate(vec_ptype_full(x), 8))
   } else if (is_list(x)) {
     named <- is_character(names(x))
-    # Always print "named" even if !check_named, for compatibility
+    # Always print "named" even if !prefix_named, for compatibility
     paste0(if (named) "named ", "list", vec_ptype_shape(x))
   } else if (is_vector(x)) {
     abbr <- switch(typeof(x),
@@ -81,7 +81,7 @@ vec_ptype_abbr.default <- function(x, ..., check_named = FALSE, shape = TRUE) {
       abbreviate(typeof(x))
     )
     paste0(
-      if (check_named && !is.null(x) && !is.null(vec_names(x))) "named ",
+      if (prefix_named && !is.null(x) && !is.null(vec_names(x))) "named ",
       abbr,
       if (shape) vec_ptype_shape(x)
     )

--- a/R/ptype-abbr-full.R
+++ b/R/ptype-abbr-full.R
@@ -13,6 +13,8 @@
 #' characters where possible.
 #'
 #' @param x A vector.
+#' @param check_named Add a prefix for named vectors.
+#' @param shape Include the shape of the vector.
 #' @inheritParams ellipsis::dots_empty
 #'
 #' @keywords internal
@@ -32,7 +34,7 @@ vec_ptype_full <- function(x, ...) {
 
 #' @export
 #' @rdname vec_ptype_full
-vec_ptype_abbr <- function(x, ...) {
+vec_ptype_abbr <- function(x, ..., check_named = FALSE, shape = TRUE) {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
@@ -59,11 +61,12 @@ vec_ptype_full.default <- function(x, ...) {
 }
 
 #' @export
-vec_ptype_abbr.default <- function(x, ...) {
+vec_ptype_abbr.default <- function(x, ..., check_named = FALSE, shape = TRUE) {
   if (is.object(x)) {
     unname(abbreviate(vec_ptype_full(x), 8))
   } else if (is_list(x)) {
     named <- is_character(names(x))
+    # Always print "named" even if !check_named, for compatibility
     paste0(if (named) "named ", "list", vec_ptype_shape(x))
   } else if (is_vector(x)) {
     abbr <- switch(typeof(x),
@@ -77,7 +80,11 @@ vec_ptype_abbr.default <- function(x, ...) {
       raw = "raw",
       abbreviate(typeof(x))
     )
-    paste0(abbr, vec_ptype_shape(x))
+    paste0(
+      if (check_named && !is.null(x) && !is.null(vec_names(x))) "named ",
+      abbr,
+      if (shape) vec_ptype_shape(x)
+    )
   } else {
     abort("Not a vector.")
   }

--- a/R/ptype-abbr-full.R
+++ b/R/ptype-abbr-full.R
@@ -38,6 +38,17 @@ vec_ptype_abbr <- function(x, ..., prefix_named = FALSE, suffix_shape = TRUE) {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
+
+  abbr <- vec_ptype_abbr_(x, prefix_named = prefix_named, suffix_shape = suffix_shape)
+
+  return(paste0(
+    if (prefix_named && !is.null(vec_names(x))) "named ",
+    abbr,
+    if (suffix_shape) vec_ptype_shape(x)
+  ))
+  UseMethod("vec_ptype_abbr")
+}
+vec_ptype_abbr_ <- function(x, ..., prefix_named = FALSE, suffix_shape = TRUE) {
   UseMethod("vec_ptype_abbr")
 }
 
@@ -61,15 +72,15 @@ vec_ptype_full.default <- function(x, ...) {
 }
 
 #' @export
-vec_ptype_abbr.default <- function(x, ..., prefix_named = FALSE, suffix_shape = TRUE) {
+vec_ptype_abbr.default <- function(x, ..., prefix_named = FALSE) {
   if (is.object(x)) {
     unname(abbreviate(vec_ptype_full(x), 8))
   } else if (is_list(x)) {
     named <- is_character(names(x))
     # Always print "named" even if !prefix_named, for compatibility
-    paste0(if (named) "named ", "list", vec_ptype_shape(x))
+    paste0(if (named && !prefix_named) "named ", "list")
   } else if (is_vector(x)) {
-    abbr <- switch(typeof(x),
+    switch(typeof(x),
       logical = "lgl",
       integer = "int",
       double = "dbl",
@@ -79,11 +90,6 @@ vec_ptype_abbr.default <- function(x, ..., prefix_named = FALSE, suffix_shape = 
       expression = "expr",
       raw = "raw",
       abbreviate(typeof(x))
-    )
-    paste0(
-      if (prefix_named && !is.null(x) && !is.null(vec_names(x))) "named ",
-      abbr,
-      if (suffix_shape) vec_ptype_shape(x)
     )
   } else {
     abort("Not a vector.")

--- a/R/ptype-abbr-full.R
+++ b/R/ptype-abbr-full.R
@@ -12,13 +12,14 @@
 #' to 8 characters. You should almost always override, aiming for 4-6
 #' characters where possible.
 #'
+#' These arguments are handled by the generic and not passed to methods:
+#' * `prefix_named`
+#' * `suffix_shape`
+#'
 #' @param x A vector.
-#' @param prefix_named
-#'   If `TRUE`, to add a prefix for named vectors.
-#'   This argument is handled by the generic and will not be passed on to methods.
-#' @param suffix_shape
-#'   If `TRUE` (the default), append the shape of the vector.
-#'   This argument is handled by the generic and will not be passed on to methods.
+#' @param prefix_named If `TRUE`, add a prefix for named vectors.
+#' @param suffix_shape If `TRUE` (the default), append the shape of
+#'   the vector.
 #' @inheritParams ellipsis::dots_empty
 #'
 #' @keywords internal

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -184,11 +184,10 @@ vec_ptype_full.data.frame <- function(x, ...) {
 #' @export
 vec_ptype_abbr.data.frame <- function(x, ...) {
   if (inherits_only(x, "data.frame")) {
-    abbr <- "df"
+    "df"
   } else {
-    abbr <- class(x)[[1]]
+    class(x)[[1]]
   }
-  paste0(abbr, vec_ptype_shape(x))
 }
 
 #' @export

--- a/man/vec_ptype_full.Rd
+++ b/man/vec_ptype_full.Rd
@@ -14,11 +14,10 @@ vec_ptype_abbr(x, ..., prefix_named = FALSE, suffix_shape = TRUE)
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{prefix_named}{If \code{TRUE}, to add a prefix for named vectors.
-This argument is handled by the generic and will not be passed on to methods.}
+\item{prefix_named}{If \code{TRUE}, add a prefix for named vectors.}
 
-\item{suffix_shape}{If \code{TRUE} (the default), append the shape of the vector.
-This argument is handled by the generic and will not be passed on to methods.}
+\item{suffix_shape}{If \code{TRUE} (the default), append the shape of
+the vector.}
 }
 \value{
 A string.
@@ -36,6 +35,12 @@ be prominently displayed.
 The default method for \code{vec_ptype_abbr()} \code{\link[=abbreviate]{abbreviate()}}s \code{vec_ptype_full()}
 to 8 characters. You should almost always override, aiming for 4-6
 characters where possible.
+
+These arguments are handled by the generic and not passed to methods:
+\itemize{
+\item \code{prefix_named}
+\item \code{suffix_shape}
+}
 }
 
 \examples{

--- a/man/vec_ptype_full.Rd
+++ b/man/vec_ptype_full.Rd
@@ -7,14 +7,14 @@
 \usage{
 vec_ptype_full(x, ...)
 
-vec_ptype_abbr(x, ..., check_named = FALSE, shape = TRUE)
+vec_ptype_abbr(x, ..., prefix_named = FALSE, shape = TRUE)
 }
 \arguments{
 \item{x}{A vector.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{check_named}{Add a prefix for named vectors.}
+\item{prefix_named}{Add a prefix for named vectors.}
 
 \item{shape}{Include the shape of the vector.}
 }

--- a/man/vec_ptype_full.Rd
+++ b/man/vec_ptype_full.Rd
@@ -7,12 +7,16 @@
 \usage{
 vec_ptype_full(x, ...)
 
-vec_ptype_abbr(x, ...)
+vec_ptype_abbr(x, ..., check_named = FALSE, shape = TRUE)
 }
 \arguments{
 \item{x}{A vector.}
 
 \item{...}{These dots are for future extensions and must be empty.}
+
+\item{check_named}{Add a prefix for named vectors.}
+
+\item{shape}{Include the shape of the vector.}
 }
 \value{
 A string.

--- a/man/vec_ptype_full.Rd
+++ b/man/vec_ptype_full.Rd
@@ -7,16 +7,18 @@
 \usage{
 vec_ptype_full(x, ...)
 
-vec_ptype_abbr(x, ..., prefix_named = FALSE, shape = TRUE)
+vec_ptype_abbr(x, ..., prefix_named = FALSE, suffix_shape = TRUE)
 }
 \arguments{
 \item{x}{A vector.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{prefix_named}{Add a prefix for named vectors.}
+\item{prefix_named}{If \code{TRUE}, to add a prefix for named vectors.
+This argument is handled by the generic and will not be passed on to methods.}
 
-\item{shape}{Include the shape of the vector.}
+\item{suffix_shape}{If \code{TRUE} (the default), append the shape of the vector.
+This argument is handled by the generic and will not be passed on to methods.}
 }
 \value{
 A string.

--- a/tests/testthat/test-ptype-abbr-full.R
+++ b/tests/testthat/test-ptype-abbr-full.R
@@ -53,3 +53,17 @@ test_that("named atomics are tagged optionally (#781)", {
   expect_identical(vec_ptype_abbr(c(x = 1, y = 2), prefix_named = TRUE), "named dbl")
   expect_identical(vec_ptype_abbr(c(x = 1L, y = 2L), prefix_named = TRUE), "named int")
 })
+
+test_that("vec_ptype_abbr() adds named tag in case of row names", {
+  expect_equal(
+    vec_ptype_abbr(mtcars, prefix_named = TRUE),
+    "named df[,11]"
+  )
+
+  mat <- matrix(1:4, 2)
+  rownames(mat) <- c("foo", "bar")
+  expect_equal(
+    vec_ptype_abbr(mat, prefix_named = TRUE),
+    "named int[,2]"
+  )
+})

--- a/tests/testthat/test-ptype-abbr-full.R
+++ b/tests/testthat/test-ptype-abbr-full.R
@@ -21,9 +21,9 @@ test_that("non objects default to type + shape", {
 })
 
 test_that("non objects can omit shape", {
-  expect_equal(vec_ptype_abbr(ones(10), shape = FALSE), "dbl")
-  expect_equal(vec_ptype_abbr(ones(0, 10), shape = FALSE), "dbl")
-  expect_equal(vec_ptype_abbr(ones(10, 0), shape = FALSE), "dbl")
+  expect_equal(vec_ptype_abbr(ones(10), suffix_shape = FALSE), "dbl")
+  expect_equal(vec_ptype_abbr(ones(0, 10), suffix_shape = FALSE), "dbl")
+  expect_equal(vec_ptype_abbr(ones(10, 0), suffix_shape = FALSE), "dbl")
 })
 
 test_that("objects default to first class", {

--- a/tests/testthat/test-ptype-abbr-full.R
+++ b/tests/testthat/test-ptype-abbr-full.R
@@ -46,10 +46,10 @@ test_that("complex and factor as expected (#323)", {
 
 test_that("named lists are always tagged (#322)", {
   expect_identical(vec_ptype_abbr(list(x = 1, y = 2)), "named list")
-  expect_identical(vec_ptype_abbr(list(x = 1, y = 2), check_named = TRUE), "named list")
+  expect_identical(vec_ptype_abbr(list(x = 1, y = 2), prefix_named = TRUE), "named list")
 })
 
 test_that("named atomics are tagged optionally (#781)", {
-  expect_identical(vec_ptype_abbr(c(x = 1, y = 2), check_named = TRUE), "named dbl")
-  expect_identical(vec_ptype_abbr(c(x = 1L, y = 2L), check_named = TRUE), "named int")
+  expect_identical(vec_ptype_abbr(c(x = 1, y = 2), prefix_named = TRUE), "named dbl")
+  expect_identical(vec_ptype_abbr(c(x = 1L, y = 2L), prefix_named = TRUE), "named int")
 })

--- a/tests/testthat/test-ptype-abbr-full.R
+++ b/tests/testthat/test-ptype-abbr-full.R
@@ -20,8 +20,14 @@ test_that("non objects default to type + shape", {
 
 })
 
+test_that("non objects can omit shape", {
+  expect_equal(vec_ptype_abbr(ones(10), shape = FALSE), "dbl")
+  expect_equal(vec_ptype_abbr(ones(0, 10), shape = FALSE), "dbl")
+  expect_equal(vec_ptype_abbr(ones(10, 0), shape = FALSE), "dbl")
+})
+
 test_that("objects default to first class", {
-  x <- structure(1, class = "foofy")
+  x <- structure(1, class = c("foofy", "goofy"))
   expect_equal(vec_ptype_full(x), "foofy")
   expect_equal(vec_ptype_abbr(x), "foofy")
 })
@@ -38,6 +44,12 @@ test_that("complex and factor as expected (#323)", {
   expect_equal(vec_ptype_abbr(factor()), "fct")
 })
 
-test_that("named lists are tagged (#322)", {
+test_that("named lists are always tagged (#322)", {
   expect_identical(vec_ptype_abbr(list(x = 1, y = 2)), "named list")
+  expect_identical(vec_ptype_abbr(list(x = 1, y = 2), check_named = TRUE), "named list")
+})
+
+test_that("named atomics are tagged optionally (#781)", {
+  expect_identical(vec_ptype_abbr(c(x = 1, y = 2), check_named = TRUE), "named dbl")
+  expect_identical(vec_ptype_abbr(c(x = 1L, y = 2L), check_named = TRUE), "named int")
 })

--- a/tests/testthat/test-type-table.R
+++ b/tests/testthat/test-type-table.R
@@ -6,7 +6,7 @@ test_that("ptype print methods are descriptive", {
   tab2 <- new_table(dim = c(0L, 1L, 2L, 1L))
 
   expect_equal(vec_ptype_abbr(tab1), "table")
-  expect_equal(vec_ptype_abbr(tab2), "table")
+  expect_equal(vec_ptype_abbr(tab2), "table[,1,2,1]")
 
   expect_equal(vec_ptype_full(tab1), "table")
   expect_equal(vec_ptype_full(tab2), "table[,1,2,1]")


### PR DESCRIPTION
Closes #781.

Helps https://github.com/r-lib/pillar/issues/168.

Do we extend to `vec_ptype_full()`? Which parts?