### PR TITLE
Early exit from `df_flatten()` when no flattening is required

### DIFF
--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -856,7 +856,13 @@ static R_len_t df_flatten_loop(SEXP x, SEXP out, SEXP out_names, R_len_t counter
 //
 // [[ register(); include("type-data-frame.h") ]]
 SEXP df_flatten(SEXP x) {
+  R_len_t n_cols = Rf_length(x);
   R_len_t width = df_flat_width(x);
+
+  if (n_cols == width) {
+    return x;
+  }
+
   SEXP out = PROTECT(Rf_allocVector(VECSXP, width));
   SEXP out_names = PROTECT(Rf_allocVector(STRSXP, width));
   r_poke_names(out, out_names);

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -391,7 +391,7 @@ test_that("can flatten data frames", {
   df_flatten <- function(x) {
     .Call(vctrs_df_flatten, x)
   }
-  expect_identical(df_flatten(mtcars), as.data.frame(as.list(mtcars)))
+  expect_identical(df_flatten(mtcars), mtcars)
 
   df <- tibble(x = 1, y = tibble(x = 2, y = tibble(x = 3), z = 4), z = 5)
   expect_identical(df_flatten(df), new_data_frame(list(x = 1, x = 2, x = 3, z = 4, z = 5)))


### PR DESCRIPTION
Closes #1253 

Small PR to early exit from `df_flatten()` when there is nothing to do.

Test needed adjustment because it used to always allocate a new vector and row names were not being copied over. Now it can just return its input unmodified so the row names are maintained