### PR TITLE
Allow returning `NULL` names from a `name_spec`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,24 @@
 
 # vctrs (development version)
 
+* Name specifications can now return `NULL`. The names vector will
+  only be allocated if the spec function returns non-`NULL` during the
+  concatenation. This makes it possible to ignore outer names without
+  having to create an empty names vector when there are no inner
+  names:
+
+  ```
+  zap_outer_spec <- function(outer, inner) if (is_character(inner)) inner
+
+  # `NULL` names rather than a vector of ""
+  names(vec_c(a = 1:2, .name_spec = zap_outer_spec))
+  #> NULL
+
+  # Names are allocated when inner names exist
+  names(vec_c(a = 1:2, c(b = 3L), .name_spec = zap_outer_spec))
+  #> [1] ""  ""  "b"
+  ```
+
 * Fixed several performance issues in `vec_c()` and `vec_unchop()`
   with named vectors.
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -129,8 +129,8 @@ static SEXP vec_rbind(SEXP xs,
   SEXP out = vec_init(proxy, n_rows);
   PROTECT_WITH_INDEX(out, &out_pi);
 
-  SEXP idx = PROTECT_N(compact_seq(0, 0, true), &n_prot);
-  int* idx_ptr = INTEGER(idx);
+  SEXP loc = PROTECT_N(compact_seq(0, 0, true), &n_prot);
+  int* p_loc = INTEGER(loc);
 
   PROTECT_INDEX rownames_pi;
   SEXP rownames = R_NilValue;
@@ -178,10 +178,10 @@ static SEXP vec_rbind(SEXP xs,
     }
     SEXP x = VECTOR_ELT(xs, i);
 
-    init_compact_seq(idx_ptr, counter, size, true);
+    init_compact_seq(p_loc, counter, size, true);
 
     // Total ownership of `out` because it was freshly created with `vec_init()`
-    out = df_assign(out, idx, x, VCTRS_OWNED_true, &bind_assign_opts);
+    out = df_assign(out, loc, x, VCTRS_OWNED_true, &bind_assign_opts);
     REPROTECT(out, out_pi);
 
     // FIXME: This work happens in parallel to the names assignment in
@@ -203,7 +203,7 @@ static SEXP vec_rbind(SEXP xs,
       PROTECT(rn);
 
       if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
-        rownames = chr_assign(rownames, idx, rn, VCTRS_OWNED_true);
+        rownames = chr_assign(rownames, loc, rn, VCTRS_OWNED_true);
         REPROTECT(rownames, rownames_pi);
       }
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -77,18 +77,22 @@ static SEXP vec_rbind(SEXP xs,
     Rf_errorcall(R_NilValue, "Can't bind objects that are not coercible to a data frame.");
   }
 
-  SEXP nms = PROTECT_N(r_names(xs), &n_prot);
-  bool has_names = nms != R_NilValue;
+  bool assign_names = !Rf_inherits(name_spec, "rlang_zap");
+
   bool has_names_to = names_to != R_NilValue;
   R_len_t names_to_loc = 0;
 
   if (has_names_to) {
+    if (!assign_names) {
+      r_abort("Can't zap outer names when `.names_to` is supplied.");
+    }
+
     SEXP ptype_nms = PROTECT(r_names(ptype));
     names_to_loc = r_chr_find(ptype_nms, names_to);
     UNPROTECT(1);
 
     if (names_to_loc < 0) {
-      ptype = PROTECT_N(cbind_names_to(has_names, names_to, ptype), &n_prot);
+      ptype = PROTECT_N(cbind_names_to(r_names(xs) != R_NilValue, names_to, ptype), &n_prot);
       names_to_loc = 0;
     }
   }
@@ -100,12 +104,6 @@ static SEXP vec_rbind(SEXP xs,
   // Find individual input sizes and total size of output
   R_len_t n_rows = 0;
 
-  bool has_rownames = false;
-  if (!has_names_to && r_names(xs) != R_NilValue) {
-    // Names of inputs become row names when `names_to` isn't supplied
-    has_rownames = true;
-  }
-
   SEXP ns_placeholder = PROTECT_N(Rf_allocVector(INTSXP, n_inputs), &n_prot);
   int* ns = INTEGER(ns_placeholder);
 
@@ -114,13 +112,9 @@ static SEXP vec_rbind(SEXP xs,
     R_len_t size = (elt == R_NilValue) ? 0 : vec_size(elt);
     n_rows += size;
     ns[i] = size;
-
-    if (!has_rownames && is_data_frame(elt)) {
-      has_rownames = rownames_type(df_rownames(elt)) == ROWNAMES_IDENTIFIERS;
-    }
   }
 
-  SEXP proxy = PROTECT(vec_proxy(ptype));
+  SEXP proxy = PROTECT_N(vec_proxy(ptype), &n_prot);
   if (!is_data_frame(proxy)) {
     Rf_errorcall(R_NilValue, "Can't fill a data frame that doesn't have a data frame proxy.");
   }
@@ -128,31 +122,28 @@ static SEXP vec_rbind(SEXP xs,
   PROTECT_INDEX out_pi;
   SEXP out = vec_init(proxy, n_rows);
   PROTECT_WITH_INDEX(out, &out_pi);
+  ++n_prot;
 
   SEXP loc = PROTECT_N(compact_seq(0, 0, true), &n_prot);
   int* p_loc = INTEGER(loc);
 
-  PROTECT_INDEX rownames_pi;
   SEXP rownames = R_NilValue;
-  if (has_rownames) {
-    rownames = Rf_allocVector(STRSXP, n_rows);
-  }
+  PROTECT_INDEX rownames_pi;
   PROTECT_WITH_INDEX(rownames, &rownames_pi);
-
-  const SEXP* nms_p = NULL;
-  if (has_names) {
-    nms_p = STRING_PTR_RO(nms);
-  }
+  ++n_prot;
 
   SEXP names_to_col = R_NilValue;
   SEXPTYPE names_to_type = 99;
   void* p_names_to_col = NULL;
   const void* p_index = NULL;
 
+  SEXP xs_names = PROTECT_N(r_names(xs), &n_prot);
+  bool xs_is_named = xs_names != R_NilValue;
+
   if (has_names_to) {
     SEXP index = R_NilValue;
-    if (has_names) {
-      index = nms;
+    if (xs_is_named) {
+      index = xs_names;
     } else {
       index = PROTECT_N(Rf_allocVector(INTSXP, n_inputs), &n_prot);
       r_int_fill_seq(index, 1, n_inputs);
@@ -162,13 +153,21 @@ static SEXP vec_rbind(SEXP xs,
 
     p_index = r_vec_deref_barrier_const(index);
     p_names_to_col = r_vec_deref_barrier(names_to_col);
+
+    xs_names = R_NilValue;
+    xs_is_named = false;
+  }
+
+  const SEXP* p_xs_names = NULL;
+  if (xs_is_named) {
+    p_xs_names = STRING_PTR_RO(xs_names);
   }
 
   // Compact sequences use 0-based counters
   R_len_t counter = 0;
 
   const struct vec_assign_opts bind_assign_opts = {
-    .assign_names = true
+    .assign_names = assign_names
   };
 
   for (R_len_t i = 0; i < n_inputs; ++i) {
@@ -188,28 +187,21 @@ static SEXP vec_rbind(SEXP xs,
     // `df_assign()`. We should add a way to instruct df-assign to
     // ignore the outermost names (but still assign inner names in
     // case of data frames).
-    if (has_rownames) {
-      SEXP rn = df_rownames(x);
+    if (assign_names) {
+      SEXP outer = xs_is_named ? p_xs_names[i] : R_NilValue;
+      SEXP inner = PROTECT(vec_names(x));
+      SEXP x_nms = PROTECT(apply_name_spec(name_spec, outer, inner, size));
 
-      if (has_names && nms_p[i] != strings_empty && !has_names_to) {
-        if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
-          rn = apply_name_spec(name_spec, nms_p[i], rn, size);
-        } else if (size > 1) {
-          rn = r_seq_chr(CHAR(nms_p[i]), size);
-        } else {
-          rn = r_str_as_character(nms_p[i]);
+      if (x_nms != R_NilValue) {
+        R_LAZY_ALLOC(rownames, rownames_pi, STRSXP, n_rows);
+        if (inner != chrs_empty) {
+          rownames = chr_assign(rownames, loc, x_nms, VCTRS_OWNED_true);
+          REPROTECT(rownames, rownames_pi);
         }
       }
-      PROTECT(rn);
 
-      if (rownames_type(rn) == ROWNAMES_IDENTIFIERS) {
-        rownames = chr_assign(rownames, loc, rn, VCTRS_OWNED_true);
-        REPROTECT(rownames, rownames_pi);
-      }
-
-      UNPROTECT(1);
+      UNPROTECT(2);
     }
-    PROTECT(rownames);
 
     // Assign current name to group vector, if supplied
     if (has_names_to) {
@@ -217,17 +209,9 @@ static SEXP vec_rbind(SEXP xs,
     }
 
     counter += size;
-    UNPROTECT(1);
   }
 
-  if (has_rownames) {
-    const struct name_repair_opts rownames_repair = {
-      .type = name_repair_unique,
-      .fn = R_NilValue,
-      .quiet = true
-    };
-    rownames = vec_as_names(rownames, &rownames_repair);
-    REPROTECT(rownames, rownames_pi);
+  if (rownames != R_NilValue) {
     Rf_setAttrib(out, R_RowNamesSymbol, rownames);
   }
 
@@ -251,10 +235,10 @@ static SEXP vec_rbind(SEXP xs,
     }
   }
 
-  out = vec_restore(out, ptype, PROTECT(r_int(n_rows)), VCTRS_OWNED_true);
+  SEXP r_n_rows = PROTECT_N(r_int(n_rows), &n_prot);
+  out = vec_restore(out, ptype, r_n_rows, VCTRS_OWNED_true);
 
   UNPROTECT(n_prot);
-  UNPROTECT(4);
   return out;
 }
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -194,6 +194,9 @@ static SEXP vec_rbind(SEXP xs,
 
       if (x_nms != R_NilValue) {
         R_LAZY_ALLOC(rownames, rownames_pi, STRSXP, n_rows);
+
+        // If there is no name to assign, skip the assignment since
+        // `out_names` already contains empty strings
         if (inner != chrs_empty) {
           rownames = chr_assign(rownames, loc, x_nms, VCTRS_OWNED_true);
           REPROTECT(rownames, rownames_pi);

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -144,6 +144,9 @@ static SEXP vec_unchop(SEXP xs,
 
       if (x_nms != R_NilValue) {
         R_LAZY_ALLOC(out_names, out_names_pi, STRSXP, out_size);
+
+        // If there is no name to assign, skip the assignment since
+        // `out_names` already contains empty strings
         if (x_nms != chrs_empty) {
           out_names = chr_assign(out_names, loc, x_nms, VCTRS_OWNED_true);
           REPROTECT(out_names, out_names_pi);

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -51,11 +51,11 @@ static SEXP vec_unchop(SEXP xs,
     return vec_c(xs, ptype, name_spec, name_repair);
   }
 
-  R_len_t x_size = vec_size(xs);
+  R_len_t xs_size = vec_size(xs);
 
   // Apply size/type checking to `indices` before possibly exiting early from
   // having a `NULL` common type
-  if (x_size != vec_size(indices)) {
+  if (xs_size != vec_size(indices)) {
     Rf_errorcall(R_NilValue, "`x` and `indices` must be lists of the same size");
   }
 
@@ -91,7 +91,7 @@ static SEXP vec_unchop(SEXP xs,
   R_len_t out_size = 0;
 
   // `out_size` is computed from `indices`
-  for (R_len_t i = 0; i < x_size; ++i) {
+  for (R_len_t i = 0; i < xs_size; ++i) {
     SEXP x = VECTOR_ELT(xs, i);
 
     if (x == R_NilValue) {
@@ -123,7 +123,7 @@ static SEXP vec_unchop(SEXP xs,
     .assign_names = assign_names
   };
 
-  for (R_len_t i = 0; i < x_size; ++i) {
+  for (R_len_t i = 0; i < xs_size; ++i) {
     SEXP x = VECTOR_ELT(xs, i);
 
     if (x == R_NilValue) {

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -123,7 +123,7 @@ static SEXP vec_unchop(SEXP xs,
     SET_VECTOR_ELT(xs, i, x);
   }
 
-  indices = PROTECT(vec_as_indices(indices, out_size, R_NilValue));
+  SEXP locs = PROTECT(vec_as_indices(indices, out_size, R_NilValue));
 
   SEXP proxy = vec_proxy(ptype);
   PROTECT_INDEX proxy_pi;
@@ -150,10 +150,10 @@ static SEXP vec_unchop(SEXP xs,
       continue;
     }
 
-    SEXP index = VECTOR_ELT(indices, i);
+    SEXP loc = VECTOR_ELT(locs, i);
 
     // Total ownership of `proxy` because it was freshly created with `vec_init()`
-    proxy = vec_proxy_assign_opts(proxy, index, x, VCTRS_OWNED_true, &unchop_assign_opts);
+    proxy = vec_proxy_assign_opts(proxy, loc, x, VCTRS_OWNED_true, &unchop_assign_opts);
     REPROTECT(proxy, proxy_pi);
 
     if (has_names) {
@@ -162,7 +162,7 @@ static SEXP vec_unchop(SEXP xs,
       SEXP inner = PROTECT(vec_names(x));
       SEXP x_names = PROTECT(apply_name_spec(name_spec, outer, inner, size));
       if (x_names != R_NilValue) {
-        out_names = chr_assign(out_names, index, x_names, VCTRS_OWNED_true);
+        out_names = chr_assign(out_names, loc, x_names, VCTRS_OWNED_true);
         REPROTECT(out_names, out_names_pi);
       }
       UNPROTECT(2);

--- a/src/c.c
+++ b/src/c.c
@@ -95,9 +95,10 @@ SEXP vec_c_opts(SEXP xs,
     p_sizes[i] = size;
   }
 
-  PROTECT_INDEX out_pi;
   SEXP out = vec_init(ptype, out_size);
+  PROTECT_INDEX out_pi;
   PROTECT_WITH_INDEX(out, &out_pi);
+
   out = vec_proxy(out);
   REPROTECT(out, out_pi);
 

--- a/src/c.c
+++ b/src/c.c
@@ -102,8 +102,8 @@ SEXP vec_c_opts(SEXP xs,
   out = vec_proxy(out);
   REPROTECT(out, out_pi);
 
-  SEXP idx = PROTECT(compact_seq(0, 0, true));
-  int* p_idx = INTEGER(idx);
+  SEXP loc = PROTECT(compact_seq(0, 0, true));
+  int* p_loc = INTEGER(loc);
 
   SEXP xs_names = PROTECT(r_names(xs));
   bool assign_names = !Rf_inherits(name_spec, "rlang_zap");
@@ -134,10 +134,10 @@ SEXP vec_c_opts(SEXP xs,
     };
     SEXP x = PROTECT(vec_cast_opts(&opts));
 
-    init_compact_seq(p_idx, counter, size, true);
+    init_compact_seq(p_loc, counter, size, true);
 
     // Total ownership of `out` because it was freshly created with `vec_init()`
-    out = vec_proxy_assign_opts(out, idx, x, VCTRS_OWNED_true, &c_assign_opts);
+    out = vec_proxy_assign_opts(out, loc, x, VCTRS_OWNED_true, &c_assign_opts);
     REPROTECT(out, out_pi);
 
     // FIXME: This work happens in parallel to the names assignment in
@@ -150,7 +150,7 @@ SEXP vec_c_opts(SEXP xs,
       SEXP x_nms = PROTECT(apply_name_spec(name_spec, outer, inner, size));
 
       if (x_nms != R_NilValue) {
-        out_names = chr_assign(out_names, idx, x_nms, VCTRS_OWNED_true);
+        out_names = chr_assign(out_names, loc, x_nms, VCTRS_OWNED_true);
         REPROTECT(out_names, out_names_pi);
       }
 

--- a/src/c.c
+++ b/src/c.c
@@ -150,6 +150,9 @@ SEXP vec_c_opts(SEXP xs,
 
       if (x_nms != R_NilValue) {
         R_LAZY_ALLOC(out_names, out_names_pi, STRSXP, out_size);
+
+        // If there is no name to assign, skip the assignment since
+        // `out_names` already contains empty strings
         if (x_nms != chrs_empty) {
           out_names = chr_assign(out_names, loc, x_nms, VCTRS_OWNED_true);
           REPROTECT(out_names, out_names_pi);

--- a/src/names.c
+++ b/src/names.c
@@ -537,7 +537,11 @@ SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n) {
   }
 
   if (outer == strings_empty || outer == NA_STRING) {
-    return inner;
+    if (inner == R_NilValue) {
+      return chrs_empty;
+    } else {
+      return inner;
+    }
   }
 
   if (r_is_empty_names(inner)) {

--- a/src/names.c
+++ b/src/names.c
@@ -578,11 +578,13 @@ SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n) {
                              syms_outer, outer_chr,
                              syms_inner, inner);
 
-  if (TYPEOF(out) != STRSXP) {
-    Rf_errorcall(R_NilValue, "`.name_spec` must return a character vector.");
-  }
-  if (Rf_length(out) != n) {
-    Rf_errorcall(R_NilValue, "`.name_spec` must return a character vector as long as `inner`.");
+  if (out != R_NilValue) {
+    if (TYPEOF(out) != STRSXP) {
+      Rf_errorcall(R_NilValue, "`.name_spec` must return a character vector.");
+    }
+    if (Rf_length(out) != n) {
+      Rf_errorcall(R_NilValue, "`.name_spec` must return a character vector as long as `inner`.");
+    }
   }
 
   UNPROTECT(3);

--- a/src/utils.h
+++ b/src/utils.h
@@ -233,6 +233,13 @@ R_len_t r_chr_find(SEXP x, SEXP value);
 int r_chr_max_len(SEXP x);
 SEXP r_chr_iota(R_len_t n, char* buf, int len, const char* prefix);
 
+#define R_LAZY_ALLOC(SYM, PI, R_TYPE, SIZE) do {        \
+    if (SYM == R_NilValue) {                            \
+      SYM = Rf_allocVector(R_TYPE, SIZE);               \
+      REPROTECT(SYM, PI);                               \
+    }                                                   \
+  } while (0);
+
 static inline
 SEXP r_new_logical(R_len_t n) {
   return Rf_allocVector(LGLSXP, n);

--- a/tests/testthat/performance/test-bind.txt
+++ b/tests/testthat/performance/test-bind.txt
@@ -19,22 +19,22 @@
 > dfs <- rep(list(df), 100)
 > dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
 > with_memory_prof(vec_rbind(!!!dfs))
-[1] 10.3KB
+[1] 7.42KB
 
 > # Data frame with rownames (repaired, non-recursive case)
 > dfs <- map(dfs, set_rownames_recursively)
 > with_memory_prof(vec_rbind(!!!dfs))
-[1] 25.1KB
+[1] 14.8KB
 
 > # FIXME (#1217): Data frame with rownames (non-repaired, recursive case)
 > df <- data_frame(x = 1:2, y = data_frame(x = 1:2))
 > dfs <- rep(list(df), 100)
 > dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
 > with_memory_prof(vec_rbind(!!!dfs))
-[1] 1.01MB
+[1] 1MB
 
 > # FIXME (#1217): Data frame with rownames (repaired, recursive case)
 > dfs <- map(dfs, set_rownames_recursively)
 > with_memory_prof(vec_rbind(!!!dfs))
-[1] 1.03MB
+[1] 1.02MB
 

--- a/tests/testthat/performance/test-c.txt
+++ b/tests/testthat/performance/test-c.txt
@@ -67,22 +67,22 @@ Concatenation with names
 > dfs <- rep(list(df), 100)
 > dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
 > with_memory_prof(vec_unchop(dfs))
-[1] 5.77KB
+[1] 10.3KB
 
 > # Data frame with rownames (repaired, non-recursive case)
 > dfs <- map(dfs, set_rownames_recursively)
 > with_memory_prof(vec_unchop(dfs))
-[1] 13.1KB
+[1] 25KB
 
 > # FIXME (#1217): Data frame with rownames (non-repaired, recursive case)
 > df <- data_frame(x = 1:2, y = data_frame(x = 1:2))
 > dfs <- rep(list(df), 100)
 > dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
 > with_memory_prof(vec_unchop(dfs))
-[1] 1MB
+[1] 1.01MB
 
 > # FIXME (#1217): Data frame with rownames (repaired, recursive case)
 > dfs <- map(dfs, set_rownames_recursively)
 > with_memory_prof(vec_unchop(dfs))
-[1] 1.02MB
+[1] 1.03MB
 

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -249,10 +249,11 @@ test_that("can assign row names in vec_rbind()", {
     foo = unrownames(df1),
     df2,
     bar = unrownames(mtcars[6, ]),
-    .names_to = NULL
+    .names_to = NULL,
+    .name_spec = "{outer}_{inner}"
   )
   exp <- mtcars[1:6, ]
-  row.names(exp) <- c(paste0("foo", 1:3), row.names(df2), "bar")
+  row.names(exp) <- c(paste0("foo_", 1:3), row.names(df2), "bar")
   expect_identical(out, exp)
 
   out <- vec_rbind(
@@ -928,6 +929,25 @@ test_that("vec_rbind() fallback works with tibbles", {
   expect_identical(vec_rbind(tib, tib), exp)
   expect_identical(vec_rbind(df, tib), exp)
   expect_identical(vec_rbind(tib, df), exp)
+})
+
+test_that("vec_rbind() zaps names when name-spec is zap() and names-to is NULL", {
+  expect_identical(
+    vec_rbind(foo = c(x = 1), .names_to = NULL, .name_spec = zap()),
+    data.frame(x = 1)
+  )
+})
+
+test_that("can't zap names when `.names_to` is supplied", {
+  expect_identical(
+    vec_rbind(foo = c(x = 1), .names_to = zap(), .name_spec = zap()),
+    data.frame(x = 1)
+  )
+  expect_error(
+    vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap()),
+    "Can't zap outer names when `.names_to` is supplied.",
+    fixed = TRUE
+  )
 })
 
 test_that("rows-binding performs expected allocations", {

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -950,6 +950,24 @@ test_that("can't zap names when `.names_to` is supplied", {
   )
 })
 
+test_that("can zap outer names from a name-spec (#1215)", {
+  zap_outer_spec <- function(outer, inner) if (is_character(inner)) inner
+
+  df <- data.frame(x = 1:2)
+  df_named <- data.frame(x = 3L, row.names = "foo")
+
+  expect_null(
+    vec_names(vec_rbind(a = df, .names_to = NULL, .name_spec = zap_outer_spec))
+  )
+  expect_identical(
+    vec_names(vec_rbind(a = df, df_named, .name_spec = zap_outer_spec)),
+    c("...1", "...2", "foo")
+  )
+})
+
+
+# Golden tests -------------------------------------------------------
+
 test_that("rows-binding performs expected allocations", {
   verify_output(test_path("performance", "test-bind.txt"), {
     ints <- rep(list(1L), 1e2)

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -385,6 +385,29 @@ test_that("base c() fallback handles unspecified chunks", {
   expect_identical(out, quux(c(NA, NA, 1:2, NA)))
 })
 
+test_that("can zap outer names from a name-spec (#1215)", {
+  zap_outer_spec <- function(outer, inner) if (is_character(inner)) inner
+
+  expect_null(
+    names(vec_c(a = 1:2, .name_spec = zap_outer_spec))
+  )
+  expect_identical(
+    names(vec_c(a = 1:2, c(foo = 3L), .name_spec = zap_outer_spec)),
+    c("", "", "foo")
+  )
+
+  expect_null(
+    names(vec_unchop(list(a = 1:2), indices = list(1:2), name_spec = zap_outer_spec))
+  )
+  expect_identical(
+    names(vec_unchop(list(a = 1:2, c(foo = 3L)), indices = list(1:2, 3), name_spec = zap_outer_spec)),
+    c("", "", "foo")
+  )
+})
+
+
+# Golden tests -------------------------------------------------------
+
 test_that("vec_c() has informative error messages", {
   verify_output(test_path("error", "test-c.txt"), {
     "# vec_c() fails with complex foreign S3 classes"

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -244,7 +244,7 @@ test_that("`indices` must be a list", {
 test_that("`indices` must be a list of integers", {
   expect_error(vec_unchop(list(1), list("x")), class = "vctrs_error_subscript_type")
   expect_error(vec_unchop(list(1), list(TRUE)), class = "vctrs_error_subscript_type")
-  expect_error(vec_unchop(list(1), list(quote(name))), class = "vctrs_error_scalar_type")
+  expect_error(vec_unchop(list(1), list(quote(name))), class = "vctrs_error_subscript_type")
 })
 
 test_that("`x` and `indices` must be lists of the same size", {


### PR DESCRIPTION
Branched from #1218.
Closes #1215.

This makes it possible to return `NULL` from a `name_spec`. The names vector of the concatenated vector is never allocated or assigned if the name-spec only returns `NULL`. To achieve this, the names vectors are lazily allocated.

This will be useful for implementing `purrr::flatten()` in a backward-compatible way (tidyverse/purrr#785).

The internals of `vec_c()`, `vec_unchop()` with supplied indices, and `vec_rbind()` are now a little more symmetric in style, naming, and structure.