### PR TITLE
Use `rlang::hash()` to remove dependency on digest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,6 @@ Depends:
     R (>= 3.3)
 Imports: 
     ellipsis (>= 0.2.0),
-    digest,
     glue,
     rlang (>= 0.4.10)
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     ellipsis (>= 0.2.0),
     digest,
     glue,
-    rlang (>= 0.4.7)
+    rlang (>= 0.4.10)
 Suggests: 
     bit64,
     covr,
@@ -56,3 +56,5 @@ Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
+Remotes:
+    r-lib/rlang

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,5 +55,3 @@ Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
-Remotes:
-    r-lib/rlang

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* Removed dependency on digest.
+
 * Fixed an issue where `vctrs_rcrd` objects were not being proxied correctly
   when used as a data frame column (#1318).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # vctrs (development version)
 
-* Removed dependency on digest.
+* Removed dependency on digest in favor of `rlang::hash()`.
 
 * Fixed an issue where `vctrs_rcrd` objects were not being proxied correctly
   when used as a data frame column (#1318).

--- a/R/type-factor.R
+++ b/R/type-factor.R
@@ -225,7 +225,7 @@ hash_label <- function(x, length = 5) {
   } else {
     # Can't use hash() currently because it hashes the string pointers
     # for performance, so the values in the test change each time
-    substr(digest::digest(x), 1, length)
+    substr(rlang::hash(x), 1, length)
   }
 }
 

--- a/R/type-factor.R
+++ b/R/type-factor.R
@@ -223,7 +223,7 @@ hash_label <- function(x, length = 5) {
   if (length(x) == 0) {
     ""
   } else {
-    # Can't use hash() currently because it hashes the string pointers
+    # Can't use obj_hash() because it hashes the string pointers
     # for performance, so the values in the test change each time
     substr(rlang::hash(x), 1, length)
   }

--- a/man/theory-faq-coercion.Rd
+++ b/man/theory-faq-coercion.Rd
@@ -95,7 +95,7 @@ vec_ptype2(factor("a"), "b")
 
 # But they are incompatible with integers
 vec_ptype2(factor("a"), 1L)
-#> Error: Can't combine <factor<127a2>> and <integer>.
+#> Error: Can't combine <factor<4d52a>> and <integer>.
 }\if{html}{\out{</div>}}
 }
 

--- a/tests/testthat/error/test-conditions.txt
+++ b/tests/testthat/error/test-conditions.txt
@@ -101,7 +101,7 @@ lossy cast from character to factor mentions loss of generality
 ===============================================================
 
 > vec_cast("a", factor("b"))
-Error: Can't convert from <character> to <factor<ddf10>> due to loss of generality.
+Error: Can't convert from <character> to <factor<9b7e3>> due to loss of generality.
 * Locations: 1
 
 
@@ -109,7 +109,7 @@ ordered cast failures mention conversion
 ========================================
 
 > vec_cast(ordered("x"), ordered("y"))
-Error: Can't convert <ordered<5a425>> to <ordered<df698>>.
+Error: Can't convert <ordered<bf275>> to <ordered<fd1ad>>.
 
 
 incompatible size errors

--- a/tests/testthat/error/test-type-asis.txt
+++ b/tests/testthat/error/test-type-asis.txt
@@ -10,5 +10,5 @@ AsIs objects throw cast errors with their underlying types
 ==========================================================
 
 > vec_cast(I(1), I(factor("x")))
-Error: Can't convert <double> to <factor<5a425>>.
+Error: Can't convert <double> to <factor<bf275>>.
 

--- a/tests/testthat/test-assert-explanations.txt
+++ b/tests/testthat/test-assert-explanations.txt
@@ -14,15 +14,15 @@ Instead, it has type <logical>.
 
 > vec_assert(lgl(), factor(levels = "foo")):
 
-Error: `lgl()` must be a vector with type <factor<bd40e>>.
+Error: `lgl()` must be a vector with type <factor<c1562>>.
 Instead, it has type <logical>.
 
 
 
 > vec_assert(factor(levels = "bar"), factor(levels = "foo")):
 
-Error: `factor(levels = "bar")` must be a vector with type <factor<bd40e>>.
-Instead, it has type <factor<cbd21>>.
+Error: `factor(levels = "bar")` must be a vector with type <factor<c1562>>.
+Instead, it has type <factor<9f154>>.
 
 
 

--- a/tests/testthat/test-cast-error-nested.txt
+++ b/tests/testthat/test-cast-error-nested.txt
@@ -6,7 +6,7 @@ Can't convert <character> to <double>.
 
 vec_cast(factor("foo"), 10):
 
-Can't convert <factor<bd40e>> to <double>. 
+Can't convert <factor<c1562>> to <double>. 
 
 
 vec_cast(x, y):
@@ -16,10 +16,10 @@ Can't convert `a$b` <character> to match type of `a$b` <double>.
 
 vec_cast(x, y):
 
-Can't convert `a$b` <factor<bd40e>> to match type of `a$b` <double>. 
+Can't convert `a$b` <factor<c1562>> to match type of `a$b` <double>. 
 
 
 vec_cast_common(x, y):
 
-Can't combine `..1$a$b` <factor<bd40e>> and `..2$a$b` <double>. 
+Can't combine `..1$a$b` <factor<c1562>> and `..2$a$b` <double>. 
 

--- a/tests/testthat/test-partial-factor-print-both.txt
+++ b/tests/testthat/test-partial-factor-print-both.txt
@@ -1,4 +1,4 @@
 partial_factor<
-  5a425 {partial}
-  df698
+  bf275 {partial}
+  fd1ad
 >

--- a/tests/testthat/test-partial-factor-print-learned.txt
+++ b/tests/testthat/test-partial-factor-print-learned.txt
@@ -1,3 +1,3 @@
 partial_factor<
-  df698
+  fd1ad
 >

--- a/tests/testthat/test-partial-factor-print-partial.txt
+++ b/tests/testthat/test-partial-factor-print-partial.txt
@@ -1,3 +1,3 @@
 partial_factor<
-  5a425 {partial}
+  bf275 {partial}
 >

--- a/tests/testthat/test-type-data-frame.txt
+++ b/tests/testthat/test-type-data-frame.txt
@@ -19,6 +19,6 @@ Prototype: data.frame<
   Sepal.Width : double
   Petal.Length: double
   Petal.Width : double
-  Species     : factor<12d60>
+  Species     : factor<fb977>
 >
 


### PR DESCRIPTION
Closes #107 
Closes #664 
Closes #667 

I imagine that we now will _not_ want to expose `obj_hash()` as was done in #667.