### PR TITLE
Remove proxy check in `vec_is_list()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* The restriction that S3 lists must have a list-based proxy to be considered
+  lists by `vec_is_list()` has been removed (#1208).
+
 * New performant `data_frame()` constructor for creating data frames in a way
   that follows tidyverse semantics. Among other things, inputs are recycled
   using tidyverse recycling rules, strings are never converted to factors,

--- a/R/assert.R
+++ b/R/assert.R
@@ -162,8 +162,6 @@ vec_is_vector <- function(x) {
 #' Notably, data frames and S3 record style classes like POSIXlt are not
 #' considered lists.
 #'
-#' If `x` inherits explicitly from `"list"`, it is also required that the
-#' proxy returned by [vec_proxy()] is a list. If it is not, an error is thrown.
 #' @export
 #' @examples
 #' vec_is_list(list())

--- a/man/vec_is_list.Rd
+++ b/man/vec_is_list.Rd
@@ -20,9 +20,6 @@ returns \code{TRUE} if:
 \details{
 Notably, data frames and S3 record style classes like POSIXlt are not
 considered lists.
-
-If \code{x} inherits explicitly from \code{"list"}, it is also required that the
-proxy returned by \code{\link[=vec_proxy]{vec_proxy()}} is a list. If it is not, an error is thrown.
 }
 \examples{
 vec_is_list(list())

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -105,8 +105,6 @@ SEXP vctrs_is_list(SEXP x) {
   return Rf_ScalarLogical(vec_is_list(x));
 }
 
-static bool vec_proxy_is_list(SEXP x);
-
 // [[ include("vctrs.h") ]]
 bool vec_is_list(SEXP x) {
   // Require `x` to be a list internally
@@ -120,43 +118,7 @@ bool vec_is_list(SEXP x) {
   }
 
   // Classed VECSXP are only lists if the last class is explicitly `"list"`
-  if (class_type(x) != vctrs_class_list) {
-    return false;
-  }
-
-  // If `x` is an explicit list, also require that the proxy is a list
-  if (vec_proxy_is_list(x)) {
-    return true;
-  }
-
-  Rf_errorcall(
-    R_NilValue,
-    "`x` inherits explicitly from \"list\", "
-    "but the proxy returned by `vec_proxy()` is not a list."
-  );
-}
-
-static bool vec_proxy_is_list(SEXP x) {
-  SEXP proxy = PROTECT(vec_proxy(x));
-
-  // Require `proxy` to be a list internally
-  if (TYPEOF(proxy) != VECSXP) {
-    UNPROTECT(1);
-    return false;
-  }
-
-  // Unclassed VECSXP are lists
-  if (!OBJECT(proxy)) {
-    UNPROTECT(1);
-    return true;
-  }
-
-  // If the `proxy` has a class, only require
-  // that it is not a data frame
-  bool out = class_type(proxy) != vctrs_class_data_frame;
-
-  UNPROTECT(1);
-  return out;
+  return class_type(x) == vctrs_class_list;
 }
 
 

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -283,8 +283,28 @@ test_that("data frames of all types are not lists", {
   expect_false(vec_is_list(tibble::tibble()))
 })
 
-test_that("proxy of S3 lists must be a list", {
+test_that("S3 list with non-list proxy is still a list (#1208)", {
   x <- structure(list(), class = c("foobar", "list"))
   local_methods(vec_proxy.foobar = function(x) 1)
-  expect_error(vec_is_list(x), "`x` inherits")
+  # This used to be an error (#1003)
+  # expect_error(vec_is_list(x), "`x` inherits")
+  expect_true(vec_is_list(x))
+})
+
+test_that("list-rcrds with data frame proxies are considered lists (#1208)", {
+  x <- structure(
+    list(1:2, "x"),
+    special = c("a", "b"),
+    class = c("list_rcrd", "list")
+  )
+
+  local_methods(
+    vec_proxy.list_rcrd = function(x) {
+      special <- attr(x, "special")
+      data <- unstructure(x)
+      new_data_frame(list(data = data, special = special))
+    }
+  )
+
+  expect_true(vec_is_list(x))
 })


### PR DESCRIPTION
Part of #1208 

The proxy check was originally suggested here https://github.com/r-lib/vctrs/pull/1003#issuecomment-612883620. I am not convinced that we need it, and it would help with list-rcrds outlined in #1208 to remove it.

I really like how simple `vec_is_list()` is now. It is very easy to explain.

Internally, we do not currently use `vec_is_list()` in any way that could cause issues after removing this restriction. We never proxy `x` after checking that it is a list with `vec_is_list()`. We only use it in:

- `vec_unchop()` to check that `x` is a list
- `vec_unchop()` to check that `indices` is a list
- `list_sizes()` to check that `x` is a list

I think all of these are valid and safe uses of `vec_is_list()`