### PR TITLE
Add `string_key` argument to `vec_order_radix()`

### DIFF
--- a/R/order-radix.R
+++ b/R/order-radix.R
@@ -52,6 +52,10 @@
 #'     length as `x`, also encoded as UTF-8.
 #'   - For data frames, `chr_transform` will be applied to all character
 #'     columns.
+#'
+#'   Common transformation functions include: `tolower()` for case-insensitive
+#'   ordering and `stringi::str_sort_key()` for locale-aware ordering. See the
+#'   Details section for more information.
 #' @return
 #' * `vec_order()` an integer vector the same size as `x`.
 #' * `vec_sort()` a vector with the same size and type as `x`.

--- a/R/order-radix.R
+++ b/R/order-radix.R
@@ -20,7 +20,7 @@
 #' the C-locale. While sorting with the C-locale can be useful for
 #' algorithmic efficiency, in many real world uses it can be the cause of
 #' data analysis mistakes. To balance these trade-offs, you can supply a
-#' `string_key` to transform character vectors into an alternative
+#' `chr_transform` to transform character vectors into an alternative
 #' representation that orders in the C-locale in a less surprising way. For
 #' example, providing [base::tolower()] as a string key will order the original
 #' string in a case-insensitive manner. Locale-aware ordering can be achieved
@@ -42,14 +42,15 @@
 #'   - For data frames, a length `1` or `ncol(x)` character vector containing
 #'     only `"largest"` or `"smallest"`, specifying how `NA`s should be treated
 #'     in each column.
-#' @param string_key Transformation of character vectors for sorting in
+#' @param chr_transform Transformation of character vectors for sorting in
 #'   alternate locales.
 #'   - If `NULL`, no transformation is done.
 #'   - Otherwise, this must be a function of one argument. The function will be
 #'     invoked with `x`, if it is a character vector, after it has been
 #'     translated to UTF-8, and should return a character vector with the same
 #'     length as `x`, also encoded as UTF-8.
-#'   - For data frames, `string_key` will be applied to all character columns.
+#'   - For data frames, `chr_transform` will be applied to all character
+#'     columns.
 #' @return
 #' * `vec_order()` an integer vector the same size as `x`.
 #' * `vec_sort()` a vector with the same size and type as `x`.
@@ -87,15 +88,15 @@
 #' y <- c("B", "A", "a")
 #' vec_sort(y)
 #'
-#' # To order in a case-insensitive manner, provide a `string_key` that
+#' # To order in a case-insensitive manner, provide a `chr_transform` that
 #' # transforms the strings to all lowercase
-#' vec_sort(y, string_key = tolower)
+#' vec_sort(y, chr_transform = tolower)
 #' @noRd
 vec_order_radix <- function(x,
                             direction = "asc",
                             na_value = "largest",
-                            string_key = NULL) {
-  .Call(vctrs_order, x, direction, na_value, string_key)
+                            chr_transform = NULL) {
+  .Call(vctrs_order, x, direction, na_value, chr_transform)
 }
 
 #' Identify ordered groups
