### PR TITLE
Call `vec_cast()` instead of `vec_cast_common()` in `vec_c()`

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -122,7 +122,7 @@ vec_default_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
 
   opts <- match_fallback_opts(...)
 
-  if (opts$s3_fallback && is_common_class_fallback(to) && length(common_class_suffix(x, to))) {
+  if (is_common_class_fallback(to) && length(common_class_suffix(x, to))) {
     return(x)
   }
 

--- a/src/c.c
+++ b/src/c.c
@@ -41,7 +41,7 @@ SEXP vec_c_opts(SEXP xs,
                 SEXP ptype,
                 SEXP name_spec,
                 const struct name_repair_opts* name_repair,
-                struct fallback_opts* fallback_opts) {
+                const struct fallback_opts* fallback_opts) {
   SEXP orig_ptype = ptype;
   ptype = PROTECT(vec_ptype_common_opts(xs, orig_ptype, fallback_opts));
 

--- a/src/c.c
+++ b/src/c.c
@@ -75,19 +75,16 @@ SEXP vec_c_opts(SEXP xs,
       vec_is_common_class_fallback(ptype)) {
     struct fallback_opts d_fallback_opts = *fallback_opts;
     d_fallback_opts.s3 = S3_FALLBACK_false;
-
-    UNPROTECT(1);
     ptype = PROTECT(vec_ptype_common_opts(xs, orig_ptype, &d_fallback_opts));
-    xs = vec_cast_common_opts(xs, ptype, &d_fallback_opts);
   } else {
-    xs = vec_cast_common_opts(xs, ptype, fallback_opts);
+    ptype = PROTECT(vec_ptype_common_opts(xs, ptype, fallback_opts));
   }
-  PROTECT(xs);
 
   // Find individual input sizes and total size of output
   R_len_t n = Rf_length(xs);
   R_len_t out_size = 0;
 
+  // Caching the sizes causes an extra allocation but it improves performance
   SEXP ns_placeholder = PROTECT(Rf_allocVector(INTSXP, n));
   int* ns = INTEGER(ns_placeholder);
 
@@ -129,7 +126,12 @@ SEXP vec_c_opts(SEXP xs,
       continue;
     }
 
-    SEXP x = VECTOR_ELT(xs, i);
+    struct cast_opts opts = (struct cast_opts) {
+      .x = VECTOR_ELT(xs, i),
+      .to = ptype,
+      .fallback = *fallback_opts
+    };
+    SEXP x = PROTECT(vec_cast_opts(&opts));
 
     init_compact_seq(idx_ptr, counter, size, true);
 
@@ -151,6 +153,7 @@ SEXP vec_c_opts(SEXP xs,
     }
 
     counter += size;
+    UNPROTECT(1);
   }
 
   out = PROTECT(vec_restore(out, ptype, R_NilValue, VCTRS_OWNED_true));

--- a/src/c.h
+++ b/src/c.h
@@ -8,7 +8,7 @@ SEXP vec_c_opts(SEXP xs,
                 SEXP ptype,
                 SEXP name_spec,
                 const struct name_repair_opts* name_repair,
-                struct fallback_opts* fallback_opts);
+                const struct fallback_opts* fallback_opts);
 
 SEXP vec_c_fallback_invoke(SEXP xs, SEXP name_spec);
 SEXP vec_c_fallback(SEXP ptype,

--- a/tests/testthat/helper-performance.R
+++ b/tests/testthat/helper-performance.R
@@ -19,3 +19,34 @@ time_of <- function(expr) {
   time <- system.time(eval_tidy(expr))
   unclass(time)[["elapsed"]]
 }
+
+# From r-lib/bench
+with_memory_prof <- function(expr) {
+  f <- tempfile()
+  on.exit(unlink(f))
+
+  utils::Rprofmem(f, threshold = 1)
+  on.exit(utils::Rprofmem(NULL), add = TRUE)
+
+  res <- force(expr)
+  utils::Rprofmem(NULL)
+
+  bytes <- parse_allocations(f)$bytes
+  sum(bytes, na.rm = TRUE)
+}
+parse_allocations <- function(filename) {
+  if (!is_installed("profmem")) {
+    testthat::skip("profmem must be installed.")
+  }
+  readRprofmem <- env_get(ns_env("profmem"), "readRprofmem")
+
+  tryCatch(
+    readRprofmem(filename),
+    error = function(cnd) {
+      testthat::skip(sprintf(
+        "Memory profiling failed: %s",
+        conditionMessage(cnd)
+      ))
+    }
+  )
+}

--- a/tests/testthat/performance/test-c.txt
+++ b/tests/testthat/performance/test-c.txt
@@ -1,0 +1,42 @@
+> ints <- rep(list(1L), 100)
+> dbls <- rep(list(1), 100)
+
+`vec_c()` 
+==========
+
+> # Integers
+> with_memory_prof(vec_c(!!!ints))
+[1] 1744
+
+> # Doubles
+> with_memory_prof(vec_c(!!!dbls))
+[1] 2144
+
+> # Integers to integer
+> with_memory_prof(vec_c(!!!ints, ptype = int()))
+[1] 3464
+
+> # Doubles to integer
+> with_memory_prof(vec_c(!!!dbls, ptype = int()))
+[1] 3864
+
+
+`vec_unchop()` 
+===============
+
+> # Integers
+> with_memory_prof(vec_unchop(ints))
+[1] 896
+
+> # Doubles
+> with_memory_prof(vec_unchop(dbls))
+[1] 1296
+
+> # Integers to integer
+> with_memory_prof(vec_unchop(ints, ptype = int()))
+[1] 896
+
+> # Doubles to integer
+> with_memory_prof(vec_unchop(dbls, ptype = int()))
+[1] 896
+

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -232,6 +232,26 @@ test_that("vec_c() falls back to c() if S3 method is available", {
   )
 })
 
