### PR TITLE
Fix `obj_maybe_translate_encoding()` crash

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* Fixed an encoding translation bug with lists containing data frames which
+  have columns where `vec_size()` is different from the low level
+  `Rf_length()` (#1233).
 
 # vctrs 0.3.4
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -217,14 +217,14 @@ static SEXP chr_translate_encoding(SEXP x, r_ssize size) {
   const void *vmax = vmaxget();
 
   for (r_ssize i = 0; i < size; ++i) {
-    SEXP chr = p_x[i];
+    SEXP elt = p_x[i];
 
-    if (Rf_getCharCE(chr) == CE_UTF8) {
-      SET_STRING_ELT(out, i, chr);
+    if (Rf_getCharCE(elt) == CE_UTF8) {
+      SET_STRING_ELT(out, i, elt);
       continue;
     }
 
-    SET_STRING_ELT(out, i, Rf_mkCharCE(Rf_translateCharUTF8(chr), CE_UTF8));
+    SET_STRING_ELT(out, i, Rf_mkCharCE(Rf_translateCharUTF8(elt), CE_UTF8));
   }
 
   vmaxset(vmax);

--- a/src/translate.c
+++ b/src/translate.c
@@ -126,7 +126,7 @@ static bool chr_any_known_encoding(SEXP x, r_ssize size) {
 
   const SEXP* p_x = STRING_PTR_RO(x);
 
-  for (int i = 0; i < size; ++i) {
+  for (r_ssize i = 0; i < size; ++i) {
     if (Rf_getCharCE(p_x[i]) != CE_NATIVE) {
       return true;
     }
@@ -136,7 +136,7 @@ static bool chr_any_known_encoding(SEXP x, r_ssize size) {
 }
 
 static bool list_any_known_encoding(SEXP x, r_ssize size) {
-  for (int i = 0; i < size; ++i) {
+  for (r_ssize i = 0; i < size; ++i) {
     if (elt_any_known_encoding(VECTOR_ELT(x, i))) {
       return true;
     }
@@ -149,9 +149,9 @@ static bool list_any_known_encoding(SEXP x, r_ssize size) {
 // performance reasons. We know the size of each column, and can
 // pass that information through.
 static bool df_any_known_encoding(SEXP x, r_ssize size) {
-  int n_col = r_length(x);
+  r_ssize n_col = r_length(x);
 
-  for (int i = 0; i < n_col; ++i) {
+  for (r_ssize i = 0; i < n_col; ++i) {
     if (obj_any_known_encoding(VECTOR_ELT(x, i), size)) {
       return true;
     }
@@ -216,7 +216,7 @@ static SEXP chr_translate_encoding(SEXP x, r_ssize size) {
 
   const void *vmax = vmaxget();
 
-  for (int i = 0; i < size; ++i) {
+  for (r_ssize i = 0; i < size; ++i) {
     SEXP chr = p_x[i];
 
     if (Rf_getCharCE(chr) == CE_UTF8) {
@@ -235,7 +235,7 @@ static SEXP chr_translate_encoding(SEXP x, r_ssize size) {
 static SEXP list_translate_encoding(SEXP x, r_ssize size) {
   x = PROTECT(r_clone_referenced(x));
 
-  for (int i = 0; i < size; ++i) {
+  for (r_ssize i = 0; i < size; ++i) {
     SEXP elt = VECTOR_ELT(x, i);
     SET_VECTOR_ELT(x, i, elt_translate_encoding(elt));
   }
@@ -245,11 +245,11 @@ static SEXP list_translate_encoding(SEXP x, r_ssize size) {
 }
 
 static SEXP df_translate_encoding(SEXP x, r_ssize size) {
-  int n_col = r_length(x);
+  r_ssize n_col = r_length(x);
 
   x = PROTECT(r_clone_referenced(x));
 
-  for (int i = 0; i < n_col; ++i) {
+  for (r_ssize i = 0; i < n_col; ++i) {
     SEXP col = VECTOR_ELT(x, i);
     SET_VECTOR_ELT(x, i, obj_translate_encoding(col, size));
   }
@@ -301,11 +301,11 @@ static SEXP list_maybe_translate_encoding(SEXP x, r_ssize size) {
 }
 
 static SEXP df_maybe_translate_encoding(SEXP x, r_ssize size) {
-  int n_col = r_length(x);
+  r_ssize n_col = r_length(x);
 
   x = PROTECT(r_clone_referenced(x));
 
-  for (int i = 0; i < n_col; ++i) {
+  for (r_ssize i = 0; i < n_col; ++i) {
     SEXP elt = VECTOR_ELT(x, i);
     SET_VECTOR_ELT(x, i, obj_maybe_translate_encoding(elt, size));
   }
@@ -389,14 +389,14 @@ static SEXP list_maybe_translate_encoding2(SEXP x, r_ssize x_size, SEXP y, r_ssi
 }
 
 static SEXP df_maybe_translate_encoding2(SEXP x, r_ssize x_size, SEXP y, r_ssize y_size) {
-  int n_col = r_length(x);
+  r_ssize n_col = r_length(x);
 
   x = PROTECT(r_clone_referenced(x));
   y = PROTECT(r_clone_referenced(y));
 
   SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
 
-  for (int i = 0; i < n_col; ++i) {
+  for (r_ssize i = 0; i < n_col; ++i) {
     SEXP x_elt = VECTOR_ELT(x, i);
     SEXP y_elt = VECTOR_ELT(y, i);
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -220,7 +220,6 @@ static SEXP chr_translate_encoding(SEXP x, r_ssize size) {
     SEXP elt = p_x[i];
 
     if (Rf_getCharCE(elt) == CE_UTF8) {
-      SET_STRING_ELT(out, i, elt);
       continue;
     }
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -13,9 +13,9 @@
 // UTF-8 translation is not attempted in these cases:
 // - (utf8 + utf8), (latin1 + latin1), (unknown + unknown), (bytes + bytes)
 
-static bool chr_translation_required_impl(const SEXP* x, r_ssize size, cetype_t reference) {
+static bool chr_translation_required_impl(const SEXP* p_x, r_ssize size, cetype_t reference) {
   for (r_ssize i = 0; i < size; ++i) {
-    if (Rf_getCharCE(x[i]) != reference) {
+    if (Rf_getCharCE(p_x[i]) != reference) {
       return true;
     }
   }

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -222,3 +222,26 @@ test_that("translation is robust against scalar types contained in lists (#633)"
   y <- list(a = c ~ d, b = e ~ f)
   expect_equal(obj_maybe_translate_encoding2(x, y), list(x, y))
 })
+
+test_that("translation treats data frames elements of lists as lists (#1233)", {
+  encs <- encodings()
+
+  field <- c(encs$utf8, encs$latin1)
+
+  a <- new_rcrd(list(field = field))
+  df <- data.frame(a = a, b = 1:2)
+  x <- list(df)
+
+  # Recursive proxy won't proxy list elements,
+  # so the rcrd column in the data frame won't get proxied
+  x <- vec_proxy_equal(x)
+
+  result <- obj_maybe_translate_encoding(x)
+
+  expect_identical(result, x)
+
+  result_field <- field(result[[1]]$a, "field")
+  expect_field <- c(encs$utf8, encs$utf8)
+
+  expect_equal_encoding(result_field, expect_field)
+})


### PR DESCRIPTION
Supersedes #1236 (where I borked the commits)
Closes #1233

The crash occurred when we had the following scenario:

- A list
- A data frame element in that list
- A rcrd column of that data frame, which has a `vec_size()` that is different from the low level `Rf_length()`

A proxy of the outer list won't proxy the elements of the list, so the rcrd column of the data frame didn't get proxied. When we eventually processed that data frame element, we assumed it had been proxied and passed the `size` of the data frame on to each column as the number of elements to iterate over. Since the rcrd wasn't proxied, the `size` didn't match up with its actual `Rf_length()` and we indexed OOB.

The fix is to treat data frames that are elements of a list as lists themselves. This forces us to compute the length of each list/character column individually with `Rf_length()`, so we correctly compute the unproxied length of the rcrd column. I think this is a more appropriate fix vs a potential alternative of proxying each list element.

I don't really expect this to have any performance impact.