### PR TITLE
Allow ordering by complex vectors in `order_proxy()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `vec_order()` can now order complex vectors (#1330).
+
 * Removed dependency on digest in favor of `rlang::hash()`.
 
 * Fixed an issue where `vctrs_rcrd` objects were not being proxied correctly

--- a/R/order.R
+++ b/R/order.R
@@ -66,7 +66,7 @@ order_proxy <- function(proxy, direction = "asc", na_value = "largest") {
       .x
     })
     exec("order", !!!args, decreasing = decreasing, na.last = na.last)
-  } else if (is_character(proxy) || is_logical(proxy) || is_integer(proxy) || is_double(proxy)) {
+  } else if (is_character(proxy) || is_logical(proxy) || is_integer(proxy) || is_double(proxy) || is.complex(proxy)) {
     if (is.object(proxy)) {
       proxy <- unstructure(proxy)
     }

--- a/tests/testthat/test-order.R
+++ b/tests/testthat/test-order.R
@@ -6,6 +6,15 @@ test_that("can request NAs sorted first", {
   expect_equal(vec_order(c(1, NA), "desc", "smallest"), 1:2)
 })
 
+test_that("can order complex vectors", {
+  x <- complex(real = c(1, 2, 2, 3, 3), imaginary = c(5, 4, 3, 2, NA))
+
+  expect_equal(vec_order(x, direction = "asc", na_value = "largest"), c(1, 3, 2, 4, 5))
+  expect_equal(vec_order(x, direction = "desc", na_value = "largest"), rev(c(1, 3, 2, 4, 5)))
+  expect_equal(vec_order(x, direction = "asc", na_value = "smallest"), c(5, 1, 3, 2, 4))
+  expect_equal(vec_order(x, direction = "desc", na_value = "smallest"), rev(c(5, 1, 3, 2, 4)))
+})
+
 test_that("can sort data frames", {
   df <- data.frame(x = c(1, 2, 1), y = c(1, 2, 2))
 


### PR DESCRIPTION
Closes #1330 