+test_that("c() fallback is consistent (FIXME)", {
+  out <- with_methods(
+    c.vctrs_foobar = function(...) structure(NextMethod(), class = "dispatched"),
+    list(
+      direct = vec_c(foobar(1L), foobar(2L)),
+      df = vec_c(data_frame(x = foobar(1L)), data_frame(x = foobar(2L))),
+      tib = vec_c(tibble(x = foobar(1L)), tibble(x = foobar(2L))),
+      foreign_df = vec_c(foobaz(data_frame(x = foobar(1L))), foobaz(data_frame(x = foobar(2L))))
+    )
+  )
+
+  # Proper `c()` dispatch:
+  expect_identical(out$direct, structure(1:2, class = "dispatched"))
+
+  # Inconsistent:
+  expect_identical(out$df$x, foobar(1:2))
+  expect_identical(out$tib$x, foobar(1:2))
+  expect_identical(out$foreign_df$x, foobar(1:2))
+})
+
 test_that("vec_c() falls back to c() if S4 method is available", {
   joe1 <- .Counts(c(1L, 2L), name = "Joe")
   joe2 <- .Counts(3L, name = "Joe")

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -405,3 +405,38 @@ test_that("vec_c() has informative error messages", {
     vec_c(a = c(b = letters), b = 1, .name_spec = zap())
   })
 })
+
+test_that("concatenation performs expected allocations", {
+  verify_output(test_path("performance", "test-c.txt"), {
+    ints <- rep(list(1L), 1e2)
+    dbls <- rep(list(1), 1e2)
+
+    # Extra allocations from `list2()`, see r-lib/rlang#937
+    "# `vec_c()` "
+    "Integers"
+    with_memory_prof(vec_c(!!!ints))
+
+    "Doubles"
+    with_memory_prof(vec_c(!!!dbls))
+
+    "Integers to integer"
+    with_memory_prof(vec_c(!!!ints, ptype = int()))
+
+    "Doubles to integer"
+    with_memory_prof(vec_c(!!!dbls, ptype = int()))
+
+
+    "# `vec_unchop()` "
+    "Integers"
+    with_memory_prof(vec_unchop(ints))
+
+    "Doubles"
+    with_memory_prof(vec_unchop(dbls))
+
+    "Integers to integer"
+    with_memory_prof(vec_unchop(ints, ptype = int()))
+
+    "Doubles to integer"
+    with_memory_prof(vec_unchop(dbls, ptype = int()))
+  })
+})


### PR DESCRIPTION
To avoid an extra list allocation:

```r
c(
  ints = with_memory_prof(vec_unchop(ints)),
  dbls = with_memory_prof(vec_unchop(dbls)),
  ints_to_int = with_memory_prof(vec_unchop(ints, ptype = int())),
  dbls_to_int = with_memory_prof(vec_unchop(dbls, ptype = int()))
)

## Before
#>        ints        dbls ints_to_int dbls_to_int
#>        1744        2144        1744        1744

## After
#>        ints        dbls ints_to_int dbls_to_int
#>         896        1296         896         896
```

Doesn't impact performance but it seems tidier to avoid allocs unless needed so we don't wonder about it. I added a note at the allocation site of the vec-size cache to mention the extra alloc does improve performance.

Added golden tests to measure the memory allocated during concatenation. `vec_c()` has a bunch of extra allocs which should be resolved with r-lib/rlang#937.