### PR TITLE
Use `VECTOR_PTR_RO()` in equality helpers

### DIFF
--- a/src/complete.c
+++ b/src/complete.c
@@ -182,23 +182,10 @@ static inline
 void raw_detect_complete_col(SEXP x, R_len_t size, int* p_out) {
   VEC_DETECT_COMPLETE_COL(Rbyte, RAW_RO, raw_equal_missing_scalar);
 }
-
-#undef VEC_DETECT_COMPLETE_COL
-
-#define VEC_DETECT_COMPLETE_COL_BARRIER(SCALAR_EQUAL_MISSING) { \
-  for (R_len_t i = 0; i < size; ++i) {                          \
-    if (SCALAR_EQUAL_MISSING(x, i)) {                           \
-      p_out[i] = 0;                                             \
-    }                                                           \
-  }                                                             \
-}
-
 static inline
 void list_detect_complete_col(SEXP x, R_len_t size, int* p_out) {
-  VEC_DETECT_COMPLETE_COL_BARRIER(list_equal_missing_scalar);
+  VEC_DETECT_COMPLETE_COL(SEXP, VECTOR_PTR_RO, list_equal_missing_scalar);
 }
-
-#undef VEC_DETECT_COMPLETE_COL_BARRIER
 
 // -----------------------------------------------------------------------------
 
@@ -296,22 +283,7 @@ static inline
 void raw_detect_any_non_missing_col(SEXP x, R_len_t size, struct df_short_circuit_info* p_info) {
   VEC_DETECT_ANY_NON_MISSING(Rbyte, RAW_RO, raw_equal_missing_scalar);
 }
-
-#undef VEC_DETECT_ANY_NON_MISSING
-
-
-#define VEC_DETECT_ANY_NON_MISSING_BARRIER(SCALAR_EQUAL_MISSING) { \
-  for (R_len_t i = 0; i < size; ++i) {                             \
-    /* At least one non-missing value exists */                    \
-    if (!SCALAR_EQUAL_MISSING(x, i)) {                             \
-      p_info->p_row_known[i] = true;                               \
-    }                                                              \
-  }                                                                \
-}
-
 static inline
 void list_detect_any_non_missing_col(SEXP x, R_len_t size, struct df_short_circuit_info* p_info) {
-  VEC_DETECT_ANY_NON_MISSING_BARRIER(list_equal_missing_scalar);
+  VEC_DETECT_ANY_NON_MISSING(SEXP, VECTOR_PTR_RO, list_equal_missing_scalar);
 }
-
-#undef VEC_DETECT_ANY_NON_MISSING_BARRIER

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -78,10 +78,10 @@ static int raw_p_equal_missing(const void* x, R_len_t i) {
 }
 
 static int list_p_equal(const void* x, R_len_t i, const void* y, R_len_t j) {
-  return list_equal_scalar_na_equal(((const SEXP) x), i, ((const SEXP) y), j);
+  return list_equal_scalar_na_equal(((const SEXP*) x) + i, ((const SEXP*) y) + j);
 }
 static int list_p_equal_missing(const void* x, R_len_t i) {
-  return list_equal_scalar_na_equal(((const SEXP) x), i, vctrs_shared_na_list, 0);
+  return list_equal_scalar_na_equal(((const SEXP*) x) + i, &R_NilValue);
 }
 
 
@@ -121,7 +121,7 @@ static void init_dictionary_raw(struct dictionary* d) {
   d->equal_missing = &raw_p_equal_missing;
 }
 static void init_dictionary_list(struct dictionary* d) {
-  d->vec_p = (const void*) d->vec;
+  d->vec_p = (const void*) VECTOR_PTR_RO(d->vec);
   d->equal = &list_p_equal;
   d->equal_missing = &list_p_equal_missing;
 }
@@ -211,12 +211,7 @@ static void init_dictionary_df(struct dictionary* d) {
     enum vctrs_type col_type = vec_proxy_typeof(col);
 
     col_types[i] = col_type;
-
-    if (col_type == vctrs_type_list) {
-      col_ptrs[i] = col;
-    } else {
-      col_ptrs[i] = r_vec_deref_const(col);
-    }
+    col_ptrs[i] = r_vec_deref_const(col);
   }
 
   d->protect = handle;

