### PR TITLE
Unstructure before mapping in `order_proxy()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # vctrs (development version)
 
+* Fixed an issue with tibble 3.0.0 where removing column names with
+  `names(x) <- NULL` is now deprecated (#1298).
+
 * Fixed a GCC 11 issue revealed by CRAN checks.
 
 # vctrs 0.3.5

--- a/R/order.R
+++ b/R/order.R
@@ -59,7 +59,7 @@ order_proxy <- function(proxy, direction = "asc", na_value = "largest") {
     if (vec_size(proxy) == 0L) {
       return(integer(0L))
     }
-    args <- map(unname(proxy), function(.x) {
+    args <- map(unstructure(proxy), function(.x) {
       if (is.data.frame(.x)) {
         .x <- order(vec_order(.x, direction = direction, na_value = na_value))
       }

--- a/tests/testthat/test-order.R
+++ b/tests/testthat/test-order.R
@@ -69,13 +69,19 @@ test_that("classed proxies do not affect performance (tidyverse/dplyr#5423)", {
   expect_time_lt(vec_order(x), 0.2)
 })
 
-test_that("can order tibbles without names warning (#1298)", {
-  skip_if_not_installed("tibble", minimum_version = "3.0.0")
+test_that("can order data frames that don't allow removing the column names (#1298)", {
   skip_if_not_installed("withr")
 
-  withr::local_envvar(c(RSTUDIO = NA_character_))
-  withr::local_options(list(lifecycle_verbosity = "error"))
+  local_methods(
+    `names<-.vctrs_foobar` = function(x, value) {
+      if (is.null(value)) {
+        abort("Cannot remove names.")
+      }
+      NextMethod()
+    }
+  )
 
-  df <- tibble::tibble(x = 1, y = 2)
+  df <- foobar(data.frame(x = 1, y = 2))
+
   expect_silent(expect_identical(vec_order(df), 1L))
 })

--- a/tests/testthat/test-order.R
+++ b/tests/testthat/test-order.R
@@ -68,3 +68,14 @@ test_that("classed proxies do not affect performance (tidyverse/dplyr#5423)", {
   x <- glue::glue("{1:10000}")
   expect_time_lt(vec_order(x), 0.2)
 })
+
+test_that("can order tibbles without names warning (#1298)", {
+  skip_if_not_installed("tibble", minimum_version = "3.0.0")
+  skip_if_not_installed("withr")
+
+  withr::local_envvar(c(RSTUDIO = NA_character_))
+  withr::local_options(list(lifecycle_verbosity = "error"))
+
+  df <- tibble::tibble(x = 1, y = 2)
+  expect_silent(expect_identical(vec_order(df), 1L))
+})


### PR DESCRIPTION
Closes #1298 

Avoids any calls to `names(x) <- NULL` by unstructuring rather than unnaming.