### PR TITLE
Add `vec_slice2()` and `vec_assign2()`

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -263,3 +263,24 @@ vec_slice2 <- function(x, i) {
     }
   )
 }
+
+vec_assign2 <- function(x, i, value, ..., x_arg = "", value_arg = "") {
+  if (!missing(...)) {
+    ellipsis::check_dots_empty()
+  }
+
+  # We may relax this in the future, e.g. for character `i`
+  if (is_zap(value)) {
+    abort("Can't zap elements.")
+  }
+
+  # If `x` is recursive, wrap RHS in a list before calling
+  # `vec_assign()`. The class of `x` must be coercible with lists. We
+  # intentionally wrap `NULL` values instead of treating them as a
+  # sentinel to zap elements.
+  if (vec_is_list(x)) {
+    value <- list(value)
+  }
+
+  vec_assign(x, i, value, x_arg = x_arg, value_arg = value_arg)
+}

--- a/R/slice.R
+++ b/R/slice.R
@@ -249,3 +249,17 @@ vec_slice_seq <- function(x, start, size, increasing = TRUE) {
 vec_slice_rep <- function(x, i, n) {
   .Call(vctrs_slice_rep, x, i, n)
 }
+
+vec_slice2 <- function(x, i) {
+  with_extract(
+    if (vec_is_list(x)) {
+      # Lists are currently guaranteed to have list storage so we can
+      # just subset them directly
+      i <- vec_as_location2(i, vec_size(x))
+      .subset2(x, i)
+    } else {
+      out <- vec_slice(x, i)
+      vec_set_names(out, NULL)
+    }
+  )
+}

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -342,3 +342,13 @@ cnd_subscript_scalar <- function(cnd) {
 
   out
 }
+
+with_extract <- function(expr) {
+  withCallingHandlers(
+    vctrs_error_subscript = function(cnd) {
+      cnd$subscript_action <- "extract"
+      cnd_signal(cnd)
+    },
+    expr
+  )
+}

--- a/tests/testthat/error/test-slice-assign.txt
+++ b/tests/testthat/error/test-slice-assign.txt
@@ -64,3 +64,19 @@ Error: Can't convert `bar` <character> to match type of `foo` <integer>.
 > vec_assign(1:2, 1L, 1:2, value_arg = "bar")
 Error: Can't recycle `bar` (size 2) to size 1.
 
+
+vec_assign2() fails with incompatible type
+==========================================
+
+> vec_assign2(1:3, 2, "")
+Error: Can't convert <character> to <integer>.
+
+
+vec_assign2() fails with OOB subscript
+======================================
+
+> vec_assign2(1:3, 4, 0)
+Error: Can't assign to elements that don't exist.
+x Location 4 doesn't exist.
+i There are only 3 elements.
+

--- a/tests/testthat/error/test-slice.txt
+++ b/tests/testthat/error/test-slice.txt
@@ -73,3 +73,17 @@ i It must be logical, numeric, or character.
 Error: Must subset elements with a valid subscript vector.
 x Subscript must be a simple vector, not a matrix.
 
+
+vec_slice2() fails if subscript is OOB
+======================================
+
+> vec_slice2(letters, 100)
+Error: Can't extract elements that don't exist.
+x Location 100 doesn't exist.
+i There are only 26 elements.
+
+> vec_slice2(list(), 100)
+Error: Can't extract elements that don't exist.
+x Location 100 doesn't exist.
+i There are only 0 elements.
+

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -718,6 +718,40 @@ test_that("can assign object of any dimensionality with compact seqs", {
   expect_identical(vec_assign_seq(x4, 2, start, size, increasing), array(rep(c(2, 2, 1), 120), dim = c(3, 4, 5, 6)))
 })
 
+test_that("vec_assign2() handles atomic vectors", {
+  x <- c(a = 1L, b = 2L, c = 3L)
+  exp <- c(a = 1L, b = 0L, c = 3L)
+
+  expect_identical(vec_assign2(x, 2, FALSE), exp)
+
+  local_hidden()
+  expect_identical(vec_assign2(new_hidden(x), 2, FALSE), new_hidden(exp))
+
+  rcrd <- new_rcrd(list(x = 1:3))
+  rcrd_exp <- new_rcrd(list(x = c(1L, 0L, 3L)))
+  expect_identical(vec_assign2(rcrd, 2, new_rcrd(list(x = FALSE))), rcrd_exp)
+})
+
+test_that("vec_assign2() handles lists", {
+  x <- list(a = 1L, b = 2L, c = 3:4)
+  exp1 <- list(a = 1L, b = FALSE, c = 3:4)
+  exp2 <- list(a = 1L, b = NULL, c = 3:4)
+  exp3 <- list(a = 1L, b = list(NULL), c = 3:4)
+
+  expect_identical(vec_assign2(x, 2, FALSE), exp1)
+  expect_identical(vec_assign2(x, 2, NULL), exp2)
+  expect_identical(vec_assign2(x, 2, list(NULL)), exp3)
+
+  local_list_rcrd_methods()
+  expect_identical(vec_assign2(new_list_rcrd(x), 2, FALSE), new_list_rcrd(exp1))
+  expect_identical(vec_assign2(new_list_rcrd(x), 2, NULL), new_list_rcrd(exp2))
+  expect_identical(vec_assign2(new_list_rcrd(x), 2, list(NULL)), new_list_rcrd(exp3))
+})
+
+test_that("zap() is currently disallowed", {
+  expect_error(vec_assign2(list(1), 1, zap()), "Can't zap")
+})
+
 
 # Golden tests ------------------------------------------------------------
 

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -752,6 +752,24 @@ test_that("zap() is currently disallowed", {
   expect_error(vec_assign2(list(1), 1, zap()), "Can't zap")
 })
 
+test_that("vec_assign2() fails with incompatible type", {
+  verify_errors({
+    expect_error(
+      vec_assign2(1:3, 2, ""),
+      class = "vctrs_error_incompatible_type"
+    )
+  })
+})
+
+test_that("vec_assign2() fails with OOB subscript", {
+  verify_errors({
+    expect_error(
+      vec_assign2(1:3, 4, 0),
+      class = "vctrs_error_subscript_oob"
+    )
+  })
+})
+
 
 # Golden tests ------------------------------------------------------------
 
@@ -777,5 +795,11 @@ test_that("slice and assign have informative errors", {
     "# `vec_assign()` error args can be overridden"
     vec_assign(1:2, 1L, "x", x_arg = "foo", value_arg = "bar")
     vec_assign(1:2, 1L, 1:2, value_arg = "bar")
+
+    "# vec_assign2() fails with incompatible type"
+    vec_assign2(1:3, 2, "")
+
+    "# vec_assign2() fails with OOB subscript"
+    vec_assign2(1:3, 4, 0)
   })
 })


