### PR TITLE
Fix redundant names handling during concatenation

### DIFF
--- a/src/bind.c
+++ b/src/bind.c
@@ -167,7 +167,10 @@ static SEXP vec_rbind(SEXP xs,
   R_len_t counter = 0;
 
   const struct vec_assign_opts bind_assign_opts = {
-    .assign_names = assign_names
+    .assign_names = assign_names,
+    // Unlike in `vec_c()` we don't need to ignore outer names because
+    // `df_assign()` doesn't deal with those
+    .ignore_outer_names = false
   };
 
   for (R_len_t i = 0; i < n_inputs; ++i) {
@@ -183,10 +186,6 @@ static SEXP vec_rbind(SEXP xs,
     out = df_assign(out, loc, x, VCTRS_OWNED_true, &bind_assign_opts);
     REPROTECT(out, out_pi);
 
-    // FIXME: This work happens in parallel to the names assignment in
-    // `df_assign()`. We should add a way to instruct df-assign to
-    // ignore the outermost names (but still assign inner names in
-    // case of data frames).
     if (assign_names) {
       SEXP outer = xs_is_named ? p_xs_names[i] : R_NilValue;
       SEXP inner = PROTECT(vec_names(x));

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -120,7 +120,8 @@ static SEXP vec_unchop(SEXP xs,
   PROTECT_WITH_INDEX(out_names, &out_names_pi);
 
   const struct vec_assign_opts unchop_assign_opts = {
-    .assign_names = assign_names
+    .assign_names = assign_names,
+    .ignore_outer_names = true
   };
 
   for (R_len_t i = 0; i < xs_size; ++i) {

--- a/src/c.c
+++ b/src/c.c
@@ -117,7 +117,8 @@ SEXP vec_c_opts(SEXP xs,
   R_len_t counter = 0;
 
   const struct vec_assign_opts c_assign_opts = {
-    .assign_names = assign_names
+    .assign_names = assign_names,
+    .ignore_outer_names = true
   };
 
   for (R_len_t i = 0; i < n; ++i) {
@@ -139,10 +140,6 @@ SEXP vec_c_opts(SEXP xs,
     out = vec_proxy_assign_opts(out, loc, x, VCTRS_OWNED_true, &c_assign_opts);
     REPROTECT(out, out_pi);
 
-    // FIXME: This work happens in parallel to the names assignment in
-    // `vec_proxy_assign()`. We should add a way to instruct
-    // proxy-assign to ignore the outermost names (but still assign
-    // inner names in case of data frames).
     if (assign_names) {
       SEXP outer = xs_is_named ? STRING_ELT(xs_names, i) : R_NilValue;
       SEXP inner = PROTECT(vec_names(x));

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -147,6 +147,10 @@ SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
                            const struct vec_assign_opts* opts) {
   int n_protect = 0;
 
+  struct vec_assign_opts mut_opts = *opts;
+  bool ignore_outer_names = mut_opts.ignore_outer_names;
+  mut_opts.ignore_outer_names = false;
+
   struct vctrs_proxy_info value_info = vec_proxy_info(value);
   PROTECT_PROXY_INFO(&value_info, &n_protect);
 
@@ -166,13 +170,13 @@ SEXP vec_proxy_assign_opts(SEXP proxy, SEXP index, SEXP value,
     out = PROTECT(vec_assign_fallback(proxy, index, value));
     ++n_protect;
   } else if (has_dim(proxy)) {
-    out = PROTECT(vec_assign_shaped(proxy, index, value_info.proxy, owned, opts));
+    out = PROTECT(vec_assign_shaped(proxy, index, value_info.proxy, owned, &mut_opts));
   } else {
-    out = PROTECT(vec_assign_switch(proxy, index, value_info.proxy, owned, opts));
+    out = PROTECT(vec_assign_switch(proxy, index, value_info.proxy, owned, &mut_opts));
   }
   ++n_protect;
 
-  if (opts->assign_names) {
+  if (!ignore_outer_names && opts->assign_names) {
     out = vec_proxy_assign_names(out, index, value_info.proxy, owned);
   }
 

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -5,6 +5,7 @@
 
 struct vec_assign_opts {
   bool assign_names;
+  bool ignore_outer_names;
   struct vctrs_arg* x_arg;
   struct vctrs_arg* value_arg;
 };

--- a/tests/testthat/performance/test-c.txt
+++ b/tests/testthat/performance/test-c.txt
@@ -47,13 +47,13 @@ Concatenation with names
 > # Named integers
 > ints <- rep(list(set_names(1:3, letters[1:3])), 100)
 > with_memory_prof(vec_unchop(ints))
-[1] 6.44KB
+[1] 4.05KB
 
 > # Named matrices
 > mat <- matrix(1:4, 2, dimnames = list(c("foo", "bar")))
 > mats <- rep(list(mat), 100)
 > with_memory_prof(vec_unchop(mats))
-[1] 5.27KB
+[1] 3.66KB
 
 > # Data frame with named columns
 > df <- data_frame(x = set_names(as.list(1:2), c("a", "b")), y = set_names(1:2, c(
@@ -67,22 +67,22 @@ Concatenation with names
 > dfs <- rep(list(df), 100)
 > dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
 > with_memory_prof(vec_unchop(dfs))
-[1] 10.3KB
+[1] 5.77KB
 
 > # Data frame with rownames (repaired, non-recursive case)
 > dfs <- map(dfs, set_rownames_recursively)
 > with_memory_prof(vec_unchop(dfs))
-[1] 25KB
+[1] 13.1KB
 
 > # FIXME (#1217): Data frame with rownames (non-repaired, recursive case)
 > df <- data_frame(x = 1:2, y = data_frame(x = 1:2))
 > dfs <- rep(list(df), 100)
 > dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
 > with_memory_prof(vec_unchop(dfs))
-[1] 1.01MB
+[1] 1MB
 
 > # FIXME (#1217): Data frame with rownames (repaired, recursive case)
 > dfs <- map(dfs, set_rownames_recursively)
 > with_memory_prof(vec_unchop(dfs))
-[1] 1.03MB
+[1] 1.02MB
 


### PR DESCRIPTION
Concatenating functions deal with outer names manually so they can apply a `name_spec`. This work is redundant with the names assignment performed in `vec_assign()`.

To fix this, we now have `ignore_outer_names` in the `struct vec_assign_opts` to indicate that outer names will be handled elsewhere but vec-assign should still handle inner names.