### PR TITLE
Fix in-place update in vec_set_names()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # vctrs (development version)
 
+* `vec_set_names()` no longer alters the input in-place (#1194).
+
 * New `vec_proxy_order()` that provides an ordering proxy for use in
   `vec_order()` and `vec_sort()`. The default method falls through to
   `vec_proxy_compare()`. Lists are special cased, and return an integer

--- a/src/names.c
+++ b/src/names.c
@@ -704,6 +704,9 @@ SEXP vec_set_rownames(SEXP x, SEXP names) {
 
   if (dim_names == R_NilValue) {
     dim_names = PROTECT_N(Rf_allocVector(VECSXP, vec_dim_n(x)), &nprot);
+  } else {
+    // Also clone attribute
+    dim_names = PROTECT_N(Rf_shallow_duplicate(dim_names), &nprot);
   }
 
   SET_VECTOR_ELT(dim_names, 0, names);

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -191,6 +191,22 @@ test_that("vec_set_names() sets matrix/array names", {
   expect_equal(vec_set_names(y, names), exp)
 })
 
+test_that("vec_set_names() doesn't alter names", {
+  x <- matrix(1, dimnames = list(rows = "a", cols = "x"))
+  vec_set_names(x, "y")
+  expect_equal(vec_names2(x), "a")
+  expect_equal(colnames(x), "x")
+  vec_set_names(x, NULL)
+  expect_equal(vec_names2(x), "a")
+  expect_equal(colnames(x), "x")
+
+  y <- array(1:4, dim = c(1, 2, 2), dimnames = list(rows = "a", one = 1:2, two = 1:2))
+  vec_set_names(y, "y")
+  expect_equal(vec_names2(y), "a")
+  vec_set_names(y, NULL)
+  expect_equal(vec_names2(y), "a")
+})
+
 test_that("vec_set_names() sets row names on data frames", {
   expect_identical(
     vec_set_names(data_frame(x = 1), "foo"),


### PR DESCRIPTION
## 97513ec

``` r
c <- matrix(1, dimnames = list(rows = "z", cols = "cc"))
dimnames(c)
#> $rows
#> [1] "z"
#> 
#> $cols
#> [1] "cc"
vctrs::vec_set_names(c, NULL)
#>       cols
#> rows   cc
#>   [1,]  1
dimnames(c)
#> $rows
#> NULL
#> 
#> $cols
#> [1] "cc"
```

<sup>Created on 2020-07-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

## This PR

``` r
c <- matrix(1, dimnames = list(rows = "z", cols = "cc"))
dimnames(c)
#> $rows
#> [1] "z"
#> 
#> $cols
#> [1] "cc"
vctrs::vec_set_names(c, NULL)
#>       cols
#> rows   cc
#>   [1,]  1
dimnames(c)
#> $rows
#> [1] "z"
#> 
#> $cols
#> [1] "cc"
```

<sup>Created on 2020-07-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
