### PR TITLE
Fix `obj_maybe_translate_encoding()` crash

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* Fixed an encoding translation bug with lists containing data frames which
+  have columns where `vec_size()` is different from the low level
+  `Rf_length()` (#1233).
 
 # vctrs 0.3.4
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -217,14 +217,14 @@ static SEXP chr_translate_encoding(SEXP x, R_len_t n) {
   const void *vmax = vmaxget();
 
   for (R_len_t i = 0; i < n; ++i) {
-    SEXP chr = p_x[i];
+    SEXP elt = p_x[i];
 
-    if (Rf_getCharCE(chr) == CE_UTF8) {
-      SET_STRING_ELT(out, i, chr);
+    if (Rf_getCharCE(elt) == CE_UTF8) {
+      SET_STRING_ELT(out, i, elt);
       continue;
     }
 
-    SET_STRING_ELT(out, i, Rf_mkCharCE(Rf_translateCharUTF8(chr), CE_UTF8));
+    SET_STRING_ELT(out, i, Rf_mkCharCE(Rf_translateCharUTF8(elt), CE_UTF8));
   }
 
   vmaxset(vmax);

--- a/src/translate.c
+++ b/src/translate.c
@@ -13,9 +13,9 @@
 // UTF-8 translation is not attempted in these cases:
 // - (utf8 + utf8), (latin1 + latin1), (unknown + unknown), (bytes + bytes)
 
-static bool chr_translation_required_impl(const SEXP* x, R_len_t n, cetype_t reference) {
+static bool chr_translation_required_impl(const SEXP* p_x, R_len_t n, cetype_t reference) {
   for (R_len_t i = 0; i < n; ++i) {
-    if (Rf_getCharCE(x[i]) != reference) {
+    if (Rf_getCharCE(p_x[i]) != reference) {
       return true;
     }
   }

--- a/src/translate.c
+++ b/src/translate.c
@@ -220,7 +220,6 @@ static SEXP chr_translate_encoding(SEXP x, R_len_t n) {
     SEXP elt = p_x[i];
 
     if (Rf_getCharCE(elt) == CE_UTF8) {
-      SET_STRING_ELT(out, i, elt);
       continue;
     }
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -126,7 +126,7 @@ static bool chr_any_known_encoding(SEXP x, R_len_t n) {
 
   const SEXP* p_x = STRING_PTR_RO(x);
 
-  for (int i = 0; i < n; ++i) {
+  for (R_len_t i = 0; i < n; ++i) {
     if (Rf_getCharCE(p_x[i]) != CE_NATIVE) {
       return true;
     }
@@ -136,7 +136,7 @@ static bool chr_any_known_encoding(SEXP x, R_len_t n) {
 }
 
 static bool list_any_known_encoding(SEXP x, R_len_t n) {
-  for (int i = 0; i < n; ++i) {
+  for (R_len_t i = 0; i < n; ++i) {
     if (elt_any_known_encoding(VECTOR_ELT(x, i))) {
       return true;
     }
@@ -149,9 +149,9 @@ static bool list_any_known_encoding(SEXP x, R_len_t n) {
 // performance reasons. We know the size of each column, and can
 // pass that information through.
 static bool df_any_known_encoding(SEXP x, R_len_t n) {
-  int n_col = Rf_length(x);
+  R_len_t n_col = Rf_length(x);
 
-  for (int i = 0; i < n_col; ++i) {
+  for (R_len_t i = 0; i < n_col; ++i) {
     if (obj_any_known_encoding(VECTOR_ELT(x, i), n)) {
       return true;
     }
@@ -216,7 +216,7 @@ static SEXP chr_translate_encoding(SEXP x, R_len_t n) {
 
   const void *vmax = vmaxget();
 
-  for (int i = 0; i < n; ++i) {
+  for (R_len_t i = 0; i < n; ++i) {
     SEXP chr = p_x[i];
 
     if (Rf_getCharCE(chr) == CE_UTF8) {
@@ -235,7 +235,7 @@ static SEXP chr_translate_encoding(SEXP x, R_len_t n) {
 static SEXP list_translate_encoding(SEXP x, R_len_t n) {
   x = PROTECT(r_clone_referenced(x));
 
-  for (int i = 0; i < n; ++i) {
+  for (R_len_t i = 0; i < n; ++i) {
     SEXP elt = VECTOR_ELT(x, i);
     SET_VECTOR_ELT(x, i, elt_translate_encoding(elt));
   }
@@ -245,11 +245,11 @@ static SEXP list_translate_encoding(SEXP x, R_len_t n) {
 }
 
 static SEXP df_translate_encoding(SEXP x, R_len_t n) {
-  int n_col = Rf_length(x);
+  R_len_t n_col = Rf_length(x);
 
   x = PROTECT(r_clone_referenced(x));
 
-  for (int i = 0; i < n_col; ++i) {
+  for (R_len_t i = 0; i < n_col; ++i) {
     SEXP col = VECTOR_ELT(x, i);
     SET_VECTOR_ELT(x, i, obj_translate_encoding(col, n));
   }
@@ -301,11 +301,11 @@ static SEXP list_maybe_translate_encoding(SEXP x, R_len_t n) {
 }
 
 static SEXP df_maybe_translate_encoding(SEXP x, R_len_t n) {
-  int n_col = Rf_length(x);
+  R_len_t n_col = Rf_length(x);
 
   x = PROTECT(r_clone_referenced(x));
 
-  for (int i = 0; i < n_col; ++i) {
+  for (R_len_t i = 0; i < n_col; ++i) {
     SEXP elt = VECTOR_ELT(x, i);
     SET_VECTOR_ELT(x, i, obj_maybe_translate_encoding(elt, n));
   }
@@ -389,14 +389,14 @@ static SEXP list_maybe_translate_encoding2(SEXP x, R_len_t x_n, SEXP y, R_len_t 
 }
 
 static SEXP df_maybe_translate_encoding2(SEXP x, R_len_t x_n, SEXP y, R_len_t y_n) {
-  int n_col = Rf_length(x);
+  R_len_t n_col = Rf_length(x);
 
   x = PROTECT(r_clone_referenced(x));
   y = PROTECT(r_clone_referenced(y));
 
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
 
-  for (int i = 0; i < n_col; ++i) {
+  for (R_len_t i = 0; i < n_col; ++i) {
     SEXP x_elt = VECTOR_ELT(x, i);
     SEXP y_elt = VECTOR_ELT(y, i);
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -13,8 +13,8 @@
 // UTF-8 translation is not attempted in these cases:
 // - (utf8 + utf8), (latin1 + latin1), (unknown + unknown), (bytes + bytes)
 
-static bool chr_translation_required_impl(const SEXP* p_x, R_len_t n, cetype_t reference) {
-  for (R_len_t i = 0; i < n; ++i) {
+static bool chr_translation_required_impl(const SEXP* p_x, R_len_t size, cetype_t reference) {
+  for (R_len_t i = 0; i < size; ++i) {
     if (Rf_getCharCE(p_x[i]) != reference) {
       return true;
     }
@@ -23,24 +23,24 @@ static bool chr_translation_required_impl(const SEXP* p_x, R_len_t n, cetype_t r
   return false;
 }
 
-static bool chr_translation_required(SEXP x, R_len_t n) {
-  if (n == 0) {
+static bool chr_translation_required(SEXP x, R_len_t size) {
+  if (size == 0) {
     return false;
   }
 
   const SEXP* p_x = STRING_PTR_RO(x);
   cetype_t reference = Rf_getCharCE(*p_x);
 
-  return chr_translation_required_impl(p_x, n, reference);
+  return chr_translation_required_impl(p_x, size, reference);
 }
 
 // Check if `x` or `y` need to be translated to UTF-8, relative to each other
-static bool chr_translation_required2(SEXP x, R_len_t x_n, SEXP y, R_len_t y_n) {
+static bool chr_translation_required2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   const SEXP* p_x;
   const SEXP* p_y;
 
-  bool x_empty = x_n == 0;
-  bool y_empty = y_n == 0;
+  bool x_empty = x_size == 0;
+  bool y_empty = y_size == 0;
 
   if (x_empty && y_empty) {
     return false;
@@ -48,24 +48,24 @@ static bool chr_translation_required2(SEXP x, R_len_t x_n, SEXP y, R_len_t y_n) 
 
   if (x_empty) {
     p_y = STRING_PTR_RO(y);
-    return chr_translation_required_impl(p_y, y_n, Rf_getCharCE(*p_y));
+    return chr_translation_required_impl(p_y, y_size, Rf_getCharCE(*p_y));
   }
 
   if (y_empty) {
     p_x = STRING_PTR_RO(x);
-    return chr_translation_required_impl(p_x, x_n, Rf_getCharCE(*p_x));
+    return chr_translation_required_impl(p_x, x_size, Rf_getCharCE(*p_x));
   }
 
   p_x = STRING_PTR_RO(x);
   cetype_t reference = Rf_getCharCE(*p_x);
 
-  if (chr_translation_required_impl(p_x, x_n, reference)) {
+  if (chr_translation_required_impl(p_x, x_size, reference)) {
     return true;
   }
 
   p_y = STRING_PTR_RO(y);
 
-  if (chr_translation_required_impl(p_y, y_n, reference)) {
+  if (chr_translation_required_impl(p_y, y_size, reference)) {
     return true;
   }
 
@@ -75,59 +75,31 @@ static bool chr_translation_required2(SEXP x, R_len_t x_n, SEXP y, R_len_t y_n) 
 // -----------------------------------------------------------------------------
 // Utilities to check if any character elements of a list have a
 // "known" encoding (UTF-8 or Latin1). This implies that we have to convert
-// all character elements of the list to UTF-8. Only `list_any_known_encoding()`
-// is ever called directly.
+// all character elements to UTF-8.
+//
+// - Only `list_any_known_encoding()` is ever called directly.
+// - Data frame elements are treated as lists here, since they won't have been
+//   proxied when the list was proxied, meaning we can't safely pass the size
+//   to each column.
 
-static bool chr_any_known_encoding(SEXP x, R_len_t n);
-static bool list_any_known_encoding(SEXP x, R_len_t n);
-static bool df_any_known_encoding(SEXP x, R_len_t n);
+static bool chr_any_known_encoding(SEXP x, R_len_t size);
+static bool list_any_known_encoding(SEXP x, R_len_t size);
 
-static bool obj_any_known_encoding(SEXP x, R_len_t n) {
-  switch (TYPEOF(x)) {
-  case STRSXP: {
-    return chr_any_known_encoding(x, n);
-  }
-  case VECSXP: {
-    if (is_data_frame(x)) {
-      return df_any_known_encoding(x, n);
-    } else {
-      return list_any_known_encoding(x, n);
-    }
-  }
-  default: {
-    return false;
-  }
-  }
-}
-
-// For usage on list elements. They have unknown n, and might be scalars.
 static bool elt_any_known_encoding(SEXP x) {
   switch (TYPEOF(x)) {
-  case STRSXP: {
-    return chr_any_known_encoding(x, Rf_length(x));
-  }
-  case VECSXP: {
-    if (is_data_frame(x)) {
-      return df_any_known_encoding(x, vec_size(x));
-    } else {
-      return list_any_known_encoding(x, Rf_length(x));
-    }
-  }
-  default: {
-    return false;
-  }
+  case STRSXP: return chr_any_known_encoding(x, Rf_length(x));
+  case VECSXP: return list_any_known_encoding(x, Rf_length(x));
+  default: return false;
   }
 }
 
-static bool chr_any_known_encoding(SEXP x, R_len_t n) {
-  if (n == 0) {
-    return false;
-  }
-
+static bool chr_any_known_encoding(SEXP x, R_len_t size) {
   const SEXP* p_x = STRING_PTR_RO(x);
 
-  for (R_len_t i = 0; i < n; ++i) {
-    if (Rf_getCharCE(p_x[i]) != CE_NATIVE) {
+  for (R_len_t i = 0; i < size; ++i) {
+    const SEXP elt = p_x[i];
+
+    if (Rf_getCharCE(elt) != CE_NATIVE) {
       return true;
     }
   }
@@ -135,24 +107,11 @@ static bool chr_any_known_encoding(SEXP x, R_len_t n) {
   return false;
 }
 
-static bool list_any_known_encoding(SEXP x, R_len_t n) {
-  for (R_len_t i = 0; i < n; ++i) {
-    if (elt_any_known_encoding(VECTOR_ELT(x, i))) {
-      return true;
-    }
-  }
+static bool list_any_known_encoding(SEXP x, R_len_t size) {
+  for (R_len_t i = 0; i < size; ++i) {
+    SEXP elt = VECTOR_ELT(x, i);
 
-  return false;
-}
-
-// Data frames have a separate path from lists here purely for
-// performance reasons. We know the size of each column, and can
-// pass that information through.
-static bool df_any_known_encoding(SEXP x, R_len_t n) {
-  R_len_t n_col = Rf_length(x);
-
-  for (R_len_t i = 0; i < n_col; ++i) {
-    if (obj_any_known_encoding(VECTOR_ELT(x, i), n)) {
+    if (elt_any_known_encoding(elt)) {
       return true;
     }
   }
@@ -161,62 +120,34 @@ static bool df_any_known_encoding(SEXP x, R_len_t n) {
 }
 
 // -----------------------------------------------------------------------------
-// Utilities to translate all character vector elements of an object to UTF-8.
-// This does not check if a translation is required.
+// Utilities to translate all character vector elements of a list to UTF-8.
+//
+// - This does not check if a translation is required.
+// - Only `list_translate_encoding()` or `chr_translate_encoding()` are
+//   called directly.
+// - Data frame elements of lists are treated as lists here, since they won't
+//   have been proxied when the list was proxied, meaning we can't safely pass
+//   the size to each column.
 
-static SEXP chr_translate_encoding(SEXP x, R_len_t n);
-static SEXP list_translate_encoding(SEXP x, R_len_t n);
-static SEXP df_translate_encoding(SEXP x, R_len_t n);
+static SEXP chr_translate_encoding(SEXP x, R_len_t size);
+static SEXP list_translate_encoding(SEXP x, R_len_t size);
 
-static SEXP obj_translate_encoding(SEXP x, R_len_t n) {
-  switch (TYPEOF(x)) {
-  case STRSXP: {
-    return chr_translate_encoding(x, n);
-  }
-  case VECSXP: {
-    if (is_data_frame(x)) {
-      return df_translate_encoding(x, n);
-    } else {
-      return list_translate_encoding(x, n);
-    }
-  }
-  default: {
-    return x;
-  }
-  }
-}
-
-// For usage on list elements. They have unknown size, and might be scalars.
 static SEXP elt_translate_encoding(SEXP x) {
   switch (TYPEOF(x)) {
-  case STRSXP: {
-    return chr_translate_encoding(x, Rf_length(x));
-  }
-  case VECSXP: {
-    if (is_data_frame(x)) {
-      return df_translate_encoding(x, vec_size(x));
-    } else {
-      return list_translate_encoding(x, Rf_length(x));
-    }
-  }
-  default: {
-    return x;
-  }
+  case STRSXP: return chr_translate_encoding(x, Rf_length(x));
+  case VECSXP: return list_translate_encoding(x, Rf_length(x));
+  default: return x;
   }
 }
 
-static SEXP chr_translate_encoding(SEXP x, R_len_t n) {
-  if (n == 0) {
-    return x;
-  }
-
+static SEXP chr_translate_encoding(SEXP x, R_len_t size) {
   const SEXP* p_x = STRING_PTR_RO(x);
 
   SEXP out = PROTECT(r_clone_referenced(x));
 
   const void *vmax = vmaxget();
 
-  for (R_len_t i = 0; i < n; ++i) {
+  for (R_len_t i = 0; i < size; ++i) {
     SEXP elt = p_x[i];
 
     if (Rf_getCharCE(elt) == CE_UTF8) {
@@ -231,26 +162,13 @@ static SEXP chr_translate_encoding(SEXP x, R_len_t n) {
   return out;
 }
 
-static SEXP list_translate_encoding(SEXP x, R_len_t n) {
+static SEXP list_translate_encoding(SEXP x, R_len_t size) {
   x = PROTECT(r_clone_referenced(x));
 
-  for (R_len_t i = 0; i < n; ++i) {
+  for (R_len_t i = 0; i < size; ++i) {
     SEXP elt = VECTOR_ELT(x, i);
-    SET_VECTOR_ELT(x, i, elt_translate_encoding(elt));
-  }
-
-  UNPROTECT(1);
-  return x;
-}
-
-static SEXP df_translate_encoding(SEXP x, R_len_t n) {
-  R_len_t n_col = Rf_length(x);
-
-  x = PROTECT(r_clone_referenced(x));
-
-  for (R_len_t i = 0; i < n_col; ++i) {
-    SEXP col = VECTOR_ELT(x, i);
-    SET_VECTOR_ELT(x, i, obj_translate_encoding(col, n));
+    elt = elt_translate_encoding(elt);
+    SET_VECTOR_ELT(x, i, elt);
   }
 
   UNPROTECT(1);
@@ -268,21 +186,21 @@ static SEXP df_translate_encoding(SEXP x, R_len_t n) {
 // Notes:
 // - Assumes that `x` has been proxied recursively.
 
-static SEXP chr_maybe_translate_encoding(SEXP x, R_len_t n);
-static SEXP list_maybe_translate_encoding(SEXP x, R_len_t n);
-static SEXP df_maybe_translate_encoding(SEXP x, R_len_t n);
+static SEXP chr_maybe_translate_encoding(SEXP x, R_len_t size);
+static SEXP list_maybe_translate_encoding(SEXP x, R_len_t size);
+static SEXP df_maybe_translate_encoding(SEXP x, R_len_t size);
 
 // [[ include("vctrs.h") ]]
-SEXP obj_maybe_translate_encoding(SEXP x, R_len_t n) {
+SEXP obj_maybe_translate_encoding(SEXP x, R_len_t size) {
   switch (TYPEOF(x)) {
   case STRSXP: {
-    return chr_maybe_translate_encoding(x, n);
+    return chr_maybe_translate_encoding(x, size);
   }
   case VECSXP: {
     if (is_data_frame(x)) {
-      return df_maybe_translate_encoding(x, n);
+      return df_maybe_translate_encoding(x, size);
     } else {
-      return list_maybe_translate_encoding(x, n);
+      return list_maybe_translate_encoding(x, size);
     }
   }
   default: {
@@ -291,22 +209,22 @@ SEXP obj_maybe_translate_encoding(SEXP x, R_len_t n) {
   }
 }
 
-static SEXP chr_maybe_translate_encoding(SEXP x, R_len_t n) {
-  return chr_translation_required(x, n) ? chr_translate_encoding(x, n) : x;
+static SEXP chr_maybe_translate_encoding(SEXP x, R_len_t size) {
+  return chr_translation_required(x, size) ? chr_translate_encoding(x, size) : x;
 }
 
-static SEXP list_maybe_translate_encoding(SEXP x, R_len_t n) {
-  return list_any_known_encoding(x, n) ? list_translate_encoding(x, n) : x;
+static SEXP list_maybe_translate_encoding(SEXP x, R_len_t size) {
+  return list_any_known_encoding(x, size) ? list_translate_encoding(x, size) : x;
 }
 
-static SEXP df_maybe_translate_encoding(SEXP x, R_len_t n) {
+static SEXP df_maybe_translate_encoding(SEXP x, R_len_t size) {
   R_len_t n_col = Rf_length(x);
 
   x = PROTECT(r_clone_referenced(x));
 
   for (R_len_t i = 0; i < n_col; ++i) {
     SEXP elt = VECTOR_ELT(x, i);
-    SET_VECTOR_ELT(x, i, obj_maybe_translate_encoding(elt, n));
+    SET_VECTOR_ELT(x, i, obj_maybe_translate_encoding(elt, size));
   }
 
   UNPROTECT(1);
@@ -318,9 +236,9 @@ static SEXP df_maybe_translate_encoding(SEXP x, R_len_t n) {
 // if required.
 
 static SEXP translate_none(SEXP x, SEXP y);
-static SEXP chr_maybe_translate_encoding2(SEXP x, R_len_t x_n, SEXP y, R_len_t y_n);
-static SEXP list_maybe_translate_encoding2(SEXP x, R_len_t x_n, SEXP y, R_len_t y_n);
-static SEXP df_maybe_translate_encoding2(SEXP x, R_len_t x_n, SEXP y, R_len_t y_n);
+static SEXP chr_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+static SEXP list_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+static SEXP df_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
 
 // Notes:
 // - Assumes that `x` and `y` are the same type from calling `vec_cast()`.
@@ -329,16 +247,16 @@ static SEXP df_maybe_translate_encoding2(SEXP x, R_len_t x_n, SEXP y, R_len_t y_
 // - Returns a list holding `x` and `y` translated to their common encoding.
 
 // [[ include("vctrs.h") ]]
-SEXP obj_maybe_translate_encoding2(SEXP x, R_len_t x_n, SEXP y, R_len_t y_n) {
+SEXP obj_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   switch (TYPEOF(x)) {
   case STRSXP: {
-    return chr_maybe_translate_encoding2(x, x_n, y, y_n);
+    return chr_maybe_translate_encoding2(x, x_size, y, y_size);
   }
   case VECSXP: {
     if (is_data_frame(x)) {
-      return df_maybe_translate_encoding2(x, x_n, y, y_n);
+      return df_maybe_translate_encoding2(x, x_size, y, y_size);
     } else {
-      return list_maybe_translate_encoding2(x, x_n, y, y_n);
+      return list_maybe_translate_encoding2(x, x_size, y, y_size);
     }
   }
   default: {
@@ -357,12 +275,12 @@ static SEXP translate_none(SEXP x, SEXP y) {
   return out;
 }
 
-static SEXP chr_maybe_translate_encoding2(SEXP x, R_len_t x_n, SEXP y, R_len_t y_n) {
+static SEXP chr_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
 
-  if (chr_translation_required2(x, x_n, y, y_n)) {
-    SET_VECTOR_ELT(out, 0, chr_translate_encoding(x, x_n));
-    SET_VECTOR_ELT(out, 1, chr_translate_encoding(y, y_n));
+  if (chr_translation_required2(x, x_size, y, y_size)) {
+    SET_VECTOR_ELT(out, 0, chr_translate_encoding(x, x_size));
+    SET_VECTOR_ELT(out, 1, chr_translate_encoding(y, y_size));
   } else {
     SET_VECTOR_ELT(out, 0, x);
     SET_VECTOR_ELT(out, 1, y);
@@ -372,12 +290,12 @@ static SEXP chr_maybe_translate_encoding2(SEXP x, R_len_t x_n, SEXP y, R_len_t y
   return out;
 }
 
-static SEXP list_maybe_translate_encoding2(SEXP x, R_len_t x_n, SEXP y, R_len_t y_n) {
+static SEXP list_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
 
-  if (list_any_known_encoding(x, x_n) || list_any_known_encoding(y, y_n)) {
-    SET_VECTOR_ELT(out, 0, list_translate_encoding(x, x_n));
-    SET_VECTOR_ELT(out, 1, list_translate_encoding(y, y_n));
+  if (list_any_known_encoding(x, x_size) || list_any_known_encoding(y, y_size)) {
+    SET_VECTOR_ELT(out, 0, list_translate_encoding(x, x_size));
+    SET_VECTOR_ELT(out, 1, list_translate_encoding(y, y_size));
   } else {
     SET_VECTOR_ELT(out, 0, x);
     SET_VECTOR_ELT(out, 1, y);
@@ -387,7 +305,7 @@ static SEXP list_maybe_translate_encoding2(SEXP x, R_len_t x_n, SEXP y, R_len_t 
   return out;
 }
 
-static SEXP df_maybe_translate_encoding2(SEXP x, R_len_t x_n, SEXP y, R_len_t y_n) {
+static SEXP df_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size) {
   R_len_t n_col = Rf_length(x);
 
   x = PROTECT(r_clone_referenced(x));
@@ -399,7 +317,7 @@ static SEXP df_maybe_translate_encoding2(SEXP x, R_len_t x_n, SEXP y, R_len_t y_
     SEXP x_elt = VECTOR_ELT(x, i);
     SEXP y_elt = VECTOR_ELT(y, i);
 
-    SEXP translated = PROTECT(obj_maybe_translate_encoding2(x_elt, x_n, y_elt, y_n));
+    SEXP translated = PROTECT(obj_maybe_translate_encoding2(x_elt, x_size, y_elt, y_size));
 
     SET_VECTOR_ELT(x, i, VECTOR_ELT(translated, 0));
     SET_VECTOR_ELT(y, i, VECTOR_ELT(translated, 1));

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -566,8 +566,8 @@ SEXP datetime_datetime_ptype2(SEXP x, SEXP y);
 
 // Character translation ---------------------------------------------
 
-SEXP obj_maybe_translate_encoding(SEXP x, R_len_t size);
-SEXP obj_maybe_translate_encoding2(SEXP x, R_len_t x_size, SEXP y, R_len_t y_size);
+SEXP obj_maybe_translate_encoding(SEXP x, r_ssize size);
+SEXP obj_maybe_translate_encoding2(SEXP x, r_ssize x_size, SEXP y, r_ssize y_size);
 
 // Growable vector ----------------------------------------------
 

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -222,3 +222,26 @@ test_that("translation is robust against scalar types contained in lists (#633)"
   y <- list(a = c ~ d, b = e ~ f)
   expect_equal(obj_maybe_translate_encoding2(x, y), list(x, y))
 })
+
+test_that("translation treats data frames elements of lists as lists (#1233)", {
+  encs <- encodings()
+
+  field <- c(encs$utf8, encs$latin1)
+
+  a <- new_rcrd(list(field = field))
+  df <- data.frame(a = a, b = 1:2)
+  x <- list(df)
+
+  # Recursive proxy won't proxy list elements,
+  # so the rcrd column in the data frame won't get proxied
+  x <- vec_proxy_equal(x)
+
+  result <- obj_maybe_translate_encoding(x)
+
+  expect_identical(result, x)
+
+  result_field <- field(result[[1]]$a, "field")
+  expect_field <- c(encs$utf8, encs$utf8)
+
+  expect_equal_encoding(result_field, expect_field)
+})


### PR DESCRIPTION
Closes #1233 

The crash occurred when we had the following scenario:

- A list
- A data frame element in that list
- A rcrd column of that data frame, which has a `vec_size()` that is different from the low level `Rf_length()`

A proxy of the outer list won't proxy the elements of the list, so the rcrd column of the data frame didn't get proxied. When we eventually processed that data frame element, we assumed it had been proxied and passed the `size` of the data frame on to each column as the number of elements to iterate over. Since the rcrd wasn't proxied, the `size` didn't match up with its actual `Rf_length()` and we indexed OOB.

The fix is to treat data frames that are elements of a list as lists themselves. This forces us to compute the length of each list/character column individually with `Rf_length()`, so we correctly compute the unproxied length of the rcrd column. I think this is a more appropriate fix vs a potential alternative of proxying each list element.

I don't really expect this to have any performance impact.

I somehow forgot to add the meaningful part of the fix as its own commit, so it got tied in with the commit "Revert `size` to `n` change" 😞 , sorry. I only just noticed that.