### PR TITLE
Simplify translation helpers to always convert to ASCII or UTF-8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # vctrs (development version)
 
+* Functions that make comparisons within a single vector, such as
+  `vec_unique()`, or between two vectors, such as `vec_match()`, now
+  convert all character input to UTF-8 before making comparisons (#1246).
+
 * New `df_detect_complete()` which returns a logical vector that detects
   if rows of `x` are complete, i.e. they have no missing values.
 

--- a/R/translate.R
+++ b/R/translate.R
@@ -1,3 +1,3 @@
-proxy_normalize_encoding <- function(x) {
-  .Call(vctrs_proxy_normalize_encoding, x)
+vec_normalize_encoding <- function(x) {
+  .Call(vctrs_normalize_encoding, x)
 }

--- a/R/translate.R
+++ b/R/translate.R
@@ -1,3 +1,3 @@
-vec_normalize_encoding <- function(x) {
-  .Call(vctrs_normalize_encoding, x)
+proxy_normalize_encoding <- function(x) {
+  .Call(vctrs_proxy_normalize_encoding, x)
 }

--- a/R/translate.R
+++ b/R/translate.R
@@ -1,7 +1,3 @@
-obj_maybe_translate_encoding <- function(x) {
-  .Call(vctrs_maybe_translate_encoding, x)
-}
-
-obj_maybe_translate_encoding2 <- function(x, y) {
-  .Call(vctrs_maybe_translate_encoding2, x, y)
+vec_normalize_encoding <- function(x) {
+  .Call(vctrs_normalize_encoding, x)
 }

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -372,7 +372,7 @@ SEXP vctrs_unique_loc(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
+  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -415,7 +415,7 @@ bool duplicated_any(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
+  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -443,7 +443,7 @@ SEXP vctrs_n_distinct(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
+  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -466,7 +466,7 @@ SEXP vctrs_id(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
+  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -535,14 +535,13 @@ SEXP vec_match_params(SEXP needles,
   PROTECT_N(haystack, &nprot);
 
   needles = PROTECT_N(vec_proxy_equal(needles), &nprot);
+  needles = PROTECT_N(proxy_normalize_encoding(needles), &nprot);
+
   haystack = PROTECT_N(vec_proxy_equal(haystack), &nprot);
+  haystack = PROTECT_N(proxy_normalize_encoding(haystack), &nprot);
 
   R_len_t n_haystack = vec_size(haystack);
   R_len_t n_needle = vec_size(needles);
-
-  SEXP translated = PROTECT_N(obj_maybe_translate_encoding2(needles, n_needle, haystack, n_haystack), &nprot);
-  needles = VECTOR_ELT(translated, 0);
-  haystack = VECTOR_ELT(translated, 1);
 
   struct dictionary* d = new_dictionary_params(haystack, false, na_equal);
   PROTECT_DICT(d, &nprot);
@@ -638,14 +637,13 @@ SEXP vctrs_in(SEXP needles, SEXP haystack, SEXP na_equal_,
   PROTECT_N(haystack, &nprot);
 
   needles = PROTECT_N(vec_proxy_equal(needles), &nprot);
+  needles = PROTECT_N(proxy_normalize_encoding(needles), &nprot);
+
   haystack = PROTECT_N(vec_proxy_equal(haystack), &nprot);
+  haystack = PROTECT_N(proxy_normalize_encoding(haystack), &nprot);
 
   R_len_t n_haystack = vec_size(haystack);
   R_len_t n_needle = vec_size(needles);
-
-  SEXP translated = PROTECT_N(obj_maybe_translate_encoding2(needles, n_needle, haystack, n_haystack), &nprot);
-  needles = VECTOR_ELT(translated, 0);
-  haystack = VECTOR_ELT(translated, 1);
 
   struct dictionary* d = new_dictionary_params(haystack, false, na_equal);
   PROTECT_DICT(d, &nprot);
@@ -687,7 +685,7 @@ SEXP vctrs_count(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
+  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -739,7 +737,7 @@ SEXP vctrs_duplicated(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
+  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -373,7 +373,7 @@ SEXP vctrs_unique_loc(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
+  x = PROTECT_N(vec_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -416,7 +416,7 @@ bool duplicated_any(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
+  x = PROTECT_N(vec_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -444,7 +444,7 @@ SEXP vctrs_n_distinct(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
+  x = PROTECT_N(vec_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -467,7 +467,7 @@ SEXP vctrs_id(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
+  x = PROTECT_N(vec_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -536,10 +536,10 @@ SEXP vec_match_params(SEXP needles,
   PROTECT_N(haystack, &nprot);
 
   needles = PROTECT_N(vec_proxy_equal(needles), &nprot);
-  needles = PROTECT_N(proxy_normalize_encoding(needles), &nprot);
+  needles = PROTECT_N(vec_normalize_encoding(needles), &nprot);
 
   haystack = PROTECT_N(vec_proxy_equal(haystack), &nprot);
-  haystack = PROTECT_N(proxy_normalize_encoding(haystack), &nprot);
+  haystack = PROTECT_N(vec_normalize_encoding(haystack), &nprot);
 
   R_len_t n_haystack = vec_size(haystack);
   R_len_t n_needle = vec_size(needles);
@@ -638,10 +638,10 @@ SEXP vctrs_in(SEXP needles, SEXP haystack, SEXP na_equal_,
   PROTECT_N(haystack, &nprot);
 
   needles = PROTECT_N(vec_proxy_equal(needles), &nprot);
-  needles = PROTECT_N(proxy_normalize_encoding(needles), &nprot);
+  needles = PROTECT_N(vec_normalize_encoding(needles), &nprot);
 
   haystack = PROTECT_N(vec_proxy_equal(haystack), &nprot);
-  haystack = PROTECT_N(proxy_normalize_encoding(haystack), &nprot);
+  haystack = PROTECT_N(vec_normalize_encoding(haystack), &nprot);
 
   R_len_t n_haystack = vec_size(haystack);
   R_len_t n_needle = vec_size(needles);
@@ -686,7 +686,7 @@ SEXP vctrs_count(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
+  x = PROTECT_N(vec_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -738,7 +738,7 @@ SEXP vctrs_duplicated(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
+  x = PROTECT_N(vec_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -1,5 +1,6 @@
 #include "vctrs.h"
 #include "dictionary.h"
+#include "translate.h"
 #include "equal.h"
 #include "hash.h"
 #include "ptype2.h"

--- a/src/group.c
+++ b/src/group.c
@@ -1,5 +1,6 @@
 #include "vctrs.h"
 #include "dictionary.h"
+#include "translate.h"
 #include "type-data-frame.h"
 #include "utils.h"
 

--- a/src/group.c
+++ b/src/group.c
@@ -10,7 +10,7 @@ SEXP vctrs_group_id(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
+  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -51,7 +51,7 @@ SEXP vctrs_group_rle(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(obj_maybe_translate_encoding(x, n), &nprot);
+  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -142,7 +142,7 @@ SEXP vec_group_loc(SEXP x) {
   R_len_t n = vec_size(x);
 
   SEXP proxy = PROTECT_N(vec_proxy_equal(x), &nprot);
-  proxy = PROTECT_N(obj_maybe_translate_encoding(proxy, n), &nprot);
+  proxy = PROTECT_N(proxy_normalize_encoding(proxy), &nprot);
 
   struct dictionary* d = new_dictionary(proxy);
   PROTECT_DICT(d, &nprot);

--- a/src/group.c
+++ b/src/group.c
@@ -11,7 +11,7 @@ SEXP vctrs_group_id(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
+  x = PROTECT_N(vec_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -52,7 +52,7 @@ SEXP vctrs_group_rle(SEXP x) {
   R_len_t n = vec_size(x);
 
   x = PROTECT_N(vec_proxy_equal(x), &nprot);
-  x = PROTECT_N(proxy_normalize_encoding(x), &nprot);
+  x = PROTECT_N(vec_normalize_encoding(x), &nprot);
 
   struct dictionary* d = new_dictionary(x);
   PROTECT_DICT(d, &nprot);
@@ -143,7 +143,7 @@ SEXP vec_group_loc(SEXP x) {
   R_len_t n = vec_size(x);
 
   SEXP proxy = PROTECT_N(vec_proxy_equal(x), &nprot);
-  proxy = PROTECT_N(proxy_normalize_encoding(proxy), &nprot);
+  proxy = PROTECT_N(vec_normalize_encoding(proxy), &nprot);
 
   struct dictionary* d = new_dictionary(proxy);
   PROTECT_DICT(d, &nprot);

--- a/src/init.c
+++ b/src/init.c
@@ -87,8 +87,6 @@ extern SEXP vctrs_df_size(SEXP);
 extern SEXP vctrs_as_df_col(SEXP, SEXP);
 extern SEXP vctrs_apply_name_spec(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_unset_s4(SEXP);
-extern SEXP vctrs_maybe_translate_encoding(SEXP);
-extern SEXP vctrs_maybe_translate_encoding2(SEXP, SEXP);
 extern SEXP vctrs_validate_name_repair_arg(SEXP);
 extern SEXP vctrs_validate_minimal_names(SEXP, SEXP);
 extern SEXP vctrs_as_names(SEXP, SEXP, SEXP, SEXP);
@@ -130,6 +128,7 @@ extern SEXP vctrs_detect_runs(SEXP, SEXP);
 extern SEXP vctrs_df_slice_complete(SEXP);
 extern SEXP vctrs_df_locate_complete(SEXP);
 extern SEXP vctrs_df_detect_complete(SEXP);
+extern SEXP vctrs_normalize_encoding(SEXP);
 
 
 // Maturing
@@ -233,8 +232,6 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_as_df_col",                  (DL_FUNC) &vctrs_as_df_col, 2},
   {"vctrs_apply_name_spec",            (DL_FUNC) &vctrs_apply_name_spec, 4},
   {"vctrs_unset_s4",                   (DL_FUNC) &vctrs_unset_s4, 1},
-  {"vctrs_maybe_translate_encoding",   (DL_FUNC) &vctrs_maybe_translate_encoding, 1},
-  {"vctrs_maybe_translate_encoding2",  (DL_FUNC) &vctrs_maybe_translate_encoding2, 2},
   {"vctrs_rle",                        (DL_FUNC) &altrep_rle_Make, 1},
   {"vctrs_validate_name_repair_arg",   (DL_FUNC) &vctrs_validate_name_repair_arg, 1},
   {"vctrs_validate_minimal_names",     (DL_FUNC) &vctrs_validate_minimal_names, 2},
@@ -277,6 +274,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_df_slice_complete",          (DL_FUNC) &vctrs_df_slice_complete, 1},
   {"vctrs_df_locate_complete",         (DL_FUNC) &vctrs_df_locate_complete, 1},
   {"vctrs_df_detect_complete",         (DL_FUNC) &vctrs_df_detect_complete, 1},
+  {"vctrs_normalize_encoding",         (DL_FUNC) &vctrs_normalize_encoding, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -128,7 +128,7 @@ extern SEXP vctrs_detect_runs(SEXP, SEXP);
 extern SEXP vctrs_df_slice_complete(SEXP);
 extern SEXP vctrs_df_locate_complete(SEXP);
 extern SEXP vctrs_df_detect_complete(SEXP);
-extern SEXP vctrs_proxy_normalize_encoding(SEXP);
+extern SEXP vctrs_normalize_encoding(SEXP);
 
 
 // Maturing
@@ -274,7 +274,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_df_slice_complete",          (DL_FUNC) &vctrs_df_slice_complete, 1},
   {"vctrs_df_locate_complete",         (DL_FUNC) &vctrs_df_locate_complete, 1},
   {"vctrs_df_detect_complete",         (DL_FUNC) &vctrs_df_detect_complete, 1},
-  {"vctrs_proxy_normalize_encoding",   (DL_FUNC) &vctrs_proxy_normalize_encoding, 1},
+  {"vctrs_normalize_encoding",         (DL_FUNC) &vctrs_normalize_encoding, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -128,7 +128,7 @@ extern SEXP vctrs_detect_runs(SEXP, SEXP);
 extern SEXP vctrs_df_slice_complete(SEXP);
 extern SEXP vctrs_df_locate_complete(SEXP);
 extern SEXP vctrs_df_detect_complete(SEXP);
-extern SEXP vctrs_normalize_encoding(SEXP);
+extern SEXP vctrs_proxy_normalize_encoding(SEXP);
 
 
 // Maturing
@@ -274,7 +274,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_df_slice_complete",          (DL_FUNC) &vctrs_df_slice_complete, 1},
   {"vctrs_df_locate_complete",         (DL_FUNC) &vctrs_df_locate_complete, 1},
   {"vctrs_df_detect_complete",         (DL_FUNC) &vctrs_df_detect_complete, 1},
-  {"vctrs_normalize_encoding",         (DL_FUNC) &vctrs_normalize_encoding, 1},
+  {"vctrs_proxy_normalize_encoding",   (DL_FUNC) &vctrs_proxy_normalize_encoding, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/runs.c
+++ b/src/runs.c
@@ -185,7 +185,7 @@ static
 SEXP vec_identify_runs(SEXP x) {
   SEXP proxy = PROTECT(vec_proxy_equal(x));
   R_len_t size = vec_size(proxy);
-  proxy = PROTECT(proxy_normalize_encoding(proxy));
+  proxy = PROTECT(vec_normalize_encoding(proxy));
 
   SEXP out = PROTECT(Rf_allocVector(INTSXP, size));
   int* p_out = INTEGER(out);

--- a/src/runs.c
+++ b/src/runs.c
@@ -1,6 +1,7 @@
 #include "vctrs.h"
 #include "utils.h"
 #include "equal.h"
+#include "translate.h"
 
 static SEXP vec_identify_runs(SEXP x);
 

--- a/src/runs.c
+++ b/src/runs.c
@@ -184,7 +184,7 @@ static
 SEXP vec_identify_runs(SEXP x) {
   SEXP proxy = PROTECT(vec_proxy_equal(x));
   R_len_t size = vec_size(proxy);
-  proxy = PROTECT(obj_maybe_translate_encoding(proxy, size));
+  proxy = PROTECT(proxy_normalize_encoding(proxy));
 
   SEXP out = PROTECT(Rf_allocVector(INTSXP, size));
   int* p_out = INTEGER(out);

--- a/src/translate.c
+++ b/src/translate.c
@@ -31,7 +31,7 @@ static SEXP list_normalize_encoding(SEXP x, r_ssize size, r_ssize start);
  * Vectors with "bytes" encodings are not supported, as they cannot be
  * converted to UTF-8 by `Rf_translateCharUTF8()`.
  *
- * [[ include("vctrs.h") ]]
+ * [[ include("translate.h") ]]
  */
 SEXP proxy_normalize_encoding(SEXP proxy) {
   switch (TYPEOF(proxy)) {

--- a/src/translate.c
+++ b/src/translate.c
@@ -13,16 +13,16 @@ static SEXP list_normalize_encoding(SEXP x, r_ssize size, r_ssize start);
  *
  * A CHARSXP is considered normalized if:
  * - It is the NA_STRING
- * - It is ASCII, with any encoding (UTF-8, Latin-1, native)
- * - It is UTF-8
+ * - It is ASCII, which means the encoding will be unmarked
+ * - It is marked as UTF-8
  *
- * ASCII strings are the same regardless of the underlying encoding. This
- * allows us to avoid a large amount of overhead with the most common case
- * of having a native/unknown encoding. As long as the string is ASCII, we
- * won't ever need to translate it, even if we don't know that it is UTF-8.
+ * ASCII strings will never get marked with an encoding when they go
+ * through `Rf_mkCharLenCE()`, but they will get marked as ASCII. Since
+ * UTF-8 is fully compatible with ASCII and ASCII is by far the most common
+ * case, we let ASCII strings through without translating them.
  *
- * This converts vectors that are completely Latin-1 (but also not just ASCII)
- * to UTF-8. In theory we could leave these as Latin-1, and comparing within
+ * This converts vectors that are completely marked as Latin-1 to UTF-8. In
+ * theory we could leave these as Latin-1, and comparing within
  * a single vector would be fine, since the encoding would be consistent.
  * However, this makes comparing between vectors difficult because we then
  * have to normalize the vectors relative to each other's encodings.

--- a/src/translate.c
+++ b/src/translate.c
@@ -11,6 +11,14 @@ static SEXP list_normalize_encoding(SEXP x, r_ssize size, r_ssize start);
 /*
  * Recursively normalize encodings of character vectors.
  *
+ * This can be called on any vector, but is generally called on a proxy vector.
+ *
+ * Note that attributes are currently not translated. This means that it is
+ * often important to call this function on the proxy, rather than the original
+ * vector. For example, a list-rcrd with a vectorized character attribute must
+ * be proxied to have the attribute promoted to a data frame column first before
+ * calling `vec_normalize_encoding()`.
+ *
  * A CHARSXP is considered normalized if:
  * - It is the NA_STRING
  * - It is ASCII, which means the encoding will be unmarked

--- a/src/translate.c
+++ b/src/translate.c
@@ -33,30 +33,30 @@ static SEXP list_normalize_encoding(SEXP x, r_ssize size, r_ssize start);
  *
  * [[ include("translate.h") ]]
  */
-SEXP proxy_normalize_encoding(SEXP proxy) {
-  switch (TYPEOF(proxy)) {
+SEXP vec_normalize_encoding(SEXP x) {
+  switch (TYPEOF(x)) {
   case STRSXP: {
-    r_ssize size = r_length(proxy);
-    r_ssize start = chr_find_normalize_start(proxy, size);
+    r_ssize size = r_length(x);
+    r_ssize start = chr_find_normalize_start(x, size);
 
     if (size == start) {
-      return proxy;
+      return x;
     } else {
-      return chr_normalize_encoding(proxy, size, start);
+      return chr_normalize_encoding(x, size, start);
     }
   }
   case VECSXP: {
-    r_ssize size = r_length(proxy);
-    r_ssize start = list_find_normalize_start(proxy, size);
+    r_ssize size = r_length(x);
+    r_ssize start = list_find_normalize_start(x, size);
 
     if (size == start) {
-      return proxy;
+      return x;
     } else {
-      return list_normalize_encoding(proxy, size, start);
+      return list_normalize_encoding(x, size, start);
     }
   }
   default: {
-    return proxy;
+    return x;
   }
   }
 }
@@ -183,6 +183,6 @@ static inline bool elt_all_normalized(SEXP x) {
 
 // For testing
 // [[ register() ]]
-SEXP vctrs_proxy_normalize_encoding(SEXP proxy) {
-  return proxy_normalize_encoding(proxy);
+SEXP vctrs_normalize_encoding(SEXP x) {
+  return vec_normalize_encoding(x);
 }

--- a/src/translate.c
+++ b/src/translate.c
@@ -1,359 +1,208 @@
 #include "vctrs.h"
-#include "ptype2.h"
-#include "utils.h"
 
 // -----------------------------------------------------------------------------
-// Helpers for determining if UTF-8 translation is required for character
-// vectors
 
-// UTF-8 translation will be successful in these cases:
-// - (utf8 + latin1), (unknown + utf8), (unknown + latin1)
-// UTF-8 translation will fail purposefully in these cases:
-// - (bytes + utf8), (bytes + latin1), (bytes + unknown)
-// UTF-8 translation is not attempted in these cases:
-// - (utf8 + utf8), (latin1 + latin1), (unknown + unknown), (bytes + bytes)
+static bool chr_all_normalized(SEXP x, r_ssize size);
+static bool list_all_normalized(SEXP x, r_ssize size);
 
-static bool chr_translation_required_impl(const SEXP* p_x, r_ssize size, cetype_t reference) {
-  for (r_ssize i = 0; i < size; ++i) {
-    if (Rf_getCharCE(p_x[i]) != reference) {
-      return true;
+static SEXP chr_normalize_encoding(SEXP x, r_ssize size);
+static SEXP list_normalize_encoding(SEXP x, r_ssize size);
+
+/*
+ * Recursively normalize encodings of character vectors.
+ *
+ * A CHARSXP is considered normalized if:
+ * - It is the NA_STRING
+ * - It is ASCII, with any encoding (UTF-8, Latin-1, native)
+ * - It is UTF-8
+ *
+ * ASCII strings are the same regardless of the underlying encoding. This
+ * allows us to avoid a large amount of overhead with the most common case
+ * of having a native/unknown encoding. As long as the string is ASCII, we
+ * won't ever need to translate it, even if we don't know that it is UTF-8.
+ *
+ * This converts vectors that are completely Latin-1 (but also not just ASCII)
+ * to UTF-8. In theory we could leave these as Latin-1, and comparing within
+ * a single vector would be fine, since the encoding would be consistent.
+ * However, this makes comparing between vectors difficult because we then
+ * have to normalize the vectors relative to each other's encodings.
+ * Consistently converting to UTF-8 avoids this issue altogether.
+ *
+ * Vectors with "bytes" encodings are not supported, as they cannot be
+ * converted to UTF-8 by `Rf_translateCharUTF8()`.
+ *
+ * [[ include("vctrs.h") ]]
+ */
+SEXP proxy_normalize_encoding(SEXP proxy) {
+  switch (TYPEOF(proxy)) {
+  case STRSXP: {
+    r_ssize size = r_length(proxy);
+
+    if (chr_all_normalized(proxy, size)) {
+      return proxy;
+    } else {
+      return chr_normalize_encoding(proxy, size);
     }
   }
+  case VECSXP: {
+    r_ssize size = r_length(proxy);
 
-  return false;
-}
-
-static bool chr_translation_required(SEXP x, r_ssize size) {
-  if (size == 0) {
-    return false;
+    if (list_all_normalized(proxy, size)) {
+      return proxy;
+    } else {
+      return list_normalize_encoding(proxy, size);
+    }
   }
-
-  const SEXP* p_x = STRING_PTR_RO(x);
-  cetype_t reference = Rf_getCharCE(*p_x);
-
-  return chr_translation_required_impl(p_x, size, reference);
-}
-
-// Check if `x` or `y` need to be translated to UTF-8, relative to each other
-static bool chr_translation_required2(SEXP x, r_ssize x_size, SEXP y, r_ssize y_size) {
-  const SEXP* p_x;
-  const SEXP* p_y;
-
-  bool x_empty = x_size == 0;
-  bool y_empty = y_size == 0;
-
-  if (x_empty && y_empty) {
-    return false;
+  default: {
+    return proxy;
   }
-
-  if (x_empty) {
-    p_y = STRING_PTR_RO(y);
-    return chr_translation_required_impl(p_y, y_size, Rf_getCharCE(*p_y));
   }
-
-  if (y_empty) {
-    p_x = STRING_PTR_RO(x);
-    return chr_translation_required_impl(p_x, x_size, Rf_getCharCE(*p_x));
-  }
-
-  p_x = STRING_PTR_RO(x);
-  cetype_t reference = Rf_getCharCE(*p_x);
-
-  if (chr_translation_required_impl(p_x, x_size, reference)) {
-    return true;
-  }
-
-  p_y = STRING_PTR_RO(y);
-
-  if (chr_translation_required_impl(p_y, y_size, reference)) {
-    return true;
-  }
-
-  return false;
 }
 
 // -----------------------------------------------------------------------------
-// Utilities to check if any character elements of a list have a
-// "known" encoding (UTF-8 or Latin1). This implies that we have to convert
-// all character elements to UTF-8.
-//
-// - Only `list_any_known_encoding()` is ever called directly.
-// - Data frame elements are treated as lists here, since they won't have been
-//   proxied when the list was proxied, meaning we can't safely pass the size
-//   to each column.
 
-static bool chr_any_known_encoding(SEXP x, r_ssize size);
-static bool list_any_known_encoding(SEXP x, r_ssize size);
+static inline SEXP char_normalize(SEXP x);
+static inline bool char_is_normalized(SEXP x);
 
-static bool elt_any_known_encoding(SEXP x) {
-  switch (TYPEOF(x)) {
-  case STRSXP: return chr_any_known_encoding(x, r_length(x));
-  case VECSXP: return list_any_known_encoding(x, r_length(x));
-  default: return false;
+static SEXP chr_normalize_encoding(SEXP x, r_ssize size) {
+  x = PROTECT(r_clone_referenced(x));
+  const SEXP* p_x = STRING_PTR_RO(x);
+
+  const void* vmax = vmaxget();
+
+  for (r_ssize i = 0; i < size; ++i) {
+    const SEXP elt = p_x[i];
+
+    if (char_is_normalized(elt)) {
+      continue;
+    }
+
+    SET_STRING_ELT(x, i, char_normalize(elt));
   }
+
+  vmaxset(vmax);
+  UNPROTECT(1);
+  return x;
 }
 
-static bool chr_any_known_encoding(SEXP x, r_ssize size) {
+static bool chr_all_normalized(SEXP x, r_ssize size) {
   const SEXP* p_x = STRING_PTR_RO(x);
 
   for (r_ssize i = 0; i < size; ++i) {
     const SEXP elt = p_x[i];
 
-    if (Rf_getCharCE(elt) != CE_NATIVE) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-static bool list_any_known_encoding(SEXP x, r_ssize size) {
-  for (r_ssize i = 0; i < size; ++i) {
-    SEXP elt = VECTOR_ELT(x, i);
-
-    if (elt_any_known_encoding(elt)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-// -----------------------------------------------------------------------------
-// Utilities to translate all character vector elements of a list to UTF-8.
-//
-// - This does not check if a translation is required.
-// - Only `list_translate_encoding()` or `chr_translate_encoding()` are
-//   called directly.
-// - Data frame elements of lists are treated as lists here, since they won't
-//   have been proxied when the list was proxied, meaning we can't safely pass
-//   the size to each column.
-
-static SEXP chr_translate_encoding(SEXP x, r_ssize size);
-static SEXP list_translate_encoding(SEXP x, r_ssize size);
-
-static SEXP elt_translate_encoding(SEXP x) {
-  switch (TYPEOF(x)) {
-  case STRSXP: return chr_translate_encoding(x, r_length(x));
-  case VECSXP: return list_translate_encoding(x, r_length(x));
-  default: return x;
-  }
-}
-
-static SEXP chr_translate_encoding(SEXP x, r_ssize size) {
-  const SEXP* p_x = STRING_PTR_RO(x);
-
-  SEXP out = PROTECT(r_clone_referenced(x));
-
-  const void *vmax = vmaxget();
-
-  for (r_ssize i = 0; i < size; ++i) {
-    SEXP elt = p_x[i];
-
-    if (Rf_getCharCE(elt) == CE_UTF8) {
+    if (char_is_normalized(elt)) {
       continue;
     }
 
-    SET_STRING_ELT(out, i, Rf_mkCharCE(Rf_translateCharUTF8(elt), CE_UTF8));
+    return false;
   }
 
-  vmaxset(vmax);
-  UNPROTECT(1);
-  return out;
+  return true;
 }
 
-static SEXP list_translate_encoding(SEXP x, r_ssize size) {
+// -----------------------------------------------------------------------------
+
+static SEXP list_normalize_encoding(SEXP x, r_ssize size) {
   x = PROTECT(r_clone_referenced(x));
+  const SEXP* p_x = VECTOR_PTR_RO(x);
 
   for (r_ssize i = 0; i < size; ++i) {
-    SEXP elt = VECTOR_ELT(x, i);
-    elt = elt_translate_encoding(elt);
-    SET_VECTOR_ELT(x, i, elt);
+    const SEXP elt = p_x[i];
+
+    switch (TYPEOF(elt)) {
+    case STRSXP: {
+      r_ssize size = r_length(elt);
+
+      if (chr_all_normalized(elt, size)) {
+        break;
+      }
+
+      SET_VECTOR_ELT(x, i, chr_normalize_encoding(elt, size));
+      break;
+    }
+    case VECSXP: {
+      r_ssize size = r_length(elt);
+
+      if (list_all_normalized(elt, size)) {
+        break;
+      }
+
+      SET_VECTOR_ELT(x, i, list_normalize_encoding(elt, size));
+      break;
+    }
+    default:
+      continue;
+    }
   }
 
   UNPROTECT(1);
   return x;
 }
 
-// -----------------------------------------------------------------------------
-// Utilities for translating encodings within one vector, if required.
+static inline bool elt_all_normalized(SEXP x);
 
-// - If `x` is a character vector requiring translation, translate it.
-// - If `x` is a list where any element has a "known" encoding, force a
-//   translation of every element in the list.
-// - If `x` is a data frame, translate the columns one by one, independently.
+static bool list_all_normalized(SEXP x, r_ssize size) {
+  const SEXP* p_x = VECTOR_PTR_RO(x);
 
-// Notes:
-// - Assumes that `x` has been proxied recursively.
+  for (r_ssize i = 0; i < size; ++i) {
+    const SEXP elt = p_x[i];
 
-static SEXP chr_maybe_translate_encoding(SEXP x, r_ssize size);
-static SEXP list_maybe_translate_encoding(SEXP x, r_ssize size);
-static SEXP df_maybe_translate_encoding(SEXP x, r_ssize size);
-
-// [[ include("vctrs.h") ]]
-SEXP obj_maybe_translate_encoding(SEXP x, r_ssize size) {
-  switch (TYPEOF(x)) {
-  case STRSXP: {
-    return chr_maybe_translate_encoding(x, size);
-  }
-  case VECSXP: {
-    if (is_data_frame(x)) {
-      return df_maybe_translate_encoding(x, size);
-    } else {
-      return list_maybe_translate_encoding(x, size);
+    if (elt_all_normalized(elt)) {
+      continue;
     }
-  }
-  default: {
-    return x;
-  }
-  }
-}
 
-static SEXP chr_maybe_translate_encoding(SEXP x, r_ssize size) {
-  return chr_translation_required(x, size) ? chr_translate_encoding(x, size) : x;
-}
-
-static SEXP list_maybe_translate_encoding(SEXP x, r_ssize size) {
-  return list_any_known_encoding(x, size) ? list_translate_encoding(x, size) : x;
-}
-
-static SEXP df_maybe_translate_encoding(SEXP x, r_ssize size) {
-  r_ssize n_col = r_length(x);
-
-  x = PROTECT(r_clone_referenced(x));
-
-  for (r_ssize i = 0; i < n_col; ++i) {
-    SEXP elt = VECTOR_ELT(x, i);
-    SET_VECTOR_ELT(x, i, obj_maybe_translate_encoding(elt, size));
+    return false;
   }
 
-  UNPROTECT(1);
-  return x;
+  return true;
 }
 
-// -----------------------------------------------------------------------------
-// Utilities for translating encodings of `x` and `y` relative to each other,
-// if required.
-
-static SEXP translate_none(SEXP x, SEXP y);
-static SEXP chr_maybe_translate_encoding2(SEXP x, r_ssize x_size, SEXP y, r_ssize y_size);
-static SEXP list_maybe_translate_encoding2(SEXP x, r_ssize x_size, SEXP y, r_ssize y_size);
-static SEXP df_maybe_translate_encoding2(SEXP x, r_ssize x_size, SEXP y, r_ssize y_size);
-
-// Notes:
-// - Assumes that `x` and `y` are the same type from calling `vec_cast()`.
-// - Assumes that `x` and `y` have been recursively proxied.
-// - Does not assume that `x` and `y` are the same size.
-// - Returns a list holding `x` and `y` translated to their common encoding.
-
-// [[ include("vctrs.h") ]]
-SEXP obj_maybe_translate_encoding2(SEXP x, r_ssize x_size, SEXP y, r_ssize y_size) {
+static inline bool elt_all_normalized(SEXP x) {
   switch (TYPEOF(x)) {
-  case STRSXP: {
-    return chr_maybe_translate_encoding2(x, x_size, y, y_size);
+  case STRSXP: return chr_all_normalized(x, r_length(x));
+  case VECSXP: return list_all_normalized(x, r_length(x));
+  default: return true;
   }
-  case VECSXP: {
-    if (is_data_frame(x)) {
-      return df_maybe_translate_encoding2(x, x_size, y, y_size);
-    } else {
-      return list_maybe_translate_encoding2(x, x_size, y, y_size);
-    }
-  }
-  default: {
-    return translate_none(x, y);
-  }
-  }
-}
-
-static SEXP translate_none(SEXP x, SEXP y) {
-  SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
-
-  SET_VECTOR_ELT(out, 0, x);
-  SET_VECTOR_ELT(out, 1, y);
-
-  UNPROTECT(1);
-  return out;
-}
-
-static SEXP chr_maybe_translate_encoding2(SEXP x, r_ssize x_size, SEXP y, r_ssize y_size) {
-  SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
-
-  if (chr_translation_required2(x, x_size, y, y_size)) {
-    SET_VECTOR_ELT(out, 0, chr_translate_encoding(x, x_size));
-    SET_VECTOR_ELT(out, 1, chr_translate_encoding(y, y_size));
-  } else {
-    SET_VECTOR_ELT(out, 0, x);
-    SET_VECTOR_ELT(out, 1, y);
-  }
-
-  UNPROTECT(1);
-  return out;
-}
-
-static SEXP list_maybe_translate_encoding2(SEXP x, r_ssize x_size, SEXP y, r_ssize y_size) {
-  SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
-
-  if (list_any_known_encoding(x, x_size) || list_any_known_encoding(y, y_size)) {
-    SET_VECTOR_ELT(out, 0, list_translate_encoding(x, x_size));
-    SET_VECTOR_ELT(out, 1, list_translate_encoding(y, y_size));
-  } else {
-    SET_VECTOR_ELT(out, 0, x);
-    SET_VECTOR_ELT(out, 1, y);
-  }
-
-  UNPROTECT(1);
-  return out;
-}
-
-static SEXP df_maybe_translate_encoding2(SEXP x, r_ssize x_size, SEXP y, r_ssize y_size) {
-  r_ssize n_col = r_length(x);
-
-  x = PROTECT(r_clone_referenced(x));
-  y = PROTECT(r_clone_referenced(y));
-
-  SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
-
-  for (r_ssize i = 0; i < n_col; ++i) {
-    SEXP x_elt = VECTOR_ELT(x, i);
-    SEXP y_elt = VECTOR_ELT(y, i);
-
-    SEXP translated = PROTECT(obj_maybe_translate_encoding2(x_elt, x_size, y_elt, y_size));
-
-    SET_VECTOR_ELT(x, i, VECTOR_ELT(translated, 0));
-    SET_VECTOR_ELT(y, i, VECTOR_ELT(translated, 1));
-
-    UNPROTECT(1);
-  }
-
-  SET_VECTOR_ELT(out, 0, x);
-  SET_VECTOR_ELT(out, 1, y);
-
-  UNPROTECT(3);
-  return out;
 }
 
 // -----------------------------------------------------------------------------
 
-// [[ register() ]]
-SEXP vctrs_maybe_translate_encoding(SEXP x) {
-  SEXP out = PROTECT(obj_maybe_translate_encoding(x, vec_size(x)));
+static inline bool char_is_ascii_or_utf8(SEXP x);
 
+
+static inline SEXP char_normalize(SEXP x) {
+  return Rf_mkCharCE(Rf_translateCharUTF8(x), CE_UTF8);
+}
+static inline bool char_is_normalized(SEXP x) {
+  return char_is_ascii_or_utf8(x) || (x == NA_STRING);
+}
+
+
+static inline bool levels_is_ascii(int levels);
+static inline bool levels_is_utf8(int levels);
+
+// The first 128 values are ASCII, and are the same regardless of the encoding.
+// Otherwise we enforce UTF-8.
+static inline bool char_is_ascii_or_utf8(SEXP x) {
+  const int levels = LEVELS(x);
+  return levels_is_ascii(levels) || levels_is_utf8(levels);
+}
+
+static inline bool levels_is_ascii(int levels) {
+  return levels & 8;
+}
+static inline bool levels_is_utf8(int levels) {
+  return levels & 64;
+}
+
+// -----------------------------------------------------------------------------
+
+// For testing
+// [[ register() ]]
+SEXP vctrs_normalize_encoding(SEXP x) {
+  SEXP proxy = PROTECT(vec_proxy_equal(x));
+  SEXP out = proxy_normalize_encoding(proxy);
   UNPROTECT(1);
   return out;
 }
-
-// [[ register() ]]
-SEXP vctrs_maybe_translate_encoding2(SEXP x, SEXP y) {
-  int _;
-
-  SEXP type = PROTECT(vec_ptype2(x, y, args_empty, args_empty, &_));
-
-  x = PROTECT(vec_cast(x, type, args_empty, args_empty));
-  y = PROTECT(vec_cast(y, type, args_empty, args_empty));
-
-  SEXP out = obj_maybe_translate_encoding2(x, vec_size(x), y, vec_size(y));
-
-  UNPROTECT(3);
-  return out;
-}
-

--- a/src/translate.c
+++ b/src/translate.c
@@ -1,4 +1,4 @@
-#include "vctrs.h"
+#include "translate.h"
 
 // -----------------------------------------------------------------------------
 
@@ -63,9 +63,6 @@ SEXP proxy_normalize_encoding(SEXP proxy) {
 
 // -----------------------------------------------------------------------------
 
-static inline SEXP char_normalize(SEXP x);
-static inline bool char_is_normalized(SEXP x);
-
 static SEXP chr_normalize_encoding(SEXP x, r_ssize size, r_ssize start) {
   x = PROTECT(r_clone_referenced(x));
   const SEXP* p_x = STRING_PTR_RO(x);
@@ -75,11 +72,11 @@ static SEXP chr_normalize_encoding(SEXP x, r_ssize size, r_ssize start) {
   for (r_ssize i = start; i < size; ++i) {
     const SEXP elt = p_x[i];
 
-    if (char_is_normalized(elt)) {
+    if (string_is_normalized(elt)) {
       continue;
     }
 
-    SET_STRING_ELT(x, i, char_normalize(elt));
+    SET_STRING_ELT(x, i, string_normalize(elt));
   }
 
   vmaxset(vmax);
@@ -93,7 +90,7 @@ static r_ssize chr_find_normalize_start(SEXP x, r_ssize size) {
   for (r_ssize i = 0; i < size; ++i) {
     const SEXP elt = p_x[i];
 
-    if (char_is_normalized(elt)) {
+    if (string_is_normalized(elt)) {
       continue;
     }
 
@@ -180,36 +177,6 @@ static inline bool elt_all_normalized(SEXP x) {
     return true;
   }
   }
-}
-
-// -----------------------------------------------------------------------------
-
-static inline bool char_is_ascii_or_utf8(SEXP x);
-
-
-static inline SEXP char_normalize(SEXP x) {
-  return Rf_mkCharCE(Rf_translateCharUTF8(x), CE_UTF8);
-}
-static inline bool char_is_normalized(SEXP x) {
-  return char_is_ascii_or_utf8(x) || (x == NA_STRING);
-}
-
-
-static inline bool levels_is_ascii(int levels);
-static inline bool levels_is_utf8(int levels);
-
-// The first 128 values are ASCII, and are the same regardless of the encoding.
-// Otherwise we enforce UTF-8.
-static inline bool char_is_ascii_or_utf8(SEXP x) {
-  const int levels = LEVELS(x);
-  return levels_is_ascii(levels) || levels_is_utf8(levels);
-}
-
-static inline bool levels_is_ascii(int levels) {
-  return levels & 8;
-}
-static inline bool levels_is_utf8(int levels) {
-  return levels & 64;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/translate.c
+++ b/src/translate.c
@@ -216,9 +216,6 @@ static inline bool levels_is_utf8(int levels) {
 
 // For testing
 // [[ register() ]]
-SEXP vctrs_normalize_encoding(SEXP x) {
-  SEXP proxy = PROTECT(vec_proxy_equal(x));
-  SEXP out = proxy_normalize_encoding(proxy);
-  UNPROTECT(1);
-  return out;
+SEXP vctrs_proxy_normalize_encoding(SEXP proxy) {
+  return proxy_normalize_encoding(proxy);
 }

--- a/src/translate.h
+++ b/src/translate.h
@@ -1,0 +1,36 @@
+#ifndef VCTRS_TRANSLATE_H
+#define VCTRS_TRANSLATE_H
+
+#include "vctrs.h"
+
+// -----------------------------------------------------------------------------
+// Proxy vector translation
+
+SEXP proxy_normalize_encoding(SEXP proxy);
+
+// -----------------------------------------------------------------------------
+// Low-level string translation
+
+#define MASK_ASCII 8
+#define MASK_UTF8 64
+
+// The first 128 values are ASCII, and are the same regardless of the encoding.
+// Otherwise we enforce UTF-8.
+static inline bool string_is_ascii_or_utf8(SEXP x) {
+  const int levels = LEVELS(x);
+  return (levels & MASK_ASCII) || (levels & MASK_UTF8);
+}
+
+#undef MASK_ASCII
+#undef MASK_UTF8
+
+static inline SEXP string_normalize(SEXP x) {
+  return Rf_mkCharCE(Rf_translateCharUTF8(x), CE_UTF8);
+}
+
+static inline bool string_is_normalized(SEXP x) {
+  return string_is_ascii_or_utf8(x) || (x == NA_STRING);
+}
+
+// -----------------------------------------------------------------------------
+#endif

--- a/src/translate.h
+++ b/src/translate.h
@@ -4,9 +4,9 @@
 #include "vctrs.h"
 
 // -----------------------------------------------------------------------------
-// Proxy vector translation
+// Vector translation
 
-SEXP proxy_normalize_encoding(SEXP proxy);
+SEXP vec_normalize_encoding(SEXP x);
 
 // -----------------------------------------------------------------------------
 // Low-level string translation

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -586,8 +586,7 @@ SEXP datetime_datetime_ptype2(SEXP x, SEXP y);
 
 // Character translation ---------------------------------------------
 
-SEXP obj_maybe_translate_encoding(SEXP x, r_ssize size);
-SEXP obj_maybe_translate_encoding2(SEXP x, r_ssize x_size, SEXP y, r_ssize y_size);
+SEXP proxy_normalize_encoding(SEXP x);
 
 // Growable vector ----------------------------------------------
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -584,10 +584,6 @@ SEXP vec_posixlt_restore(SEXP x, SEXP to, const enum vctrs_owned owned);
 SEXP date_datetime_ptype2(SEXP x, SEXP y);
 SEXP datetime_datetime_ptype2(SEXP x, SEXP y);
 
-// Character translation ---------------------------------------------
-
-SEXP proxy_normalize_encoding(SEXP x);
-
 // Growable vector ----------------------------------------------
 
 struct growable {

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -1,35 +1,40 @@
-
 # ------------------------------------------------------------------------------
-# obj_maybe_translate_encoding()
+# vec_normalize_encoding()
 
 test_that("can translate a character vector of various encodings (#553)", {
   x <- unlist(encodings(), use.names = FALSE)
 
-  results <- obj_maybe_translate_encoding(x)
+  results <- vec_normalize_encoding(x)
 
   expect_equal_encoding(results, encodings()$utf8)
 })
 
-test_that("does not perform translation when encodings are all the same", {
-  encs <- encodings(bytes = TRUE)
+test_that("translates all encodings to UTF-8", {
+  encs <- encodings()
 
   for (enc in encs) {
-    x <- c(enc, enc)
-    expect_equal_encoding(obj_maybe_translate_encoding(x), x)
+    expect_equal_encoding(vec_normalize_encoding(enc), encodings()$utf8)
   }
 })
 
 test_that("can translate a list containing character vectors with different encodings", {
-  results <- obj_maybe_translate_encoding(encodings())
+  results <- vec_normalize_encoding(encodings())
   results <- unlist(results)
 
   expect_equal_encoding(results, encodings()$utf8)
 })
 
+test_that("translation fails purposefully with any bytes", {
+  expect_error(
+    vec_normalize_encoding(encoding_bytes()),
+    "translating strings with \"bytes\" encoding"
+  )
+})
+
 test_that("translation fails purposefully when mixing with bytes with other encodings", {
   for (enc in encodings()) {
     x <- c(encoding_bytes(), enc)
-    expect_error(obj_maybe_translate_encoding(x), "translating strings with \"bytes\" encoding")
+    expect_error(vec_normalize_encoding(x), "translating strings with \"bytes\" encoding")
   }
 })
 
@@ -39,19 +44,19 @@ test_that("attributes are kept on translation (#599)", {
   x <- c(encs$utf8, encs$latin1)
   x <- structure(x, names = c("a", "b"), extra = 1)
 
-  expect_equal(attributes(obj_maybe_translate_encoding(x)), attributes(x))
+  expect_equal(attributes(vec_normalize_encoding(x)), attributes(x))
 })
 
 test_that("translation is robust against scalar types contained in lists (#633)", {
   x <- list(a = z ~ y, b = z ~ z)
-  expect_equal(obj_maybe_translate_encoding(x), x)
+  expect_equal(vec_normalize_encoding(x), x)
 })
 
 test_that("translation can still occur even if a scalar type is in a list", {
   encs <- encodings()
   x <- list(a = z ~ y, b = encs$latin1)
 
-  result <- obj_maybe_translate_encoding(x)
+  result <- vec_normalize_encoding(x)
 
   expect_equal_encoding(result$b, encs$utf8)
 })
@@ -62,165 +67,9 @@ test_that("translation occurs inside scalars contained in a list", {
   scalar <- structure(list(x = encs$latin1), class = "scalar_list")
   lst <- list(scalar)
 
-  result <- obj_maybe_translate_encoding(lst)
+  result <- vec_normalize_encoding(lst)
 
   expect_equal_encoding(result[[1]]$x, encs$utf8)
-})
-
-# ------------------------------------------------------------------------------
-# obj_maybe_translate_encoding2()
-
-test_that("can find a common encoding between various encoding combinations", {
-  encs <- encodings()
-
-  for (x_enc in encs) {
-    for (y_enc in encs) {
-      together <- obj_maybe_translate_encoding(c(x_enc, y_enc))
-
-      separate <- obj_maybe_translate_encoding2(x_enc, y_enc)
-      separate <- unlist(separate)
-
-      expect_equal_encoding(separate, together)
-    }
-  }
-})
-
-test_that("can ignore strings containing only bytes", {
-  bytes <- encoding_bytes()
-
-  result <- obj_maybe_translate_encoding2(bytes, bytes)
-  result <- unlist(result)
-
-  expect_equal_encoding(result, bytes)
-})
-
-test_that("cannot find a common encoding when mixing bytes with other encodings", {
-  encs <- encodings()
-  bytes <- encoding_bytes()
-
-  for (enc in encs) {
-    expect_error(obj_maybe_translate_encoding2(enc, bytes), "translating strings with \"bytes\" encoding")
-  }
-})
-
-test_that("can find a common encoding when one string has multiple encodings", {
-  encs <- encodings()
-
-  utf8_unknown <- c(encs$utf8, encs$unknown)
-
-  together <- obj_maybe_translate_encoding(c(utf8_unknown, encs$latin1))
-
-  separate <- obj_maybe_translate_encoding2(utf8_unknown, encs$latin1)
-  separate <- unlist(separate)
-
-  expect_equal_encoding(separate, together)
-})
-
-test_that("can find a common encoding between lists of characters with different encodings", {
-  encs <- encodings()
-
-
-  lst_utf8 <- list(encs$utf8)
-  lst_ascii_latin1 <- list("ascii", encs$latin1)
-
-  together <- obj_maybe_translate_encoding(c(lst_utf8, lst_ascii_latin1))
-  together <- unlist(together)
-
-  separate <- obj_maybe_translate_encoding2(lst_utf8, lst_ascii_latin1)
-  separate <- unlist(separate)
-
-  expect_equal_encoding(separate, together)
-
-
-  lst_of_lst_utf8 <- list(lst_utf8)
-  lst_of_lst_ascii_latin1 <- list(list("ascii"), list(encs$latin1))
-
-  together <- obj_maybe_translate_encoding(c(lst_of_lst_utf8, lst_of_lst_ascii_latin1))
-  together <- unlist(together)
-
-  separate <- obj_maybe_translate_encoding2(lst_of_lst_utf8, lst_of_lst_ascii_latin1)
-  separate <- unlist(separate)
-
-  expect_equal_encoding(separate, together)
-})
-
-test_that("can find a common encoding with data frames with character columns", {
-  encs <- encodings()
-
-  df_utf8 <- data_frame(x = encs$utf8)
-  df_unknown <- data_frame(x = encs$unknown)
-
-  results <- obj_maybe_translate_encoding2(df_utf8, df_unknown)
-
-  expect_equal_encoding(results[[1L]]$x, df_utf8$x)
-  expect_equal_encoding(results[[2L]]$x, df_utf8$x)
-})
-
-test_that("can find a common encoding with data frame subclasses with character columns", {
-  encs <- encodings()
-
-  df_utf8 <- new_data_frame(list(x = encs$utf8), class = "subclass")
-  df_unknown <- new_data_frame(list(x = encs$unknown), class = "subclass")
-
-  results <- obj_maybe_translate_encoding2(df_utf8, df_unknown)
-
-  expect_equal_encoding(results[[1L]]$x, df_utf8$x)
-  expect_equal_encoding(results[[2L]]$x, df_utf8$x)
-})
-
-test_that("only columns requiring translation are affected", {
-  encs <- encodings()
-
-  df_utf8_latin1 <- data_frame(x = encs$utf8, y = encs$latin1)
-  df_unknown_latin1 <- data_frame(x = encs$unknown, y = encs$latin1)
-
-  results <- obj_maybe_translate_encoding2(df_utf8_latin1, df_unknown_latin1)
-
-  expect_equal_encoding(results[[1L]]$y, df_utf8_latin1$y)
-  expect_equal_encoding(results[[2L]]$y, df_unknown_latin1$y)
-})
-
-test_that("can find a common encoding with lists of data frames with string columns", {
-  encs <- encodings()
-
-  df_utf8 <- data_frame(x = encs$utf8)
-  df_unknown_1 <- data_frame(x = encs$unknown)
-  df_unknown_2 <- data_frame(x = encs$unknown)
-
-  lst_of_df_utf8 <- list(df_utf8)
-  lst_of_df_unknown <- list(df_unknown_1, df_unknown_2)
-
-  results <- obj_maybe_translate_encoding2(lst_of_df_utf8, lst_of_df_unknown)
-  result1 <- results[[1L]]
-  result2 <- results[[2L]]
-
-  expect_equal_encoding(result1[[1]]$x, df_utf8$x)
-  expect_equal_encoding(result2[[1]]$x, df_utf8$x)
-  expect_equal_encoding(result2[[2]]$x, df_utf8$x)
-})
-
-test_that("all elements are affected when any translation is required in a list", {
-  encs <- encodings()
-
-  lst_of_utf8 <- list(encs$utf8)
-
-  # Both elements of the list are recursively translated
-  df_latin1 <- data_frame(x = encs$latin1)
-  lst_of_unknown_df_latin1 <- list(encs$unknown, df_latin1)
-
-  results <- obj_maybe_translate_encoding2(lst_of_utf8, lst_of_unknown_df_latin1)
-  result1 <- results[[1L]]
-  result2 <- results[[2L]]
-
-  expect_equal_encoding(result1[[1]], encs$utf8)
-  expect_equal_encoding(result2[[1]], encs$utf8)
-  expect_equal_encoding(result2[[2]]$x, encs$utf8)
-})
-
-test_that("translation is robust against scalar types contained in lists (#633)", {
-  x <- list(a = z ~ y, b = z ~ z)
-  y <- list(a = c ~ d, b = e ~ f)
-  expect_equal(obj_maybe_translate_encoding2(x, y), list(x, y))
 })
 
 test_that("translation treats data frames elements of lists as lists (#1233)", {
@@ -234,9 +83,7 @@ test_that("translation treats data frames elements of lists as lists (#1233)", {
 
   # Recursive proxy won't proxy list elements,
   # so the rcrd column in the data frame won't get proxied
-  x <- vec_proxy_equal(x)
-
-  result <- obj_maybe_translate_encoding(x)
+  result <- vec_normalize_encoding(x)
 
   expect_identical(result, x)
 

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -94,3 +94,25 @@ test_that("translation treats data frames elements of lists as lists (#1233)", {
 
   expect_equal_encoding(result_field, expect_field)
 })
+
+# FIXME: Should we translate attributes to fix this? Can it be done efficiently?
+test_that("attributes are currently not translated", {
+  utf8 <- encodings()$utf8
+  latin1 <- encodings()$latin1
+
+  a <- structure(1, enc = utf8)
+  b <- structure(1, enc = latin1)
+  x <- list(a, b)
+
+  result <- vec_normalize_encoding(x)
+
+  a_enc <- attr(result[[1]], "enc")
+  b_enc <- attr(result[[2]], "enc")
+
+  # Ideally both would be utf8
+  expect_equal_encoding(a_enc, utf8)
+  expect_equal_encoding(b_enc, latin1)
+
+  # Ideally the list elements are considered duplicates
+  expect_identical(vec_unique(x), x)
+})

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -1,10 +1,10 @@
 # ------------------------------------------------------------------------------
-# vec_normalize_encoding()
+# proxy_normalize_encoding()
 
 test_that("can translate a character vector of various encodings (#553)", {
   x <- unlist(encodings(), use.names = FALSE)
 
-  results <- vec_normalize_encoding(x)
+  results <- proxy_normalize_encoding(x)
 
   expect_equal_encoding(results, encodings()$utf8)
 })
@@ -13,12 +13,12 @@ test_that("translates all encodings to UTF-8", {
   encs <- encodings()
 
   for (enc in encs) {
-    expect_equal_encoding(vec_normalize_encoding(enc), encodings()$utf8)
+    expect_equal_encoding(proxy_normalize_encoding(enc), encodings()$utf8)
   }
 })
 
 test_that("can translate a list containing character vectors with different encodings", {
-  results <- vec_normalize_encoding(encodings())
+  results <- proxy_normalize_encoding(encodings())
   results <- unlist(results)
 
   expect_equal_encoding(results, encodings()$utf8)
@@ -26,7 +26,7 @@ test_that("can translate a list containing character vectors with different enco
 
 test_that("translation fails purposefully with any bytes", {
   expect_error(
-    vec_normalize_encoding(encoding_bytes()),
+    proxy_normalize_encoding(encoding_bytes()),
     "translating strings with \"bytes\" encoding"
   )
 })
@@ -34,7 +34,7 @@ test_that("translation fails purposefully with any bytes", {
 test_that("translation fails purposefully when mixing with bytes with other encodings", {
   for (enc in encodings()) {
     x <- c(encoding_bytes(), enc)
-    expect_error(vec_normalize_encoding(x), "translating strings with \"bytes\" encoding")
+    expect_error(proxy_normalize_encoding(x), "translating strings with \"bytes\" encoding")
   }
 })
 
@@ -44,19 +44,19 @@ test_that("attributes are kept on translation (#599)", {
   x <- c(encs$utf8, encs$latin1)
   x <- structure(x, names = c("a", "b"), extra = 1)
 
-  expect_equal(attributes(vec_normalize_encoding(x)), attributes(x))
+  expect_equal(attributes(proxy_normalize_encoding(x)), attributes(x))
 })
 
 test_that("translation is robust against scalar types contained in lists (#633)", {
   x <- list(a = z ~ y, b = z ~ z)
-  expect_equal(vec_normalize_encoding(x), x)
+  expect_equal(proxy_normalize_encoding(x), x)
 })
 
 test_that("translation can still occur even if a scalar type is in a list", {
   encs <- encodings()
   x <- list(a = z ~ y, b = encs$latin1)
 
-  result <- vec_normalize_encoding(x)
+  result <- proxy_normalize_encoding(x)
 
   expect_equal_encoding(result$b, encs$utf8)
 })
@@ -67,7 +67,7 @@ test_that("translation occurs inside scalars contained in a list", {
   scalar <- structure(list(x = encs$latin1), class = "scalar_list")
   lst <- list(scalar)
 
-  result <- vec_normalize_encoding(lst)
+  result <- proxy_normalize_encoding(lst)
 
   expect_equal_encoding(result[[1]]$x, encs$utf8)
 })
@@ -83,7 +83,9 @@ test_that("translation treats data frames elements of lists as lists (#1233)", {
 
   # Recursive proxy won't proxy list elements,
   # so the rcrd column in the data frame won't get proxied
-  result <- vec_normalize_encoding(x)
+  proxy <- vec_proxy_equal(x)
+
+  result <- proxy_normalize_encoding(proxy)
 
   expect_identical(result, x)
 

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -1,10 +1,10 @@
 # ------------------------------------------------------------------------------
-# proxy_normalize_encoding()
+# vec_normalize_encoding()
 
 test_that("can translate a character vector of various encodings (#553)", {
   x <- unlist(encodings(), use.names = FALSE)
 
-  results <- proxy_normalize_encoding(x)
+  results <- vec_normalize_encoding(x)
 
   expect_equal_encoding(results, encodings()$utf8)
 })
@@ -13,12 +13,12 @@ test_that("translates all encodings to UTF-8", {
   encs <- encodings()
 
   for (enc in encs) {
-    expect_equal_encoding(proxy_normalize_encoding(enc), encodings()$utf8)
+    expect_equal_encoding(vec_normalize_encoding(enc), encodings()$utf8)
   }
 })
 
 test_that("can translate a list containing character vectors with different encodings", {
-  results <- proxy_normalize_encoding(encodings())
+  results <- vec_normalize_encoding(encodings())
   results <- unlist(results)
 
   expect_equal_encoding(results, encodings()$utf8)
@@ -26,7 +26,7 @@ test_that("can translate a list containing character vectors with different enco
 
 test_that("translation fails purposefully with any bytes", {
   expect_error(
-    proxy_normalize_encoding(encoding_bytes()),
+    vec_normalize_encoding(encoding_bytes()),
     "translating strings with \"bytes\" encoding"
   )
 })
@@ -34,7 +34,7 @@ test_that("translation fails purposefully with any bytes", {
 test_that("translation fails purposefully when mixing with bytes with other encodings", {
   for (enc in encodings()) {
     x <- c(encoding_bytes(), enc)
-    expect_error(proxy_normalize_encoding(x), "translating strings with \"bytes\" encoding")
+    expect_error(vec_normalize_encoding(x), "translating strings with \"bytes\" encoding")
   }
 })
 
@@ -44,19 +44,19 @@ test_that("attributes are kept on translation (#599)", {
   x <- c(encs$utf8, encs$latin1)
   x <- structure(x, names = c("a", "b"), extra = 1)
 
-  expect_equal(attributes(proxy_normalize_encoding(x)), attributes(x))
+  expect_equal(attributes(vec_normalize_encoding(x)), attributes(x))
 })
 
 test_that("translation is robust against scalar types contained in lists (#633)", {
   x <- list(a = z ~ y, b = z ~ z)
-  expect_equal(proxy_normalize_encoding(x), x)
+  expect_equal(vec_normalize_encoding(x), x)
 })
 
 test_that("translation can still occur even if a scalar type is in a list", {
   encs <- encodings()
   x <- list(a = z ~ y, b = encs$latin1)
 
-  result <- proxy_normalize_encoding(x)
+  result <- vec_normalize_encoding(x)
 
   expect_equal_encoding(result$b, encs$utf8)
 })
@@ -67,7 +67,7 @@ test_that("translation occurs inside scalars contained in a list", {
   scalar <- structure(list(x = encs$latin1), class = "scalar_list")
   lst <- list(scalar)
 
-  result <- proxy_normalize_encoding(lst)
+  result <- vec_normalize_encoding(lst)
 
   expect_equal_encoding(result[[1]]$x, encs$utf8)
 })
@@ -85,7 +85,7 @@ test_that("translation treats data frames elements of lists as lists (#1233)", {
   # so the rcrd column in the data frame won't get proxied
   proxy <- vec_proxy_equal(x)
 
-  result <- proxy_normalize_encoding(proxy)
+  result <- vec_normalize_encoding(proxy)
 
   expect_identical(result, x)
 


### PR DESCRIPTION
Closes #1246 

New `proxy_normalize_encoding()` to replace `obj_maybe_translate_encoding()` and `obj_maybe_translate_encoding2()`. It has been rewritten from scratch, so the diff for `translate.c` isn't really meaningful.

We now translate to UTF-8 unconditionally (the exact rule is to translate to UTF-8 if the CHARSXP is both not marked as ASCII and not marked as UTF-8). There are a few reasons for this:

- This greatly simplifies the translation code, and is much easier to explain and maintain.

- The result of `proxy_normalize_encoding()` will work _within_ a single vector (`vec_unique()`) and _between_ multiple vectors (`vec_match()`). We no longer need a version that takes 1 vector and a version that takes 2.

- This would allow us to always translate in `vec_proxy_equal()` and friends, i.e. #1245 

- I am hopeful that this would mean that we can simplify the `compare.c` and `equal.h` code related to strings, since we could assume that all string input was UTF-8. This would make string comparisons a simple SEXP pointer comparison, which would be very fast.

- The new `vec_order()` always compares in a UTF-8 encoding, so this makes other vctrs functions consistent with that. In fact, calling `proxy_normalize_encoding()` up front might allow us to simplify the internal of `vec_order()` as well, since we can assume UTF-8 already.

- Packages like readr and readxl always return results with UTF-8 encoding, which should make translation from other encodings less likely.

---

Generally, the behavior of functions that use this translation helper hasn't changed. Previously they always tried to convert to some common encoding, and they still do. The way we figure out that common encoding is just different now.

This does have the following side effects:

- Character vectors that only have "bytes" encodings are no longer supported in any function using these translation features. This should be incredibly rare though. They are no longer supported because `Rf_translateCharUTF8()` can't translate bytes->UTF8.

- Character vectors that are marked completely with Latin-1 encodings will be translated to UTF-8 now.  It is worth noting that base R will also translate these to UTF-8. Previously we tried to avoid translating these. This was nice for performance, but was complicated for two reasons:

   1) When comparing within a single list, if any element of the list required translation, we'd have to go back and translate the whole list to a common encoding. 

   2) When comparing between two vectors, we had to reconcile their two individual encodings with each other. For example, if `x` was all UTF8 and `y` was all Latin1, we'd have to make sure that we translate these to the same encoding, which is why we needed `obj_maybe_translate_encoding2()`.

  Always translating to UTF8 avoids these issues.