### PR TITLE
Implement `vec_map()`

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -184,7 +184,7 @@ order_proxy <- function(proxy, direction = "asc", na_value = "largest") {
     if (vec_size(proxy) == 0L) {
       return(integer(0L))
     }
-    args <- map(unname(proxy), function(.x) {
+    args <- map(unstructure(proxy), function(.x) {
       if (is.data.frame(.x)) {
         .x <- order(vec_order(.x, direction = direction, na_value = na_value))
       }

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -4,7 +4,7 @@ map <- function(.x, .f, ...) {
   if (is.data.frame(.x)) {
     .x <- unclass(.x)
   }
-  vec_map(.x, .f, ...)
+  vctrs::vec_map(.x, .f, ...)
 }
 map_lgl <- function(.x, .f, ...) {
   map(.x, .f, ..., .ptype = lgl())

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -1,33 +1,25 @@
-# nocov start - compat-purrr (last updated: rlang 0.2.0)
-
-# This file serves as a reference for compatibility functions for
-# purrr. They are not drop-in replacements but allow a similar style
-# of programming. This is useful in cases where purrr is too heavy a
-# package to depend on. Please find the most recent version in rlang's
-# repository.
+# nocov start --- compat-purrr-vctrs --- 2020-08-18
 
 map <- function(.x, .f, ...) {
-  lapply(.x, .f, ...)
-}
-map_mold <- function(.x, .f, .mold, ...) {
-  out <- vapply(.x, .f, .mold, ..., USE.NAMES = FALSE)
-  names(out) <- names(.x)
-  out
+  if (is.data.frame(.x)) {
+    .x <- unclass(.x)
+  }
+  vec_map(.x, .f, ...)
 }
 map_lgl <- function(.x, .f, ...) {
-  map_mold(.x, .f, logical(1), ...)
+  map(.x, .f, ..., .ptype = lgl())
 }
 map_int <- function(.x, .f, ...) {
-  map_mold(.x, .f, integer(1), ...)
+  map(.x, .f, ..., .ptype = int())
 }
 map_dbl <- function(.x, .f, ...) {
-  map_mold(.x, .f, double(1), ...)
+  map(.x, .f, ..., .ptype = dbl())
 }
 map_chr <- function(.x, .f, ...) {
-  map_mold(.x, .f, character(1), ...)
+  map(.x, .f, ..., .ptype = chr())
 }
 map_cpl <- function(.x, .f, ...) {
-  map_mold(.x, .f, complex(1), ...)
+  map(.x, .f, ..., .ptype = cpl())
 }
 
 walk <- function(.x, .f, ...) {

--- a/R/map.R
+++ b/R/map.R
@@ -1,0 +1,6 @@
+
+vec_map <- function(.x, .fn, ..., .ptype = list()) {
+  .elt <- NULL # Defined in the mapping loop
+  .fn <- as_function(.fn)
+  .External(vctrs_map, .x, environment(), .ptype)
+}

--- a/R/partial-factor.R
+++ b/R/partial-factor.R
@@ -50,7 +50,7 @@ new_partial_factor <- function(partial = factor(), learned = factor()) {
 vec_ptype_full.vctrs_partial_factor <- function(x, ...) {
   empty <- ""
 
-  levels <- map(x, levels)
+  levels <- map(unclass(x), levels)
   hashes <- map_chr(levels, hash_label)
 
   needs_indent <- hashes != empty

--- a/src/init.c
+++ b/src/init.c
@@ -124,6 +124,7 @@ extern SEXP vctrs_cast_dispatch_native(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_fast_c(SEXP, SEXP);
 extern SEXP vctrs_data_frame(SEXP, SEXP, SEXP);
 extern SEXP vctrs_df_list(SEXP, SEXP, SEXP);
+extern SEXP vctrs_map(SEXP, SEXP, SEXP);
 
 
 // Maturing
@@ -292,6 +293,7 @@ static const R_ExternalMethodDef ExtEntries[] = {
   {"vctrs_c",                          (DL_FUNC) &vctrs_c, 3},
   {"vctrs_new_data_frame",             (DL_FUNC) &vctrs_new_data_frame, -1},
   {"vctrs_chop2",                      (DL_FUNC) &vctrs_chop2, 1},
+  {"vctrs_map",                        (DL_FUNC) &vctrs_map, 3},
   {NULL, NULL, 0}
 };
 
@@ -325,6 +327,7 @@ void vctrs_init_bind(SEXP ns);
 void vctrs_init_cast(SEXP ns);
 void vctrs_init_data(SEXP ns);
 void vctrs_init_dictionary(SEXP ns);
+void vctrs_init_map(SEXP ns);
 void vctrs_init_names(SEXP ns);
 void vctrs_init_proxy_restore(SEXP ns);
 void vctrs_init_slice(SEXP ns);
@@ -346,6 +349,7 @@ SEXP vctrs_init_library(SEXP ns) {
   vctrs_init_cast(ns);
   vctrs_init_data(ns);
   vctrs_init_dictionary(ns);
+  vctrs_init_map(ns);
   vctrs_init_names(ns);
   vctrs_init_proxy_restore(ns);
   vctrs_init_slice(ns);

--- a/src/map.c
+++ b/src/map.c
@@ -86,6 +86,10 @@ SEXP atomic_map(SEXP x, SEXP env, SEXP ptype) {
     r_env_poke(env, syms_dot_elt, p_x[i]);
 
     SEXP elt_out = PROTECT(r_eval_force(vec_map_call, env));
+    if (vec_size(elt_out) != 1) {
+      r_abort("Mapped function must return a size 1 vector.");
+    }
+
     elt_out = PROTECT(vec_cast(elt_out, ptype, NULL, NULL));
 
     init_compact_seq(p_loc, i, 1, true);

--- a/src/map.c
+++ b/src/map.c
@@ -44,7 +44,7 @@ SEXP vctrs_map(SEXP args) {
     if (vec_is_list(ptype)) {
       for (r_ssize i = 0; i < n; ++i) {
         r_env_poke(env, syms_dot_elt, p_x[i]);
-        SET_VECTOR_ELT(out, i, Rf_eval(vec_map_call, env));
+        SET_VECTOR_ELT(out, i, r_eval_force(vec_map_call, env));
       }
 
       // Should use a ptype identity check before casting. Probably
@@ -60,7 +60,7 @@ SEXP vctrs_map(SEXP args) {
       for (r_ssize i = 0; i < n; ++i) {
         r_env_poke(env, syms_dot_elt, p_x[i]);
 
-        SEXP elt_out = PROTECT(Rf_eval(vec_map_call, env));
+        SEXP elt_out = PROTECT(r_eval_force(vec_map_call, env));
         elt_out = PROTECT(vec_cast(elt_out, ptype, NULL, NULL));
 
         init_compact_seq(p_loc, i, 1, true);

--- a/src/map.c
+++ b/src/map.c
@@ -5,6 +5,9 @@
 // Defined at load time
 SEXP vec_map_call = NULL;
 
+static SEXP atomic_map(SEXP x, SEXP env, SEXP ptype);
+static SEXP list_map(SEXP x, SEXP env, SEXP ptype);
+
 
 SEXP vctrs_map(SEXP args) {
     args = CDR(args);
@@ -12,78 +15,90 @@ SEXP vctrs_map(SEXP args) {
     SEXP env = CAR(args); args = CDR(args);
     SEXP ptype = CAR(args);
 
-    SEXP orig = x;
-    bool list_input = vec_is_list(orig);
-    bool list_output = vec_is_list(ptype);
-
-    if (list_input) {
-      x = PROTECT(x);
-    } else {
-      x = PROTECT(vec_chop2(x));
-    }
-
-    r_ssize n = r_length(x);
-    const SEXP* p_x = VECTOR_PTR_RO(x);
-
     if (ptype == R_NilValue) {
       r_abort("`.ptype` can't be NULL.");
     }
 
+    SEXP orig = x;
+    bool list_input = vec_is_list(orig);
+    bool list_output = vec_is_list(ptype);
+
+    if (!list_input) {
+      x = vec_chop2(x);
+    }
+    PROTECT(x);
+
     SEXP out;
-    SEXP out_proxy;
-
     if (list_output) {
-      out = PROTECT(r_clone_referenced(x));
-      SET_ATTRIB(out, R_NilValue);
-      SET_OBJECT(out, 0);
-      out_proxy = PROTECT(R_NilValue);
+      out = list_map(x, env, ptype);
     } else {
-      out = PROTECT(vec_init(ptype, n));
-      out_proxy = PROTECT(vec_proxy(out));
+      out = atomic_map(x, env, ptype);
     }
-
-    SEXP loc = PROTECT(compact_seq(0, 0, true));
-    int* p_loc = INTEGER(loc);
-
-    if (list_output) {
-      for (r_ssize i = 0; i < n; ++i) {
-        r_env_poke(env, syms_dot_elt, p_x[i]);
-        SET_VECTOR_ELT(out, i, r_eval_force(vec_map_call, env));
-      }
-
-      // Should use a ptype identity check before casting. Probably
-      // `vec_cast()` should make that check.
-      if (OBJECT(ptype)) {
-        out = vec_cast(out, ptype, NULL, NULL);
-      }
-      PROTECT(out);
-    } else {
-      PROTECT_INDEX out_proxy_pi;
-      PROTECT_WITH_INDEX(out_proxy, &out_proxy_pi);
-
-      for (r_ssize i = 0; i < n; ++i) {
-        r_env_poke(env, syms_dot_elt, p_x[i]);
-
-        SEXP elt_out = PROTECT(r_eval_force(vec_map_call, env));
-        elt_out = PROTECT(vec_cast(elt_out, ptype, NULL, NULL));
-
-        init_compact_seq(p_loc, i, 1, true);
-        out_proxy = vec_proxy_assign(out_proxy, loc, elt_out);
-
-        UNPROTECT(2);
-        REPROTECT(out_proxy, out_proxy_pi);
-      }
-
-      out = vec_restore(out_proxy, ptype, R_NilValue, VCTRS_OWNED_true);
-      UNPROTECT(1);
-      PROTECT(out);
-    }
+    PROTECT(out);
 
     SEXP names = PROTECT(vec_names(orig));
     vec_set_names(out, names);
 
-    UNPROTECT(6);
+    UNPROTECT(3);
     return out;
+}
+
+static
+SEXP list_map(SEXP x, SEXP env, SEXP ptype) {
+  SEXP out = PROTECT(r_clone_referenced(x));
+  SET_ATTRIB(out, R_NilValue);
+  SET_OBJECT(out, 0);
+
+  r_ssize n = r_length(x);
+  const SEXP* p_x = VECTOR_PTR_RO(x);
+
+  for (r_ssize i = 0; i < n; ++i) {
+    r_env_poke(env, syms_dot_elt, p_x[i]);
+    SET_VECTOR_ELT(out, i, r_eval_force(vec_map_call, env));
+  }
+
+  // Should use a ptype identity check before casting. Probably
+  // `vec_cast()` should make that check.
+  if (OBJECT(ptype)) {
+    out = vec_cast(out, ptype, NULL, NULL);
+  }
+
+  UNPROTECT(1);
+  return out;
+}
+
+static
+SEXP atomic_map(SEXP x, SEXP env, SEXP ptype) {
+  r_ssize n = r_length(x);
+
+  SEXP out = PROTECT(vec_init(ptype, n));
+
+  SEXP out_proxy = vec_proxy(out);
+  PROTECT_INDEX out_proxy_pi;
+  PROTECT_WITH_INDEX(out_proxy, &out_proxy_pi);
+
+  SEXP loc = PROTECT(compact_seq(0, 0, true));
+  int* p_loc = INTEGER(loc);
+
+  const SEXP* p_x = VECTOR_PTR_RO(x);
+
+  for (r_ssize i = 0; i < n; ++i) {
+    r_env_poke(env, syms_dot_elt, p_x[i]);
+
+    SEXP elt_out = PROTECT(r_eval_force(vec_map_call, env));
+    elt_out = PROTECT(vec_cast(elt_out, ptype, NULL, NULL));
+
+    init_compact_seq(p_loc, i, 1, true);
+    out_proxy = vec_proxy_assign(out_proxy, loc, elt_out);
+
+    UNPROTECT(2);
+    REPROTECT(out_proxy, out_proxy_pi);
+  }
+
+  out = vec_restore(out_proxy, ptype, R_NilValue, VCTRS_OWNED_true);
+
+  UNPROTECT(3);
+  return out;
 }
 
 

--- a/src/map.c
+++ b/src/map.c
@@ -39,7 +39,9 @@ SEXP vctrs_map(SEXP args) {
     PROTECT(out);
 
     SEXP names = PROTECT(vec_names(orig));
-    vec_set_names(out, names);
+    if (names != R_NilValue) {
+      vec_set_names(out, names);
+    }
 
     UNPROTECT(3);
     return out;

--- a/src/map.c
+++ b/src/map.c
@@ -13,8 +13,10 @@ SEXP vctrs_map(SEXP args) {
     SEXP ptype = CAR(args);
 
     SEXP orig = x;
+    bool list_input = vec_is_list(orig);
+    bool list_output = vec_is_list(ptype);
 
-    if (vec_is_list(x)) {
+    if (list_input) {
       x = PROTECT(x);
     } else {
       x = PROTECT(vec_chop2(x));
@@ -30,8 +32,10 @@ SEXP vctrs_map(SEXP args) {
     SEXP out;
     SEXP out_proxy;
 
-    if (vec_is_list(ptype)) {
+    if (list_output) {
       out = PROTECT(r_clone_referenced(x));
+      SET_ATTRIB(out, R_NilValue);
+      SET_OBJECT(out, 0);
       out_proxy = PROTECT(R_NilValue);
     } else {
       out = PROTECT(vec_init(ptype, n));
@@ -41,7 +45,7 @@ SEXP vctrs_map(SEXP args) {
     SEXP loc = PROTECT(compact_seq(0, 0, true));
     int* p_loc = INTEGER(loc);
 
-    if (vec_is_list(ptype)) {
+    if (list_output) {
       for (r_ssize i = 0; i < n; ++i) {
         r_env_poke(env, syms_dot_elt, p_x[i]);
         SET_VECTOR_ELT(out, i, r_eval_force(vec_map_call, env));

--- a/src/map.c
+++ b/src/map.c
@@ -1,0 +1,89 @@
+#include "vctrs.h"
+#include "slice.h"
+#include "utils.h"
+
+// Defined at load time
+SEXP vec_map_call = NULL;
+
+
+SEXP vctrs_map(SEXP args) {
+    args = CDR(args);
+    SEXP x = CAR(args); args = CDR(args);
+    SEXP env = CAR(args); args = CDR(args);
+    SEXP ptype = CAR(args);
+
+    SEXP orig = x;
+
+    if (vec_is_list(x)) {
+      x = PROTECT(x);
+    } else {
+      x = PROTECT(vec_chop2(x));
+    }
+
+    r_ssize n = r_length(x);
+    const SEXP* p_x = VECTOR_PTR_RO(x);
+
+    if (ptype == R_NilValue) {
+      Rf_error("TODO");
+    }
+
+    SEXP out;
+    SEXP out_proxy;
+
+    if (vec_is_list(ptype)) {
+      out = PROTECT(r_clone_referenced(x));
+      out_proxy = PROTECT(R_NilValue);
+    } else {
+      out = PROTECT(vec_init(ptype, n));
+      out_proxy = PROTECT(vec_proxy(out));
+    }
+
+    SEXP loc = PROTECT(compact_seq(0, 0, true));
+    int* p_loc = INTEGER(loc);
+
+    if (vec_is_list(ptype)) {
+      for (r_ssize i = 0; i < n; ++i) {
+        r_env_poke(env, syms_dot_elt, p_x[i]);
+        SET_VECTOR_ELT(out, i, Rf_eval(vec_map_call, env));
+      }
+
+      // Should use a ptype identity check before casting. Probably
+      // `vec_cast()` should make that check.
+      if (OBJECT(ptype)) {
+        out = vec_cast(out, ptype, NULL, NULL);
+      }
+      PROTECT(out);
+    } else {
+      PROTECT_INDEX out_proxy_pi;
+      PROTECT_WITH_INDEX(out_proxy, &out_proxy_pi);
+
+      for (r_ssize i = 0; i < n; ++i) {
+        r_env_poke(env, syms_dot_elt, p_x[i]);
+
+        SEXP elt_out = PROTECT(Rf_eval(vec_map_call, env));
+        elt_out = PROTECT(vec_cast(elt_out, ptype, NULL, NULL));
+
+        init_compact_seq(p_loc, i, 1, true);
+        out_proxy = vec_proxy_assign(out_proxy, loc, elt_out);
+
+        UNPROTECT(2);
+        REPROTECT(out_proxy, out_proxy_pi);
+      }
+
+      out = vec_restore(out_proxy, ptype, R_NilValue, VCTRS_OWNED_true);
+      UNPROTECT(1);
+      PROTECT(out);
+    }
+
+    SEXP names = PROTECT(vec_names(orig));
+    vec_set_names(out, names);
+
+    UNPROTECT(6);
+    return out;
+}
+
+
+void vctrs_init_map(SEXP ns) {
+  vec_map_call = r_parse(".fn(.elt, ...)");
+  R_PreserveObject(vec_map_call);
+}

--- a/src/map.c
+++ b/src/map.c
@@ -26,7 +26,7 @@ SEXP vctrs_map(SEXP args) {
     const SEXP* p_x = VECTOR_PTR_RO(x);
 
     if (ptype == R_NilValue) {
-      Rf_error("TODO");
+      r_abort("`.ptype` can't be NULL.");
     }
 
     SEXP out;

--- a/src/utils.c
+++ b/src/utils.c
@@ -911,6 +911,7 @@ const void* r_vec_deref_const(SEXP x) {
   case CPLXSXP: return COMPLEX_RO(x);
   case STRSXP: return STRING_PTR_RO(x);
   case RAWSXP: return RAW_RO(x);
+  case VECSXP: return VECTOR_PTR_RO(x);
   default: stop_unimplemented_type("r_vec_deref_const", TYPEOF(x));
   }
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -1752,6 +1752,7 @@ SEXP syms_vctrs_common_class_fallback = NULL;
 SEXP syms_fallback_class = NULL;
 SEXP syms_abort = NULL;
 SEXP syms_message = NULL;
+SEXP syms_dot_elt = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -2023,6 +2024,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_fallback_class = Rf_install("fallback_class");
   syms_abort = Rf_install("abort");
   syms_message = Rf_install("message");
+  syms_dot_elt = Rf_install(".elt");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.h
+++ b/src/utils.h
@@ -605,6 +605,7 @@ extern SEXP syms_vctrs_common_class_fallback;
 extern SEXP syms_fallback_class;
 extern SEXP syms_abort;
 extern SEXP syms_message;
+extern SEXP syms_dot_elt;
 
 static const char * const c_strs_vctrs_common_class_fallback = "vctrs:::common_class_fallback";
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -103,6 +103,14 @@ void stop_unimplemented_type(const char* fn, SEXPTYPE type) {
   stop_internal(fn, "Unimplemented type `%s`.", Rf_type2char(type));
 }
 
+static inline
+SEXP r_eval_force(SEXP expr, SEXP env) {
+#if R_VERSION >= R_Version(3, 2, 3)
+  return R_forceAndCall(expr, 1, env);
+#else
+  return Rf_eval(expr, env);
+#endif
+}
 
 SEXP map(SEXP x, SEXP (*fn)(SEXP));
 SEXP map_with_data(SEXP x, SEXP (*fn)(SEXP, void*), void* data);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -637,7 +637,10 @@ void stop_corrupt_ordered_levels(SEXP x, struct vctrs_arg* arg) __attribute__((n
 # define COMPLEX_RO(x) ((const Rcomplex*) COMPLEX(x))
 # define STRING_PTR_RO(x) ((const SEXP*) STRING_PTR(x))
 # define RAW_RO(x) ((const Rbyte*) RAW(x))
+# define DATAPTR_RO(x) ((const void*) DATAPTR(x))
 #endif
+
+#define VECTOR_PTR_RO(x) ((const SEXP*) DATAPTR_RO(x))
 
 
 #endif

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -1,0 +1,134 @@
+
+# Tests imported from purrr -----------------------------------------------
+
+# These tests rely on compat-purrr-vctrs
+
+test_that("preserves names", {
+  out <- map(list(x = 1, y = 2), identity)
+  expect_equal(names(out), c("x", "y"))
+})
+
+test_that("creates simple call", {
+  out <- map(1, function(x) sys.call())[[1]]
+  expect_equal(out, quote(.fn(.elt, ...)))
+})
+
+test_that("fails on non-vectors", {
+  expect_error(map(environment(), identity), class = "vctrs_error_scalar_type")
+  expect_error(map(quote(a), identity), class = "vctrs_error_scalar_type")
+})
+
+test_that("0 length input gives 0 length output", {
+  out1 <- map(list(), identity)
+  expect_equal(out1, list())
+
+  return("Used to work in purrr")
+
+  out2 <- map(NULL, identity)
+  expect_equal(out2, list())
+})
+
+test_that("map() always returns a list", {
+  expect_is(map(mtcars, mean), "list")
+})
+
+test_that("types automatically coerced upwards", {
+  expect_identical(map_int(c(FALSE, TRUE), identity), c(0L, 1L))
+
+  expect_identical(map_dbl(c(FALSE, TRUE), identity), c(0, 1))
+  expect_identical(map_dbl(c(1L, 2L), identity), c(1, 2))
+
+  return("Used to work in purrr")
+
+  expect_identical(map_int(as.raw(0:1), identity), 0:1)
+  expect_identical(map_dbl(as.raw(0:1), identity), c(0, 1))
+  expect_identical(map_chr(as.raw(0:255), identity), as.character(as.raw(0:255)))
+
+  expect_identical(map_chr(c(FALSE, TRUE), identity), c("FALSE", "TRUE"))
+  expect_identical(map_chr(c(1L, 2L), identity), c("1", "2"))
+  expect_identical(map_chr(c(1.5, 2.5), identity), c("1.500000", "2.500000"))
+})
+
+test_that("map_raw",{
+  expect_equal(map_raw("a", charToRaw), charToRaw("a"))
+})
+
+test_that("logical and integer NA become correct double NA", {
+  expect_identical(
+    map_dbl(list(NA, NA_integer_), identity),
+    c(NA_real_, NA_real_)
+  )
+})
+
+test_that("map forces arguments in same way as base R", {
+  f_map <- map(1:2, function(i) function(x) x + i)
+  f_base <- lapply(1:2, function(i) function(x) x + i)
+
+  expect_equal(f_map[[1]](0), f_base[[1]](0))
+  expect_equal(f_map[[2]](0), f_base[[2]](0))
+})
+
+test_that("walk is used for side-effects", {
+  expect_output(walk(1:3, str))
+})
+
+test_that("map_if() and map_at() always return a list", {
+  skip_if_not_installed("tibble")
+  df <- tibble::tibble(x = 1, y = "a")
+  expect_identical(map_if(df, is.character, ~"out"), list(x = 1, y = "out"))
+  expect_identical(map_at(df, 1, ~"out"), list(x = "out", y = "a"))
+})
+
+test_that("map_at() works with tidyselect", {
+  skip_if_not_installed("tidyselect")
+  x <- list(a = "b", b = "c", aa = "bb")
+  one <- map_at(x, quos(a), toupper)
+  expect_identical(one$a, "B")
+  expect_identical(one$aa, "bb")
+  two <- map_at(x, quos(tidyselect::contains("a")), toupper)
+  expect_identical(two$a, "B")
+  expect_identical(two$aa, "BB")
+})
+
+test_that("negative .at omits locations", {
+  x <- c(1, 2, 3)
+  out <- map_at(x, -1, ~ .x * 2)
+  expect_equal(out, list(1, 4, 6))
+})
+
+test_that("map works with calls and pairlists", {
+  expect_true(TRUE)
+  return("Used to work in purrr")
+
+  out <- map(quote(f(x)), ~ quote(z))
+  expect_equal(out, list(quote(z), quote(z)))
+
+  out <- map(pairlist(1, 2), ~ . + 1)
+  expect_equal(out, list(2, 3))
+})
+
+test_that("primitive dispatch correctly", {
+  local_bindings(.env = global_env(),
+    as.character.test_class = function(x) "dispatched!"
+  )
+  x <- structure(list(), class = "test_class")
+  expect_identical(map(list(x, x), as.character), list("dispatched!", "dispatched!"))
+})
+
+test_that("map_if requires predicate functions", {
+  expect_error(map_if(1:3, ~ NA, ~ "foo"), "must return")
+})
+
+test_that("`.else` maps false elements", {
+  expect_identical(map_if(-1:1, ~ .x > 0, paste, .else = ~ "bar", "suffix"), list("bar", "bar", "1 suffix"))
+})
+
+test_that("map() with empty input copies names", {
+  named_list <- named(list())
+  expect_identical(    map(named_list, identity), named(list()))
+  expect_identical(map_lgl(named_list, identity), named(lgl()))
+  expect_identical(map_int(named_list, identity), named(int()))
+  expect_identical(map_dbl(named_list, identity), named(dbl()))
+  expect_identical(map_chr(named_list, identity), named(chr()))
+  expect_identical(map_raw(named_list, identity), named(raw()))
+})

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -1,4 +1,21 @@
 
+test_that("vec_map() handles S3 lists", {
+  local_list_rcrd_methods()
+  x <- new_list_rcrd(list(1:2, 3:5, 6:9))
+
+  exp <- list(1:2, 3:4, 6:7)
+  expect_identical(
+    vec_map(x, `[`, 1:2),
+    exp
+  )
+
+  expect_identical(
+    vec_map(x, `[`, 1:2, .ptype = x),
+    new_list_rcrd(exp)
+  )
+})
+
+
 # Tests imported from purrr -----------------------------------------------
 
 # These tests rely on compat-purrr-vctrs

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -38,6 +38,10 @@ test_that("vec_map() handles S3 lists", {
   )
 })
 
+test_that("vec_map() requires a non-NULL ptype", {
+  expect_error(vec_map(1, identity, .ptype = NULL), "can't be NULL")
+})
+
 
 # Tests imported from purrr -----------------------------------------------
 

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -42,6 +42,13 @@ test_that("vec_map() requires a non-NULL ptype", {
   expect_error(vec_map(1, identity, .ptype = NULL), "can't be NULL")
 })
 
+test_that("functions must return size 1 vector when mapping to atomic", {
+  expect_error(
+    map(1:2, rep, 2, .ptype = int()),
+    "must return a size 1 vector"
+  )
+})
+
 
 # Tests imported from purrr -----------------------------------------------
 

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -1,4 +1,27 @@
 
+test_that("vec_map() handles S3 vectors", {
+  vctr <- new_vctr(1:3)
+  rcrd <- new_rcrd(list(x = 1:3, y = 4:6))
+
+  expect_identical(
+    vec_map(vctr, identity),
+    vec_chop(vctr)
+  )
+  expect_identical(
+    vec_map(rcrd, identity),
+    vec_chop(rcrd)
+  )
+
+  expect_identical(
+    vec_map(vctr, identity, .ptype = vctr),
+    vctr
+  )
+  expect_identical(
+    vec_map(rcrd, identity, .ptype = rcrd),
+    rcrd
+  )
+})
+
 test_that("vec_map() handles S3 lists", {
   local_list_rcrd_methods()
   x <- new_list_rcrd(list(1:2, 3:5, 6:9))


### PR DESCRIPTION
Branched from #1226.

This implements `vec_map()`. Depending on the supplied prototype, it covers a range of functionality provided in purrr and more:

- `.ptype = list()` implements `map()`
- `.ptype = integer()` or other base atomic types implements `map_int()` etc
- `.ptype` can also be set to any vctrs type

It isn't possible to infer the prototype from the list results because this would have no advantage over piping into `vec_simplify()` at the end.

The implementation follows two code paths depending on whether `.ptype` is a list or an atomic vector.

- When mapping to a list, we update the input in place in the mapping loop and coerce the complete list of outputs to the target ptype at the end. This way the coercion is vectorised.

- When mapping to an atomic vector we initialise an output vector and then coerce each input before assignment.

This vctrs implementation is competitive with purrr and base:

```r
### Mapping to list

x <- list(1, b = 2)
bench::mark(
  base = lapply(x, plus_one),
  purrr = map(x, plus_one),
  vctrs = vec_map(x, plus_one)
)[1:8]
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#> 1 base         2.43µs   3.51µs   268997.        0B     0    10000     0
#> 2 purrr       14.92µs  17.33µs    54736.        0B     5.47  9999     1
#> 3 vctrs        3.91µs   4.91µs   194467.        0B    19.4   9999     1

short <- rep(list(1, b = 2), 20)
bench::mark(
  base = lapply(short, plus_one),
  purrr = map(short, plus_one),
  vctrs = vec_map(short, plus_one)
)[1:8]
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#> 1 base         21.6µs   25.8µs    36666.      368B     29.4  9992     8
#> 2 purrr        35.7µs   41.7µs    22743.      368B     25.0  9989    11
#> 3 vctrs        17.1µs     21µs    44847.      368B     31.4  9993     7

long <- rep(list(1, b = 2), 1e5)
bench::mark(
  base = lapply(long, plus_one),
  purrr = map(long, plus_one),
  vctrs = vec_map(long, plus_one)
)[1:8]
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#> 1 base          120ms    126ms      6.81    1.53MB     15.3     4     9
#> 2 purrr         128ms    135ms      7.37    1.53MB     12.9     4     7
#> 3 vctrs          79ms     88ms     11.6     1.53MB     17.4     6     9


### Mapping to atomic vector

x <- list(1L, b = 2L)
bench::mark(
  base = vapply(x, plus_one, integer(1)),
  purrr = map_int(x, plus_one),
  vctrs = vec_map(x, plus_one, .ptype = int())
)[1:8]
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#> 1 base         3.54µs    4.8µs   199405.        0B      0   10000     0
#> 2 purrr        5.67µs   7.28µs   130768.        0B     13.1  9999     1
#> 3 vctrs        6.82µs    8.2µs   114366.        0B      0   10000     0

short <- rep(list(1L, b = 2L), 20)
bench::mark(
  base = vapply(short, plus_one, integer(1)),
  purrr = map_int(short, plus_one),
  vctrs = vec_map(short, plus_one, .ptype = int())
)[1:8]
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#> 1 base         22.7µs   26.9µs    35467.      208B     7.09  9998     2
#> 2 purrr        24.4µs   29.5µs    32371.      208B     6.48  9998     2
#> 3 vctrs        23.5µs   26.8µs    35572.      208B     3.56  9999     1

long <- rep(list(1L, b = 2L), 1e5)
bench::mark(
  base = vapply(long, plus_one, integer(1)),
  purrr = map_int(long, plus_one),
  vctrs = vec_map(long, plus_one, .ptype = int())
)[1:8]
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#> 1 base          104ms  104.1ms      9.61     781KB     38.4     1     4
#> 2 purrr         115ms  115.2ms      8.68     781KB     34.7     1     4
#> 3 vctrs          89ms   89.4ms     11.2      781KB     22.4     2     4
```

The purrr compat file has been updated to use the `vec_map()` to get some internal testing and to make it easy to import unit tests from purrr.