--- a/src/equal.h
+++ b/src/equal.h
@@ -155,8 +155,8 @@ static inline int chr_equal_scalar(const SEXP* x, const SEXP* y, bool na_equal) 
   }
 }
 
-static inline bool list_equal_missing_scalar(SEXP x, R_len_t i) {
-  return VECTOR_ELT(x, i) == R_NilValue;
+static inline bool list_equal_missing_scalar(SEXP x) {
+  return x == R_NilValue;
 }
 static inline int list_equal_scalar_na_equal(SEXP x, R_len_t i, SEXP y, R_len_t j) {
   const SEXP xi = VECTOR_ELT(x, i);

--- a/src/equal.h
+++ b/src/equal.h
@@ -158,21 +158,19 @@ static inline int chr_equal_scalar(const SEXP* x, const SEXP* y, bool na_equal) 
 static inline bool list_equal_missing_scalar(SEXP x) {
   return x == R_NilValue;
 }
-static inline int list_equal_scalar_na_equal(SEXP x, R_len_t i, SEXP y, R_len_t j) {
-  const SEXP xi = VECTOR_ELT(x, i);
-  const SEXP yj = VECTOR_ELT(y, j);
-  return equal_object(xi, yj);
+static inline int list_equal_scalar_na_equal(const SEXP* x, const SEXP* y) {
+  return equal_object(*x, *y);
 }
-static inline int list_equal_scalar_na_propagate(SEXP x, R_len_t i, SEXP y, R_len_t j) {
-  const SEXP xi = VECTOR_ELT(x, i);
-  const SEXP yj = VECTOR_ELT(y, j);
+static inline int list_equal_scalar_na_propagate(const SEXP* x, const SEXP* y) {
+  const SEXP xi = *x;
+  const SEXP yj = *y;
   return (xi == R_NilValue || yj == R_NilValue) ? NA_LOGICAL : equal_object(xi, yj);
 }
-static inline int list_equal_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
+static inline int list_equal_scalar(const SEXP* x, const SEXP* y, bool na_equal) {
   if (na_equal) {
-    return list_equal_scalar_na_equal(x, i, y, j);
+    return list_equal_scalar_na_equal(x, y);
   } else {
-    return list_equal_scalar_na_propagate(x, i, y, j);
+    return list_equal_scalar_na_propagate(x, y);
   }
 }
 

--- a/src/runs.c
+++ b/src/runs.c
@@ -268,34 +268,12 @@ static
 int raw_identify_runs(SEXP x, R_len_t size, int* p_out) {
   VEC_IDENTIFY_RUNS(Rbyte, RAW_RO, raw_equal_scalar_na_equal);
 }
-
-#undef VEC_IDENTIFY_RUNS
-
-#define VEC_IDENTIFY_RUNS_BARRIER(SCALAR_EQUAL) {              \
-  int id = 1;                                                  \
-                                                               \
-  /* Handle first case */                                      \
-  int loc = 0;                                                 \
-  p_out[0] = id;                                               \
-                                                               \
-  for (R_len_t i = 1; i < size; ++i) {                         \
-    if (SCALAR_EQUAL(x, i, x, loc) == 0) {                     \
-      ++id;                                                    \
-      loc = i;                                                 \
-    }                                                          \
-                                                               \
-    p_out[i] = id;                                             \
-  }                                                            \
-                                                               \
-  return id;                                                   \
-}
-
 static
 int list_identify_runs(SEXP x, R_len_t size, int* p_out) {
-  VEC_IDENTIFY_RUNS_BARRIER(list_equal_scalar_na_equal);
+  VEC_IDENTIFY_RUNS(SEXP, VECTOR_PTR_RO, list_equal_scalar_na_equal);
 }
 
-#undef VEC_IDENTIFY_RUNS_BARRIER
+#undef VEC_IDENTIFY_RUNS
 
 // -----------------------------------------------------------------------------
 
@@ -495,55 +473,12 @@ int raw_identify_runs_col(SEXP x,
                           int* p_out) {
   VEC_IDENTIFY_RUNS_COL(Rbyte, RAW_RO, raw_equal_scalar_na_equal);
 }
-
-#undef VEC_IDENTIFY_RUNS_COL
-
-#define VEC_IDENTIFY_RUNS_COL_BARRIER(EQUAL_SCALAR) { \
-  /* First row is always known, so `run_loc` */       \
-  /* and `run_id` will always be initialized below */ \
-  R_len_t run_loc;                                    \
-  int run_id;                                         \
-                                                      \
-  for (R_len_t i = 0; i < p_info->size; ++i) {        \
-    /* Start of new run */                            \
-    if (p_info->p_row_known[i]) {                     \
-      run_loc = i;                                    \
-      run_id = p_out[i];                              \
-      continue;                                       \
-    }                                                 \
-                                                      \
-    const int eq = EQUAL_SCALAR(x, i, x, run_loc);    \
-                                                      \
-    /* Update ID of identical values */               \
-    if (eq != 0) {                                    \
-      p_out[i] = run_id;                              \
-      continue;                                       \
-    }                                                 \
-                                                      \
-    ++id;                                             \
-    run_loc = i;                                      \
-    run_id = id;                                      \
-    p_out[i] = id;                                    \
-                                                      \
-    /* This is a run change, */                       \
-    /* so don't check this row again */               \
-    p_info->p_row_known[i] = true;                    \
-    --p_info->remaining;                              \
-                                                      \
-    if (p_info->remaining == 0) {                     \
-      break;                                          \
-    }                                                 \
-  }                                                   \
-                                                      \
-  return id;                                          \
-}
-
 static
 int list_identify_runs_col(SEXP x,
                            int id,
                            struct df_short_circuit_info* p_info,
                            int* p_out) {
-  VEC_IDENTIFY_RUNS_COL_BARRIER(list_equal_scalar_na_equal);
+  VEC_IDENTIFY_RUNS_COL(SEXP, VECTOR_PTR_RO, list_equal_scalar_na_equal);
 }
 
-#undef VEC_IDENTIFY_RUNS_COL_BARRIER
+#undef VEC_IDENTIFY_RUNS_COL

--- a/src/utils.h
+++ b/src/utils.h
@@ -465,7 +465,7 @@ static inline const void* vec_type_missing_value(enum vctrs_type type) {
   case vctrs_type_double: return &NA_REAL;
   case vctrs_type_complex: return &vctrs_shared_na_cpl;
   case vctrs_type_character: return &NA_STRING;
-  case vctrs_type_list: return vctrs_shared_na_list;
+  case vctrs_type_list: return &R_NilValue;
   default: stop_unimplemented_vctrs_type("vec_type_missing_value", type);
   }
 }


### PR DESCRIPTION
Closes #1247 

A very satisfying PR! Many of the macros specific to lists have been removed since we can now use `VECTOR_PTR_RO()`.

Updated equality helpers used in:
- `vec_equal()`
- `vec_equal_na()`
- Dictionary functions
- `vec_identify_runs()`

Generally improves performance with lists a little bit

```r
library(vctrs)

x <- rep(list("a"), 1e5)
```

```r
# before
bench::mark(vec_equal(x, x), iterations = 1000)
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal(x, x)    872µs    997µs      971.     616KB     6.85

# after
bench::mark(vec_equal(x, x), iterations = 1000)
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal(x, x)    550µs    626µs     1547.     616KB     10.9
```

```r
# before
bench::mark(vec_equal_na(x), iterations = 1000)
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(x)    352µs    447µs     2288.     395KB     13.8

# after
bench::mark(vec_equal_na(x), iterations = 1000)
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(x)   50.3µs   73.1µs    10872.     395KB     65.6
```

```r
# before
bench::mark(vec_identify_runs(x), iterations = 1000)
#> # A tibble: 1 x 6
#>   expression                min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>           <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_identify_runs(x)   1.52ms   1.64ms      582.     397KB     4.11

# after
bench::mark(vec_identify_runs(x), iterations = 1000)
#> # A tibble: 1 x 6
#>   expression                min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>           <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_identify_runs(x)   1.05ms   1.13ms      861.     397KB     6.07
```

```r
# before
bench::mark(vec_match(x, x), iterations = 1000)
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_match(x, x)   5.59ms   6.11ms      159.    1.66MB     4.93

# after
bench::mark(vec_match(x, x), iterations = 1000)
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_match(x, x)   4.82ms   5.24ms      189.    1.66MB     5.85
```