### PR TITLE
Add self protection to vec-order structs

### DIFF
--- a/src/order-groups.c
+++ b/src/order-groups.c
@@ -16,28 +16,46 @@
 // -----------------------------------------------------------------------------
 
 // Pair with `PROTECT_GROUP_INFO()` in the caller
-struct group_info new_group_info() {
-  return (struct group_info) {
-    .data_size = 0,
-    .data = vctrs_shared_empty_int,
-    .n_groups = 0,
-    .max_group_size = 0
-  };
+struct group_info* new_group_info() {
+  SEXP self = PROTECT(r_new_raw(sizeof(struct group_info)));
+  struct group_info* p_group_info = (struct group_info*) RAW(self);
+
+  p_group_info->self = self;
+  p_group_info->data_size = 0;
+  p_group_info->data = vctrs_shared_empty_int;
+  p_group_info->n_groups = 0;
+  p_group_info->max_group_size = 0;
+
+  UNPROTECT(1);
+  return p_group_info;
 }
 
 // -----------------------------------------------------------------------------
 
-struct group_infos new_group_infos(struct group_info** p_p_group_info,
-                                   r_ssize max_data_size,
-                                   bool force_groups,
-                                   bool ignore_groups) {
-  return (struct group_infos) {
-    .p_p_group_info = p_p_group_info,
-    .max_data_size = max_data_size,
-    .current = 0,
-    .force_groups = force_groups,
-    .ignore_groups = ignore_groups
-  };
+struct group_infos* new_group_infos(struct group_info* p_group_info0,
+                                    struct group_info* p_group_info1,
+                                    r_ssize max_data_size,
+                                    bool force_groups,
+                                    bool ignore_groups) {
+  SEXP self = PROTECT(r_new_raw(sizeof(struct group_infos)));
+  struct group_infos* p_group_infos = (struct group_infos*) RAW(self);
+
+  SEXP p_p_group_info_data = PROTECT(r_new_raw(2 * sizeof(struct group_info*)));
+  struct group_info** p_p_group_info = (struct group_info**) RAW(p_p_group_info_data);
+
+  p_p_group_info[0] = p_group_info0;
+  p_p_group_info[1] = p_group_info1;
+
+  p_group_infos->self = self;
+  p_group_infos->p_p_group_info_data = p_p_group_info_data;
+  p_group_infos->p_p_group_info = p_p_group_info;
+  p_group_infos->max_data_size = max_data_size;
+  p_group_infos->current = 0;
+  p_group_infos->force_groups = force_groups;
+  p_group_infos->ignore_groups = ignore_groups;
+
+  UNPROTECT(2);
+  return p_group_infos;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -276,25 +276,25 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
 
   // Auxiliary vectors to hold intermediate results while ordering.
   // If `x` is a data frame we allocate enough room for the largest column type.
-  struct lazy_raw lazy_x_chunk = new_lazy_raw(size, n_bytes_lazy_raw);
-  PROTECT_LAZY_VEC(&lazy_x_chunk, p_n_prot);
+  struct lazy_raw* p_lazy_x_chunk = new_lazy_raw(size, n_bytes_lazy_raw);
+  PROTECT_LAZY_VEC(p_lazy_x_chunk, p_n_prot);
 
-  struct lazy_raw lazy_x_aux = new_lazy_raw(size, n_bytes_lazy_raw);
-  PROTECT_LAZY_VEC(&lazy_x_aux, p_n_prot);
+  struct lazy_raw* p_lazy_x_aux = new_lazy_raw(size, n_bytes_lazy_raw);
+  PROTECT_LAZY_VEC(p_lazy_x_aux, p_n_prot);
 
-  struct lazy_raw lazy_o_aux = new_lazy_raw(size, sizeof(int));
-  PROTECT_LAZY_VEC(&lazy_o_aux, p_n_prot);
+  struct lazy_raw* p_lazy_o_aux = new_lazy_raw(size, sizeof(int));
+  PROTECT_LAZY_VEC(p_lazy_o_aux, p_n_prot);
 
-  struct lazy_raw lazy_bytes = new_lazy_raw(size, sizeof(uint8_t));
-  PROTECT_LAZY_VEC(&lazy_bytes, p_n_prot);
+  struct lazy_raw* p_lazy_bytes = new_lazy_raw(size, sizeof(uint8_t));
+  PROTECT_LAZY_VEC(p_lazy_bytes, p_n_prot);
 
   // Compute the maximum size of the `counts` vector needed during radix
   // ordering. 4 * 256 for integers, 8 * 256 for doubles.
   size_t n_bytes_lazy_counts = vec_compute_n_bytes_lazy_counts(proxy, type);
   r_ssize size_lazy_counts = UINT8_MAX_SIZE * n_bytes_lazy_counts;
 
-  struct lazy_raw lazy_counts = new_lazy_raw(size_lazy_counts, sizeof(r_ssize));
-  PROTECT_LAZY_VEC(&lazy_counts, p_n_prot);
+  struct lazy_raw* p_lazy_counts = new_lazy_raw(size_lazy_counts, sizeof(r_ssize));
+  PROTECT_LAZY_VEC(p_lazy_counts, p_n_prot);
 
   // Determine if group tracking can be turned off.
   // We turn if off if ordering non-data frame input as long as
@@ -327,8 +327,8 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
   struct truelength_info truelength_info = new_truelength_info(size);
   PROTECT_TRUELENGTH_INFO(&truelength_info, p_n_prot);
 
-  struct lazy_chr lazy_x_reencoded = new_lazy_chr(size);
-  PROTECT_LAZY_VEC(&lazy_x_reencoded, p_n_prot);
+  struct lazy_chr* p_lazy_x_reencoded = new_lazy_chr(size);
+  PROTECT_LAZY_VEC(p_lazy_x_reencoded, p_n_prot);
 
   struct order order = new_order(size);
   PROTECT_ORDER(&order, p_n_prot);
@@ -340,13 +340,13 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
     size,
     type,
     &order,
-    &lazy_x_chunk,
-    &lazy_x_aux,
-    &lazy_o_aux,
-    &lazy_bytes,
-    &lazy_counts,
+    p_lazy_x_chunk,
+    p_lazy_x_aux,
+    p_lazy_o_aux,
+    p_lazy_bytes,
+    p_lazy_counts,
     &group_infos,
-    &lazy_x_reencoded,
+    p_lazy_x_reencoded,
     &truelength_info
   );
 

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -305,22 +305,20 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
 
   // Construct the two sets of group info needed for tracking groups.
   // We switch between them after each data frame column is processed.
-  struct group_info group_info0 = new_group_info();
-  PROTECT_GROUP_INFO(&group_info0, p_n_prot);
+  struct group_info* p_group_info0 = new_group_info();
+  PROTECT_GROUP_INFO(p_group_info0, p_n_prot);
 
-  struct group_info group_info1 = new_group_info();
-  PROTECT_GROUP_INFO(&group_info1, p_n_prot);
+  struct group_info* p_group_info1 = new_group_info();
+  PROTECT_GROUP_INFO(p_group_info1, p_n_prot);
 
-  struct group_info* p_p_group_info[2];
-  p_p_group_info[0] = &group_info0;
-  p_p_group_info[1] = &group_info1;
-
-  struct group_infos group_infos = new_group_infos(
-    p_p_group_info,
+  struct group_infos* p_group_infos = new_group_infos(
+    p_group_info0,
+    p_group_info1,
     size,
     force_groups,
     ignore_groups
   );
+  PROTECT_GROUP_INFOS(p_group_infos, p_n_prot);
 
   // Used for character ordering - lazily generated to be fast
   // when not ordering character vectors
@@ -345,14 +343,14 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
     p_lazy_o_aux,
     p_lazy_bytes,
     p_lazy_counts,
-    &group_infos,
+    p_group_infos,
     p_lazy_x_reencoded,
     &truelength_info
   );
 
   // Return ordered location info rather than ordering
   if (locations) {
-    struct group_info* p_group_info = groups_current(&group_infos);
+    struct group_info* p_group_info = groups_current(p_group_infos);
     const int* p_sizes = p_group_info->p_data;
     r_ssize n_groups = p_group_info->n_groups;
 

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -322,8 +322,8 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
 
   // Used for character ordering - lazily generated to be fast
   // when not ordering character vectors
-  struct truelength_info truelength_info = new_truelength_info(size);
-  PROTECT_TRUELENGTH_INFO(&truelength_info, p_n_prot);
+  struct truelength_info* p_truelength_info = new_truelength_info(size);
+  PROTECT_TRUELENGTH_INFO(p_truelength_info, p_n_prot);
 
   struct lazy_chr* p_lazy_x_reencoded = new_lazy_chr(size);
   PROTECT_LAZY_VEC(p_lazy_x_reencoded, p_n_prot);
@@ -345,7 +345,7 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
     p_lazy_counts,
     p_group_infos,
     p_lazy_x_reencoded,
-    &truelength_info
+    p_truelength_info
   );
 
   // Return ordered location info rather than ordering

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -328,8 +328,8 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
   struct lazy_chr* p_lazy_x_reencoded = new_lazy_chr(size);
   PROTECT_LAZY_VEC(p_lazy_x_reencoded, p_n_prot);
 
-  struct order order = new_order(size);
-  PROTECT_ORDER(&order, p_n_prot);
+  struct order* p_order = new_order(size);
+  PROTECT_ORDER(p_order, p_n_prot);
 
   vec_order_switch(
     proxy,
@@ -337,7 +337,7 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
     na_last,
     size,
     type,
-    &order,
+    p_order,
     p_lazy_x_chunk,
     p_lazy_x_aux,
     p_lazy_o_aux,
@@ -354,7 +354,7 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
     const int* p_sizes = p_group_info->p_data;
     r_ssize n_groups = p_group_info->n_groups;
 
-    const int* p_o = order.p_data;
+    const int* p_o = p_order->p_data;
 
     SEXP out = vec_order_locs_impl(x, p_o, p_sizes, n_groups);
 
@@ -363,7 +363,7 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
   }
 
   UNPROTECT(n_prot);
-  return order.data;
+  return p_order->data;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/order-radix.h
+++ b/src/order-radix.h
@@ -31,6 +31,7 @@ SEXP parse_direction(SEXP direction);
  * column, which can result in a nice performance improvement.
  */
 struct order {
+  SEXP self;
   SEXP data;
   int* p_data;
   r_ssize size;
@@ -38,24 +39,27 @@ struct order {
 };
 
 #define PROTECT_ORDER(p_order, p_n) do { \
+  PROTECT((p_order)->self);              \
   PROTECT((p_order)->data);              \
-  *(p_n) += 1;                           \
+  *(p_n) += 2;                           \
 } while (0)
 
 static inline
-struct order new_order(r_ssize size) {
+struct order* new_order(r_ssize size) {
+  SEXP self = PROTECT(r_new_raw(sizeof(struct order)));
+  struct order* p_order = (struct order*) RAW(self);
+
   SEXP data = PROTECT(Rf_allocVector(INTSXP, size));
   int* p_data = INTEGER(data);
 
-  struct order out = {
-    .data = data,
-    .p_data = p_data,
-    .size = size,
-    .initialized = false
-  };
+  p_order->self = self;
+  p_order->data = data;
+  p_order->p_data = p_data;
+  p_order->size = size;
+  p_order->initialized = false;
 
-  UNPROTECT(1);
-  return out;
+  UNPROTECT(2);
+  return p_order;
 }
 
 static inline

--- a/src/order-truelength.c
+++ b/src/order-truelength.c
@@ -28,22 +28,28 @@
  *
  * Pair with `PROTECT_TRUELENGTH_INFO()` in the caller
  */
-struct truelength_info new_truelength_info(r_ssize max_size_alloc) {
-  return (struct truelength_info) {
-    .strings = vctrs_shared_empty_chr,
-    .lengths = vctrs_shared_empty_raw,
-    .uniques = vctrs_shared_empty_chr,
-    .sizes = vctrs_shared_empty_int,
-    .sizes_aux = vctrs_shared_empty_int,
+struct truelength_info* new_truelength_info(r_ssize max_size_alloc) {
+  SEXP self = PROTECT(r_new_raw(sizeof(struct truelength_info)));
+  struct truelength_info* p_truelength_info = (struct truelength_info*) RAW(self);
 
-    .size_alloc = 0,
-    .max_size_alloc = max_size_alloc,
-    .size_used = 0,
+  p_truelength_info->self = self;
 
-    .max_string_size = 0,
+  p_truelength_info->strings = vctrs_shared_empty_chr;
+  p_truelength_info->lengths = vctrs_shared_empty_raw;
+  p_truelength_info->uniques = vctrs_shared_empty_chr;
+  p_truelength_info->sizes = vctrs_shared_empty_int;
+  p_truelength_info->sizes_aux = vctrs_shared_empty_int;
 
-    .reencode = false
-  };
+  p_truelength_info->size_alloc = 0;
+  p_truelength_info->max_size_alloc = max_size_alloc;
+  p_truelength_info->size_used = 0;
+
+  p_truelength_info->max_string_size = 0;
+
+  p_truelength_info->reencode = false;
+
+  UNPROTECT(1);
+  return p_truelength_info;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/order-truelength.h
+++ b/src/order-truelength.h
@@ -28,6 +28,8 @@
  * Struct of information required to track truelengths of character vectors
  * when ordering them
  *
+ * @member self A RAWSXP for the struct memory.
+ *
  * @members strings,p_strings,strings_pi The unique CHARSXP seen during
  *   ordering.
  * @members lengths,p_lengths,lengths_pi The original truelengths of the
@@ -54,6 +56,8 @@
  *   copied and re-encoded.
  */
 struct truelength_info {
+  SEXP self;
+
   SEXP strings;
   SEXP* p_strings;
   PROTECT_INDEX strings_pi;
@@ -84,16 +88,17 @@ struct truelength_info {
 };
 
 #define PROTECT_TRUELENGTH_INFO(p_info, p_n) do {                   \
+  PROTECT((p_info)->self);                                          \
   PROTECT_WITH_INDEX((p_info)->strings, &(p_info)->strings_pi);     \
   PROTECT_WITH_INDEX((p_info)->lengths, &(p_info)->lengths_pi);     \
   PROTECT_WITH_INDEX((p_info)->uniques, &(p_info)->uniques_pi);     \
   PROTECT_WITH_INDEX((p_info)->sizes, &(p_info)->sizes_pi);         \
   PROTECT_WITH_INDEX((p_info)->sizes_aux, &(p_info)->sizes_aux_pi); \
-  *(p_n) += 5;                                                      \
+  *(p_n) += 6;                                                      \
 } while(0)
 
 
-struct truelength_info new_truelength_info(r_ssize max_size_alloc);
+struct truelength_info* new_truelength_info(r_ssize max_size_alloc);
 void truelength_reset(struct truelength_info* p_truelength_info);
 
 void truelength_save(SEXP x,


### PR DESCRIPTION
Extracted from #1266 - it got too big and is more manageable as multiple PRs

This is an intermediate step towards allowing pieces of `vec_order()` to be called from other files efficiently (i.e. for `vec_rank()` and potential rewrites of dictionary functions).

The main change to the existing structs is that they can now "self protect" themselves so they can be returned from functions. This follows the same model as `struct dictionary`. The trickiest one was `group_infos`, because now the array of 2 `group_info` pointers can't be allocated on the stack anymore.

The eventual idea is to have a meta struct called `order_info` that contains and returns all of these smaller structs.