@@ -133,6 +134,6 @@ vec_order_radix <- function(x,
 vec_order_locs <- function(x,
                            direction = "asc",
                            na_value = "largest",
-                           string_key = NULL) {
-  .Call(vctrs_order_locs, x, direction, na_value, string_key)
+                           chr_transform = NULL) {
+  .Call(vctrs_order_locs, x, direction, na_value, chr_transform)
 }

--- a/R/order-radix.R
+++ b/R/order-radix.R
@@ -22,12 +22,13 @@
 #' data analysis mistakes. To balance these trade-offs, you can supply a
 #' `chr_transform` to transform character vectors into an alternative
 #' representation that orders in the C-locale in a less surprising way. For
-#' example, providing [base::tolower()] as a string key will order the original
-#' string in a case-insensitive manner. Locale-aware ordering can be achieved
-#' by providing `stringi::stri_sort_key()` as a string key, setting the
+#' example, providing [base::tolower()] as a transform will order the original
+#' vector in a case-insensitive manner. Locale-aware ordering can be achieved
+#' by providing `stringi::stri_sort_key()` as a transform, setting the
 #' collation options as appropriate for your locale.
 #'
-#' Character vectors are always translated to UTF-8 before ordering.
+#' Character vectors are always translated to UTF-8 before ordering, and before
+#' any transform is applied by `chr_transform`.
 #'
 #' @param x A vector
 #' @param direction Direction to sort in.

--- a/R/order-radix.R
+++ b/R/order-radix.R
@@ -19,7 +19,13 @@
 #' unless `base::order(method = "radix")` is explicitly set, which also uses
 #' the C-locale. While sorting with the C-locale can be useful for
 #' algorithmic efficiency, in many real world uses it can be the cause of
-#' data analysis mistakes.
+#' data analysis mistakes. To balance these trade-offs, you can supply a
+#' `string_key` to transform character vectors into an alternative
+#' representation that orders in the C-locale in a less surprising way. For
+#' example, providing [base::tolower()] as a string key will order the original
+#' string in a case-insensitive manner. Locale-aware ordering can be achieved
+#' by providing `stringi::stri_sort_key()` as a string key, setting the
+#' collation options as appropriate for your locale.
 #'
 #' Character vectors are always translated to UTF-8 before ordering.
 #'
@@ -36,6 +42,14 @@
 #'   - For data frames, a length `1` or `ncol(x)` character vector containing
 #'     only `"largest"` or `"smallest"`, specifying how `NA`s should be treated
 #'     in each column.
+#' @param string_key Transformation of character vectors for sorting in
+#'   alternate locales.
+#'   - If `NULL`, no transformation is done.
+#'   - Otherwise, this must be a function of one argument. The function will be
+#'     invoked with `x`, if it is a character vector, after it has been
+#'     translated to UTF-8, and should return a character vector with the same
+#'     length as `x`, also encoded as UTF-8.
+#'   - For data frames, `string_key` will be applied to all character columns.
 #' @return
 #' * `vec_order()` an integer vector the same size as `x`.
 #' * `vec_sort()` a vector with the same size and type as `x`.
@@ -67,9 +81,21 @@
 #'   direction = c("desc", "asc"),
 #'   na_value = c("largest", "smallest")
 #' )
+#'
+#' # Character vectors are ordered in the C locale, which orders capital letters
+#' # below lowercase ones
+#' y <- c("B", "A", "a")
+#' vec_sort(y)
+#'
+#' # To order in a case-insensitive manner, provide a `string_key` that
+#' # transforms the strings to all lowercase
+#' vec_sort(y, string_key = tolower)
 #' @noRd
-vec_order_radix <- function(x, direction = "asc", na_value = "largest") {
-  .Call(vctrs_order, x, direction, na_value)
+vec_order_radix <- function(x,
+                            direction = "asc",
+                            na_value = "largest",
+                            string_key = NULL) {
+  .Call(vctrs_order, x, direction, na_value, string_key)
 }
 
 #' Identify ordered groups
@@ -104,6 +130,9 @@ vec_order_radix <- function(x, direction = "asc", na_value = "largest") {
 #'
 #' vec_group_loc(df)
 #' @noRd
-vec_order_locs <- function(x, direction = "asc", na_value = "largest") {
-  .Call(vctrs_order_locs, x, direction, na_value)
+vec_order_locs <- function(x,
+                           direction = "asc",
+                           na_value = "largest",
+                           string_key = NULL) {
+  .Call(vctrs_order_locs, x, direction, na_value, string_key)
 }

--- a/src/init.c
+++ b/src/init.c
@@ -129,8 +129,8 @@ extern SEXP vctrs_slice_complete(SEXP);
 extern SEXP vctrs_locate_complete(SEXP);
 extern SEXP vctrs_detect_complete(SEXP);
 extern SEXP vctrs_normalize_encoding(SEXP);
-extern SEXP vctrs_order(SEXP, SEXP, SEXP);
-extern SEXP vctrs_order_locs(SEXP, SEXP, SEXP);
+extern SEXP vctrs_order(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_order_locs(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_unrep(SEXP);
 extern SEXP vctrs_fill_missing(SEXP, SEXP, SEXP);
 extern SEXP vctrs_chr_paste_prefix(SEXP, SEXP, SEXP);
@@ -280,8 +280,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_locate_complete",            (DL_FUNC) &vctrs_locate_complete, 1},
   {"vctrs_detect_complete",            (DL_FUNC) &vctrs_detect_complete, 1},
   {"vctrs_normalize_encoding",         (DL_FUNC) &vctrs_normalize_encoding, 1},
-  {"vctrs_order",                      (DL_FUNC) &vctrs_order, 3},
-  {"vctrs_order_locs",                 (DL_FUNC) &vctrs_order_locs, 3},
+  {"vctrs_order",                      (DL_FUNC) &vctrs_order, 4},
+  {"vctrs_order_locs",                 (DL_FUNC) &vctrs_order_locs, 4},
   {"vctrs_unrep",                      (DL_FUNC) &vctrs_unrep, 1},
   {"vctrs_fill_missing",               (DL_FUNC) &vctrs_fill_missing, 3},
   {"vctrs_chr_paste_prefix",           (DL_FUNC) &vctrs_chr_paste_prefix, 3},

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -4209,7 +4209,7 @@ SEXP string_key_invoke(SEXP x, SEXP string_key) {
   if (vec_typeof(out) != vctrs_type_character) {
     Rf_errorcall(
       R_NilValue,
-      "Applying `string_key` must result in a character vector."
+      "`string_key` must return a character vector."
     );
   }
 
@@ -4219,7 +4219,7 @@ SEXP string_key_invoke(SEXP x, SEXP string_key) {
   if (x_size != out_size) {
     Rf_errorcall(
       R_NilValue,
-      "Applying `string_key` must result in a vector with length %i, not %i.",
+      "`string_key` must return a vector of the same length (%i, not %i).",
       x_size,
       out_size
     );

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -3583,6 +3583,9 @@ void df_order_internal(SEXP x,
     int* p_o_col = p_order->p_data;
 
     col = VECTOR_ELT(x, i);
+    PROTECT_INDEX col_pi;
+    PROTECT_WITH_INDEX(col, &col_pi);
+
     type = vec_proxy_typeof(col);
 
     // If we are on the rerun pass, flip this back off so the
@@ -3594,7 +3597,8 @@ void df_order_internal(SEXP x,
     // Apply `string_key` and pre-sort unique characters once for
     // the whole column
     if (type == vctrs_type_character) {
-      col = PROTECT(string_key_invoke(col, string_key));
+      col = string_key_invoke(col, string_key);
+      REPROTECT(col, col_pi);
 
       const SEXP* p_col = STRING_PTR_RO(col);
 
@@ -3663,8 +3667,9 @@ void df_order_internal(SEXP x,
     // and unprotect result of applying `string_key`
     if (type == vctrs_type_character) {
       truelength_reset(p_truelength_info);
-      UNPROTECT(1);
     }
+
+    UNPROTECT(1);
   }
 }
 

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -183,15 +183,15 @@
 
 // -----------------------------------------------------------------------------
 
-static SEXP vec_order(SEXP x, SEXP decreasing, SEXP na_last, SEXP string_key);
+static SEXP vec_order(SEXP x, SEXP decreasing, SEXP na_last, SEXP chr_transform);
 
 // [[ register() ]]
-SEXP vctrs_order(SEXP x, SEXP direction, SEXP na_value, SEXP string_key) {
+SEXP vctrs_order(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform) {
   SEXP decreasing = PROTECT(parse_direction(direction));
   SEXP na_last = PROTECT(parse_na_value(na_value));
-  string_key = PROTECT(as_string_key(string_key));
+  chr_transform = PROTECT(as_chr_transform(chr_transform));
 
-  SEXP out = vec_order(x, decreasing, na_last, string_key);
+  SEXP out = vec_order(x, decreasing, na_last, chr_transform);
 
   UNPROTECT(3);
   return out;
@@ -201,25 +201,25 @@ SEXP vctrs_order(SEXP x, SEXP direction, SEXP na_value, SEXP string_key) {
 static SEXP vec_order_impl(SEXP x,
                            SEXP decreasing,
                            SEXP na_last,
-                           SEXP string_key,
+                           SEXP chr_transform,
                            bool locations);
 
 static
-SEXP vec_order(SEXP x, SEXP decreasing, SEXP na_last, SEXP string_key) {
-  return vec_order_impl(x, decreasing, na_last, string_key, false);
+SEXP vec_order(SEXP x, SEXP decreasing, SEXP na_last, SEXP chr_transform) {
+  return vec_order_impl(x, decreasing, na_last, chr_transform, false);
 }
 
 // -----------------------------------------------------------------------------
 
-static SEXP vec_order_locs(SEXP x, SEXP decreasing, SEXP na_last, SEXP string_key);
+static SEXP vec_order_locs(SEXP x, SEXP decreasing, SEXP na_last, SEXP chr_transform);
 
 // [[ register() ]]
-SEXP vctrs_order_locs(SEXP x, SEXP direction, SEXP na_value, SEXP string_key) {
+SEXP vctrs_order_locs(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform) {
   SEXP decreasing = PROTECT(parse_direction(direction));
   SEXP na_last = PROTECT(parse_na_value(na_value));
-  string_key = PROTECT(as_string_key(string_key));
+  chr_transform = PROTECT(as_chr_transform(chr_transform));
 
-  SEXP out = vec_order_locs(x, decreasing, na_last, string_key);
+  SEXP out = vec_order_locs(x, decreasing, na_last, chr_transform);
 
   UNPROTECT(3);
   return out;
@@ -227,8 +227,8 @@ SEXP vctrs_order_locs(SEXP x, SEXP direction, SEXP na_value, SEXP string_key) {
 
 
 static
-SEXP vec_order_locs(SEXP x, SEXP decreasing, SEXP na_last, SEXP string_key) {
-  return vec_order_impl(x, decreasing, na_last, string_key, true);
+SEXP vec_order_locs(SEXP x, SEXP decreasing, SEXP na_last, SEXP chr_transform) {
+  return vec_order_impl(x, decreasing, na_last, chr_transform, true);
 }
 
 // -----------------------------------------------------------------------------
@@ -245,7 +245,7 @@ static SEXP vec_order_expand_args(SEXP x, SEXP decreasing, SEXP na_last);
 static void vec_order_switch(SEXP x,
                              SEXP decreasing,
                              SEXP na_last,
-                             SEXP string_key,
+                             SEXP chr_transform,
                              r_ssize size,
                              const enum vctrs_type type,
                              struct order* p_order,
@@ -265,7 +265,7 @@ static void vec_order_switch(SEXP x,
  * the locations in `x` corresponding to each key.
  */
 static
-SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, SEXP string_key, bool locations) {
+SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, SEXP chr_transform, bool locations) {
   int n_prot = 0;
   int* p_n_prot = &n_prot;
 
@@ -341,7 +341,7 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, SEXP string_key, bool
     proxy,
     decreasing,
     na_last,
-    string_key,
+    chr_transform,
     size,
     type,
     p_order,
@@ -428,7 +428,7 @@ SEXP vec_order_locs_impl(SEXP x,
 static void df_order(SEXP x,
                      SEXP decreasing,
                      SEXP na_last,
-                     SEXP string_key,
+                     SEXP chr_transform,
                      r_ssize size,
                      struct order* p_order,
                      struct lazy_raw* p_lazy_x_chunk,
@@ -442,7 +442,7 @@ static void df_order(SEXP x,
 static void vec_order_base_switch(SEXP x,
                                   bool decreasing,
                                   bool na_last,
-                                  SEXP string_key,
+                                  SEXP chr_transform,
                                   r_ssize size,
                                   const enum vctrs_type type,
                                   struct order* p_order,
@@ -458,7 +458,7 @@ static
 void vec_order_switch(SEXP x,
                       SEXP decreasing,
                       SEXP na_last,
-                      SEXP string_key,
+                      SEXP chr_transform,
                       r_ssize size,
                       const enum vctrs_type type,
                       struct order* p_order,
@@ -474,7 +474,7 @@ void vec_order_switch(SEXP x,
       x,
       decreasing,
       na_last,
-      string_key,
+      chr_transform,
       size,
       p_order,
       p_lazy_x_chunk,
@@ -512,7 +512,7 @@ void vec_order_switch(SEXP x,
     x,
     c_decreasing,
     c_na_last,
-    string_key,
+    chr_transform,
     size,
     type,
     p_order,
@@ -579,7 +579,7 @@ static void cpl_order(SEXP x,
 static void chr_order(SEXP x,
                       bool decreasing,
                       bool na_last,
-                      SEXP string_key,
+                      SEXP chr_transform,
                       r_ssize size,
                       struct order* p_order,
                       struct lazy_raw* p_lazy_x_chunk,
@@ -595,7 +595,7 @@ static
 void vec_order_base_switch(SEXP x,
                            bool decreasing,
                            bool na_last,
-                           SEXP string_key,
+                           SEXP chr_transform,
                            r_ssize size,
                            const enum vctrs_type type,
                            struct order* p_order,
@@ -680,7 +680,7 @@ void vec_order_base_switch(SEXP x,
       x,
       decreasing,
       na_last,
-      string_key,
+      chr_transform,
       size,
       p_order,
       p_lazy_x_chunk,
@@ -2688,7 +2688,7 @@ struct chr_order_info {
   SEXP x;
   bool decreasing;
   bool na_last;
-  SEXP string_key;
+  SEXP chr_transform;
   r_ssize size;
   struct order* p_order;
   struct lazy_raw* p_lazy_x_chunk;
@@ -2717,7 +2717,7 @@ static
 void chr_order(SEXP x,
                bool decreasing,
                bool na_last,
-               SEXP string_key,
+               SEXP chr_transform,
                r_ssize size,
                struct order* p_order,
                struct lazy_raw* p_lazy_x_chunk,
@@ -2731,7 +2731,7 @@ void chr_order(SEXP x,
     .x = x,
     .decreasing = decreasing,
     .na_last = na_last,
-    .string_key = string_key,
+    .chr_transform = chr_transform,
     .size = size,
     .p_order = p_order,
     .p_lazy_x_chunk = p_lazy_x_chunk,
@@ -2758,7 +2758,7 @@ void chr_order(SEXP x,
 static void chr_order_internal(SEXP x,
                                bool decreasing,
                                bool na_last,
-                               SEXP string_key,
+                               SEXP chr_transform,
                                r_ssize size,
                                struct order* p_order,
                                struct lazy_raw* p_lazy_x_chunk,
@@ -2777,7 +2777,7 @@ SEXP chr_order_exec(void* p_data) {
     p_info->x,
     p_info->decreasing,
     p_info->na_last,
-    p_info->string_key,
+    p_info->chr_transform,
     p_info->size,
     p_info->p_order,
     p_info->p_lazy_x_chunk,
@@ -2802,7 +2802,7 @@ static
 void chr_order_internal(SEXP x,
                         bool decreasing,
                         bool na_last,
-                        SEXP string_key,
+                        SEXP chr_transform,
                         r_ssize size,
                         struct order* p_order,
                         struct lazy_raw* p_lazy_x_chunk,
@@ -2812,7 +2812,7 @@ void chr_order_internal(SEXP x,
                         struct lazy_raw* p_lazy_counts,
                         struct group_infos* p_group_infos,
                         struct truelength_info* p_truelength_info) {
-  x = PROTECT(string_key_invoke(x, string_key));
+  x = PROTECT(chr_transform_invoke(x, chr_transform));
 
   const SEXP* p_x = STRING_PTR_RO(x);
 
@@ -3303,7 +3303,7 @@ struct df_order_info {
   SEXP x;
   SEXP decreasing;
   SEXP na_last;
-  SEXP string_key;
+  SEXP chr_transform;
   r_ssize size;
   struct order* p_order;
   struct lazy_raw* p_lazy_x_chunk;
@@ -3344,7 +3344,7 @@ static
 void df_order(SEXP x,
               SEXP decreasing,
               SEXP na_last,
-              SEXP string_key,
+              SEXP chr_transform,
               r_ssize size,
               struct order* p_order,
               struct lazy_raw* p_lazy_x_chunk,
@@ -3358,7 +3358,7 @@ void df_order(SEXP x,
     .x = x,
     .decreasing = decreasing,
     .na_last = na_last,
-    .string_key = string_key,
+    .chr_transform = chr_transform,
     .size = size,
     .p_order = p_order,
     .p_lazy_x_chunk = p_lazy_x_chunk,
@@ -3385,7 +3385,7 @@ void df_order(SEXP x,
 static void df_order_internal(SEXP x,
                               SEXP decreasing,
                               SEXP na_last,
-                              SEXP string_key,
+                              SEXP chr_transform,
                               r_ssize size,
                               struct order* p_order,
                               struct lazy_raw* p_lazy_x_chunk,
@@ -3404,7 +3404,7 @@ SEXP df_order_exec(void* p_data) {
     p_info->x,
     p_info->decreasing,
     p_info->na_last,
-    p_info->string_key,
+    p_info->chr_transform,
     p_info->size,
     p_info->p_order,
     p_info->p_lazy_x_chunk,
@@ -3477,7 +3477,7 @@ static
 void df_order_internal(SEXP x,
                        SEXP decreasing,
                        SEXP na_last,
-                       SEXP string_key,
+                       SEXP chr_transform,
                        r_ssize size,
                        struct order* p_order,
                        struct lazy_raw* p_lazy_x_chunk,
@@ -3540,7 +3540,7 @@ void df_order_internal(SEXP x,
     col,
     col_decreasing,
     col_na_last,
-    string_key,
+    chr_transform,
     size,
     type,
     p_order,
@@ -3594,10 +3594,10 @@ void df_order_internal(SEXP x,
       rerun_complex = rerun_complex ? false : true;
     }
 
-    // Apply `string_key` and pre-sort unique characters once for
+    // Apply `chr_transform` and pre-sort unique characters once for
     // the whole column
     if (type == vctrs_type_character) {
-      col = string_key_invoke(col, string_key);
+      col = chr_transform_invoke(col, chr_transform);
       REPROTECT(col, col_pi);
 
       const SEXP* p_col = STRING_PTR_RO(col);
@@ -3664,7 +3664,7 @@ void df_order_internal(SEXP x,
     }
 
     // Reset TRUELENGTHs between columns
-    // and unprotect result of applying `string_key`
+    // and unprotect result of applying `chr_transform`
     if (type == vctrs_type_character) {
       truelength_reset(p_truelength_info);
     }
@@ -4187,21 +4187,21 @@ int parse_direction_one(SEXP x) {
 // -----------------------------------------------------------------------------
 
 // [[ include("order-radix.h") ]]
-SEXP as_string_key(SEXP string_key) {
-  return string_key == r_null ? string_key : r_as_function(string_key, "string_key");
+SEXP as_chr_transform(SEXP chr_transform) {
+  return chr_transform == r_null ? chr_transform : r_as_function(chr_transform, "chr_transform");
 }
 
 // [[ include("order-radix.h") ]]
-SEXP string_key_invoke(SEXP x, SEXP string_key) {
-  if (string_key == r_null) {
+SEXP chr_transform_invoke(SEXP x, SEXP chr_transform) {
+  if (chr_transform == r_null) {
     return x;
   }
 
   // Don't use vctrs dispatch utils because we match argument positionally
-  SEXP call = PROTECT(Rf_lang2(syms_string_key, syms_x));
+  SEXP call = PROTECT(Rf_lang2(syms_chr_transform, syms_x));
 
   SEXP mask = PROTECT(r_new_environment(R_GlobalEnv));
-  Rf_defineVar(syms_string_key, string_key, mask);
+  Rf_defineVar(syms_chr_transform, chr_transform, mask);
   Rf_defineVar(syms_x, x, mask);
 
   SEXP out = PROTECT(Rf_eval(call, mask));
@@ -4209,7 +4209,7 @@ SEXP string_key_invoke(SEXP x, SEXP string_key) {
   if (vec_typeof(out) != vctrs_type_character) {
     Rf_errorcall(
       R_NilValue,
-      "`string_key` must return a character vector."
+      "`chr_transform` must return a character vector."
     );
   }
 
@@ -4219,7 +4219,7 @@ SEXP string_key_invoke(SEXP x, SEXP string_key) {
   if (x_size != out_size) {
     Rf_errorcall(
       R_NilValue,
-      "`string_key` must return a vector of the same length (%i, not %i).",
+      "`chr_transform` must return a vector of the same length (%i, not %i).",
       x_size,
       out_size
     );

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -183,46 +183,52 @@
 
 // -----------------------------------------------------------------------------
 
-static SEXP vec_order(SEXP x, SEXP decreasing, SEXP na_last);
+static SEXP vec_order(SEXP x, SEXP decreasing, SEXP na_last, SEXP string_key);
 
 // [[ register() ]]
-SEXP vctrs_order(SEXP x, SEXP direction, SEXP na_value) {
+SEXP vctrs_order(SEXP x, SEXP direction, SEXP na_value, SEXP string_key) {
   SEXP decreasing = PROTECT(parse_direction(direction));
   SEXP na_last = PROTECT(parse_na_value(na_value));
+  string_key = PROTECT(as_string_key(string_key));
 
-  SEXP out = vec_order(x, decreasing, na_last);
+  SEXP out = vec_order(x, decreasing, na_last, string_key);
 
-  UNPROTECT(2);
+  UNPROTECT(3);
   return out;
 }
 
 
-static SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations);
+static SEXP vec_order_impl(SEXP x,
+                           SEXP decreasing,
+                           SEXP na_last,
+                           SEXP string_key,
+                           bool locations);
 
 static
-SEXP vec_order(SEXP x, SEXP decreasing, SEXP na_last) {
-  return vec_order_impl(x, decreasing, na_last, false);
+SEXP vec_order(SEXP x, SEXP decreasing, SEXP na_last, SEXP string_key) {
+  return vec_order_impl(x, decreasing, na_last, string_key, false);
 }
 
 // -----------------------------------------------------------------------------
 
-static SEXP vec_order_locs(SEXP x, SEXP decreasing, SEXP na_last);
+static SEXP vec_order_locs(SEXP x, SEXP decreasing, SEXP na_last, SEXP string_key);
 
 // [[ register() ]]
-SEXP vctrs_order_locs(SEXP x, SEXP direction, SEXP na_value) {
+SEXP vctrs_order_locs(SEXP x, SEXP direction, SEXP na_value, SEXP string_key) {
   SEXP decreasing = PROTECT(parse_direction(direction));
   SEXP na_last = PROTECT(parse_na_value(na_value));
+  string_key = PROTECT(as_string_key(string_key));
 
-  SEXP out = vec_order_locs(x, decreasing, na_last);
+  SEXP out = vec_order_locs(x, decreasing, na_last, string_key);
 
-  UNPROTECT(2);
+  UNPROTECT(3);
   return out;
 }
 
 
 static
-SEXP vec_order_locs(SEXP x, SEXP decreasing, SEXP na_last) {
-  return vec_order_impl(x, decreasing, na_last, true);
+SEXP vec_order_locs(SEXP x, SEXP decreasing, SEXP na_last, SEXP string_key) {
+  return vec_order_impl(x, decreasing, na_last, string_key, true);
 }
 
 // -----------------------------------------------------------------------------
@@ -239,6 +245,7 @@ static SEXP vec_order_expand_args(SEXP x, SEXP decreasing, SEXP na_last);
 static void vec_order_switch(SEXP x,
                              SEXP decreasing,
                              SEXP na_last,
+                             SEXP string_key,
                              r_ssize size,
                              const enum vctrs_type type,
                              struct order* p_order,
@@ -258,7 +265,7 @@ static void vec_order_switch(SEXP x,
  * the locations in `x` corresponding to each key.
  */
 static
-SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
+SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, SEXP string_key, bool locations) {
   int n_prot = 0;
   int* p_n_prot = &n_prot;
 
@@ -334,6 +341,7 @@ SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, bool locations) {
     proxy,
     decreasing,
     na_last,
+    string_key,
     size,
     type,
     p_order,
@@ -420,6 +428,7 @@ SEXP vec_order_locs_impl(SEXP x,
 static void df_order(SEXP x,
                      SEXP decreasing,
                      SEXP na_last,
+                     SEXP string_key,
                      r_ssize size,
                      struct order* p_order,
                      struct lazy_raw* p_lazy_x_chunk,
@@ -433,6 +442,7 @@ static void df_order(SEXP x,
 static void vec_order_base_switch(SEXP x,
                                   bool decreasing,
                                   bool na_last,
+                                  SEXP string_key,
                                   r_ssize size,
                                   const enum vctrs_type type,
                                   struct order* p_order,
@@ -448,6 +458,7 @@ static
 void vec_order_switch(SEXP x,
                       SEXP decreasing,
                       SEXP na_last,
+                      SEXP string_key,
                       r_ssize size,
                       const enum vctrs_type type,
                       struct order* p_order,
@@ -463,6 +474,7 @@ void vec_order_switch(SEXP x,
       x,
       decreasing,
       na_last,
+      string_key,
       size,
       p_order,
       p_lazy_x_chunk,
@@ -500,6 +512,7 @@ void vec_order_switch(SEXP x,
     x,
     c_decreasing,
     c_na_last,
+    string_key,
     size,
     type,
     p_order,
@@ -566,6 +579,7 @@ static void cpl_order(SEXP x,
 static void chr_order(SEXP x,
                       bool decreasing,
                       bool na_last,
+                      SEXP string_key,
                       r_ssize size,
                       struct order* p_order,
                       struct lazy_raw* p_lazy_x_chunk,
@@ -581,6 +595,7 @@ static
 void vec_order_base_switch(SEXP x,
                            bool decreasing,
                            bool na_last,
+                           SEXP string_key,
                            r_ssize size,
                            const enum vctrs_type type,
                            struct order* p_order,
@@ -665,6 +680,7 @@ void vec_order_base_switch(SEXP x,
       x,
       decreasing,
       na_last,
+      string_key,
       size,
       p_order,
       p_lazy_x_chunk,
@@ -2672,6 +2688,7 @@ struct chr_order_info {
   SEXP x;
   bool decreasing;
   bool na_last;
+  SEXP string_key;
   r_ssize size;
   struct order* p_order;
   struct lazy_raw* p_lazy_x_chunk;
@@ -2700,6 +2717,7 @@ static
 void chr_order(SEXP x,
                bool decreasing,
                bool na_last,
+               SEXP string_key,
                r_ssize size,
                struct order* p_order,
                struct lazy_raw* p_lazy_x_chunk,
@@ -2713,6 +2731,7 @@ void chr_order(SEXP x,
     .x = x,
     .decreasing = decreasing,
     .na_last = na_last,
+    .string_key = string_key,
     .size = size,
     .p_order = p_order,
     .p_lazy_x_chunk = p_lazy_x_chunk,
@@ -2739,6 +2758,7 @@ void chr_order(SEXP x,
 static void chr_order_internal(SEXP x,
                                bool decreasing,
                                bool na_last,
+                               SEXP string_key,
                                r_ssize size,
                                struct order* p_order,
                                struct lazy_raw* p_lazy_x_chunk,
@@ -2757,6 +2777,7 @@ SEXP chr_order_exec(void* p_data) {
     p_info->x,
     p_info->decreasing,
     p_info->na_last,
+    p_info->string_key,
     p_info->size,
     p_info->p_order,
     p_info->p_lazy_x_chunk,
@@ -2781,6 +2802,7 @@ static
 void chr_order_internal(SEXP x,
                         bool decreasing,
                         bool na_last,
+                        SEXP string_key,
                         r_ssize size,
                         struct order* p_order,
                         struct lazy_raw* p_lazy_x_chunk,
@@ -2790,6 +2812,8 @@ void chr_order_internal(SEXP x,
                         struct lazy_raw* p_lazy_counts,
                         struct group_infos* p_group_infos,
                         struct truelength_info* p_truelength_info) {
+  x = PROTECT(string_key_invoke(x, string_key));
+
   const SEXP* p_x = STRING_PTR_RO(x);
 
   const enum vctrs_sortedness sortedness = chr_sortedness(
@@ -2805,6 +2829,7 @@ void chr_order_internal(SEXP x,
     int* p_o = p_order->p_data;
     ord_resolve_sortedness(sortedness, size, p_o);
     p_order->initialized = true;
+    UNPROTECT(1);
     return;
   }
 
@@ -2847,6 +2872,8 @@ void chr_order_internal(SEXP x,
     p_lazy_counts,
     p_group_infos
   );
+
+  UNPROTECT(1);
 }
 
 // -----------------------------------------------------------------------------
@@ -3276,6 +3303,7 @@ struct df_order_info {
   SEXP x;
   SEXP decreasing;
   SEXP na_last;
+  SEXP string_key;
   r_ssize size;
   struct order* p_order;
   struct lazy_raw* p_lazy_x_chunk;
@@ -3316,6 +3344,7 @@ static
 void df_order(SEXP x,
               SEXP decreasing,
               SEXP na_last,
+              SEXP string_key,
               r_ssize size,
               struct order* p_order,
               struct lazy_raw* p_lazy_x_chunk,
@@ -3329,6 +3358,7 @@ void df_order(SEXP x,
     .x = x,
     .decreasing = decreasing,
     .na_last = na_last,
+    .string_key = string_key,
     .size = size,
     .p_order = p_order,
     .p_lazy_x_chunk = p_lazy_x_chunk,
@@ -3355,6 +3385,7 @@ void df_order(SEXP x,
 static void df_order_internal(SEXP x,
                               SEXP decreasing,
                               SEXP na_last,
+                              SEXP string_key,
                               r_ssize size,
                               struct order* p_order,
                               struct lazy_raw* p_lazy_x_chunk,
@@ -3373,6 +3404,7 @@ SEXP df_order_exec(void* p_data) {
     p_info->x,
     p_info->decreasing,
     p_info->na_last,
+    p_info->string_key,
     p_info->size,
     p_info->p_order,
     p_info->p_lazy_x_chunk,
@@ -3445,6 +3477,7 @@ static
 void df_order_internal(SEXP x,
                        SEXP decreasing,
                        SEXP na_last,
+                       SEXP string_key,
                        r_ssize size,
                        struct order* p_order,
                        struct lazy_raw* p_lazy_x_chunk,
@@ -3507,6 +3540,7 @@ void df_order_internal(SEXP x,
     col,
     col_decreasing,
     col_na_last,
+    string_key,
     size,
     type,
     p_order,
@@ -3558,8 +3592,11 @@ void df_order_internal(SEXP x,
       rerun_complex = rerun_complex ? false : true;
     }
 
-    // Pre sort unique characters once for the whole column
+    // Apply `string_key` and pre-sort unique characters once for
+    // the whole column
     if (type == vctrs_type_character) {
+      col = PROTECT(string_key_invoke(col, string_key));
+
       const SEXP* p_col = STRING_PTR_RO(col);
 
       chr_mark_sorted_uniques(
@@ -3624,8 +3661,10 @@ void df_order_internal(SEXP x,
     }
 
     // Reset TRUELENGTHs between columns
+    // and unprotect result of applying `string_key`
     if (type == vctrs_type_character) {
       truelength_reset(p_truelength_info);
+      UNPROTECT(1);
     }
   }
 }
@@ -4139,4 +4178,49 @@ int parse_direction_one(SEXP x) {
     R_NilValue,
     "`direction` must contain only \"asc\" or \"desc\"."
   );
+}
+
+// -----------------------------------------------------------------------------
+
+// [[ include("order-radix.h") ]]
+SEXP as_string_key(SEXP string_key) {
+  return string_key == r_null ? string_key : r_as_function(string_key, "string_key");
+}
+
+// [[ include("order-radix.h") ]]
+SEXP string_key_invoke(SEXP x, SEXP string_key) {
+  if (string_key == r_null) {
+    return x;
+  }
+
+  // Don't use vctrs dispatch utils because we match argument positionally
+  SEXP call = PROTECT(Rf_lang2(syms_string_key, syms_x));
+
+  SEXP mask = PROTECT(r_new_environment(R_GlobalEnv));
+  Rf_defineVar(syms_string_key, string_key, mask);
+  Rf_defineVar(syms_x, x, mask);
+
+  SEXP out = PROTECT(Rf_eval(call, mask));
+
+  if (vec_typeof(out) != vctrs_type_character) {
+    Rf_errorcall(
+      R_NilValue,
+      "Applying `string_key` must result in a character vector."
+    );
+  }
+
+  R_len_t x_size = vec_size(x);
+  R_len_t out_size = vec_size(out);
+
+  if (x_size != out_size) {
+    Rf_errorcall(
+      R_NilValue,
+      "Applying `string_key` must result in a vector with length %i, not %i.",
+      x_size,
+      out_size
+    );
+  }
+
+  UNPROTECT(3);
+  return out;
 }

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -3560,7 +3560,14 @@ void df_order_internal(SEXP x,
 
   // Iterate over remaining columns by group chunk
   for (r_ssize i = 1; i < n_cols; ++i) {
-    col = VECTOR_ELT(x, i);
+    // Get the number of group chunks from previous column group info
+    struct group_info* p_group_info_pre = groups_current(p_group_infos);
+    r_ssize n_groups = p_group_info_pre->n_groups;
+
+    // If there were no ties, we are completely done
+    if (n_groups == size) {
+      break;
+    }
 
     if (!recycle_decreasing) {
       col_decreasing = p_decreasing[i];
@@ -3575,15 +3582,7 @@ void df_order_internal(SEXP x,
     // processed at least one column.
     int* p_o_col = p_order->p_data;
 
-    // Get the number of group chunks from previous column group info
-    struct group_info* p_group_info_pre = groups_current(p_group_infos);
-    r_ssize n_groups = p_group_info_pre->n_groups;
-
-    // If there were no ties, we are completely done
-    if (n_groups == size) {
-      break;
-    }
-
+    col = VECTOR_ELT(x, i);
     type = vec_proxy_typeof(col);
 
     // If we are on the rerun pass, flip this back off so the

--- a/src/order-radix.h
+++ b/src/order-radix.h
@@ -20,8 +20,8 @@
 SEXP parse_na_value(SEXP na_value);
 SEXP parse_direction(SEXP direction);
 
-SEXP as_string_key(SEXP string_key);
-SEXP string_key_invoke(SEXP x, SEXP string_key);
+SEXP as_chr_transform(SEXP chr_transform);
+SEXP chr_transform_invoke(SEXP x, SEXP chr_transform);
 
 // -----------------------------------------------------------------------------
 

--- a/src/order-radix.h
+++ b/src/order-radix.h
@@ -20,6 +20,9 @@
 SEXP parse_na_value(SEXP na_value);
 SEXP parse_direction(SEXP direction);
 
+SEXP as_string_key(SEXP string_key);
+SEXP string_key_invoke(SEXP x, SEXP string_key);
+
 // -----------------------------------------------------------------------------
 
 /*

--- a/src/order-radix.h
+++ b/src/order-radix.h
@@ -20,9 +20,6 @@
 SEXP parse_na_value(SEXP na_value);
 SEXP parse_direction(SEXP direction);
 
-SEXP as_chr_transform(SEXP chr_transform);
-SEXP chr_transform_invoke(SEXP x, SEXP chr_transform);
-
 // -----------------------------------------------------------------------------
 
 /*

--- a/src/order-transform.c
+++ b/src/order-transform.c
@@ -1,0 +1,113 @@
+/*
+ * The implementation of vec_order() is based on data.table’s forder() and their
+ * earlier contribution to R’s order(). See LICENSE.note for more information.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2020, RStudio
+ * Copyright (c) 2020, Data table team
+ */
+
+#include "order-transform.h"
+#include "utils.h"
+
+// -----------------------------------------------------------------------------
+
+static SEXP chr_apply_transform(SEXP x, SEXP chr_transform);
+static SEXP df_apply_transform(SEXP x, SEXP chr_transform);
+
+// [[ include("order-transform.h") ]]
+SEXP proxy_chr_transform(SEXP proxy, SEXP chr_transform) {
+  if (chr_transform == r_null) {
+    return proxy;
+  }
+
+  chr_transform = PROTECT(r_as_function(chr_transform, "chr_transform"));
+
+  SEXP out;
+
+  switch (vec_proxy_typeof(proxy)) {
+  case vctrs_type_character: out = chr_apply_transform(proxy, chr_transform); break;
+  case vctrs_type_dataframe: out = df_apply_transform(proxy, chr_transform); break;
+  default: out = proxy;
+  }
+
+  UNPROTECT(1);
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+
+static
+SEXP chr_apply_transform(SEXP x, SEXP chr_transform) {
+  // Don't use vctrs dispatch utils because we match argument positionally
+  SEXP call = PROTECT(Rf_lang2(syms_chr_transform, syms_x));
+
+  SEXP mask = PROTECT(r_new_environment(R_GlobalEnv));
+  Rf_defineVar(syms_chr_transform, chr_transform, mask);
+  Rf_defineVar(syms_x, x, mask);
+
+  SEXP out = PROTECT(Rf_eval(call, mask));
+
+  if (vec_typeof(out) != vctrs_type_character) {
+    Rf_errorcall(
+      R_NilValue,
+      "`chr_transform` must return a character vector."
+    );
+  }
+
+  R_len_t x_size = vec_size(x);
+  R_len_t out_size = vec_size(out);
+
+  if (x_size != out_size) {
+    Rf_errorcall(
+      R_NilValue,
+      "`chr_transform` must return a vector of the same length (%i, not %i).",
+      x_size,
+      out_size
+    );
+  }
+
+  UNPROTECT(3);
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+
+static
+SEXP df_apply_transform(SEXP x, SEXP chr_transform) {
+  const r_ssize n_cols = r_length(x);
+  const SEXP* v_x = VECTOR_PTR_RO(x);
+
+  r_ssize i = 0;
+
+  for (; i < n_cols; ++i) {
+    SEXP col = v_x[i];
+    if (vec_proxy_typeof(col) == vctrs_type_character) {
+      break;
+    }
+  }
+
+  if (i == n_cols) {
+    // No character columns
+    return x;
+  }
+
+  SEXP out = PROTECT(r_clone_referenced(x));
+
+  for (; i < n_cols; ++i) {
+    SEXP col = v_x[i];
+
+    if (vec_proxy_typeof(col) != vctrs_type_character) {
+      continue;
+    }
+
+    col = chr_apply_transform(col, chr_transform);
+    SET_VECTOR_ELT(out, i, col);
+  }
+
+  UNPROTECT(1);
+  return out;
+}

--- a/src/order-transform.h
+++ b/src/order-transform.h
@@ -1,0 +1,33 @@
+/*
+ * The implementation of vec_order() is based on data.table’s forder() and their
+ * earlier contribution to R’s order(). See LICENSE.note for more information.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2020, RStudio
+ * Copyright (c) 2020, Data table team
+ */
+
+#ifndef VCTRS_ORDER_TRANSFORM_H
+#define VCTRS_ORDER_TRANSFORM_H
+
+#include "vctrs.h"
+
+// -----------------------------------------------------------------------------
+
+/*
+ * `proxy_chr_transform()` iterates over `proxy`, applying `chr_transform`
+ * on any character vectors that it detects.
+ *
+ * It expects that:
+ * - If `proxy` is a data frame, it has been flattened by its corresponding
+ *   `vec_proxy_*()` function.
+ * - All character vectors in `proxy` have already been normalized to UTF-8
+ *   by `vec_normalize_encoding()`.
+ */
+SEXP proxy_chr_transform(SEXP proxy, SEXP chr_transform);
+
+// -----------------------------------------------------------------------------
+#endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -1835,6 +1835,7 @@ SEXP syms_vctrs_common_class_fallback = NULL;
 SEXP syms_fallback_class = NULL;
 SEXP syms_abort = NULL;
 SEXP syms_message = NULL;
+SEXP syms_string_key = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -2110,6 +2111,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_fallback_class = Rf_install("fallback_class");
   syms_abort = Rf_install("abort");
   syms_message = Rf_install("message");
+  syms_string_key = Rf_install("string_key");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1835,7 +1835,7 @@ SEXP syms_vctrs_common_class_fallback = NULL;
 SEXP syms_fallback_class = NULL;
 SEXP syms_abort = NULL;
 SEXP syms_message = NULL;
-SEXP syms_string_key = NULL;
+SEXP syms_chr_transform = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -2111,7 +2111,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_fallback_class = Rf_install("fallback_class");
   syms_abort = Rf_install("abort");
   syms_message = Rf_install("message");
-  syms_string_key = Rf_install("string_key");
+  syms_chr_transform = Rf_install("chr_transform");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.h
+++ b/src/utils.h
@@ -631,7 +631,7 @@ extern SEXP syms_vctrs_common_class_fallback;
 extern SEXP syms_fallback_class;
 extern SEXP syms_abort;
 extern SEXP syms_message;
-extern SEXP syms_string_key;
+extern SEXP syms_chr_transform;
 
 static const char * const c_strs_vctrs_common_class_fallback = "vctrs:::common_class_fallback";
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -631,6 +631,7 @@ extern SEXP syms_vctrs_common_class_fallback;
 extern SEXP syms_fallback_class;
 extern SEXP syms_abort;
 extern SEXP syms_message;
+extern SEXP syms_string_key;
 
 static const char * const c_strs_vctrs_common_class_fallback = "vctrs:::common_class_fallback";
 

--- a/tests/testthat/test-order-radix.R
+++ b/tests/testthat/test-order-radix.R
@@ -857,7 +857,7 @@ test_that("`string_key` works with data frame columns and is applied to all stri
 
 test_that("`string_key` is validated", {
   expect_error(vec_order_radix("x", string_key = 1), "Can't convert `string_key` to a function")
-  expect_error(vec_order_radix("x", string_key = ~c("y", "z")), "length 1, not 2")
+  expect_error(vec_order_radix("x", string_key = ~c("y", "z")), "1, not 2")
   expect_error(vec_order_radix("x", string_key = ~1), "character vector")
   expect_error(vec_order_radix("x", string_key = function() {"y"}))
 })

--- a/tests/testthat/test-order-radix.R
+++ b/tests/testthat/test-order-radix.R
@@ -842,24 +842,24 @@ test_that("can order 2+ double column chunks with radix sort", {
 })
 
 # ------------------------------------------------------------------------------
-# vec_order_radix() - string_key
+# vec_order_radix() - chr_transform
 
-test_that("`string_key` transforms string input", {
+test_that("`chr_transform` transforms string input", {
   x <- c("b", "a", "A")
-  expect_identical(vec_order_radix(x, string_key = tolower), c(2L, 3L, 1L))
-  expect_identical(vec_order_radix(x, string_key = ~tolower(.x)), c(2L, 3L, 1L))
+  expect_identical(vec_order_radix(x, chr_transform = tolower), c(2L, 3L, 1L))
+  expect_identical(vec_order_radix(x, chr_transform = ~tolower(.x)), c(2L, 3L, 1L))
 })
 
-test_that("`string_key` works with data frame columns and is applied to all string columns", {
+test_that("`chr_transform` works with data frame columns and is applied to all string columns", {
   df <- data_frame(x = c(1, 1, 1), y = c("B", "a", "a"), z = c("a", "D", "c"))
-  expect_identical(vec_order_radix(df, string_key = tolower), c(3L, 2L, 1L))
+  expect_identical(vec_order_radix(df, chr_transform = tolower), c(3L, 2L, 1L))
 })
 
-test_that("`string_key` is validated", {
-  expect_error(vec_order_radix("x", string_key = 1), "Can't convert `string_key` to a function")
-  expect_error(vec_order_radix("x", string_key = ~c("y", "z")), "1, not 2")
-  expect_error(vec_order_radix("x", string_key = ~1), "character vector")
-  expect_error(vec_order_radix("x", string_key = function() {"y"}))
+test_that("`chr_transform` is validated", {
+  expect_error(vec_order_radix("x", chr_transform = 1), "Can't convert `chr_transform` to a function")
+  expect_error(vec_order_radix("x", chr_transform = ~c("y", "z")), "1, not 2")
+  expect_error(vec_order_radix("x", chr_transform = ~1), "character vector")
+  expect_error(vec_order_radix("x", chr_transform = function() {"y"}))
 })
 
 # ------------------------------------------------------------------------------
@@ -967,15 +967,15 @@ test_that("`vec_order_locs()` is working", {
   expect_identical(vec_order_locs(x), expect)
 })
 
-test_that("`string_key` can result in keys being seen as identical", {
+test_that("`chr_transform` can result in keys being seen as identical", {
   x <- c("b", "A", "a")
   y <- c("b", "a", "A")
 
   x_expect <- data_frame(key = c("A", "b"), loc = list(c(2L, 3L), 1L))
   y_expect <- data_frame(key = c("a", "b"), loc = list(c(2L, 3L), 1L))
 
-  expect_identical(vec_order_locs(x, string_key = tolower), x_expect)
-  expect_identical(vec_order_locs(y, string_key = tolower), y_expect)
+  expect_identical(vec_order_locs(x, chr_transform = tolower), x_expect)
+  expect_identical(vec_order_locs(y, chr_transform = tolower), y_expect)
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-order-radix.R
+++ b/tests/testthat/test-order-radix.R
@@ -842,6 +842,27 @@ test_that("can order 2+ double column chunks with radix sort", {
 })
 
 # ------------------------------------------------------------------------------
+# vec_order_radix() - string_key
+
+test_that("`string_key` transforms string input", {
+  x <- c("b", "a", "A")
+  expect_identical(vec_order_radix(x, string_key = tolower), c(2L, 3L, 1L))
+  expect_identical(vec_order_radix(x, string_key = ~tolower(.x)), c(2L, 3L, 1L))
+})
+
+test_that("`string_key` works with data frame columns and is applied to all string columns", {
+  df <- data_frame(x = c(1, 1, 1), y = c("B", "a", "a"), z = c("a", "D", "c"))
+  expect_identical(vec_order_radix(df, string_key = tolower), c(3L, 2L, 1L))
+})
+
+test_that("`string_key` is validated", {
+  expect_error(vec_order_radix("x", string_key = 1), "Can't convert `string_key` to a function")
+  expect_error(vec_order_radix("x", string_key = ~c("y", "z")), "length 1, not 2")
+  expect_error(vec_order_radix("x", string_key = ~1), "character vector")
+  expect_error(vec_order_radix("x", string_key = function() {"y"}))
+})
+
+# ------------------------------------------------------------------------------
 # vec_order_radix() - error checking
 
 test_that("`na_value` is checked", {
@@ -944,6 +965,17 @@ test_that("`vec_order_locs()` is working", {
   )
 
   expect_identical(vec_order_locs(x), expect)
+})
+
+test_that("`string_key` can result in keys being seen as identical", {
+  x <- c("b", "A", "a")
+  y <- c("b", "a", "A")
+
+  x_expect <- data_frame(key = c("A", "b"), loc = list(c(2L, 3L), 1L))
+  y_expect <- data_frame(key = c("a", "b"), loc = list(c(2L, 3L), 1L))
+
+  expect_identical(vec_order_locs(x, string_key = tolower), x_expect)
+  expect_identical(vec_order_locs(y, string_key = tolower), y_expect)
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Will need to rebase on #1328, which will ensure that `x` is UTF-8 _before_ we apply `string_key`

This PR adds the long awaited `string_key` argument to `vec_order_radix()`. This adds a lot of flexibility, giving the user the power to do things like:

``` r
library(vctrs)

vec_sort_radix <- function(x, string_key = NULL) {
  o <- vctrs:::vec_order_radix(x, string_key = string_key)
  vec_slice(x, o)
}

x <- c("B", "A", "a", "A")

# capital before lower case
vec_sort_radix(x)
#> [1] "A" "A" "B" "a"

# case insensitive
vec_sort_radix(x, tolower)
#> [1] "A" "a" "A" "B"

# en_US
vec_sort_radix(x, ~stringi::stri_sort_key(.x, locale = "en_US"))
#> [1] "a" "A" "A" "B"
```

The only thing that is mildly surprising is that, with `vec_order_locs()` (which I doubt we ever expose as is), if the `string_key` makes strings that were previously different look identical (as with `tolower()`), then the keys and locations returned reflect that. I think this is expected behavior. Also note that it doesn't affect typical usage of `stri_sort_key()`, since this orders `"a"` before `"A"` rather than making them look identical.

```r
library(vctrs)

x <- c("B", "A", "a", "A")

vctrs:::vec_order_locs(x, string_key = tolower)
#>   key     loc
#> 1   A 2, 3, 4
#> 2   B       1

vctrs:::vec_order_locs(x, string_key = ~stringi::stri_sort_key(.x, locale = "en_US"))
#>   key  loc
#> 1   a    3
#> 2   A 2, 4
#> 3   B    1
```