### PR TITLE
Remove translation code from equal/compare

### DIFF
--- a/src/equal.c
+++ b/src/equal.c
@@ -2,6 +2,7 @@
 #include "equal.h"
 #include "vctrs.h"
 #include "utils.h"
+#include "translate.h"
 
 // -----------------------------------------------------------------------------
 
@@ -30,6 +31,9 @@ SEXP vec_equal(SEXP x, SEXP y, bool na_equal) {
   SEXP x_proxy = PROTECT(vec_proxy_equal(x));
   SEXP y_proxy = PROTECT(vec_proxy_equal(y));
 
+  x_proxy = PROTECT(vec_normalize_encoding(x_proxy));
+  y_proxy = PROTECT(vec_normalize_encoding(y_proxy));
+
   R_len_t size = vec_size(x_proxy);
   enum vctrs_type type = vec_proxy_typeof(x_proxy);
 
@@ -52,7 +56,7 @@ SEXP vec_equal(SEXP x, SEXP y, bool na_equal) {
   default: stop_unimplemented_vctrs_type("vec_equal", type);
   }
 
-  UNPROTECT(2);
+  UNPROTECT(4);
   return out;
 }
 

--- a/src/equal.c
+++ b/src/equal.c
@@ -260,6 +260,18 @@ static inline bool vec_equal_attrib(SEXP x, SEXP y);
 
 // [[ include("vctrs.h") ]]
 bool equal_object(SEXP x, SEXP y) {
+  x = PROTECT(vec_normalize_encoding(x));
+  y = PROTECT(vec_normalize_encoding(y));
+
+  bool out = equal_object_normalized(x, y);
+
+  UNPROTECT(2);
+  return out;
+}
+
+// Assumes `vec_normalize_encoding()` has already been called
+// [[ include("vctrs.h") ]]
+bool equal_object_normalized(SEXP x, SEXP y) {
   SEXPTYPE type = TYPEOF(x);
 
   if (type != TYPEOF(y)) {
@@ -299,18 +311,18 @@ bool equal_object(SEXP x, SEXP y) {
   case LANGSXP:
   case LISTSXP:
   case BCODESXP: {
-    if (!equal_object(ATTRIB(x), ATTRIB(y))) {
+    if (!equal_object_normalized(ATTRIB(x), ATTRIB(y))) {
       return false;
     }
 
-    if (!equal_object(CAR(x), CAR(y))) {
+    if (!equal_object_normalized(CAR(x), CAR(y))) {
       return false;
     }
 
     x = CDR(x);
     y = CDR(y);
 
-    if (!equal_object(x, y)) {
+    if (!equal_object_normalized(x, y)) {
       return false;
     }
 
@@ -318,16 +330,16 @@ bool equal_object(SEXP x, SEXP y) {
   }
 
   case CLOSXP:
-    if (!equal_object(ATTRIB(x), ATTRIB(y))) {
+    if (!equal_object_normalized(ATTRIB(x), ATTRIB(y))) {
       return false;
     }
-    if (!equal_object(BODY(x), BODY(y))) {
+    if (!equal_object_normalized(BODY(x), BODY(y))) {
       return false;
     }
-    if (!equal_object(CLOENV(x), CLOENV(y))) {
+    if (!equal_object_normalized(CLOENV(x), CLOENV(y))) {
       return false;
     }
-    if (!equal_object(FORMALS(x), FORMALS(y))) {
+    if (!equal_object_normalized(FORMALS(x), FORMALS(y))) {
       return false;
     }
     return true;
@@ -340,10 +352,10 @@ bool equal_object(SEXP x, SEXP y) {
   case ENVSXP:
   case EXTPTRSXP:
     // These are handled above with pointer comparison
-    stop_internal("equal_object", "Unexpected reference type.");
+    stop_internal("equal_object_normalized", "Unexpected reference type.");
 
   default:
-    stop_unimplemented_type("equal_object", TYPEOF(x));
+    stop_unimplemented_type("equal_object_normalized", TYPEOF(x));
   }
 
   R_len_t n = Rf_length(x);
@@ -393,7 +405,7 @@ static inline bool vec_equal_attrib(SEXP x, SEXP y) {
       return false;
     }
 
-    if (!equal_object(CAR(x_attrs), CAR(y_attrs))) {
+    if (!equal_object_normalized(CAR(x_attrs), CAR(y_attrs))) {
       return false;
     }
 

--- a/src/equal.h
+++ b/src/equal.h
@@ -102,7 +102,7 @@ static inline int raw_equal_na_equal(Rbyte x, Rbyte y) {
   return x == y;
 }
 static inline int list_equal_na_equal(SEXP x, SEXP y) {
-  return equal_object(x, y);
+  return equal_object_normalized(x, y);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/equal.h
+++ b/src/equal.h
@@ -96,18 +96,7 @@ static inline int cpl_equal_na_equal(Rcomplex x, Rcomplex y) {
   return dbl_equal_na_equal(x.r, y.r) && dbl_equal_na_equal(x.i, y.i);
 }
 static inline int chr_equal_na_equal(SEXP x, SEXP y) {
-  if (x == y) {
-    return 1;
-  }
-
-  if (Rf_getCharCE(x) != Rf_getCharCE(y)) {
-    const void *vmax = vmaxget();
-    int out = !strcmp(Rf_translateCharUTF8(x), Rf_translateCharUTF8(y));
-    vmaxset(vmax);
-    return out;
-  }
-
-  return 0;
+  return x == y;
 }
 static inline int raw_equal_na_equal(Rbyte x, Rbyte y) {
   return x == y;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -429,6 +429,7 @@ SEXP vec_df_restore(SEXP x, SEXP to, SEXP n, const enum vctrs_owned owned);
 // equal_object() never propagates missingness, so
 // it can return a `bool`
 bool equal_object(SEXP x, SEXP y);
+bool equal_object_normalized(SEXP x, SEXP y);
 bool equal_names(SEXP x, SEXP y);
 
 int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal);

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -236,15 +236,21 @@ test_that("can compare non-equal strings with different encodings", {
   expect_equal(vec_compare(x, y), -1L)
 })
 
-test_that("equality can always be determined when strings have identical encodings", {
-  encs <- encodings(bytes = TRUE)
+test_that("comparison can be determined when strings have identical encodings", {
+  encs <- encodings()
 
   for (enc in encs) {
     expect_equal(vec_compare(enc, enc), 0L)
   }
 })
 
-test_that("equality is known to fail when comparing bytes to other encodings", {
+test_that("comparison is known to always fail with bytes", {
+  enc <- encoding_bytes()
+  error <- "translating strings with \"bytes\" encoding"
+  expect_error(vec_compare(enc, enc), error)
+})
+
+test_that("comparison is known to fail when comparing bytes to other encodings", {
   error <- "translating strings with \"bytes\" encoding"
 
   for (enc in encodings()) {

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -167,12 +167,18 @@ test_that("can determine equality of strings with different encodings (#553)", {
 })
 
 test_that("equality can be determined when strings have identical encodings", {
-  encs <- encodings(bytes = TRUE)
+  encs <- encodings()
 
   for (enc in encs) {
     expect_true(vec_equal(enc, enc))
     expect_equal(vec_equal(enc, enc), enc == enc)
   }
+})
+
+test_that("equality is known to always fail with bytes", {
+  enc <- encoding_bytes()
+  error <- "translating strings with \"bytes\" encoding"
+  expect_error(vec_equal(enc, enc), error)
 })
 
 test_that("equality is known to fail when comparing bytes to other encodings", {


### PR DESCRIPTION
We now rely on `vec_normalize_encoding()` to do translation up front

`equal_object()` has been tweaked to call `vec_normalize_encoding()` since we use it as a standalone equality checker in a number of places. I've factored out the old behavior into `equal_object_normalized()` which assumes that its inputs have been normalized. `equal_object_normalized()` is used in `list_equal_na_equal()` since users of that (dictionary functions, vec-equal) will have already called `vec_normalize_encoding()` themselves