### PR TITLE
Translate attributes in `vec_normalize_encoding()`

### DIFF
--- a/src/translate.c
+++ b/src/translate.c
@@ -129,8 +129,9 @@ SEXP list_normalize_encoding(SEXP x) {
     }
     PROTECT(elt_new);
 
+    // Only cloned once, at which point `x` is free of references
     if (MAYBE_REFERENCED(x)) {
-      x = PROTECT(r_clone_referenced(x));
+      x = PROTECT(r_clone(x));
       ++nprot;
       p_x = VECTOR_PTR_RO(x);
     }
@@ -182,8 +183,9 @@ SEXP attrib_normalize_encoding(SEXP x) {
     }
     PROTECT(elt_new);
 
+    // Only cloned once, at which point `x` is free of references
     if (MAYBE_REFERENCED(x)) {
-      x = PROTECT(r_clone_referenced(x));
+      x = PROTECT(r_clone(x));
       ++nprot;
       node = x;
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -172,6 +172,7 @@ static
 SEXP attrib_normalize_encoding(SEXP x) {
   int nprot = 0;
   r_ssize loc = 0;
+  bool owned = false;
 
   for (SEXP node = x; node != r_null; node = r_node_cdr(node), ++loc) {
     SEXP elt_old = r_node_car(node);
@@ -182,9 +183,12 @@ SEXP attrib_normalize_encoding(SEXP x) {
     }
     PROTECT(elt_new);
 
-    // Cloned once, at which point `x` and all `node`s are free of references
-    if (MAYBE_REFERENCED(x)) {
+    if (!owned) {
+      // Shallow clone entire pairlist if not owned.
+      // Should be fast because these are generally short.
       x = PROTECT_N(r_clone(x), &nprot);
+      owned = true;
+
       node = x;
 
       // Restore original positioning post-clone

--- a/src/translate.c
+++ b/src/translate.c
@@ -183,7 +183,7 @@ SEXP attrib_normalize_encoding(SEXP x) {
     PROTECT(elt_new);
 
     // Cloned once, at which point `x` and all `node`s are free of references
-    if (MAYBE_REFERENCED(x)) {
+    if (MAYBE_REFERENCED(node)) {
       x = PROTECT_N(r_clone(x), &nprot);
       node = x;
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -183,7 +183,7 @@ SEXP attrib_normalize_encoding(SEXP x) {
     PROTECT(elt_new);
 
     // Cloned once, at which point `x` and all `node`s are free of references
-    if (MAYBE_REFERENCED(node)) {
+    if (MAYBE_REFERENCED(x)) {
       x = PROTECT_N(r_clone(x), &nprot);
       node = x;
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -131,8 +131,7 @@ SEXP list_normalize_encoding(SEXP x) {
 
     // Cloned once, at which point `x` is free of references
     if (MAYBE_REFERENCED(x)) {
-      x = PROTECT(r_clone(x));
-      ++nprot;
+      x = PROTECT_N(r_clone(x), &nprot);
       p_x = VECTOR_PTR_RO(x);
     }
 
@@ -185,8 +184,7 @@ SEXP attrib_normalize_encoding(SEXP x) {
 
     // Cloned once, at which point `x` and all `node`s are free of references
     if (MAYBE_REFERENCED(x)) {
-      x = PROTECT(r_clone(x));
-      ++nprot;
+      x = PROTECT_N(r_clone(x), &nprot);
       node = x;
 
       // Restore original positioning post-clone

--- a/src/translate.c
+++ b/src/translate.c
@@ -129,7 +129,7 @@ SEXP list_normalize_encoding(SEXP x) {
     }
     PROTECT(elt_new);
 
-    // Only cloned once, at which point `x` is free of references
+    // Cloned once, at which point `x` is free of references
     if (MAYBE_REFERENCED(x)) {
       x = PROTECT(r_clone(x));
       ++nprot;
@@ -183,7 +183,7 @@ SEXP attrib_normalize_encoding(SEXP x) {
     }
     PROTECT(elt_new);
 
-    // Only cloned once, at which point `x` is free of references
+    // Cloned once, at which point `x` and all `node`s are free of references
     if (MAYBE_REFERENCED(x)) {
       x = PROTECT(r_clone(x));
       ++nprot;

--- a/src/translate.c
+++ b/src/translate.c
@@ -1,28 +1,24 @@
 #include "translate.h"
+#include "vctrs.h"
+#include "utils.h"
 
-// -----------------------------------------------------------------------------
+// For testing
+// [[ register() ]]
+SEXP vctrs_normalize_encoding(SEXP x) {
+  return vec_normalize_encoding(x);
+}
 
-static r_ssize chr_find_normalize_start(SEXP x, r_ssize size);
-static r_ssize list_find_normalize_start(SEXP x, r_ssize size);
-
-static SEXP chr_normalize_encoding(SEXP x, r_ssize size, r_ssize start);
-static SEXP list_normalize_encoding(SEXP x, r_ssize size, r_ssize start);
+static inline SEXP obj_normalize_encoding(SEXP x);
 
 /*
  * Recursively normalize encodings of character vectors.
- *
- * This can be called on any vector, but is generally called on a proxy vector.
- *
- * Note that attributes are currently not translated. This means that it is
- * often important to call this function on the proxy, rather than the original
- * vector. For example, a list-rcrd with a vectorized character attribute must
- * be proxied to have the attribute promoted to a data frame column first before
- * calling `vec_normalize_encoding()`.
  *
  * A CHARSXP is considered normalized if:
  * - It is the NA_STRING
  * - It is ASCII, which means the encoding will be unmarked
  * - It is marked as UTF-8
+ *
+ * Attributes are translated as well.
  *
  * ASCII strings will never get marked with an encoding when they go
  * through `Rf_mkCharLenCE()`, but they will get marked as ASCII. Since
@@ -42,36 +38,40 @@ static SEXP list_normalize_encoding(SEXP x, r_ssize size, r_ssize start);
  * [[ include("translate.h") ]]
  */
 SEXP vec_normalize_encoding(SEXP x) {
-  switch (TYPEOF(x)) {
-  case STRSXP: {
-    r_ssize size = r_length(x);
-    r_ssize start = chr_find_normalize_start(x, size);
-
-    if (size == start) {
-      return x;
-    } else {
-      return chr_normalize_encoding(x, size, start);
-    }
-  }
-  case VECSXP: {
-    r_ssize size = r_length(x);
-    r_ssize start = list_find_normalize_start(x, size);
-
-    if (size == start) {
-      return x;
-    } else {
-      return list_normalize_encoding(x, size, start);
-    }
-  }
-  default: {
-    return x;
-  }
-  }
+  return obj_normalize_encoding(x);
 }
 
 // -----------------------------------------------------------------------------
 
-static SEXP chr_normalize_encoding(SEXP x, r_ssize size, r_ssize start) {
+static SEXP chr_normalize_encoding(SEXP x);
+static SEXP list_normalize_encoding(SEXP x);
+static SEXP obj_attrib_normalize_encoding(SEXP x);
+
+static inline SEXP obj_normalize_encoding(SEXP x) {
+  x = PROTECT(obj_attrib_normalize_encoding(x));
+
+  switch (TYPEOF(x)) {
+  case STRSXP: x = chr_normalize_encoding(x); break;
+  case VECSXP: x = list_normalize_encoding(x); break;
+  default: break;
+  }
+
+  UNPROTECT(1);
+  return x;
+}
+
+// -----------------------------------------------------------------------------
+
+static inline r_ssize chr_find_normalize_start(SEXP x, r_ssize size);
+
+static SEXP chr_normalize_encoding(SEXP x) {
+  r_ssize size = r_length(x);
+  r_ssize start = chr_find_normalize_start(x, size);
+
+  if (size == start) {
+    return x;
+  }
+
   x = PROTECT(r_clone_referenced(x));
   const SEXP* p_x = STRING_PTR_RO(x);
 
@@ -92,7 +92,7 @@ static SEXP chr_normalize_encoding(SEXP x, r_ssize size, r_ssize start) {
   return x;
 }
 
-static r_ssize chr_find_normalize_start(SEXP x, r_ssize size) {
+static inline r_ssize chr_find_normalize_start(SEXP x, r_ssize size) {
   const SEXP* p_x = STRING_PTR_RO(x);
 
   for (r_ssize i = 0; i < size; ++i) {
@@ -110,87 +110,87 @@ static r_ssize chr_find_normalize_start(SEXP x, r_ssize size) {
 
 // -----------------------------------------------------------------------------
 
-static SEXP list_normalize_encoding(SEXP x, r_ssize size, r_ssize start) {
-  x = PROTECT(r_clone_referenced(x));
-  const SEXP* p_x = VECTOR_PTR_RO(x);
+static SEXP list_normalize_encoding(SEXP x) {
+  int nprot = 0;
 
-  for (r_ssize i = start; i < size; ++i) {
-    SEXP elt = p_x[i];
-
-    switch (TYPEOF(elt)) {
-    case STRSXP: {
-      r_ssize elt_size = r_length(elt);
-      r_ssize elt_start = chr_find_normalize_start(elt, elt_size);
-
-      if (elt_size == elt_start) {
-        break;
-      }
-
-      elt = chr_normalize_encoding(elt, elt_size, elt_start);
-      SET_VECTOR_ELT(x, i, elt);
-      break;
-    }
-    case VECSXP: {
-      r_ssize elt_size = r_length(elt);
-      r_ssize elt_start = list_find_normalize_start(elt, elt_size);
-
-      if (elt_size == elt_start) {
-        break;
-      }
-
-      elt = list_normalize_encoding(elt, elt_size, elt_start);
-      SET_VECTOR_ELT(x, i, elt);
-      break;
-    }
-    default:
-      continue;
-    }
-  }
-
-  UNPROTECT(1);
-  return x;
-}
-
-static inline bool elt_all_normalized(SEXP x);
-
-static r_ssize list_find_normalize_start(SEXP x, r_ssize size) {
+  r_ssize size = r_length(x);
   const SEXP* p_x = VECTOR_PTR_RO(x);
 
   for (r_ssize i = 0; i < size; ++i) {
-    const SEXP elt = p_x[i];
+    SEXP elt_old = p_x[i];
 
-    if (elt_all_normalized(elt)) {
+    SEXP elt_new = obj_normalize_encoding(elt_old);
+    if (elt_old == elt_new) {
       continue;
     }
+    PROTECT(elt_new);
 
-    return i;
+    if (MAYBE_REFERENCED(x)) {
+      x = PROTECT(r_clone_referenced(x));
+      ++nprot;
+      p_x = VECTOR_PTR_RO(x);
+    }
+
+    SET_VECTOR_ELT(x, i, elt_new);
+    UNPROTECT(1);
   }
 
-  return size;
-}
-
-static inline bool elt_all_normalized(SEXP x) {
-  switch (TYPEOF(x)) {
-  case STRSXP: {
-    r_ssize size = r_length(x);
-    r_ssize start = chr_find_normalize_start(x, size);
-    return size == start;
-  }
-  case VECSXP: {
-    r_ssize size = r_length(x);
-    r_ssize start = list_find_normalize_start(x, size);
-    return size == start;
-  }
-  default: {
-    return true;
-  }
-  }
+  UNPROTECT(nprot);
+  return x;
 }
 
 // -----------------------------------------------------------------------------
 
-// For testing
-// [[ register() ]]
-SEXP vctrs_normalize_encoding(SEXP x) {
-  return vec_normalize_encoding(x);
+static SEXP attrib_normalize_encoding(SEXP x);
+
+static SEXP obj_attrib_normalize_encoding(SEXP x) {
+  SEXP attrib_old = r_attrib(x);
+
+  if (attrib_old == r_null) {
+    return x;
+  }
+
+  SEXP attrib_new = attrib_normalize_encoding(attrib_old);
+  if (attrib_new == attrib_old) {
+    return x;
+  }
+  PROTECT(attrib_new);
+
+  x = PROTECT(r_clone_referenced(x));
+  r_poke_attrib(x, attrib_new);
+
+  UNPROTECT(2);
+  return x;
+}
+
+static SEXP attrib_normalize_encoding(SEXP x) {
+  int nprot = 0;
+  r_ssize loc = 0;
+
+  for (SEXP node = x; node != r_null; node = r_node_cdr(node), ++loc) {
+    SEXP elt_old = r_node_car(node);
+
+    SEXP elt_new = obj_normalize_encoding(elt_old);
+    if (elt_old == elt_new) {
+      continue;
+    }
+    PROTECT(elt_new);
+
+    if (MAYBE_REFERENCED(x)) {
+      x = PROTECT(r_clone_referenced(x));
+      ++nprot;
+      node = x;
+
+      // Restore original positioning post-clone
+      for (r_ssize i = 0; i < loc; ++i) {
+        node = r_node_cdr(node);
+      }
+    }
+
+    r_node_poke_car(node, elt_new);
+    UNPROTECT(1);
+  }
+
+  UNPROTECT(nprot);
+  return x;
 }

--- a/src/translate.c
+++ b/src/translate.c
@@ -47,7 +47,8 @@ static SEXP chr_normalize_encoding(SEXP x);
 static SEXP list_normalize_encoding(SEXP x);
 static SEXP obj_attrib_normalize_encoding(SEXP x);
 
-static inline SEXP obj_normalize_encoding(SEXP x) {
+static inline
+SEXP obj_normalize_encoding(SEXP x) {
   x = PROTECT(obj_attrib_normalize_encoding(x));
 
   switch (TYPEOF(x)) {
@@ -64,7 +65,8 @@ static inline SEXP obj_normalize_encoding(SEXP x) {
 
 static inline r_ssize chr_find_normalize_start(SEXP x, r_ssize size);
 
-static SEXP chr_normalize_encoding(SEXP x) {
+static
+SEXP chr_normalize_encoding(SEXP x) {
   r_ssize size = r_length(x);
   r_ssize start = chr_find_normalize_start(x, size);
 
@@ -92,7 +94,8 @@ static SEXP chr_normalize_encoding(SEXP x) {
   return x;
 }
 
-static inline r_ssize chr_find_normalize_start(SEXP x, r_ssize size) {
+static inline
+r_ssize chr_find_normalize_start(SEXP x, r_ssize size) {
   const SEXP* p_x = STRING_PTR_RO(x);
 
   for (r_ssize i = 0; i < size; ++i) {
@@ -110,7 +113,8 @@ static inline r_ssize chr_find_normalize_start(SEXP x, r_ssize size) {
 
 // -----------------------------------------------------------------------------
 
-static SEXP list_normalize_encoding(SEXP x) {
+static
+SEXP list_normalize_encoding(SEXP x) {
   int nprot = 0;
 
   r_ssize size = r_length(x);
@@ -143,7 +147,8 @@ static SEXP list_normalize_encoding(SEXP x) {
 
 static SEXP attrib_normalize_encoding(SEXP x);
 
-static SEXP obj_attrib_normalize_encoding(SEXP x) {
+static
+SEXP obj_attrib_normalize_encoding(SEXP x) {
   SEXP attrib_old = r_attrib(x);
 
   if (attrib_old == r_null) {
@@ -163,7 +168,8 @@ static SEXP obj_attrib_normalize_encoding(SEXP x) {
   return x;
 }
 
-static SEXP attrib_normalize_encoding(SEXP x) {
+static
+SEXP attrib_normalize_encoding(SEXP x) {
   int nprot = 0;
   r_ssize loc = 0;
 

--- a/src/translate.c
+++ b/src/translate.c
@@ -169,25 +169,12 @@ SEXP obj_attrib_normalize_encoding(SEXP x) {
   return x;
 }
 
-/*
- * If a copy of the attribute pairlist is required in
- * `attrib_normalize_encoding()`, then we try to copy as little as possible.
- * It will first copy up to the pairlist element that requires translation,
- * insert that newly translated element, and then reuse the tail of the
- * pairlist. If future elements also need translation, then it "knows" that
- * it has already copied part of the pairlist and will only copy the middle
- * section between the last copied node and the new node that needs translation.
- */
 static
 SEXP attrib_normalize_encoding(SEXP x) {
   int nprot = 0;
+  r_ssize loc = 0;
 
-  // Updatable positions of the head we have to start copying from
-  // and the head that we start copying to
-  SEXP head_from = x;
-  SEXP head_to = r_null;
-
-  for (SEXP node = x; node != r_null; node = r_node_cdr(node)) {
+  for (SEXP node = x; node != r_null; node = r_node_cdr(node), ++loc) {
     SEXP elt_old = r_node_car(node);
 
     SEXP elt_new = obj_normalize_encoding(elt_old);
@@ -196,49 +183,19 @@ SEXP attrib_normalize_encoding(SEXP x) {
     }
     PROTECT(elt_new);
 
-    // Update directly if possible
-    if (!MAYBE_REFERENCED(node)) {
-      r_node_poke_car(node, elt_new);
-      UNPROTECT(1);
-      continue;
+    // Only cloned once, at which point `x` is free of references
+    if (MAYBE_REFERENCED(x)) {
+      x = PROTECT(r_clone(x));
+      ++nprot;
+      node = x;
+
+      // Restore original positioning post-clone
+      for (r_ssize i = 0; i < loc; ++i) {
+        node = r_node_cdr(node);
+      }
     }
 
-    SEXP old;
-    SEXP new;
-
-    SEXP middle = R_NilValue;
-    SEXP next = r_node_cdr(node);
-
-    // Create a new middle section for the pairlist
-    for (old = head_from; old != next; old = r_node_cdr(old)) {
-      middle = r_new_node(R_NilValue, middle);
-    }
-
-    // Link to the middle section
-    if (head_to == r_null) {
-      // This is the first time we've had to copy
-      x = middle;
-      PROTECT_N(x, &nprot);
-    } else {
-      r_node_poke_cdr(head_to, middle);
-    }
-
-    // Copy values into that new middle section up to `elt_new`
-    for (old = head_from, new = middle; old != node; old = r_node_cdr(old), new = r_node_cdr(new)) {
-      r_node_poke_car(new, r_node_car(old));
-      r_node_poke_tag(new, r_node_tag(old));
-    }
-
-    // Insert `elt_new`
-    r_node_poke_car(new, elt_new);
-    r_node_poke_tag(new, r_node_tag(old));
-
-    head_from = next;
-    head_to = new;
-
-    // Reuse the tail
-    r_node_poke_cdr(head_to, head_from);
-
+    r_node_poke_car(node, elt_new);
     UNPROTECT(1);
   }
 

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -95,24 +95,29 @@ test_that("translation treats data frames elements of lists as lists (#1233)", {
   expect_equal_encoding(result_field, expect_field)
 })
 
-# FIXME: Should we translate attributes to fix this? Can it be done efficiently?
-test_that("attributes are currently not translated", {
+test_that("attributes are translated", {
   utf8 <- encodings()$utf8
   latin1 <- encodings()$latin1
 
   a <- structure(1, enc = utf8)
   b <- structure(1, enc = latin1)
-  x <- list(a, b)
+  c <- structure(1, enc = list(latin1))
+  x <- list(a, b, c)
 
   result <- vec_normalize_encoding(x)
 
   a_enc <- attr(result[[1]], "enc")
   b_enc <- attr(result[[2]], "enc")
+  c_enc <- attr(result[[3]], "enc")[[1]]
 
-  # Ideally both would be utf8
   expect_equal_encoding(a_enc, utf8)
-  expect_equal_encoding(b_enc, latin1)
+  expect_equal_encoding(b_enc, utf8)
+  expect_equal_encoding(c_enc, utf8)
 
-  # Ideally the list elements are considered duplicates
-  expect_identical(vec_unique(x), x)
+  expect <- list(
+    structure(1, enc = utf8),
+    structure(1, enc = list(utf8))
+  )
+
+  expect_identical(vec_unique(x), expect)
 })

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -125,3 +125,18 @@ test_that("attributes are translated", {
 
   expect_identical(vec_unique(x), expect)
 })
+
+test_that("attributes are translated recursively", {
+  utf8 <- encodings()$utf8
+  latin1 <- encodings()$latin1
+
+  nested <- structure(1, latin1 = latin1)
+  x <- structure(2, nested = nested, foo = 1, latin1 = latin1)
+
+  result <- vec_normalize_encoding(x)
+  attrib <- attributes(result)
+  attrib_nested <- attributes(attrib$nested)
+
+  expect_equal_encoding(attrib$latin1, utf8)
+  expect_equal_encoding(attrib_nested$latin1, utf8)
+})

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -101,22 +101,26 @@ test_that("attributes are translated", {
 
   a <- structure(1, enc = utf8)
   b <- structure(1, enc = latin1)
-  c <- structure(1, enc = list(latin1))
+  c <- structure(1, enc1 = utf8, enc2 = list(latin1), enc3 = latin1)
   x <- list(a, b, c)
 
   result <- vec_normalize_encoding(x)
 
   a_enc <- attr(result[[1]], "enc")
   b_enc <- attr(result[[2]], "enc")
-  c_enc <- attr(result[[3]], "enc")[[1]]
+  c_enc1 <- attr(result[[3]], "enc1")
+  c_enc2 <- attr(result[[3]], "enc2")[[1]]
+  c_enc3 <- attr(result[[3]], "enc3")
 
   expect_equal_encoding(a_enc, utf8)
   expect_equal_encoding(b_enc, utf8)
-  expect_equal_encoding(c_enc, utf8)
+  expect_equal_encoding(c_enc1, utf8)
+  expect_equal_encoding(c_enc2, utf8)
+  expect_equal_encoding(c_enc3, utf8)
 
   expect <- list(
     structure(1, enc = utf8),
-    structure(1, enc = list(utf8))
+    structure(1, enc1 = utf8, enc2 = list(utf8), enc3 = utf8)
   )
 
   expect_identical(vec_unique(x), expect)


### PR DESCRIPTION
Closes #1258 

After much head-banging, I think I've finally gotten the recursive pattern correct in such a way that we can elegantly translate attributes recursively. It required rewriting it again, but I think it is overall even more elegant than before.

This is a bit slower than what we used to do (not translate attributes), but it really is only noticeable if you have deeply nested lists. The most common place this could arise is with multiple list columns, as is often done in tidymodels.

That said, translating the attributes here means that we can rip out the character translation parts of `equal.h` and `compare.c`, which I'm hoping will recover a bit of the lost performance.

Overall, I think it is worth it to put the translation code in one place, so we don't have to worry about it in other vctrs functions.

Here are a few examples, side by side with `vec_unique()`, which internally calls `vec_normalize_encoding()`, so you can get a feel for its impact.

Seems to have no impact on a sampled version of `flights`, which I consider to be fairly realistic.

``` r
library(nycflights13)
library(tidymodels)
library(vctrs)

vec_normalize_encoding <- vctrs:::vec_normalize_encoding

# sample the first 5 rows ~400k times
# 19 cols, 1 has attributes
flights <- vec_slice(flights, sample(1:5, nrow(flights), replace = TRUE))

# A fairly realistic dataset
bench::mark(
  vec_unique(flights),
  vec_normalize_encoding(flights), 
  iterations = 100,
  check = FALSE
)

# before
#> # A tibble: 2 x 6
#>   expression                           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_unique(flights)               38.7ms  41.33ms      24.0    3.31MB     1.53
#> 2 vec_normalize_encoding(flights)    2.2ms   2.39ms     416.         0B     0

# after
#> # A tibble: 2 x 6
#>   expression                           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_unique(flights)              36.03ms  38.84ms      25.8    3.31MB     1.65
#> 2 vec_normalize_encoding(flights)   1.88ms   2.17ms     472.         0B     0
```

Does have some impact on a deeply nested tibble that occurs naturally in tidymodels, but it isn't too bad.

```r
resamples <- bootstraps(mtcars, times = 100)

spline_rec <- recipe(mpg ~ ., data = mtcars) %>%
  step_ns(disp) %>%
  step_ns(wt)

lin_mod <- linear_reg() %>%
  set_engine("lm")

spline_res <- fit_resamples(lin_mod, spline_rec, resamples)

# 100 rows, some list columns that have tibbles in them
spline_res
#> # Resampling results
#> # Bootstrap sampling 
#> # A tibble: 100 x 4
#>    splits          id           .metrics         .notes          
#>    <list>          <chr>        <list>           <list>          
#>  1 <split [32/13]> Bootstrap001 <tibble [2 × 3]> <tibble [0 × 1]>
#>  2 <split [32/9]>  Bootstrap002 <tibble [2 × 3]> <tibble [0 × 1]>
#>  3 <split [32/13]> Bootstrap003 <tibble [2 × 3]> <tibble [0 × 1]>
#>  4 <split [32/13]> Bootstrap004 <tibble [2 × 3]> <tibble [0 × 1]>
#>  5 <split [32/10]> Bootstrap005 <tibble [2 × 3]> <tibble [0 × 1]>
#>  6 <split [32/10]> Bootstrap006 <tibble [2 × 3]> <tibble [0 × 1]>
#>  7 <split [32/11]> Bootstrap007 <tibble [2 × 3]> <tibble [0 × 1]>
#>  8 <split [32/11]> Bootstrap008 <tibble [2 × 3]> <tibble [0 × 1]>
#>  9 <split [32/12]> Bootstrap009 <tibble [2 × 3]> <tibble [0 × 1]>
#> 10 <split [32/9]>  Bootstrap010 <tibble [2 × 3]> <tibble [0 × 1]>
#> # … with 90 more rows

bench::mark(
  vec_unique(spline_res),
  vec_normalize_encoding(spline_res), 
  iterations = 100,
  check = FALSE
)

# before
#> # A tibble: 2 x 6
#>   expression                             min  median `itr/sec` mem_alloc
#>   <bch:expr>                         <bch:t> <bch:t>     <dbl> <bch:byt>
#> 1 vec_unique(spline_res)             777.3µs 852.6µs     1133.     103KB
#> 2 vec_normalize_encoding(spline_res)  11.7µs  11.8µs    76472.        0B
#> # … with 1 more variable: `gc/sec` <dbl>

# after
#> # A tibble: 2 x 6
#>   expression                             min  median `itr/sec` mem_alloc
#>   <bch:expr>                         <bch:t> <bch:t>     <dbl> <bch:byt>
#> 1 vec_unique(spline_res)             823.8µs 886.9µs     1116.     103KB
#> 2 vec_normalize_encoding(spline_res)  63.1µs  66.2µs    14950.        0B
#> # … with 1 more variable: `gc/sec` <dbl>
```