### PR TITLE
Stop using `STRING_PTR()`

### DIFF
--- a/src/bind.c
+++ b/src/bind.c
@@ -163,7 +163,7 @@ static SEXP vec_rbind(SEXP xs,
       p_index = (void*) index;
       p_names_to_col = (void*) names_to_col;
     } else {
-      p_index = r_vec_const_deref(index);
+      p_index = r_vec_deref_const(index);
       p_names_to_col = r_vec_deref(names_to_col);
     }
   }

--- a/src/bind.c
+++ b/src/bind.c
@@ -159,13 +159,9 @@ static SEXP vec_rbind(SEXP xs,
     }
     names_to_type = TYPEOF(index);
     names_to_col = PROTECT_N(Rf_allocVector(names_to_type, n_rows), &n_prot);
-    if (names_to_type == STRSXP) {
-      p_index = (void*) index;
-      p_names_to_col = (void*) names_to_col;
-    } else {
-      p_index = r_vec_deref_const(index);
-      p_names_to_col = r_vec_deref(names_to_col);
-    }
+
+    p_index = r_vec_deref_barrier_const(index);
+    p_names_to_col = r_vec_deref_barrier(names_to_col);
   }
 
   // Compact sequences use 0-based counters

--- a/src/bind.c
+++ b/src/bind.c
@@ -146,8 +146,8 @@ static SEXP vec_rbind(SEXP xs,
 
   SEXP names_to_col = R_NilValue;
   SEXPTYPE names_to_type = 99;
-  void* names_to_p = NULL;
-  const void* index_p = NULL;
+  void* p_names_to_col = NULL;
+  const void* p_index = NULL;
 
   if (has_names_to) {
     SEXP index = R_NilValue;
@@ -157,11 +157,15 @@ static SEXP vec_rbind(SEXP xs,
       index = PROTECT_N(Rf_allocVector(INTSXP, n_inputs), &n_prot);
       r_int_fill_seq(index, 1, n_inputs);
     }
-    index_p = r_vec_const_deref(index);
-
     names_to_type = TYPEOF(index);
     names_to_col = PROTECT_N(Rf_allocVector(names_to_type, n_rows), &n_prot);
-    names_to_p = r_vec_deref(names_to_col);
+    if (names_to_type == STRSXP) {
+      p_index = (void*) index;
+      p_names_to_col = (void*) names_to_col;
+    } else {
+      p_index = r_vec_const_deref(index);
+      p_names_to_col = r_vec_deref(names_to_col);
+    }
   }
 
   // Compact sequences use 0-based counters
@@ -209,8 +213,7 @@ static SEXP vec_rbind(SEXP xs,
 
     // Assign current name to group vector, if supplied
     if (has_names_to) {
-      r_vec_fill(names_to_type, names_to_p, index_p, i, size);
-      r_vec_ptr_inc(names_to_type, &names_to_p, size);
+      r_vec_fill(names_to_type, p_names_to_col, counter, p_index, i, size);
     }
 
     counter += size;

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -214,7 +214,7 @@ static void init_dictionary_df(struct dictionary* d) {
     if (col_type == vctrs_type_list) {
       col_ptrs[i] = col;
     } else {
-      col_ptrs[i] = r_vec_const_deref(col);
+      col_ptrs[i] = r_vec_deref_const(col);
     }
   }
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -127,7 +127,7 @@ static void init_dictionary_list(struct dictionary* d) {
 
 struct dictionary_df_data {
   enum vctrs_type* col_types;
-  void** col_ptrs;
+  const void** col_ptrs;
   R_len_t n_col;
 };
 
@@ -141,8 +141,8 @@ static int df_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
   }
 
   enum vctrs_type* types = x_data->col_types;
-  void** x_ptrs = x_data->col_ptrs;
-  void** y_ptrs = y_data->col_ptrs;
+  const void** x_ptrs = x_data->col_ptrs;
+  const void** y_ptrs = y_data->col_ptrs;
 
   // `vec_proxy_equal()` flattens data frames so we don't need to
   // worry about df-cols
@@ -161,7 +161,7 @@ static int df_equal_missing(const void* x, R_len_t i) {
   struct dictionary_df_data* x_data = (struct dictionary_df_data*) x;
 
   enum vctrs_type* types = x_data->col_types;
-  void** x_ptrs = x_data->col_ptrs;
+  const void** x_ptrs = x_data->col_ptrs;
   R_len_t n_col = x_data->n_col;
 
   for (R_len_t col = 0; col < n_col; ++col) {
@@ -199,7 +199,7 @@ static void init_dictionary_df(struct dictionary* d) {
 
   struct dictionary_df_data* data = (struct dictionary_df_data*) RAW(data_handle);
   enum vctrs_type* col_types = (enum vctrs_type*) RAW(col_types_handle);
-  void** col_ptrs = (void**) RAW(col_ptrs_handle);
+  const void** col_ptrs = (const void**) RAW(col_ptrs_handle);
 
   data->col_types = col_types;
   data->col_ptrs = col_ptrs;
@@ -214,7 +214,7 @@ static void init_dictionary_df(struct dictionary* d) {
     if (col_type == vctrs_type_list) {
       col_ptrs[i] = col;
     } else {
-      col_ptrs[i] = r_vec_deref(col);
+      col_ptrs[i] = r_vec_const_deref(col);
     }
   }
 

--- a/src/slice.c
+++ b/src/slice.c
@@ -278,7 +278,6 @@ static void repair_na_names(SEXP names, SEXP subscript) {
     return;
   }
 
-  SEXP* p_names = STRING_PTR(names);
   const int* p_subscript = INTEGER_RO(subscript);
 
   // Special handling for a compact_rep object with repeated `NA`
@@ -288,7 +287,7 @@ static void repair_na_names(SEXP names, SEXP subscript) {
     }
 
     for (R_len_t i = 0; i < n; ++i) {
-      p_names[i] = strings_empty;
+      SET_STRING_ELT(names, i, strings_empty);
     }
 
     return;
@@ -296,7 +295,7 @@ static void repair_na_names(SEXP names, SEXP subscript) {
 
   for (R_len_t i = 0; i < n; ++i) {
     if (p_subscript[i] == NA_INTEGER) {
-      p_names[i] = strings_empty;
+      SET_STRING_ELT(names, i, strings_empty);
     }
   }
 }

--- a/src/translate.c
+++ b/src/translate.c
@@ -213,7 +213,6 @@ static SEXP chr_translate_encoding(SEXP x, R_len_t size) {
   const SEXP* p_x = STRING_PTR_RO(x);
 
   SEXP out = PROTECT(r_clone_referenced(x));
-  SEXP* p_out = STRING_PTR(out);
 
   const void *vmax = vmaxget();
 
@@ -221,11 +220,11 @@ static SEXP chr_translate_encoding(SEXP x, R_len_t size) {
     SEXP chr = p_x[i];
 
     if (Rf_getCharCE(chr) == CE_UTF8) {
-      p_out[i] = chr;
+      SET_STRING_ELT(out, i, chr);
       continue;
     }
 
-    p_out[i] = Rf_mkCharCE(Rf_translateCharUTF8(chr), CE_UTF8);
+    SET_STRING_ELT(out, i, Rf_mkCharCE(Rf_translateCharUTF8(chr), CE_UTF8));
   }
 
   vmaxset(vmax);

--- a/src/utils.c
+++ b/src/utils.c
@@ -898,7 +898,6 @@ void* r_vec_deref(SEXP x) {
   case INTSXP: return INTEGER(x);
   case REALSXP: return REAL(x);
   case CPLXSXP: return COMPLEX(x);
-  case STRSXP: return STRING_PTR(x);
   case RAWSXP: return RAW(x);
   default: stop_unimplemented_type("r_vec_deref", TYPEOF(x));
   }
@@ -913,6 +912,26 @@ const void* r_vec_deref_const(SEXP x) {
   case STRSXP: return STRING_PTR_RO(x);
   case RAWSXP: return RAW_RO(x);
   default: stop_unimplemented_type("r_vec_deref_const", TYPEOF(x));
+  }
+}
+
+void* r_vec_deref_barrier(SEXP x) {
+  switch (TYPEOF(x)) {
+  case STRSXP:
+  case VECSXP:
+    return (void*) x;
+  default:
+    return r_vec_deref(x);
+  }
+}
+
+const void* r_vec_deref_barrier_const(SEXP x) {
+  switch (TYPEOF(x)) {
+  case STRSXP:
+  case VECSXP:
+    return (const void*) x;
+  default:
+    return r_vec_deref_const(x);
   }
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -904,7 +904,7 @@ void* r_vec_deref(SEXP x) {
   }
 }
 
-const void* r_vec_const_deref(SEXP x) {
+const void* r_vec_deref_const(SEXP x) {
   switch (TYPEOF(x)) {
   case LGLSXP: return LOGICAL_RO(x);
   case INTSXP: return INTEGER_RO(x);
@@ -912,7 +912,7 @@ const void* r_vec_const_deref(SEXP x) {
   case CPLXSXP: return COMPLEX_RO(x);
   case STRSXP: return STRING_PTR_RO(x);
   case RAWSXP: return RAW_RO(x);
-  default: stop_unimplemented_type("r_vec_const_deref", TYPEOF(x));
+  default: stop_unimplemented_type("r_vec_deref_const", TYPEOF(x));
   }
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1526,15 +1526,14 @@ SEXP chr_c(SEXP x, SEXP y) {
   r_ssize out_n = r_ssize_add(x_n, y_n);
   SEXP out = PROTECT(r_new_vector(STRSXP, out_n));
 
-  SEXP* p_out = STRING_PTR(out);
   const SEXP* p_x = STRING_PTR_RO(x);
   const SEXP* p_y = STRING_PTR_RO(y);
 
   for (r_ssize i = 0; i < x_n; ++i) {
-    p_out[i] = p_x[i];
+    SET_STRING_ELT(out, i, p_x[i]);
   }
   for (r_ssize i = 0, j = x_n; i < y_n; ++i, ++j) {
-    p_out[j] = p_y[i];
+    SET_STRING_ELT(out, j, p_y[i]);
   }
 
   UNPROTECT(1);

--- a/src/utils.c
+++ b/src/utils.c
@@ -906,8 +906,12 @@ void* r_vec_deref(SEXP x) {
 
 const void* r_vec_const_deref(SEXP x) {
   switch (TYPEOF(x)) {
+  case LGLSXP: return LOGICAL_RO(x);
   case INTSXP: return INTEGER_RO(x);
+  case REALSXP: return REAL_RO(x);
+  case CPLXSXP: return COMPLEX_RO(x);
   case STRSXP: return STRING_PTR_RO(x);
+  case RAWSXP: return RAW_RO(x);
   default: stop_unimplemented_type("r_vec_const_deref", TYPEOF(x));
   }
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -206,7 +206,12 @@ void* r_vec_deref(SEXP x);
 const void* r_vec_const_deref(SEXP x);
 
 void r_vec_ptr_inc(SEXPTYPE type, void** p, R_len_t i);
-void r_vec_fill(SEXPTYPE type, void* p, const void* value_p, R_len_t value_i, R_len_t n);
+void r_vec_fill(SEXPTYPE type,
+                void* p_dest,
+                r_ssize dest_i,
+                const void* p_src,
+                r_ssize src_i,
+                r_ssize n);
 
 R_len_t r_lgl_sum(SEXP lgl, bool na_true);
 SEXP r_lgl_which(SEXP x, bool na_true);

--- a/src/utils.h
+++ b/src/utils.h
@@ -203,7 +203,7 @@ extern SEXP (*rlang_env_dots_values)(SEXP);
 extern SEXP (*rlang_env_dots_list)(SEXP);
 
 void* r_vec_deref(SEXP x);
-const void* r_vec_const_deref(SEXP x);
+const void* r_vec_deref_const(SEXP x);
 
 void r_vec_ptr_inc(SEXPTYPE type, void** p, R_len_t i);
 void r_vec_fill(SEXPTYPE type,

--- a/src/utils.h
+++ b/src/utils.h
@@ -204,6 +204,8 @@ extern SEXP (*rlang_env_dots_list)(SEXP);
 
 void* r_vec_deref(SEXP x);
 const void* r_vec_deref_const(SEXP x);
+void* r_vec_deref_barrier(SEXP x);
+const void* r_vec_deref_barrier_const(SEXP x);
 
 void r_vec_ptr_inc(SEXPTYPE type, void** p, R_len_t i);
 void r_vec_fill(SEXPTYPE type,

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -191,6 +191,7 @@ test_that("can repair names in `vec_rbind()` (#229)", {
 
 test_that("can construct an id column", {
   df <- data.frame(x = 1)
+  vec_rbind(a = df, b = df, .names_to = "id")$id
 
   expect_named(vec_rbind(df, df, .names_to = "id"), c("id", "x"))
   expect_equal(vec_rbind(df, df, .names_to = "id")$id, c(1L, 2L))

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -191,7 +191,6 @@ test_that("can repair names in `vec_rbind()` (#229)", {
 
 test_that("can construct an id column", {
   df <- data.frame(x = 1)
-  vec_rbind(a = df, b = df, .names_to = "id")$id
 
   expect_named(vec_rbind(df, df, .names_to = "id"), c("id", "x"))
   expect_equal(vec_rbind(df, df, .names_to = "id")$id, c(1L, 2L))


### PR DESCRIPTION
So we don't mess up refcounts of CHARSXP.