### PR TITLE
Rework `df_flatten()` to flatten whenever df-cols are encountered

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* Fixed an issue where `vctrs_rcrd` objects were not being proxied correctly
+  when used as a data frame column (#1318).
+
 * `register_s3()` is now licensed with the "unlicense" which makes it very
   clear that it's fine to copy and paste into your own package 
   (@maxheld83, #1254).

--- a/src/init.c
+++ b/src/init.c
@@ -97,7 +97,7 @@ extern SEXP vctrs_try_catch_callback(SEXP, SEXP);
 extern SEXP vctrs_is_coercible(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_as_subscript(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_as_subscript_result(SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP vctrs_df_flat_width(SEXP);
+extern SEXP vctrs_df_flatten_info(SEXP);
 extern SEXP df_flatten(SEXP);
 extern SEXP vctrs_linked_version();
 extern SEXP vctrs_tib_ptype2(SEXP x, SEXP y, SEXP x_arg_, SEXP y_arg_);
@@ -248,7 +248,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_is_coercible",               (DL_FUNC) &vctrs_is_coercible, 5},
   {"vctrs_as_subscript",               (DL_FUNC) &vctrs_as_subscript, 5},
   {"vctrs_as_subscript_result",        (DL_FUNC) &vctrs_as_subscript_result, 5},
-  {"vctrs_df_flat_width",              (DL_FUNC) &vctrs_df_flat_width, 1},
+  {"vctrs_df_flatten_info",            (DL_FUNC) &vctrs_df_flatten_info, 1},
   {"vctrs_df_flatten",                 (DL_FUNC) &df_flatten, 1},
   {"vctrs_linked_version",             (DL_FUNC) &vctrs_linked_version, 0},
   {"vctrs_tib_ptype2",                 (DL_FUNC) &vctrs_tib_ptype2, 4},

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -832,10 +832,10 @@ R_len_t df_flat_width(SEXP x) {
   R_len_t n = Rf_length(x);
   R_len_t out = n;
 
-  const SEXP* p_x = VECTOR_PTR_RO(x);
+  const SEXP* v_x = VECTOR_PTR_RO(x);
 
   for (R_len_t i = 0; i < n; ++i) {
-    SEXP col = p_x[i];
+    SEXP col = v_x[i];
     if (is_data_frame(col)) {
       out = out + df_flat_width(col) - 1;
     }
@@ -856,10 +856,10 @@ struct flatten_info df_flatten_info(SEXP x) {
   R_len_t n = Rf_length(x);
   R_len_t width = n;
 
-  const SEXP* p_x = VECTOR_PTR_RO(x);
+  const SEXP* v_x = VECTOR_PTR_RO(x);
 
   for (R_len_t i = 0; i < n; ++i) {
-    SEXP col = p_x[i];
+    SEXP col = v_x[i];
     if (is_data_frame(col)) {
       flatten = true;
       width = width + df_flat_width(col) - 1;

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -827,7 +827,7 @@ SEXP df_poke_at(SEXP x, SEXP name, SEXP value) {
   return x;
 }
 
-// [[ include("type-data-frame.h") ]]
+static inline
 R_len_t df_flat_width(SEXP x) {
   R_len_t n = Rf_length(x);
   R_len_t out = n;

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -832,8 +832,10 @@ R_len_t df_flat_width(SEXP x) {
   R_len_t n = Rf_length(x);
   R_len_t out = n;
 
+  const SEXP* p_x = VECTOR_PTR_RO(x);
+
   for (R_len_t i = 0; i < n; ++i) {
-    SEXP col = VECTOR_ELT(x, i);
+    SEXP col = p_x[i];
     if (is_data_frame(col)) {
       out = out + df_flat_width(col) - 1;
     }

--- a/src/type-data-frame.h
+++ b/src/type-data-frame.h
@@ -19,7 +19,6 @@ SEXP df_rownames(SEXP x) {
 bool is_native_df(SEXP x);
 SEXP df_poke(SEXP x, R_len_t i, SEXP value);
 SEXP df_poke_at(SEXP x, SEXP name, SEXP value);
-R_len_t df_flat_width(SEXP x);
 SEXP df_flatten(SEXP x);
 SEXP df_repair_names(SEXP x, struct name_repair_opts* name_repair);
 

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -377,14 +377,14 @@ test_that("`class` must be a character vector", {
   expect_error(new_data_frame(class = 1), "must be NULL or a character vector")
 })
 
-test_that("flat width is computed", {
-  df_flat_width <- function(x) {
-    .Call(vctrs_df_flat_width, x)
+test_that("flatten info is computed", {
+  df_flatten_info <- function(x) {
+    .Call(vctrs_df_flatten_info, x)
   }
-  expect_identical(df_flat_width(mtcars), ncol(mtcars))
+  expect_identical(df_flatten_info(mtcars), list(FALSE, ncol(mtcars)))
 
   df <- tibble(x = 1, y = tibble(x = 2, y = tibble(x = 3), z = 4), z = 5)
-  expect_identical(df_flat_width(df), 5L)
+  expect_identical(df_flatten_info(df), list(TRUE, 5L))
 })
 
 test_that("can flatten data frames", {

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -397,6 +397,12 @@ test_that("can flatten data frames", {
   expect_identical(df_flatten(df), new_data_frame(list(x = 1, x = 2, x = 3, z = 4, z = 5)))
 })
 
+test_that("can flatten data frames with rcrd columns containing 1 field (#1318)", {
+  col <- new_rcrd(list(x = 1))
+  df <- data_frame(col = col, y = 1)
+  expect_identical(vec_proxy_equal(df), data_frame(x = 1, y = 1))
+})
+
 test_that("new_data_frame() zaps existing attributes", {
   struct <- structure(list(), foo = 1)
   expect_identical(


### PR DESCRIPTION
Closes #1318 

We now no longer use the width changing as a signal for whether or not to flatten. Instead, we use the presence of any df-cols as our signal, which is more robust to the issues of #1318.

Introduces new `df_flatten_info()` and `struct flatten_info`, just as a nice way to wrap up whether or not we are going to flatten with the flat width.