### PR TITLE
Assign names before skipping empty input in `vec_c()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* `vec_c()` now correctly returns a named result with named empty inputs
+  (#1263).
+
 * vctrs has been relicensed as MIT (#1259).
 
 * Functions that make comparisons within a single vector, such as

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -133,10 +133,6 @@ static SEXP vec_unchop(SEXP xs,
 
     SEXP loc = VECTOR_ELT(locs, i);
 
-    // Total ownership of `proxy` because it was freshly created with `vec_init()`
-    proxy = vec_proxy_assign_opts(proxy, loc, x, VCTRS_OWNED_true, &unchop_assign_opts);
-    REPROTECT(proxy, proxy_pi);
-
     if (assign_names) {
       R_len_t size = Rf_length(loc);
       SEXP outer = xs_is_named ? STRING_ELT(xs_names, i) : R_NilValue;
@@ -156,6 +152,10 @@ static SEXP vec_unchop(SEXP xs,
 
       UNPROTECT(2);
     }
+
+    // Total ownership of `proxy` because it was freshly created with `vec_init()`
+    proxy = vec_proxy_assign_opts(proxy, loc, x, VCTRS_OWNED_true, &unchop_assign_opts);
+    REPROTECT(proxy, proxy_pi);
   }
 
   SEXP out_size_sexp = PROTECT(r_int(out_size));

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -404,6 +404,24 @@ test_that("can zap outer names from a name-spec (#1215)", {
   )
 })
 
+test_that("named empty vectors force named output (#1263)", {
+  x <- set_names(int(), chr())
+
+  expect_named(vec_c(x), chr())
+  expect_named(vec_c(x, x), chr())
+  expect_named(vec_c(x, 1L), "")
+  expect_named(vec_c(x, 1), "")
+
+  expect_named(vec_unchop(list(x), list(int())), chr())
+  expect_named(vec_unchop(list(x, x), list(int(), int())), chr())
+  expect_named(vec_unchop(list(x, 1L), list(int(), 1)), "")
+
+  # FIXME: `vec_cast_common()` dropped names
+  # https://github.com/r-lib/vctrs/issues/623
+  expect_failure(
+    expect_named(vec_unchop(list(x, 1), list(int(), 1)), "")
+  )
+})
 
 # Golden tests -------------------------------------------------------
 

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -780,8 +780,7 @@ test_that("NULL name specs works with scalars", {
 
   expect_identical(apply_name_spec(NULL, "foo", chr(), 0L), chr())
   expect_named(vec_c(foo = set_names(dbl())), chr())
-  # FIXME: #1263
-  # expect_named(vec_c(foo = set_names(dbl()), bar = set_names(dbl())), chr())
+  expect_named(vec_c(foo = set_names(dbl()), bar = set_names(dbl())), chr())
 
   expect_error(apply_name_spec(NULL, "foo", c("a", "b")), "vector of length > 1")
   expect_error(vec_c(foo = c(a = 1, b = 2)), "vector of length > 1")


### PR DESCRIPTION
Closes https://github.com/r-lib/vctrs/issues/1263

This also has the side effect of avoiding the `vec_c()` issue noted in https://github.com/r-lib/vctrs/issues/623#issuecomment-696946634, since names are now extracted before the cast. `vec_unchop()` still exhibits this issue, since it uses `vec_cast_common()` before the loop. The real solution is to fix `vec_cast()`, I think.