### PR TITLE
Delegate encoding normalization to `vec_normalize_encoding()`

### DIFF
--- a/src/order-sortedness.h
+++ b/src/order-sortedness.h
@@ -42,7 +42,6 @@ enum vctrs_sortedness chr_sortedness(const SEXP* p_x,
                                      r_ssize size,
                                      bool decreasing,
                                      bool na_last,
-                                     bool check_encoding,
                                      struct group_infos* p_group_infos);
 
 // -----------------------------------------------------------------------------

--- a/src/order-truelength.c
+++ b/src/order-truelength.c
@@ -46,8 +46,6 @@ struct truelength_info* new_truelength_info(r_ssize max_size_alloc) {
 
   p_truelength_info->max_string_size = 0;
 
-  p_truelength_info->reencode = false;
-
   UNPROTECT(1);
   return p_truelength_info;
 }
@@ -74,7 +72,6 @@ void truelength_reset(struct truelength_info* p_truelength_info) {
   // Also reset vector specific details
   p_truelength_info->size_used = 0;
   p_truelength_info->max_string_size = 0;
-  p_truelength_info->reencode = false;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/order-truelength.h
+++ b/src/order-truelength.h
@@ -50,10 +50,6 @@
  * @member size_used The number of unique strings currently in `strings`.
  * @member max_string_size The maximum string size of the unique strings stored
  *   in `strings`. This controls the depth of recursion in `chr_radix_order()`.
- * @member reencode Should the encoding be checked to see if a translation to
- *   UTF-8 is required? This is used by `df_order()` when extracting out each
- *   group chunk, and by `chr_order()` to decide whether the input needs to be
- *   copied and re-encoded.
  */
 struct truelength_info {
   SEXP self;
@@ -83,8 +79,6 @@ struct truelength_info {
   r_ssize size_used;
 
   r_ssize max_string_size;
-
-  bool reencode;
 };
 
 #define PROTECT_TRUELENGTH_INFO(p_info, p_n) do {                   \

--- a/src/utils.c
+++ b/src/utils.c
@@ -419,35 +419,6 @@ SEXP chr_resize(SEXP x, r_ssize x_size, r_ssize size) {
 #undef RESIZE
 #undef RESIZE_BARRIER
 
-// [[ include("utils.h") ]]
-bool p_chr_any_reencode(const SEXP* p_x, r_ssize size) {
-  for (r_ssize i = 0; i < size; ++i) {
-    SEXP elt = p_x[i];
-
-    if (CHAR_NEEDS_REENCODE(elt)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-// [[ include("utils.h") ]]
-void p_chr_copy_with_reencode(const SEXP* p_x, SEXP x_result, r_ssize size) {
-  const void* vmax = vmaxget();
-
-  for (r_ssize i = 0; i < size; ++i) {
-    SEXP elt = p_x[i];
-
-    if (CHAR_NEEDS_REENCODE(elt)) {
-      SET_STRING_ELT(x_result, i, CHAR_REENCODE(elt));
-    } else {
-      SET_STRING_ELT(x_result, i, elt);
-    }
-  }
-
-  vmaxset(vmax);
-}
 
 inline void never_reached(const char* fn) {
   Rf_error("Internal error in `%s()`: Reached the unreachable.", fn);

--- a/src/utils.h
+++ b/src/utils.h
@@ -118,9 +118,6 @@ SEXP int_resize(SEXP x, r_ssize x_size, r_ssize size);
 SEXP raw_resize(SEXP x, r_ssize x_size, r_ssize size);
 SEXP chr_resize(SEXP x, r_ssize x_size, r_ssize size);
 
-bool p_chr_any_reencode(const SEXP* p_x, r_ssize size);
-void p_chr_copy_with_reencode(const SEXP* p_x, SEXP x_result, r_ssize size);
-
 SEXP vec_unique_names(SEXP x, bool quiet);
 SEXP vec_unique_colnames(SEXP x, bool quiet);
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -26,12 +26,6 @@ typedef R_xlen_t r_ssize;
 // condition object otherwise
 #define ERR SEXP
 
-// Utilities for deciding whether or not to re-encode as UTF-8
-#define CHAR_IS_UTF8(x)  (LEVELS(x) & 8)
-#define CHAR_IS_ASCII(x) (LEVELS(x) & 64)
-#define CHAR_NEEDS_REENCODE(x) (!(CHAR_IS_ASCII(x) || (x) == NA_STRING || CHAR_IS_UTF8(x)))
-#define CHAR_REENCODE(x) Rf_mkCharCE(Rf_translateCharUTF8(x), CE_UTF8)
-
 // Vector types -------------------------------------------------
 
 enum vctrs_type {


### PR DESCRIPTION
This PR strips out all of the encoding logic from `vec_order_radix()`, replacing it with a single call to `vec_normalize_encoding()` at the top.

This greatly simplifies the character encoding logic, at the cost of some performance in two ways:

- Previously, we only checked the encodings of the _unique_ strings to determine if any re-encoding was required. Now we are forced to loop through the whole vector up front, checking the encoding of each string. This generally isn't that bad, but...

- ...When there are _lots_ of unique values, `vec_normalize_encoding()` is slower than when there are just a few. I assume this has something to do with the CPU caching and reusing the result of `LEVELS(x)` (which we use in `string_is_normalized()`) when there are just a few unique values.

I still think this tradeoff is worth it, as it further standardizes how we handle encodings throughout vctrs and is much easier to reason about. The performance hit from calling `vec_normalize_encoding()` will really only be noticeable if there are a massive amount of unique values.

``` r
library(vctrs)

set.seed(123)

vec_order_radix <- vctrs:::vec_order_radix
vec_normalize_encoding <- vctrs:::vec_normalize_encoding
```

```r
# few uniques
dict <- c("apples", "bananas")
x1 <- sample(dict, size = 1e6, replace = TRUE)
x2 <- sample(dict, size = 1e7, replace = TRUE)

## few uniques / short
# before
bench::mark(vec_order_radix(x1), iterations = 50)
#> # A tibble: 1 x 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_order_radix(x1)   8.72ms   11.3ms      88.6    12.7MB     19.4

# after
bench::mark(vec_order_radix(x1), iterations = 50)
#> # A tibble: 1 x 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_order_radix(x1)   10.6ms   13.3ms      75.4    12.7MB     16.5

# normalization cost
bench::mark(vec_normalize_encoding(x1))
#> # A tibble: 1 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_normalize_encoding(x1)   1.34ms   1.56ms      629.        0B        0


## few uniques / long
# before
bench::mark(vec_order_radix(x2), iterations = 50)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_order_radix(x2)   98.9ms    104ms      9.45     124MB     9.45

# after
bench::mark(vec_order_radix(x2), iterations = 50)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_order_radix(x2)    116ms    121ms      8.13     124MB     8.13

# normalization cost
bench::mark(vec_normalize_encoding(x2))
#> # A tibble: 1 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_normalize_encoding(x2)   15.5ms   17.1ms      57.7        0B        0
```

```r
# many uniques
dict <- stringi::stri_rand_strings(200000, length = 6)
y1 <- sample(dict, size = 1e6, replace = TRUE)
y2 <- sample(dict, size = 1e7, replace = TRUE)

## many uniques / short
# before
bench::mark(vec_order_radix(y1), iterations = 50)
#> # A tibble: 1 x 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_order_radix(y1)    103ms    109ms      9.17    43.1MB     6.64

# after
bench::mark(vec_order_radix(y1), iterations = 50)
#> # A tibble: 1 x 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_order_radix(y1)    110ms    120ms      8.34    43.1MB     6.04

# normalization cost
bench::mark(vec_normalize_encoding(y1))
#> # A tibble: 1 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_normalize_encoding(y1)   7.03ms   7.93ms      125.        0B        0


## many uniques / long
# before
bench::mark(vec_order_radix(y2), iterations = 50)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_order_radix(y2)    452ms    497ms      1.96     258MB     2.16

# after
bench::mark(vec_order_radix(y2), iterations = 50)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_order_radix(y2)    531ms    570ms      1.71     258MB     1.88

# normalization cost
bench::mark(vec_normalize_encoding(y2))
#> # A tibble: 1 x 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_normalize_encoding(y2)   79.9ms   87.7ms      11.5        0B        0
```

<sup>Created on 2021-02-26 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>