### PR TITLE
Call `CHAR()` on the CHARSXP, not the STRSXP

### DIFF
--- a/src/names.c
+++ b/src/names.c
@@ -812,7 +812,7 @@ struct name_repair_opts new_name_repair_opts(SEXP name_repair, struct vctrs_arg*
     } else if (c == strings_check_unique) {
       opts.type = name_repair_check_unique;
     } else {
-      Rf_errorcall(R_NilValue, "`.name_repair` can't be \"%s\". See `?vctrs::vec_as_names`.", CHAR(name_repair));
+      Rf_errorcall(R_NilValue, "`.name_repair` can't be \"%s\". See `?vctrs::vec_as_names`.", CHAR(c));
     }
 
     return opts;

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -58,6 +58,11 @@ test_that("vec_as_names() requires character vector", {
   expect_error(vec_as_names(NULL), "`names` must be a character vector")
 })
 
+test_that("vec_as_names() validates `repair`", {
+  expect_error(vec_as_names("x", repair = "foo"), "can't be \"foo\"")
+  expect_error(vec_as_names(1, repair = 1), "string or a function")
+})
+
 test_that("vec_as_names() repairs names", {
   expect_identical(vec_as_names(chr(NA, NA)), c("", ""))
   expect_identical(vec_as_names(chr(NA, NA), repair = "unique"), c("...1", "...2"))


### PR DESCRIPTION
Previously, when i accidentally typo-d:

```r
> vec_as_names("x", repair = "minnimal")
Error in vec_as_names("x", repair = "minnimal") : 
  CHAR() can only be applied to a 'CHARSXP', not a 'character'
```

Now:

```r
> vec_as_names("x", repair = "minnimal")
Error: `.name_repair` can't be "minnimal". See `?vctrs::vec_as_names`.
```