### PR TITLE
Rewrite `vec_equal()`

### DIFF
--- a/src/equal.c
+++ b/src/equal.c
@@ -27,27 +27,27 @@ static SEXP df_equal(SEXP x, SEXP y, R_len_t size, bool na_equal);
  */
 static
 SEXP vec_equal(SEXP x, SEXP y, bool na_equal) {
-  x = PROTECT(vec_proxy_equal(x));
-  y = PROTECT(vec_proxy_equal(y));
+  SEXP x_proxy = PROTECT(vec_proxy_equal(x));
+  SEXP y_proxy = PROTECT(vec_proxy_equal(y));
 
-  R_len_t size = vec_size(x);
+  R_len_t size = vec_size(x_proxy);
+  enum vctrs_type type = vec_proxy_typeof(x_proxy);
 
-  enum vctrs_type type = vec_proxy_typeof(x);
-  if (type != vec_proxy_typeof(y) || size != vec_size(y)) {
+  if (type != vec_proxy_typeof(y_proxy) || size != vec_size(y_proxy)) {
     Rf_errorcall(R_NilValue, "`x` and `y` must have same types and lengths.");
   }
 
   SEXP out;
 
   switch (type) {
-  case vctrs_type_logical: out = lgl_equal(x, y, size, na_equal); break;
-  case vctrs_type_integer: out = int_equal(x, y, size, na_equal); break;
-  case vctrs_type_double: out = dbl_equal(x, y, size, na_equal); break;
-  case vctrs_type_complex: out = cpl_equal(x, y, size, na_equal); break;
-  case vctrs_type_character: out = chr_equal(x, y, size, na_equal); break;
-  case vctrs_type_raw: out = raw_equal(x, y, size, na_equal); break;
-  case vctrs_type_list: out = list_equal(x, y, size, na_equal); break;
-  case vctrs_type_dataframe: out = df_equal(x, y, size, na_equal); break;
+  case vctrs_type_logical: out = lgl_equal(x_proxy, y_proxy, size, na_equal); break;
+  case vctrs_type_integer: out = int_equal(x_proxy, y_proxy, size, na_equal); break;
+  case vctrs_type_double: out = dbl_equal(x_proxy, y_proxy, size, na_equal); break;
+  case vctrs_type_complex: out = cpl_equal(x_proxy, y_proxy, size, na_equal); break;
+  case vctrs_type_character: out = chr_equal(x_proxy, y_proxy, size, na_equal); break;
+  case vctrs_type_raw: out = raw_equal(x_proxy, y_proxy, size, na_equal); break;
+  case vctrs_type_list: out = list_equal(x_proxy, y_proxy, size, na_equal); break;
+  case vctrs_type_dataframe: out = df_equal(x_proxy, y_proxy, size, na_equal); break;
   case vctrs_type_scalar: Rf_errorcall(R_NilValue, "Can't compare scalars with `vec_equal()`.");
   default: stop_unimplemented_vctrs_type("vec_equal", type);
   }

--- a/src/equal.h
+++ b/src/equal.h
@@ -271,40 +271,4 @@ static inline bool p_equal_na_propagate(const void* p_x,
 
 // -----------------------------------------------------------------------------
 
-// FIXME: Remove these by rewriting `vctrs_equal()` to branch off `na_equal`
-
-#define EQUAL(EQUAL_NA_EQUAL, EQUAL_NA_PROPAGATE) do { \
-  if (na_equal) {                                      \
-    return EQUAL_NA_EQUAL(x, y);                       \
-  } else {                                             \
-    return EQUAL_NA_PROPAGATE(x, y);                   \
-  }                                                    \
-} while (0)
-
-static inline int lgl_equal(int x, int y, bool na_equal) {
-  EQUAL(lgl_equal_na_equal, lgl_equal_na_propagate);
-}
-static inline int int_equal(int x, int y, bool na_equal) {
-  EQUAL(int_equal_na_equal, int_equal_na_propagate);
-}
-static inline int dbl_equal(double x, double y, bool na_equal) {
-  EQUAL(dbl_equal_na_equal, dbl_equal_na_propagate);
-}
-static inline int cpl_equal(Rcomplex x, Rcomplex y, bool na_equal) {
-  EQUAL(cpl_equal_na_equal, cpl_equal_na_propagate);
-}
-static inline int chr_equal(SEXP x, SEXP y, bool na_equal) {
-  EQUAL(chr_equal_na_equal, chr_equal_na_propagate);
-}
-static inline int raw_equal(Rbyte x, Rbyte y, bool na_equal) {
-  EQUAL(raw_equal_na_equal, raw_equal_na_propagate);
-}
-static inline int list_equal(SEXP x, SEXP y, bool na_equal) {
-  EQUAL(list_equal_na_equal, list_equal_na_propagate);
-}
-
-#undef EQUAL
-
-// -----------------------------------------------------------------------------
-
 #endif


### PR DESCRIPTION
This PR rewrites `vec_equal()`. This is done for a few reasons:

- It is now a little faster, maybe 10-15% or so, by branching off `na_equal` outside the inner equality loop

- By doing the above bullet point, we can now remove the scalar `*_equal()` helpers that were left in `equal.h`. They weren't used anywhere else, and it is generally better to use the `*_equal_na_equal()` and `*_equal_na_propagate()` instead

- I used this chance to give vec-equal a major refresh to update to the current coding styles we are using

``` r
library(vctrs)

set.seed(123)

x <- sample(1:10, 1e8, replace = TRUE)
y <- sample(1:10, 1e8, replace = TRUE)

bench::mark(vec_equal(x, y), iterations = 50)

# before
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal(x, y)   90.2ms    101ms      8.88     382MB     9.62

# after
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal(x, y)   81.6ms   85.9ms      10.4     382MB     11.2
```

```r
df <- data.frame(x = x, y = y)
df2 <- data.frame(x = y, y = x)

bench::mark(vec_equal(df, df2), iterations = 20)

# before
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal(df, df2)    458ms    500ms      1.92     477MB     2.35

# after
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal(df, df2)    419ms    441ms      2.25     477MB     2.76
```

<sup>Created on 2020-10-06 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>