### PR TITLE
Ensure that size is preserved when cbind-ing zero column data frames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* `vec_cbind()` with only empty data frames now preserves the common size of
+  the inputs in the result (#1281).
+
 * `vec_c()` now correctly returns a named result with named empty inputs
   (#1263).
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -428,6 +428,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
   PROTECT_INDEX out_pi;
   SEXP out = Rf_allocVector(VECSXP, ncol);
   PROTECT_WITH_INDEX(out, &out_pi);
+  init_data_frame(out, nrow);
 
   PROTECT_INDEX names_pi;
   SEXP names = Rf_allocVector(STRSXP, ncol);
@@ -477,7 +478,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
     Rf_setAttrib(out, R_RowNamesSymbol, rownames);
   }
 
-  out = vec_restore(out, type, Rf_ScalarInteger(nrow), VCTRS_OWNED_true);
+  out = vec_restore(out, type, R_NilValue, VCTRS_OWNED_true);
 
   UNPROTECT(9);
   return out;

--- a/src/bind.c
+++ b/src/bind.c
@@ -477,7 +477,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
     Rf_setAttrib(out, R_RowNamesSymbol, rownames);
   }
 
-  out = vec_restore(out, type, R_NilValue, VCTRS_OWNED_true);
+  out = vec_restore(out, type, Rf_ScalarInteger(nrow), VCTRS_OWNED_true);
 
   UNPROTECT(9);
   return out;

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -375,6 +375,11 @@ test_that("empty inputs give data frame", {
   expect_equal(vec_cbind(data.frame(a = 1), NULL), data_frame(a = 1))
 })
 
+test_that("number of rows is preserved with zero column data frames (#1281)", {
+  df <- new_data_frame(n = 2L)
+  expect_size(vec_cbind(df, df), 2L)
+})
+
 test_that("NULL is idempotent", {
   df <- data_frame(x = 1)
   expect_equal(vec_cbind(df, NULL), df)


### PR DESCRIPTION
Closes #1281 

Fairly straightforward fix. Just need to pass the size through to vec-restore