### PR TITLE
Avoid calling `STRING_ELT()` on unnamed data frames

### DIFF
--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -676,17 +676,23 @@ SEXP df_flatten(SEXP x) {
 static R_len_t df_flatten_loop(SEXP x, SEXP out, SEXP out_names, R_len_t counter) {
   R_len_t n = Rf_length(x);
   SEXP x_names = PROTECT(r_names(x));
+  bool has_names = x_names != R_NilValue;
 
   for (R_len_t i = 0; i < n; ++i) {
     SEXP col = VECTOR_ELT(x, i);
 
     if (is_data_frame(col)) {
       counter = df_flatten_loop(col, out, out_names, counter);
-    } else {
-      SET_VECTOR_ELT(out, counter, col);
-      SET_STRING_ELT(out_names, counter, STRING_ELT(x_names, i));
-      ++counter;
+      continue;
     }
+
+    SET_VECTOR_ELT(out, counter, col);
+
+    if (has_names) {
+      SET_STRING_ELT(out_names, counter, STRING_ELT(x_names, i));
+    }
+
+    ++counter;
   }
 
   UNPROTECT(1);

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -396,6 +396,13 @@ test_that("can flatten data frames", {
 
   df <- tibble(x = 1, y = tibble(x = 2, y = tibble(x = 3), z = 4), z = 5)
   expect_identical(df_flatten(df), new_data_frame(list(x = 1, x = 2, x = 3, z = 4, z = 5)))
+
+  df2 <- data_frame(1, 2)
+  expect_identical(df_flatten(df2), set_names(df2, c("", "")))
+
+  df_col <- data_frame(x = 2, y = 3)
+  df3 <- data_frame(1, df_col)
+  expect_identical(df_flatten(df3), data_frame(1, x = 2, y = 3))
 })
 
 test_that("new_data_frame() zaps existing attributes", {


### PR DESCRIPTION
Closes #1198 

Simple adjustment to `df_flatten_loop()` to avoid extracting names from an unnamed data frame.

Even with unnamed data frames, we return a data frame from `df_flatten()` that at least has `""` as column names. This makes it easy to ensure proper behavior in the edge case where an unnamed data frame has a df-col that has names (this is `df3` in the added tests)