### PR TITLE
Fix performance issue in `vec_order()` with classed vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* Fixed performance issue with `vec_order()` on classed vectors which
+  affected `dplyr::group_by()` (tidyverse/dplyr#5423).
+
 * `vec_set_names()` no longer alters the input in-place (#1194).
 
 * New `vec_proxy_order()` that provides an ordering proxy for use in

--- a/R/compare.R
+++ b/R/compare.R
@@ -192,6 +192,9 @@ order_proxy <- function(proxy, direction = "asc", na_value = "largest") {
     })
     exec("order", !!!args, decreasing = decreasing, na.last = na.last)
   } else if (is_character(proxy) || is_logical(proxy) || is_integer(proxy) || is_double(proxy)) {
+    if (is.object(proxy)) {
+      proxy <- unstructure(proxy)
+    }
     order(proxy, decreasing = decreasing, na.last = na.last)
   } else {
     abort("Invalid type returned by `vec_proxy_compare()`.")

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -337,3 +337,9 @@ test_that("can order data frames (and subclasses) with matrix columns", {
   df$x <- tibble::tibble(y = matrix(1:2, 2))
   expect_identical(vec_order(df), 1:2)
 })
+
+test_that("classed proxies do not affect performance (tidyverse/dplyr#5423)", {
+  skip_on_cran()
+  x <- glue::glue("{1:10000}")
+  expect_time_lt(vec_order(x), 0.2)
+})


### PR DESCRIPTION
Closes tidyverse/dplyr#5423

Bug introduced in #1142 when I switched from `vec_data()` to `vec_proxy_equal()`. This causes a lot of OO R code to be run in `xtfrm.default()` through `[`. To fix this, we now unstructure the order proxy before use.