### PR TITLE
Refactor vec-order structs to allow "self protection"

### DIFF
--- a/src/order-groups.c
+++ b/src/order-groups.c
@@ -22,7 +22,7 @@ struct group_info* new_group_info() {
 
   p_group_info->self = self;
   p_group_info->data_size = 0;
-  p_group_info->data = R_NilValue;
+  p_group_info->data = vctrs_shared_empty_int;
   p_group_info->n_groups = 0;
   p_group_info->max_group_size = 0;
 
@@ -114,8 +114,8 @@ void group_realloc(r_ssize size, struct group_info* p_group_info) {
   }
 
   // Reallocate
-  p_group_info->data = p_int_resize(
-    p_group_info->p_data,
+  p_group_info->data = int_resize(
+    p_group_info->data,
     p_group_info->data_size,
     size
   );

--- a/src/order-groups.c
+++ b/src/order-groups.c
@@ -17,7 +17,7 @@
 
 // Pair with `PROTECT_GROUP_INFO()` in the caller
 struct group_info* new_group_info() {
-  SEXP self = PROTECT(Rf_allocVector(RAWSXP, sizeof(struct group_info)));
+  SEXP self = PROTECT(r_new_raw(sizeof(struct group_info)));
   struct group_info* p_group_info = (struct group_info*) RAW(self);
 
   p_group_info->self = self;
@@ -35,7 +35,7 @@ struct group_infos* new_group_infos(struct group_info** p_p_group_info,
                                     r_ssize max_data_size,
                                     bool requested,
                                     bool ignore) {
-  SEXP self = PROTECT(Rf_allocVector(RAWSXP, sizeof(struct group_infos)));
+  SEXP self = PROTECT(r_new_raw(sizeof(struct group_infos)));
   struct group_infos* p_group_infos = (struct group_infos*) RAW(self);
 
   p_group_infos->self = self;

--- a/src/order-groups.c
+++ b/src/order-groups.c
@@ -16,28 +16,36 @@
 // -----------------------------------------------------------------------------
 
 // Pair with `PROTECT_GROUP_INFO()` in the caller
-struct group_info new_group_info() {
-  return (struct group_info) {
-    .data_size = 0,
-    .data = R_NilValue,
-    .n_groups = 0,
-    .max_group_size = 0
-  };
+struct group_info* new_group_info() {
+  SEXP self = PROTECT(Rf_allocVector(RAWSXP, sizeof(struct group_info)));
+  struct group_info* p_group_info = (struct group_info*) RAW(self);
+
+  p_group_info->self = self;
+  p_group_info->data_size = 0;
+  p_group_info->data = R_NilValue;
+  p_group_info->n_groups = 0;
+  p_group_info->max_group_size = 0;
+
+  return p_group_info;
 }
 
 // -----------------------------------------------------------------------------
 
-struct group_infos new_group_infos(struct group_info** p_p_group_info,
-                                   r_ssize max_data_size,
-                                   bool requested,
-                                   bool ignore) {
-  return (struct group_infos) {
-    .p_p_group_info = p_p_group_info,
-    .max_data_size = max_data_size,
-    .current = 0,
-    .requested = requested,
-    .ignore = ignore
-  };
+struct group_infos* new_group_infos(struct group_info** p_p_group_info,
+                                    r_ssize max_data_size,
+                                    bool requested,
+                                    bool ignore) {
+  SEXP self = PROTECT(Rf_allocVector(RAWSXP, sizeof(struct group_infos)));
+  struct group_infos* p_group_infos = (struct group_infos*) RAW(self);
+
+  p_group_infos->self = self;
+  p_group_infos->p_p_group_info = p_p_group_info;
+  p_group_infos->max_data_size = max_data_size;
+  p_group_infos->current = 0;
+  p_group_infos->requested = requested;
+  p_group_infos->ignore = ignore;
+
+  return p_group_infos;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/order-groups.c
+++ b/src/order-groups.c
@@ -33,21 +33,29 @@ struct group_info* new_group_info() {
 // -----------------------------------------------------------------------------
 
 // Pair with `PROTECT_GROUP_INFOS()` in the caller
-struct group_infos* new_group_infos(struct group_info** p_p_group_info,
+struct group_infos* new_group_infos(struct group_info* p_group_info0,
+                                    struct group_info* p_group_info1,
                                     r_ssize max_data_size,
                                     bool requested,
                                     bool ignore) {
   SEXP self = PROTECT(r_new_raw(sizeof(struct group_infos)));
   struct group_infos* p_group_infos = (struct group_infos*) RAW(self);
 
+  SEXP p_p_group_info_data = PROTECT(r_new_raw(2 * sizeof(struct group_info*)));
+  struct group_info** p_p_group_info = (struct group_info**) RAW(p_p_group_info_data);
+
+  p_p_group_info[0] = p_group_info0;
+  p_p_group_info[1] = p_group_info1;
+
   p_group_infos->self = self;
+  p_group_infos->p_p_group_info_data = p_p_group_info_data;
   p_group_infos->p_p_group_info = p_p_group_info;
   p_group_infos->max_data_size = max_data_size;
   p_group_infos->current = 0;
   p_group_infos->requested = requested;
   p_group_infos->ignore = ignore;
 
-  UNPROTECT(1);
+  UNPROTECT(2);
   return p_group_infos;
 }
 

--- a/src/order-groups.c
+++ b/src/order-groups.c
@@ -36,8 +36,8 @@ struct group_info* new_group_info() {
 struct group_infos* new_group_infos(struct group_info* p_group_info0,
                                     struct group_info* p_group_info1,
                                     r_ssize max_data_size,
-                                    bool requested,
-                                    bool ignore) {
+                                    bool force_tracking,
+                                    bool ignore_tracking) {
   SEXP self = PROTECT(r_new_raw(sizeof(struct group_infos)));
   struct group_infos* p_group_infos = (struct group_infos*) RAW(self);
 
@@ -52,8 +52,8 @@ struct group_infos* new_group_infos(struct group_info* p_group_info0,
   p_group_infos->p_p_group_info = p_p_group_info;
   p_group_infos->max_data_size = max_data_size;
   p_group_infos->current = 0;
-  p_group_infos->requested = requested;
-  p_group_infos->ignore = ignore;
+  p_group_infos->force_tracking = force_tracking;
+  p_group_infos->ignore_tracking = ignore_tracking;
 
   UNPROTECT(2);
   return p_group_infos;
@@ -158,7 +158,7 @@ r_ssize groups_realloc_size(r_ssize data_size, r_ssize max_data_size) {
  * integer vector (because we don't know if it will get used or not).
  */
 void groups_swap(struct group_infos* p_group_infos) {
-  if (p_group_infos->ignore) {
+  if (p_group_infos->ignore_tracking) {
     return;
   }
 

--- a/src/order-groups.c
+++ b/src/order-groups.c
@@ -26,6 +26,7 @@ struct group_info* new_group_info() {
   p_group_info->n_groups = 0;
   p_group_info->max_group_size = 0;
 
+  UNPROTECT(1);
   return p_group_info;
 }
 
@@ -46,6 +47,7 @@ struct group_infos* new_group_infos(struct group_info** p_p_group_info,
   p_group_infos->requested = requested;
   p_group_infos->ignore = ignore;
 
+  UNPROTECT(1);
   return p_group_infos;
 }
 

--- a/src/order-groups.c
+++ b/src/order-groups.c
@@ -31,6 +31,7 @@ struct group_info* new_group_info() {
 
 // -----------------------------------------------------------------------------
 
+// Pair with `PROTECT_GROUP_INFOS()` in the caller
 struct group_infos* new_group_infos(struct group_info** p_p_group_info,
                                     r_ssize max_data_size,
                                     bool requested,

--- a/src/order-groups.h
+++ b/src/order-groups.h
@@ -87,6 +87,7 @@ struct group_info {
  */
 struct group_infos {
   SEXP self;
+  SEXP p_p_group_info_data;
   struct group_info** p_p_group_info;
   r_ssize max_data_size;
   int current;
@@ -96,7 +97,8 @@ struct group_infos {
 
 #define PROTECT_GROUP_INFOS(p_info, p_n) do {               \
   PROTECT((p_info)->self);                                  \
-  *(p_n) += 1;                                              \
+  PROTECT((p_info)->p_p_group_info_data);                   \
+  *(p_n) += 2;                                              \
   PROTECT_GROUP_INFO((p_info)->p_p_group_info[0], (p_n));   \
   PROTECT_GROUP_INFO((p_info)->p_p_group_info[1], (p_n));   \
 } while(0)
@@ -105,7 +107,8 @@ struct group_infos {
 
 struct group_info* new_group_info();
 
-struct group_infos* new_group_infos(struct group_info** p_p_group_info,
+struct group_infos* new_group_infos(struct group_info* p_group_info0,
+                                    struct group_info* p_group_info1,
                                     r_ssize max_data_size,
                                     bool requested,
                                     bool ignore);

--- a/src/order-groups.h
+++ b/src/order-groups.h
@@ -78,12 +78,12 @@ struct group_info {
  *   `x`.
  * @member current The current `group_info` pointer we are using. This is
  *   either 0 or 1.
- * @member requested Was group information requested by the user? If so, we
+ * @member force_tracking Was group information requested by the user? If so, we
  *   always have to track group information.
- * @member ignore Should group tracking be ignored? This is the default
+ * @member ignore_tracking Should group tracking be ignored? This is the default
  *   for atomic vectors unless groups information is explicitly requested. For
  *   data frames, this is true over all columns except the last one (for
- *   performance) unless `requested` is true.
+ *   performance) unless `force_tracking` is true.
  */
 struct group_infos {
   SEXP self;
@@ -91,8 +91,8 @@ struct group_infos {
   struct group_info** p_p_group_info;
   r_ssize max_data_size;
   int current;
-  bool requested;
-  bool ignore;
+  bool force_tracking;
+  bool ignore_tracking;
 };
 
 #define PROTECT_GROUP_INFOS(p_info, p_n) do {               \
@@ -110,8 +110,8 @@ struct group_info* new_group_info();
 struct group_infos* new_group_infos(struct group_info* p_group_info0,
                                     struct group_info* p_group_info1,
                                     r_ssize max_data_size,
-                                    bool requested,
-                                    bool ignore);
+                                    bool force_tracking,
+                                    bool ignore_tracking);
 
 void groups_swap(struct group_infos* p_group_infos);
 
@@ -136,7 +136,7 @@ void groups_size_push(r_ssize size, struct group_infos* p_group_infos);
  */
 static inline
 void groups_size_maybe_push(r_ssize size, struct group_infos* p_group_infos) {
-  if (p_group_infos->ignore) {
+  if (p_group_infos->ignore_tracking) {
     return;
   } else {
     groups_size_push(size, p_group_infos);

--- a/src/order-groups.h
+++ b/src/order-groups.h
@@ -27,6 +27,7 @@
 /*
  * Info related to 1 column / vector worth of groupings
  *
+ * @member self A RAWSXP for the struct memory.
  * @member data An integer vector of group sizes.
  * @member p_data A pointer to `data`.
  * @member data_pi The protection index for `data` which allows us to
@@ -37,6 +38,8 @@
  * @member max_group_size The maximum group size seen so far.
  */
 struct group_info {
+  SEXP self;
+
   SEXP data;
   int* p_data;
   PROTECT_INDEX data_pi;
@@ -48,8 +51,9 @@ struct group_info {
 };
 
 #define PROTECT_GROUP_INFO(p_info, p_n) do {              \
+  PROTECT((p_info)->self);                                \
   PROTECT_WITH_INDEX((p_info)->data, &(p_info)->data_pi); \
-  *(p_n) += 1;                                            \
+  *(p_n) += 2;                                            \
 } while(0)
 
 // -----------------------------------------------------------------------------
@@ -67,6 +71,7 @@ struct group_info {
  * groups) while also updating the group information of the chunks of
  * the current one.
  *
+ * @member self A RAWSXP for the struct memory.
  * @member p_p_group_info A pointer to two `group_info` pointers.
  * @member max_data_size The maximum data size that can be allocated when
  *   reallocating an individual `p_group_info`. This is set to the size of
@@ -81,6 +86,7 @@ struct group_info {
  *   performance) unless `requested` is true.
  */
 struct group_infos {
+  SEXP self;
   struct group_info** p_p_group_info;
   r_ssize max_data_size;
   int current;
@@ -88,14 +94,21 @@ struct group_infos {
   bool ignore;
 };
 
+#define PROTECT_GROUP_INFOS(p_info, p_n) do {               \
+  PROTECT((p_info)->self);                                  \
+  *(p_n) += 1;                                              \
+  PROTECT_GROUP_INFO((p_info)->p_p_group_info[0], (p_n));   \
+  PROTECT_GROUP_INFO((p_info)->p_p_group_info[1], (p_n));   \
+} while(0)
+
 // -----------------------------------------------------------------------------
 
-struct group_info new_group_info();
+struct group_info* new_group_info();
 
-struct group_infos new_group_infos(struct group_info** p_p_group_info,
-                                   r_ssize max_data_size,
-                                   bool requested,
-                                   bool ignore);
+struct group_infos* new_group_infos(struct group_info** p_p_group_info,
+                                    r_ssize max_data_size,
+                                    bool requested,
+                                    bool ignore);
 
 void groups_swap(struct group_infos* p_group_infos);
 

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -177,11 +177,6 @@
 
 // -----------------------------------------------------------------------------
 
-static SEXP parse_na_value(SEXP na_value);
-static SEXP parse_direction(SEXP direction);
-
-// -----------------------------------------------------------------------------
-
 static SEXP vec_order(SEXP x, SEXP decreasing, SEXP na_last);
 
 // [[ register() ]]
@@ -4226,7 +4221,7 @@ int df_decreasing_expansion(SEXP x) {
 
 static int parse_na_value_one(SEXP x);
 
-static
+// [[ include("order-radix.h") ]]
 SEXP parse_na_value(SEXP na_value) {
   // Don't care about length here, checked later, just type
   if (TYPEOF(na_value) != STRSXP) {
@@ -4268,7 +4263,7 @@ int parse_na_value_one(SEXP x) {
 
 static int parse_direction_one(SEXP x);
 
-static
+// [[ include("order-radix.h") ]]
 SEXP parse_direction(SEXP direction) {
   // Don't care about length here, checked later, just type
   if (TYPEOF(direction) != STRSXP) {

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -283,25 +283,25 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
 
   // Auxiliary vectors to hold intermediate results while ordering.
   // If `x` is a data frame we allocate enough room for the largest column type.
-  struct lazy_raw lazy_x_chunk = new_lazy_raw(size, n_bytes_lazy_raw);
-  PROTECT_LAZY_VEC(&lazy_x_chunk, p_n_prot);
+  struct lazy_raw* p_lazy_x_chunk = new_lazy_raw(size, n_bytes_lazy_raw);
+  PROTECT_LAZY_VEC(p_lazy_x_chunk, p_n_prot);
 
-  struct lazy_raw lazy_x_aux = new_lazy_raw(size, n_bytes_lazy_raw);
-  PROTECT_LAZY_VEC(&lazy_x_aux, p_n_prot);
+  struct lazy_raw* p_lazy_x_aux = new_lazy_raw(size, n_bytes_lazy_raw);
+  PROTECT_LAZY_VEC(p_lazy_x_aux, p_n_prot);
 
-  struct lazy_raw lazy_o_aux = new_lazy_raw(size, sizeof(int));
-  PROTECT_LAZY_VEC(&lazy_o_aux, p_n_prot);
+  struct lazy_raw* p_lazy_o_aux = new_lazy_raw(size, sizeof(int));
+  PROTECT_LAZY_VEC(p_lazy_o_aux, p_n_prot);
 
-  struct lazy_raw lazy_bytes = new_lazy_raw(size, sizeof(uint8_t));
-  PROTECT_LAZY_VEC(&lazy_bytes, p_n_prot);
+  struct lazy_raw* p_lazy_bytes = new_lazy_raw(size, sizeof(uint8_t));
+  PROTECT_LAZY_VEC(p_lazy_bytes, p_n_prot);
 
   // Compute the maximum size of the `counts` vector needed during radix
   // ordering. 4 * 256 for integers, 8 * 256 for doubles.
   size_t n_bytes_lazy_counts = vec_compute_n_bytes_lazy_counts(proxy, type);
   r_ssize size_lazy_counts = UINT8_MAX_SIZE * n_bytes_lazy_counts;
 
-  struct lazy_raw lazy_counts = new_lazy_raw(size_lazy_counts, sizeof(r_ssize));
-  PROTECT_LAZY_VEC(&lazy_counts, p_n_prot);
+  struct lazy_raw* p_lazy_counts = new_lazy_raw(size_lazy_counts, sizeof(r_ssize));
+  PROTECT_LAZY_VEC(p_lazy_counts, p_n_prot);
 
   // Determine if group tracking can be turned off.
   // We turn if off if ordering non-data frame input as long as
@@ -335,8 +335,8 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
   struct truelength_info* p_truelength_info = new_truelength_info(size);
   PROTECT_TRUELENGTH_INFO(p_truelength_info, p_n_prot);
 
-  struct lazy_chr lazy_x_reencoded = new_lazy_chr(size);
-  PROTECT_LAZY_VEC(&lazy_x_reencoded, p_n_prot);
+  struct lazy_chr* p_lazy_x_reencoded = new_lazy_chr(size);
+  PROTECT_LAZY_VEC(p_lazy_x_reencoded, p_n_prot);
 
   struct order* p_order = new_order(size);
   PROTECT_ORDER(p_order, p_n_prot);
@@ -348,13 +348,13 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
     size,
     type,
     p_order,
-    &lazy_x_chunk,
-    &lazy_x_aux,
-    &lazy_o_aux,
-    &lazy_bytes,
-    &lazy_counts,
+    p_lazy_x_chunk,
+    p_lazy_x_aux,
+    p_lazy_o_aux,
+    p_lazy_bytes,
+    p_lazy_counts,
     p_group_infos,
-    &lazy_x_reencoded,
+    p_lazy_x_reencoded,
     p_truelength_info
   );
 

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -332,8 +332,8 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
 
   // Used for character ordering - lazily generated to be fast
   // when not ordering character vectors
-  struct truelength_info truelength_info = new_truelength_info(size);
-  PROTECT_TRUELENGTH_INFO(&truelength_info, p_n_prot);
+  struct truelength_info* p_truelength_info = new_truelength_info(size);
+  PROTECT_TRUELENGTH_INFO(p_truelength_info, p_n_prot);
 
   struct lazy_chr lazy_x_reencoded = new_lazy_chr(size);
   PROTECT_LAZY_VEC(&lazy_x_reencoded, p_n_prot);
@@ -355,7 +355,7 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
     &lazy_counts,
     p_group_infos,
     &lazy_x_reencoded,
-    &truelength_info
+    p_truelength_info
   );
 
   // Return ordered location info rather than ordering

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -338,8 +338,8 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
   struct lazy_chr lazy_x_reencoded = new_lazy_chr(size);
   PROTECT_LAZY_VEC(&lazy_x_reencoded, p_n_prot);
 
-  struct order order = new_order(size);
-  PROTECT_ORDER(&order, p_n_prot);
+  struct order* p_order = new_order(size);
+  PROTECT_ORDER(p_order, p_n_prot);
 
   vec_order_switch(
     proxy,
@@ -347,7 +347,7 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
     na_last,
     size,
     type,
-    &order,
+    p_order,
     &lazy_x_chunk,
     &lazy_x_aux,
     &lazy_o_aux,
@@ -364,7 +364,7 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
     const int* p_sizes = p_group_info->p_data;
     r_ssize n_groups = p_group_info->n_groups;
 
-    const int* p_o = order.p_data;
+    const int* p_o = p_order->p_data;
 
     SEXP out = vec_order_locs_impl(x, p_o, p_sizes, n_groups);
 
@@ -373,7 +373,7 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
   }
 
   UNPROTECT(n_prot);
-  return order.data;
+  return p_order->data;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -312,22 +312,23 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
 
   // Construct the two sets of group info needed for tracking groups.
   // We switch between them after each data frame column is processed.
-  struct group_info group_info0 = new_group_info();
-  PROTECT_GROUP_INFO(&group_info0, p_n_prot);
+  struct group_info* p_group_info0 = new_group_info();
+  PROTECT_GROUP_INFO(p_group_info0, p_n_prot);
 
-  struct group_info group_info1 = new_group_info();
-  PROTECT_GROUP_INFO(&group_info1, p_n_prot);
+  struct group_info* p_group_info1 = new_group_info();
+  PROTECT_GROUP_INFO(p_group_info1, p_n_prot);
 
   struct group_info* p_p_group_info[2];
-  p_p_group_info[0] = &group_info0;
-  p_p_group_info[1] = &group_info1;
+  p_p_group_info[0] = p_group_info0;
+  p_p_group_info[1] = p_group_info1;
 
-  struct group_infos group_infos = new_group_infos(
+  struct group_infos* p_group_infos = new_group_infos(
     p_p_group_info,
     size,
     requested,
     ignore
   );
+  PROTECT_GROUP_INFOS(p_group_infos, p_n_prot);
 
   // Used for character ordering - lazily generated to be fast
   // when not ordering character vectors
@@ -352,14 +353,14 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
     &lazy_o_aux,
     &lazy_bytes,
     &lazy_counts,
-    &group_infos,
+    p_group_infos,
     &lazy_x_reencoded,
     &truelength_info
   );
 
   // Return ordered location info rather than ordering
   if (locations) {
-    struct group_info* p_group_info = groups_current(&group_infos);
+    struct group_info* p_group_info = groups_current(p_group_infos);
     const int* p_sizes = p_group_info->p_data;
     r_ssize n_groups = p_group_info->n_groups;
 

--- a/src/order-radix.h
+++ b/src/order-radix.h
@@ -15,6 +15,7 @@
 
 #include "vctrs.h"
 #include "lazy.h"
+#include "utils.h"
 #include "order-groups.h"
 #include "order-truelength.h"
 
@@ -78,12 +79,6 @@ int* init_order(struct order* p_order) {
 
 // -----------------------------------------------------------------------------
 
-SEXP parse_na_value(SEXP na_value);
-SEXP parse_direction(SEXP direction);
-SEXP vec_order_expand_args(SEXP x, SEXP decreasing, SEXP na_last);
-
-// -----------------------------------------------------------------------------
-
 /*
  * `order_info` is a meta struct that holds all of the information used to
  * call `vec_order()`. It is returned from `vec_order_info()` and can be
@@ -120,17 +115,92 @@ struct order_info {
   PROTECT_TRUELENGTH_INFO((p_order_info)->p_truelength_info, (p_n));  \
 } while (0)
 
-struct order_info* new_order_info(SEXP proxy,
-                                  r_ssize size,
-                                  const enum vctrs_type type,
-                                  bool force_tracking);
+static inline int order_info_n_groups(struct order_info* p_info) {
+  return groups_current(p_info->p_group_infos)->n_groups;
+}
 
-void vec_order_info(SEXP proxy,
-                    SEXP decreasing,
-                    SEXP na_last,
-                    r_ssize size,
-                    const enum vctrs_type type,
-                    struct order_info* p_info);
+static inline SEXP order_info_group_sizes(struct order_info* p_info) {
+  return groups_current(p_info->p_group_infos)->data;
+}
+static inline int* order_info_p_group_sizes(struct order_info* p_info) {
+  return groups_current(p_info->p_group_infos)->p_data;
+}
+static inline SEXP order_info_group_sizes_values(struct order_info* p_info) {
+  return int_resize(
+    order_info_group_sizes(p_info),
+    groups_current(p_info->p_group_infos)->data_size,
+    order_info_n_groups(p_info)
+  );
+}
+
+static inline SEXP order_info_o(struct order_info* p_info) {
+  return p_info->p_order->data;
+}
+static inline int* order_info_p_o(struct order_info* p_info) {
+  return p_info->p_order->p_data;
+}
+
+// -----------------------------------------------------------------------------
+
+enum order_force_tracking {
+  ORDER_FORCE_TRACKING_true,
+  ORDER_FORCE_TRACKING_false
+};
+
+enum order_overwrite {
+  ORDER_OVERWRITE_false,
+  ORDER_OVERWRITE_true
+};
+
+/*
+ * Order `x` and return information about the ordering
+ *
+ * `vec_order_info()` returns an `order_info` struct. Members of that struct
+ * should be accessed with one of the `order_info_*()` utilities. If
+ * `force == ORDER_FORCE_TRACKING_true`, then group sizes will be tracked as
+ * well.
+ *
+ * The result should be protected with `PROTECT_ORDER_INFO()`.
+ */
+struct order_info* vec_order_info(SEXP x,
+                                  SEXP decreasing,
+                                  SEXP na_last,
+                                  const enum order_force_tracking force);
+
+/*
+ * @member overwrite Should the order currently in `p_info->p_order` be
+ *   overwritten? If not, a new ordering vector is allocated.
+ *
+ * @member o_unique Storage for the elements of the original `p_info->p_order`
+ *   that align with the sorted unique values of `x`.
+ *
+ * @member p_info An `order_info` struct pointer from a previous call to
+ *   `vec_order_info()`. Its `p_info->p_order` element will be updated, but
+ *   the group information will be left untouched.
+ *
+ * `vec_order_uniques_by_appearance()` does the following:
+ *
+ * - The elements of `p_info->p_order` corresponding to sorted unique elements
+ *   in `x` are extracted into `o_unique`.
+ *
+ * - `o_unique` is then ordered, and the corresponding ordering is placed into
+ *   `p_info->p_order`. This second ordering allows you to construct an
+ *   ordering of `x` by appearance.
+ *
+ * Notes:
+ *
+ * - The input `p_info` should be the result of a previous call to
+ *   `vec_order_info()` with group tracking turned on.
+ *
+ * - Group tracking is turned off, so it is safe to assume that this doesn't
+ *   modify the group sizes.
+ *
+ * - The returned `p_info` might contain a newly allocated `p_info->p_order`
+ *   object, so `PROTECT_ORDER_INFO()` must be re-called on it.
+ */
+struct order_info* vec_order_uniques_by_appearance(const enum order_overwrite overwrite,
+                                                   SEXP o_unique,
+                                                   struct order_info* p_info);
 
 // -----------------------------------------------------------------------------
 #endif

--- a/src/order-radix.h
+++ b/src/order-radix.h
@@ -26,6 +26,7 @@
  * column, which can result in a nice performance improvement.
  */
 struct order {
+  SEXP self;
   SEXP data;
   int* p_data;
   r_ssize size;
@@ -33,24 +34,27 @@ struct order {
 };
 
 #define PROTECT_ORDER(p_order, p_n) do { \
+  PROTECT((p_order)->self);              \
   PROTECT((p_order)->data);              \
-  *(p_n) += 1;                           \
+  *(p_n) += 2;                           \
 } while (0)
 
 static inline
-struct order new_order(r_ssize size) {
+struct order* new_order(r_ssize size) {
+  SEXP self = PROTECT(r_new_raw(sizeof(struct order)));
+  struct order* p_order = (struct order*) RAW(self);
+
   SEXP data = PROTECT(Rf_allocVector(INTSXP, size));
   int* p_data = INTEGER(data);
 
-  struct order out = {
-    .data = data,
-    .p_data = p_data,
-    .size = size,
-    .initialized = false
-  };
+  p_order->self = self;
+  p_order->data = data;
+  p_order->p_data = p_data;
+  p_order->size = size;
+  p_order->initialized = false;
 
-  UNPROTECT(1);
-  return out;
+  UNPROTECT(2);
+  return p_order;
 }
 
 static inline

--- a/src/order-radix.h
+++ b/src/order-radix.h
@@ -123,7 +123,7 @@ struct order_info {
 struct order_info* new_order_info(SEXP proxy,
                                   r_ssize size,
                                   const enum vctrs_type type,
-                                  bool track);
+                                  bool force_tracking);
 
 void vec_order_info(SEXP proxy,
                     SEXP decreasing,

--- a/src/order-radix.h
+++ b/src/order-radix.h
@@ -79,6 +79,11 @@ int* init_order(struct order* p_order) {
 
 // -----------------------------------------------------------------------------
 
+SEXP parse_na_value(SEXP na_value);
+SEXP parse_direction(SEXP direction);
+
+// -----------------------------------------------------------------------------
+
 /*
  * `order_info` is a meta struct that holds all of the information used to
  * call `vec_order()`. It is returned from `vec_order_info()` and can be

--- a/src/order-truelength.c
+++ b/src/order-truelength.c
@@ -28,22 +28,28 @@
  *
  * Pair with `PROTECT_TRUELENGTH_INFO()` in the caller
  */
-struct truelength_info new_truelength_info(r_ssize max_size_alloc) {
-  return (struct truelength_info) {
-    .strings = R_NilValue,
-    .lengths = R_NilValue,
-    .uniques = R_NilValue,
-    .sizes = R_NilValue,
-    .sizes_aux = R_NilValue,
+struct truelength_info* new_truelength_info(r_ssize max_size_alloc) {
+  SEXP self = PROTECT(r_new_raw(sizeof(struct truelength_info)));
+  struct truelength_info* p_truelength_info = (struct truelength_info*) RAW(self);
 
-    .size_alloc = 0,
-    .max_size_alloc = max_size_alloc,
-    .size_used = 0,
+  p_truelength_info->self = self;
 
-    .max_string_size = 0,
+  p_truelength_info->strings = R_NilValue;
+  p_truelength_info->lengths = R_NilValue;
+  p_truelength_info->uniques = R_NilValue;
+  p_truelength_info->sizes = R_NilValue;
+  p_truelength_info->sizes_aux = R_NilValue;
 
-    .reencode = false
-  };
+  p_truelength_info->size_alloc = 0;
+  p_truelength_info->max_size_alloc = max_size_alloc;
+  p_truelength_info->size_used = 0;
+
+  p_truelength_info->max_string_size = 0;
+
+  p_truelength_info->reencode = false;
+
+  UNPROTECT(1);
+  return p_truelength_info;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/order-truelength.c
+++ b/src/order-truelength.c
@@ -34,11 +34,11 @@ struct truelength_info* new_truelength_info(r_ssize max_size_alloc) {
 
   p_truelength_info->self = self;
 
-  p_truelength_info->strings = R_NilValue;
-  p_truelength_info->lengths = R_NilValue;
-  p_truelength_info->uniques = R_NilValue;
-  p_truelength_info->sizes = R_NilValue;
-  p_truelength_info->sizes_aux = R_NilValue;
+  p_truelength_info->strings = vctrs_shared_empty_chr;
+  p_truelength_info->lengths = vctrs_shared_empty_raw;
+  p_truelength_info->uniques = vctrs_shared_empty_chr;
+  p_truelength_info->sizes = vctrs_shared_empty_int;
+  p_truelength_info->sizes_aux = vctrs_shared_empty_int;
 
   p_truelength_info->size_alloc = 0;
   p_truelength_info->max_size_alloc = max_size_alloc;
@@ -107,7 +107,7 @@ void truelength_save(SEXP x,
 
 static r_ssize truelength_realloc_size(struct truelength_info* p_truelength_info);
 
-static inline SEXP p_lengths_resize(const r_ssize* p_x, r_ssize x_size, r_ssize size);
+static inline SEXP lengths_resize(SEXP x, r_ssize x_size, r_ssize size);
 
 /*
  * Extend the vectors in `truelength_info`.
@@ -117,40 +117,40 @@ static
 void truelength_realloc(struct truelength_info* p_truelength_info) {
   r_ssize size = truelength_realloc_size(p_truelength_info);
 
-  p_truelength_info->strings = p_chr_resize(
-    p_truelength_info->p_strings,
+  p_truelength_info->strings = chr_resize(
+    p_truelength_info->strings,
     p_truelength_info->size_used,
     size
   );
   REPROTECT(p_truelength_info->strings, p_truelength_info->strings_pi);
   p_truelength_info->p_strings = STRING_PTR(p_truelength_info->strings);
 
-  p_truelength_info->lengths = p_lengths_resize(
-    p_truelength_info->p_lengths,
+  p_truelength_info->lengths = lengths_resize(
+    p_truelength_info->lengths,
     p_truelength_info->size_used,
     size
   );
   REPROTECT(p_truelength_info->lengths, p_truelength_info->lengths_pi);
   p_truelength_info->p_lengths = (r_ssize*) RAW(p_truelength_info->lengths);
 
-  p_truelength_info->uniques = p_chr_resize(
-    p_truelength_info->p_uniques,
+  p_truelength_info->uniques = chr_resize(
+    p_truelength_info->uniques,
     p_truelength_info->size_used,
     size
   );
   REPROTECT(p_truelength_info->uniques, p_truelength_info->uniques_pi);
   p_truelength_info->p_uniques = STRING_PTR(p_truelength_info->uniques);
 
-  p_truelength_info->sizes = p_int_resize(
-    p_truelength_info->p_sizes,
+  p_truelength_info->sizes = int_resize(
+    p_truelength_info->sizes,
     p_truelength_info->size_used,
     size
   );
   REPROTECT(p_truelength_info->sizes, p_truelength_info->sizes_pi);
   p_truelength_info->p_sizes = INTEGER(p_truelength_info->sizes);
 
-  p_truelength_info->sizes_aux = p_int_resize(
-    p_truelength_info->p_sizes_aux,
+  p_truelength_info->sizes_aux = int_resize(
+    p_truelength_info->sizes_aux,
     p_truelength_info->size_used,
     size
   );
@@ -161,11 +161,9 @@ void truelength_realloc(struct truelength_info* p_truelength_info) {
 }
 
 static inline
-SEXP p_lengths_resize(const r_ssize* p_x, r_ssize x_size, r_ssize size) {
-  const Rbyte* p_x_rbyte = (const Rbyte*) p_x;
-
-  return p_raw_resize(
-    p_x_rbyte,
+SEXP lengths_resize(SEXP x, r_ssize x_size, r_ssize size) {
+  return raw_resize(
+    x,
     x_size * sizeof(r_ssize),
     size * sizeof(r_ssize)
   );

--- a/src/order-truelength.h
+++ b/src/order-truelength.h
@@ -28,6 +28,8 @@
  * Struct of information required to track truelengths of character vectors
  * when ordering them
  *
+ * @member self A RAWSXP for the struct memory.
+ *
  * @members strings,p_strings,strings_pi The unique CHARSXP seen during
  *   ordering.
  * @members lengths,p_lengths,lengths_pi The original truelengths of the
@@ -54,6 +56,8 @@
  *   copied and re-encoded.
  */
 struct truelength_info {
+  SEXP self;
+
   SEXP strings;
   SEXP* p_strings;
   PROTECT_INDEX strings_pi;
@@ -84,16 +88,17 @@ struct truelength_info {
 };
 
 #define PROTECT_TRUELENGTH_INFO(p_info, p_n) do {                   \
+  PROTECT((p_info)->self);                                          \
   PROTECT_WITH_INDEX((p_info)->strings, &(p_info)->strings_pi);     \
   PROTECT_WITH_INDEX((p_info)->lengths, &(p_info)->lengths_pi);     \
   PROTECT_WITH_INDEX((p_info)->uniques, &(p_info)->uniques_pi);     \
   PROTECT_WITH_INDEX((p_info)->sizes, &(p_info)->sizes_pi);         \
   PROTECT_WITH_INDEX((p_info)->sizes_aux, &(p_info)->sizes_aux_pi); \
-  *(p_n) += 5;                                                      \
+  *(p_n) += 6;                                                      \
 } while(0)
 
 
-struct truelength_info new_truelength_info(r_ssize max_size_alloc);
+struct truelength_info* new_truelength_info(r_ssize max_size_alloc);
 void truelength_reset(struct truelength_info* p_truelength_info);
 
 void truelength_save(SEXP x,

--- a/src/utils.h
+++ b/src/utils.h
@@ -114,9 +114,9 @@ bool is_data_frame(SEXP x);
 bool is_bare_data_frame(SEXP x);
 bool is_bare_tibble(SEXP x);
 
-SEXP p_int_resize(const int* p_x, r_ssize x_size, r_ssize size);
-SEXP p_raw_resize(const Rbyte* p_x, r_ssize x_size, r_ssize size);
-SEXP p_chr_resize(const SEXP* p_x, r_ssize x_size, r_ssize size);
+SEXP int_resize(SEXP x, r_ssize x_size, r_ssize size);
+SEXP raw_resize(SEXP x, r_ssize x_size, r_ssize size);
+SEXP chr_resize(SEXP x, r_ssize x_size, r_ssize size);
 
 bool p_chr_any_reencode(const SEXP* p_x, r_ssize size);
 void p_chr_copy_with_reencode(const SEXP* p_x, SEXP x_result, r_ssize size);
@@ -556,6 +556,8 @@ extern SEXP strings_val;
 extern SEXP strings_group;
 extern SEXP strings_length;
 extern SEXP strings_vctrs_vctr;
+extern SEXP strings_order;
+extern SEXP strings_sizes;
 
 extern SEXP chrs_subset;
 extern SEXP chrs_extract;

--- a/src/utils.h
+++ b/src/utils.h
@@ -266,6 +266,10 @@ SEXP r_new_character(R_len_t n) {
   return Rf_allocVector(STRSXP, n);
 }
 static inline
+SEXP r_new_raw(R_len_t n) {
+  return Rf_allocVector(RAWSXP, n);
+}
+static inline
 SEXP r_new_list(R_len_t n) {
   return Rf_allocVector(VECSXP, n);
 }


### PR DESCRIPTION
This PR is an intermediate step that allows the internal parts of `vec_order()` to be called from other files. This allows additional information like the group sizes to be returned as well. It comes back in a new "meta struct" called `order_info`. 

Other vctrs functions can call `new_order_info()` to create an `order_info` struct, and then call `vec_order_info()` to compute the order and populate the `order_info` struct.

`order_info` also holds everything required to call `vec_order_info()` a second time very efficiently, which is extremely useful for reordering the results of the first call by first appearance (i.e. something that is required for `vec_unique()` and friends).

The main change to the existing structs is that they can now "self protect" themselves so they can be returned from functions. This follows the same model as `struct dictionary`. The trickiest one was `group_infos`, because now the array of 2 `group_info` pointers can't be allocated on the stack anymore.

I've also tweaked where `vec_order_expand_args()` is called from, and exposed it, `parse_direction()`, and `parse_na_value()` in `order-radix.h` for eventual use by `vec_rank()`

As a POC, I have a separate branch from this that has reimplementations of a number of vctrs functions that were dictionary based. Most of them are more efficient, with the exception of `vec_duplicate_any()`, which was more efficient with the dictionary https://github.com/DavisVaughan/vctrs/commit/d73f35f3e00917683e552f2004956cdaf18aaa23

These POCs also don't suffer from the issue where the dictionary gets full, as was seen in https://github.com/tidyverse/dplyr/issues/5291 from `vec_group_loc()` erroring (`vec_group_loc2()` works on the 1e9 strings in about 19 seconds)