### PR TITLE
Rework `vec_ptype()` into a generic for S3 types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # vctrs (development version)
 
-* `vec_ptype()` is now generic. The default behavior for S3 classes continues
-  to use `vec_slice(x, 0L)`, but S3 methods can now be written to improve
-  performance as required for custom classes.
+* `vec_ptype()` is now an optional _performance_ generic. It is not necessary
+  to implement, but if your class has a static prototype, you might consider
+  implementing a custom `vec_ptype()` method that returns a constant to
+  improve performance in some cases (such as common type imputation).
   
 * New `vec_detect_complete()`, inspired by `stats::complete.cases()`. For most
   vectors, this is identical to `!vec_equal_na()`. For data frames and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # vctrs (development version)
 
+* `vec_ptype()` is now generic. The default behavior for S3 classes continues
+  to use `vec_slice(x, 0L)`, but S3 methods can now be written to improve
+  performance as required for custom classes.
+  
 * New `vec_detect_complete()`, inspired by `stats::complete.cases()`. For most
   vectors, this is identical to `!vec_equal_na()`. For data frames and
   matrices, this detects rows that only contain non-missing values.

--- a/R/type.R
+++ b/R/type.R
@@ -39,6 +39,12 @@
 #' See [internal-faq-ptype2-identity] for more information about
 #' identity values.
 #'
+#' For performance, when developing a new S3 class you might want to override
+#' the default behavior of `vec_ptype()`, which is to call `vec_slice(x, 0L)`.
+#' To do this, write a `vec_ptype()` S3 method for your class. The method should
+#' return a result equivalent to `vec_slice(x, 0L)`, but for many classes this
+#' is a static object.
+#'
 #' Because it may contain unspecified vectors, the prototype returned
 #' by `vec_ptype()` is said to be __unfinalised__. Call
 #' [vec_ptype_finalise()] to finalise it. Commonly you will need the

--- a/R/type.R
+++ b/R/type.R
@@ -94,7 +94,8 @@ vec_ptype <- function(x, ..., x_arg = "") {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
-  .Call(vctrs_ptype, x, x_arg)
+  return(.Call(vctrs_ptype, x, x_arg))
+  UseMethod("vec_ptype")
 }
 
 #' @export

--- a/R/type.R
+++ b/R/type.R
@@ -39,11 +39,13 @@
 #' See [internal-faq-ptype2-identity] for more information about
 #' identity values.
 #'
-#' For performance, when developing a new S3 class you might want to override
-#' the default behavior of `vec_ptype()`, which is to call `vec_slice(x, 0L)`.
-#' To do this, write a `vec_ptype()` S3 method for your class. The method should
-#' return a result equivalent to `vec_slice(x, 0L)`, but for many classes this
-#' is a static object.
+#' `vec_ptype()` is a _performance_ generic. It is not necessary to implement it
+#' because the default method will work for any vctrs type. However the default
+#' method builds around other vctrs primitives like `vec_slice()` which incurs
+#' performance costs. If your class has a static prototype, you might consider
+#' implementing a custom `vec_ptype()` method that returns a constant. This will
+#' improve the performance of your class in many cases ([common
+#' type][vec_ptype2] imputation in particular).
 #'
 #' Because it may contain unspecified vectors, the prototype returned
 #' by `vec_ptype()` is said to be __unfinalised__. Call

--- a/man/vec_ptype.Rd
+++ b/man/vec_ptype.Rd
@@ -59,11 +59,12 @@ for any 1d vector type.
 See \link{internal-faq-ptype2-identity} for more information about
 identity values.
 
-For performance, when developing a new S3 class you might want to override
-the default behavior of \code{vec_ptype()}, which is to call \code{vec_slice(x, 0L)}.
-To do this, write a \code{vec_ptype()} S3 method for your class. The method should
-return a result equivalent to \code{vec_slice(x, 0L)}, but for many classes this
-is a static object.
+\code{vec_ptype()} is a \emph{performance} generic. It is not necessary to implement it
+because the default method will work for any vctrs type. However the default
+method builds around other vctrs primitives like \code{vec_slice()} which incurs
+performance costs. If your class has a static prototype, you might consider
+implementing a custom \code{vec_ptype()} method that returns a constant. This will
+improve the performance of your class in many cases (\link[=vec_ptype2]{common type} imputation in particular).
 
 Because it may contain unspecified vectors, the prototype returned
 by \code{vec_ptype()} is said to be \strong{unfinalised}. Call

