### PR TITLE
When restoring unnamed data frames, repair column names with `""`

### DIFF
--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -123,8 +123,9 @@ static SEXP vec_bare_df_restore_impl(SEXP x, SEXP to, R_len_t size,
   x = PROTECT(vec_restore_default(x, to, owned));
 
   if (Rf_getAttrib(x, R_NamesSymbol) == R_NilValue) {
-    SEXP names = Rf_allocVector(STRSXP, Rf_length(x));
+    SEXP names = PROTECT(Rf_allocVector(STRSXP, Rf_length(x)));
     Rf_setAttrib(x, R_NamesSymbol, names);
+    UNPROTECT(1);
   }
 
   SEXP rownames = PROTECT(df_rownames(x));

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -123,7 +123,8 @@ static SEXP vec_bare_df_restore_impl(SEXP x, SEXP to, R_len_t size,
   x = PROTECT(vec_restore_default(x, to, owned));
 
   if (Rf_getAttrib(x, R_NamesSymbol) == R_NilValue) {
-    Rf_setAttrib(x, R_NamesSymbol, vctrs_shared_empty_chr);
+    SEXP names = Rf_allocVector(STRSXP, Rf_length(x));
+    Rf_setAttrib(x, R_NamesSymbol, names);
   }
 
   SEXP rownames = PROTECT(df_rownames(x));

--- a/tests/testthat/test-proxy-restore.R
+++ b/tests/testthat/test-proxy-restore.R
@@ -24,6 +24,11 @@ test_that("data frame vec_restore() checks type", {
   expect_error(vec_restore(NA, mtcars), "Attempt to restore data frame from a logical")
 })
 
+test_that("data frame restore forces character column names", {
+  df <- new_data_frame(list(1))
+  expect_named(vec_restore(df, df), "")
+})
+
 test_that("can use vctrs primitives from vec_restore() without inflooping", {
   local_methods(
     vec_restore.vctrs_foobar = function(x, to, ...) {


### PR DESCRIPTION
Previously we had this untested behavior:

```r
> vec_slice(new_data_frame(list(1)), 1)
  NA
1  1
> names(vec_slice(new_data_frame(list(1)), 1))
[1] NA
```

This came from the df-restore code path, which tried to set the names to `character()`, but `Rf_setAttrib()` extended that with `Rf_lengthgets()` to the length of the data frame, and it "extends" with `NA_character_`.

I think that the names should be "repaired" to the empty string here. Now:

```r
> vec_slice(new_data_frame(list(1)), 1)
   
1 1
> names(vec_slice(new_data_frame(list(1)), 1))
[1] ""
```