### PR TITLE
Change `p_int_resize()` to `int_resize()` to allow early exiting

### DIFF
--- a/src/order-groups.c
+++ b/src/order-groups.c
@@ -19,7 +19,7 @@
 struct group_info new_group_info() {
   return (struct group_info) {
     .data_size = 0,
-    .data = R_NilValue,
+    .data = vctrs_shared_empty_int,
     .n_groups = 0,
     .max_group_size = 0
   };
@@ -95,8 +95,8 @@ void group_realloc(r_ssize size, struct group_info* p_group_info) {
   }
 
   // Reallocate
-  p_group_info->data = p_int_resize(
-    p_group_info->p_data,
+  p_group_info->data = int_resize(
+    p_group_info->data,
     p_group_info->data_size,
     size
   );

--- a/src/order-truelength.c
+++ b/src/order-truelength.c
@@ -30,11 +30,11 @@
  */
 struct truelength_info new_truelength_info(r_ssize max_size_alloc) {
   return (struct truelength_info) {
-    .strings = R_NilValue,
-    .lengths = R_NilValue,
-    .uniques = R_NilValue,
-    .sizes = R_NilValue,
-    .sizes_aux = R_NilValue,
+    .strings = vctrs_shared_empty_chr,
+    .lengths = vctrs_shared_empty_raw,
+    .uniques = vctrs_shared_empty_chr,
+    .sizes = vctrs_shared_empty_int,
+    .sizes_aux = vctrs_shared_empty_int,
 
     .size_alloc = 0,
     .max_size_alloc = max_size_alloc,
@@ -101,7 +101,7 @@ void truelength_save(SEXP x,
 
 static r_ssize truelength_realloc_size(struct truelength_info* p_truelength_info);
 
-static inline SEXP p_lengths_resize(const r_ssize* p_x, r_ssize x_size, r_ssize size);
+static inline SEXP lengths_resize(SEXP x, r_ssize x_size, r_ssize size);
 
 /*
  * Extend the vectors in `truelength_info`.
@@ -111,40 +111,40 @@ static
 void truelength_realloc(struct truelength_info* p_truelength_info) {
   r_ssize size = truelength_realloc_size(p_truelength_info);
 
-  p_truelength_info->strings = p_chr_resize(
-    p_truelength_info->p_strings,
+  p_truelength_info->strings = chr_resize(
+    p_truelength_info->strings,
     p_truelength_info->size_used,
     size
   );
   REPROTECT(p_truelength_info->strings, p_truelength_info->strings_pi);
   p_truelength_info->p_strings = STRING_PTR(p_truelength_info->strings);
 
-  p_truelength_info->lengths = p_lengths_resize(
-    p_truelength_info->p_lengths,
+  p_truelength_info->lengths = lengths_resize(
+    p_truelength_info->lengths,
     p_truelength_info->size_used,
     size
   );
   REPROTECT(p_truelength_info->lengths, p_truelength_info->lengths_pi);
   p_truelength_info->p_lengths = (r_ssize*) RAW(p_truelength_info->lengths);
 
-  p_truelength_info->uniques = p_chr_resize(
-    p_truelength_info->p_uniques,
+  p_truelength_info->uniques = chr_resize(
+    p_truelength_info->uniques,
     p_truelength_info->size_used,
     size
   );
   REPROTECT(p_truelength_info->uniques, p_truelength_info->uniques_pi);
   p_truelength_info->p_uniques = STRING_PTR(p_truelength_info->uniques);
 
-  p_truelength_info->sizes = p_int_resize(
-    p_truelength_info->p_sizes,
+  p_truelength_info->sizes = int_resize(
+    p_truelength_info->sizes,
     p_truelength_info->size_used,
     size
   );
   REPROTECT(p_truelength_info->sizes, p_truelength_info->sizes_pi);
   p_truelength_info->p_sizes = INTEGER(p_truelength_info->sizes);
 
-  p_truelength_info->sizes_aux = p_int_resize(
-    p_truelength_info->p_sizes_aux,
+  p_truelength_info->sizes_aux = int_resize(
+    p_truelength_info->sizes_aux,
     p_truelength_info->size_used,
     size
   );
@@ -155,11 +155,9 @@ void truelength_realloc(struct truelength_info* p_truelength_info) {
 }
 
 static inline
-SEXP p_lengths_resize(const r_ssize* p_x, r_ssize x_size, r_ssize size) {
-  const Rbyte* p_x_rbyte = (const Rbyte*) p_x;
-
-  return p_raw_resize(
-    p_x_rbyte,
+SEXP lengths_resize(SEXP x, r_ssize x_size, r_ssize size) {
+  return raw_resize(
+    x,
     x_size * sizeof(r_ssize),
     size * sizeof(r_ssize)
   );

--- a/src/utils.h
+++ b/src/utils.h
@@ -114,9 +114,9 @@ bool is_data_frame(SEXP x);
 bool is_bare_data_frame(SEXP x);
 bool is_bare_tibble(SEXP x);
 
-SEXP p_int_resize(const int* p_x, r_ssize x_size, r_ssize size);
-SEXP p_raw_resize(const Rbyte* p_x, r_ssize x_size, r_ssize size);
-SEXP p_chr_resize(const SEXP* p_x, r_ssize x_size, r_ssize size);
+SEXP int_resize(SEXP x, r_ssize x_size, r_ssize size);
+SEXP raw_resize(SEXP x, r_ssize x_size, r_ssize size);
+SEXP chr_resize(SEXP x, r_ssize x_size, r_ssize size);
 
 bool p_chr_any_reencode(const SEXP* p_x, r_ssize size);
 void p_chr_copy_with_reencode(const SEXP* p_x, SEXP x_result, r_ssize size);


### PR DESCRIPTION
Extracted from #1266 

Also requires updating the defaults of some order structs which previously weren't being dereferenced. A proper typed default is now required