### PR TITLE
Don't apply `.name_spec` with empty inner names

### DIFF
--- a/src/names.c
+++ b/src/names.c
@@ -545,6 +545,9 @@ SEXP apply_name_spec(SEXP name_spec, SEXP outer, SEXP inner, R_len_t n) {
   }
 
   if (r_is_empty_names(inner)) {
+    if (n == 0) {
+      return vctrs_shared_empty_chr;
+    }
     if (n == 1) {
       return r_str_as_character(outer);
     }

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -778,6 +778,11 @@ test_that("NULL name specs works with scalars", {
   expect_identical(apply_name_spec(NULL, "foo", NULL, 1L), "foo")
   expect_named(vec_c(foo = 1), "foo")
 
+  expect_identical(apply_name_spec(NULL, "foo", chr(), 0L), chr())
+  expect_named(vec_c(foo = set_names(dbl())), chr())
+  # FIXME: #1263
+  # expect_named(vec_c(foo = set_names(dbl()), bar = set_names(dbl())), chr())
+
   expect_error(apply_name_spec(NULL, "foo", c("a", "b")), "vector of length > 1")
   expect_error(vec_c(foo = c(a = 1, b = 2)), "vector of length > 1")
 


### PR DESCRIPTION
Part of #1263

When an `outer` name exists, but the `inner` name is an empty `character()`, we now skip the name-spec and recycle to size zero

This is required for #1263 as we will start handling names of empty vectors differently there