### PR TITLE
Recycle return value of `name_spec` instead of arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* `outer` is now passed unrecycled to name specifications. Instead,
+  the return value is recycled (#1099).
+
 * Name specifications can now return `NULL`. The names vector will
   only be allocated if the spec function returns non-`NULL` during the
   concatenation. This makes it possible to ignore outer names without

--- a/src/names.c
+++ b/src/names.c
@@ -570,13 +570,12 @@ SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n) {
   }
   PROTECT(name_spec);
 
-  // Recycle `outer` so specs don't need to refer to both `outer` and `inner`
-  SEXP outer_chr = PROTECT(Rf_allocVector(STRSXP, n));
-  r_chr_fill(outer_chr, outer, n);
+  SEXP outer_chr = PROTECT(r_str_as_character(outer));
 
-  SEXP out = vctrs_dispatch2(syms_dot_name_spec, name_spec,
-                             syms_outer, outer_chr,
-                             syms_inner, inner);
+  SEXP out = PROTECT(vctrs_dispatch2(syms_dot_name_spec, name_spec,
+                                     syms_outer, outer_chr,
+                                     syms_inner, inner));
+  out = vec_recycle(out, n, NULL);
 
   if (out != R_NilValue) {
     if (TYPEOF(out) != STRSXP) {
@@ -587,7 +586,7 @@ SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n) {
     }
   }
 
-  UNPROTECT(3);
+  UNPROTECT(4);
   return out;
 }
 

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -810,3 +810,19 @@ test_that("can pass glue string as name spec", {
 test_that("`outer` is recycled before name spec is invoked", {
   expect_identical(vec_c(outer = 1:2, .name_spec = "{outer}"), c(outer = 1L, outer = 2L))
 })
+
+test_that("apply_name_spec() recycles return value not arguments (#1099)", {
+  out <- unstructure(apply_name_spec("foo", "outer", c("a", "b", "c")))
+  expect_identical(out, c("foo", "foo", "foo"))
+
+  inner <- NULL
+  outer <- NULL
+  spec <- function(outer, inner) {
+    inner <<- inner
+    outer <<- outer
+  }
+
+  apply_name_spec(spec, "outer", c("a", "b", "c"))
+  expect_identical(inner, c("a", "b", "c"))
+  expect_identical(outer, "outer")
+})


### PR DESCRIPTION
Branched from #1219
Closes #1099

Don't recycle the `outer` argument of name specifications.

- It's more intuitive for name-spec implementor since the outer name is unique.
- It's more flexible, name-spec can now return a single name to be recycled.