### PR DESCRIPTION
Branched from #1226.

Following `vec_chop2()` and `vec_map()`, this further explores the idea of "extracting" variants of vctrs primitives.

- With atomic vectors, `vec_slice2()` and `vec_assign2()` are equivalent to `vec_slice()` and `vec_assign()`. The only difference is that `vec_slice2()` zaps the names of the result.

- `vec_slice2()` with lists makes use of the list storage requirement and calls `.subset2()`.

- `vec_assign2()` with lists wraps the RHS into a list. Genericity is ensured by `vec_assign()` which coerces the RHS (now a list) to the type of the LHS (a list type). This allows the class of the LHS to initialise attributes, possibly based on the contents of the RHS.

One big difference with `[[<-` is that `NULL` values are not treated as a deletion sentinel, and `list(NULL)` is not unwrapped to escape the sentinel usage.

```r
x <- list(foo = 1, bar = 2)

vec_assign2(x, 2, NULL)
#> $foo
#> [1] 1
#>
#> $bar
#> NULL

vec_assign2(x, 2, list(NULL))
#> $foo
#> [1] 1
#>
#> $bar
#> $bar[[1]]
#> NULL
```

There is currently no way to remove elements:

```r
vec_assign2(x, 2, zap())
#> Error: Can't zap elements.
```

These operations are unexported for now.