--- a/man/vec_ptype.Rd
+++ b/man/vec_ptype.Rd
@@ -59,6 +59,12 @@ for any 1d vector type.
 See \link{internal-faq-ptype2-identity} for more information about
 identity values.
 
+For performance, when developing a new S3 class you might want to override
+the default behavior of \code{vec_ptype()}, which is to call \code{vec_slice(x, 0L)}.
+To do this, write a \code{vec_ptype()} S3 method for your class. The method should
+return a result equivalent to \code{vec_slice(x, 0L)}, but for many classes this
+is a static object.
+
 Because it may contain unspecified vectors, the prototype returned
 by \code{vec_ptype()} is said to be \strong{unfinalised}. Call
 \code{\link[=vec_ptype_finalise]{vec_ptype_finalise()}} to finalise it. Commonly you will need the

--- a/src/decl/ptype-decl.h
+++ b/src/decl/ptype-decl.h
@@ -1,0 +1,7 @@
+#ifndef VCTRS_PTYPE_DECL_H
+#define VCTRS_PTYPE_DECL_H
+
+static inline SEXP vec_ptype_method(SEXP x);
+static inline SEXP vec_ptype_invoke(SEXP x, SEXP method);
+
+#endif

--- a/src/type.c
+++ b/src/type.c
@@ -4,6 +4,7 @@
 #include "ptype2.h"
 #include "type-data-frame.h"
 #include "utils.h"
+#include "decl/ptype-decl.h"
 
 // Initialised at load time
 static SEXP syms_vec_ptype = NULL;
@@ -55,9 +56,6 @@ static inline SEXP vec_ptype_slice(SEXP x, SEXP empty) {
     return vec_slice(x, R_NilValue);
   }
 }
-
-static inline SEXP vec_ptype_method(SEXP x);
-static inline SEXP vec_ptype_invoke(SEXP x, SEXP method);
 
 static SEXP s3_type(SEXP x, struct vctrs_arg* x_arg) {
   switch (class_type(x)) {

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -190,6 +190,13 @@ test_that("the type of a classed data frame with an unspecified column retains u
   expect_identical(vec_ptype(df2), expect)
 })
 
+test_that("vec_ptype() methods can be written", {
+  local_methods(
+    vec_ptype.vctrs_foobar = function(x, ...) "dispatch"
+  )
+  expect_identical(vec_ptype(foobar()), "dispatch")
+})
+
 test_that("vec_ptype_finalise() works with NULL", {
   expect_identical(vec_ptype_finalise(NULL), NULL)
 })


### PR DESCRIPTION
Demonstrated benefits of a static vec-ptype:

(It is a bit oversimplified for year-month-day, but the performance improvements remains valid)

It would be up to the developer to ensure that their vec-ptype method returns a "valid" ptype. I think this is a reasonable requirement, since we essentially require that their vec-ptype2 and vec-cast methods are also valid.

``` r
library(clock)
library(vctrs)

x <- year_month_day(2019, 1, 1)
xs <- rep(list(x), 1e5)

bench::mark(vec_ptype(x), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype(x)   14.3µs   15.2µs    62544.    29.8KB     21.9

bench::mark(vec_ptype_common(!!!xs))
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype_common(!!!xs)    7.79s    7.79s     0.128      32KB     24.5

empty_year_month_day <- year_month_day(integer(), integer(), integer())

vec_ptype.clock_year_month_day <- function(x, ..., x_arg = "") {
  empty_year_month_day
}

bench::mark(vec_ptype(x), iterations = 100000)
#> # A tibble: 1 x 6
#>   expression        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype(x)   1.83µs    2.4µs   388969.        0B     27.2

bench::mark(vec_ptype_common(!!!xs))
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_ptype_common(!!!xs)    1.29s    1.29s     0.773        0B     27.8
```

<sup>Created on 2021-02-24 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>