### PR TITLE
Treat names of one-dimensional arrays consistently

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* Named one-dimensional arrays now behave consistently with simple
+  vectors in `vec_names()` and `vec_rbind()`.
+
 * `new_rcrd()` now uses `df_list()` to validate the fields. This makes
   it more flexible as the fields are now recycled and can be of any
   type supported by vctrs, including data frames.

--- a/src/names.c
+++ b/src/names.c
@@ -110,7 +110,7 @@ SEXP vec_names_impl(SEXP x, bool proxy) {
     }
   }
 
-  if (vec_dim_n(x) == 1) {
+  if (vec_bare_dim(x) == R_NilValue) {
     if (!proxy && has_class) {
       return vctrs_dispatch1(syms_names, fns_names, syms_x, x);
     } else {

--- a/src/utils-rlang.h
+++ b/src/utils-rlang.h
@@ -75,6 +75,11 @@ sexp* r_pairlist_get(sexp* node, sexp* tag) {
 }
 
 static inline
+sexp* r_pairlist_poke(sexp* node, sexp* tag, sexp* value) {
+  return r_node_poke_car(r_pairlist_find(node, tag), value);
+}
+
+static inline
 sexp* r_pairlist_find_last(sexp* x) {
   while (CDR(x) != R_NilValue)
     x = CDR(x);
@@ -99,6 +104,10 @@ sexp* r_poke_attrib(sexp* x, sexp* attrs) {
 static inline
 sexp* r_attrib_get(sexp* x, sexp* tag) {
   return r_pairlist_get(r_attrib(x), tag);
+}
+static inline
+sexp* r_attrib_poke(sexp* x, sexp* tag, sexp* value) {
+  return r_pairlist_poke(r_attrib(x), tag, value);
 }
 
 static inline

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -964,6 +964,22 @@ test_that("can zap outer names from a name-spec (#1215)", {
   )
 })
 
+test_that("column names are treated consistently in vec_rbind()", {
+  exp <- data.frame(a = c(1L, 1L), b = c(2L, 2L))
+
+  x <- c(a = 1L, b = 2L)
+  expect_identical(vec_rbind(x, x), exp)
+
+  x <- array(1:2, dimnames = list(c("a", "b")))
+  expect_identical(vec_rbind(x, x), exp)
+
+  x <- matrix(1:2, nrow = 1, dimnames = list(NULL, c("a", "b")))
+  expect_identical(vec_rbind(x, x), exp)
+
+  x <- array(1:6, c(1, 2, 1), dimnames = list(NULL, c("a", "b"), NULL))
+  expect_error(vec_rbind(x, x), "Can't bind arrays")
+})
+
 
 # Golden tests -------------------------------------------------------
 

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -273,6 +273,12 @@ test_that("vec_set_names() errors with bad `names`", {
   expect_error(vec_set_names(1, c("x", "y")), "The size of `names`, 2")
 })
 
+test_that("vec_names() and vec_set_names() work with 1-dimensional arrays", {
+  x <- array(1:2, dimnames = list(c("a", "b")))
+  expect_identical(vec_names(x), c("a", "b"))
+  expect_identical(vec_names(vec_set_names(x, c("A", "B"))), c("A", "B"))
+})
+
 # minimal names -------------------------------------------------------------
 
 test_that("minimal names are made from `n` when `name = NULL`", {


### PR DESCRIPTION
The `vec_names()` of arrays are now picked from the dimnames:

```r
x <- array(1:2, dimnames = list(c("a", "b")))

# Before
vec_names(x)
#> NULL

# After
vec_names(x)
#> [1] "a" "b"
```

And they are now treated as column names in `vec_rbind()`, consistently with named ordinary vectors:

```r
# Before
vec_rbind(x, x)
#>   ...1 ...2
#> 1    1    2
#> 2    1    2

# After
vec_rbind(x, x)
#>   a b
#> 1 1 2
#> 2 1 2

# Consistently with
y <- c(a = 1L, b = 2L)
vec_rbind(y, y)
#>   a b
#> 1 1 2
#> 2 1 2
```