### PR TITLE
Correctly flip parsed `na_last` value when `direction = "desc"`

### DIFF
--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -184,50 +184,38 @@
 
 // -----------------------------------------------------------------------------
 
-static SEXP vec_order(SEXP x, SEXP decreasing, SEXP na_last, SEXP chr_transform);
+static SEXP vec_order(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform);
 
 // [[ register() ]]
 SEXP vctrs_order(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform) {
-  SEXP decreasing = PROTECT(parse_direction(direction));
-  SEXP na_last = PROTECT(parse_na_value(na_value));
-
-  SEXP out = vec_order(x, decreasing, na_last, chr_transform);
-
-  UNPROTECT(2);
-  return out;
+  return vec_order(x, direction, na_value, chr_transform);
 }
 
 
 static SEXP vec_order_impl(SEXP x,
-                           SEXP decreasing,
-                           SEXP na_last,
+                           SEXP direction,
+                           SEXP na_value,
                            SEXP chr_transform,
                            bool locations);
 
 static
-SEXP vec_order(SEXP x, SEXP decreasing, SEXP na_last, SEXP chr_transform) {
-  return vec_order_impl(x, decreasing, na_last, chr_transform, false);
+SEXP vec_order(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform) {
+  return vec_order_impl(x, direction, na_value, chr_transform, false);
 }
 
 // -----------------------------------------------------------------------------
 
-static SEXP vec_order_locs(SEXP x, SEXP decreasing, SEXP na_last, SEXP chr_transform);
+static SEXP vec_order_locs(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform);
 
 // [[ register() ]]
 SEXP vctrs_order_locs(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform) {
-  SEXP decreasing = PROTECT(parse_direction(direction));
-  SEXP na_last = PROTECT(parse_na_value(na_value));
-
-  SEXP out = vec_order_locs(x, decreasing, na_last, chr_transform);
-
-  UNPROTECT(2);
-  return out;
+  return vec_order_locs(x, direction, na_value, chr_transform);
 }
 
 
 static
-SEXP vec_order_locs(SEXP x, SEXP decreasing, SEXP na_last, SEXP chr_transform) {
-  return vec_order_impl(x, decreasing, na_last, chr_transform, true);
+SEXP vec_order_locs(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform) {
+  return vec_order_impl(x, direction, na_value, chr_transform, true);
 }
 
 // -----------------------------------------------------------------------------
@@ -239,6 +227,9 @@ static SEXP vec_order_locs_impl(SEXP x,
 
 static inline size_t vec_compute_n_bytes_lazy_raw(SEXP x, const enum vctrs_type type);
 static inline size_t vec_compute_n_bytes_lazy_counts(SEXP x, const enum vctrs_type type);
+
+static SEXP parse_na_value(SEXP na_value);
+static SEXP parse_direction(SEXP direction);
 static SEXP vec_order_expand_args(SEXP x, SEXP decreasing, SEXP na_last);
 
 static void vec_order_switch(SEXP x,
@@ -263,8 +254,11 @@ static void vec_order_switch(SEXP x,
  * the locations in `x` corresponding to each key.
  */
 static
-SEXP vec_order_impl(SEXP x, SEXP decreasing, SEXP na_last, SEXP chr_transform, bool locations) {
+SEXP vec_order_impl(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform, bool locations) {
   int n_prot = 0;
+
+  SEXP decreasing = PROTECT_N(parse_direction(direction), &n_prot);
+  SEXP na_last = PROTECT_N(parse_na_value(na_value), &n_prot);
 
   // Call on `x` before potentially flattening cols with `vec_proxy_order()`
   SEXP args = PROTECT_N(vec_order_expand_args(x, decreasing, na_last), &n_prot);
@@ -4067,7 +4061,7 @@ int df_decreasing_expansion(SEXP x) {
 
 static int parse_na_value_one(SEXP x);
 
-// [[ include("order-radix.h") ]]
+static
 SEXP parse_na_value(SEXP na_value) {
   // Don't care about length here, checked later
   if (TYPEOF(na_value) != STRSXP) {
@@ -4107,7 +4101,7 @@ int parse_na_value_one(SEXP x) {
 
 static int parse_direction_one(SEXP x);
 
-// [[ include("order-radix.h") ]]
+static
 SEXP parse_direction(SEXP direction) {
   // Don't care about length here, checked later
   if (TYPEOF(direction) != STRSXP) {

--- a/src/order-radix.h
+++ b/src/order-radix.h
@@ -17,11 +17,6 @@
 
 // -----------------------------------------------------------------------------
 
-SEXP parse_na_value(SEXP na_value);
-SEXP parse_direction(SEXP direction);
-
-// -----------------------------------------------------------------------------
-
 /*
  * `order` is an integer vector intended to hold the ordering vector
  * in `vec_order()`. It is allocated eagerly, but the initialization of its

--- a/tests/testthat/test-order-radix.R
+++ b/tests/testthat/test-order-radix.R
@@ -56,11 +56,11 @@ test_that("all combinations of `direction` and `na_value` work", {
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "largest", direction = "desc")],
-    x[order(x, na.last = TRUE, decreasing = TRUE)]
+    x[order(x, na.last = FALSE, decreasing = TRUE)]
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "smallest", direction = "desc")],
-    x[order(x, na.last = FALSE, decreasing = TRUE)]
+    x[order(x, na.last = TRUE, decreasing = TRUE)]
   )
 })
 
@@ -73,13 +73,13 @@ test_that("can order when in expected order", {
   x <- c(1L, 1L, 2L, NA, NA)
   expect_identical(vec_order_radix(x, direction = "asc", na_value = "largest"), 1:5)
 
-  x <- c(3L, 3L, 2L, NA, NA)
+  x <- c(NA, NA, 3L, 3L, 2L)
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "largest"), 1:5)
 
   x <- c(NA, NA, 1L, 1L, 2L)
   expect_identical(vec_order_radix(x, direction = "asc", na_value = "smallest"), 1:5)
 
-  x <- c(NA, NA, 3L, 3L, 2L)
+  x <- c(3L, 3L, 2L, NA, NA)
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "smallest"), 1:5)
 })
 
@@ -87,13 +87,13 @@ test_that("can order when in strictly opposite of expected order (no ties)", {
   x <- c(NA, 2L, 1L)
   expect_identical(vec_order_radix(x, direction = "asc", na_value = "largest"), 3:1)
 
-  x <- c(NA, 1L, 2L)
+  x <- c(1L, 2L, NA)
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "largest"), 3:1)
 
   x <- c(2L, 1L, NA)
   expect_identical(vec_order_radix(x, direction = "asc", na_value = "smallest"), 3:1)
 
-  x <- c(1L, 2L, NA)
+  x <- c(NA, 1L, 2L)
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "smallest"), 3:1)
 })
 
@@ -131,11 +131,11 @@ test_that("all combinations of `direction` and `na_value` work", {
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "largest", direction = "desc")],
-    x[order(x, na.last = TRUE, decreasing = TRUE)]
+    x[order(x, na.last = FALSE, decreasing = TRUE)]
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "smallest", direction = "desc")],
-    x[order(x, na.last = FALSE, decreasing = TRUE)]
+    x[order(x, na.last = TRUE, decreasing = TRUE)]
   )
 })
 
@@ -173,11 +173,11 @@ test_that("all combinations of `direction` and `na_value` work", {
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "largest", direction = "desc")],
-    x[order(x, na.last = TRUE, decreasing = TRUE)]
+    x[order(x, na.last = FALSE, decreasing = TRUE)]
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "smallest", direction = "desc")],
-    x[order(x, na.last = FALSE, decreasing = TRUE)]
+    x[order(x, na.last = TRUE, decreasing = TRUE)]
   )
 })
 
@@ -227,11 +227,11 @@ test_that("all combinations of `direction` and `na_value` work", {
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "largest", direction = "desc")],
-    x[order(x, na.last = TRUE, decreasing = TRUE)]
+    x[order(x, na.last = FALSE, decreasing = TRUE)]
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "smallest", direction = "desc")],
-    x[order(x, na.last = FALSE, decreasing = TRUE)]
+    x[order(x, na.last = TRUE, decreasing = TRUE)]
   )
 })
 
@@ -286,11 +286,11 @@ test_that("all combinations of `direction` and `na_value` work", {
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "largest", direction = "desc")],
-    x[order(x, na.last = TRUE, decreasing = TRUE)]
+    x[order(x, na.last = FALSE, decreasing = TRUE)]
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "smallest", direction = "desc")],
-    x[order(x, na.last = FALSE, decreasing = TRUE)]
+    x[order(x, na.last = TRUE, decreasing = TRUE)]
   )
 })
 
@@ -321,13 +321,13 @@ test_that("can order when in expected order", {
   x <- c(1, 1, 2, NA, NaN)
   expect_identical(vec_order_radix(x, direction = "asc", na_value = "largest"), 1:5)
 
-  x <- c(3, 3, 2, NA, NaN)
+  x <- c(NA, NaN, 3, 3, 2)
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "largest"), 1:5)
 
   x <- c(NA, NaN, 1, 1, 2)
   expect_identical(vec_order_radix(x, direction = "asc", na_value = "smallest"), 1:5)
 
-  x <- c(NA, NaN, 3, 3, 2)
+  x <- c(3, 3, 2, NA, NaN)
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "smallest"), 1:5)
 })
 
@@ -335,13 +335,13 @@ test_that("can order when in strictly opposite of expected order (no ties)", {
   x <- c(NA, 2, 1)
   expect_identical(vec_order_radix(x, direction = "asc", na_value = "largest"), 3:1)
 
-  x <- c(NA, 1, 2)
+  x <- c(1, 2, NA)
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "largest"), 3:1)
 
   x <- c(2, 1, NA)
   expect_identical(vec_order_radix(x, direction = "asc", na_value = "smallest"), 3:1)
 
-  x <- c(1, 2, NA)
+  x <- c(NA, 1, 2)
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "smallest"), 3:1)
 })
 
@@ -379,11 +379,11 @@ test_that("all combinations of `direction` and `na_value` work", {
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "largest", direction = "desc")],
-    x[order(x, na.last = TRUE, decreasing = TRUE)]
+    x[order(x, na.last = FALSE, decreasing = TRUE)]
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "smallest", direction = "desc")],
-    x[order(x, na.last = FALSE, decreasing = TRUE)]
+    x[order(x, na.last = TRUE, decreasing = TRUE)]
   )
 })
 
@@ -477,13 +477,13 @@ test_that("all combinations of `direction` and `na_value` work", {
   # when ordering in decreasing order with `NA` real.
   expect_identical(
     x[vec_order_radix(x, na_value = "largest", direction = "desc")],
-    #x[order(x, na.last = TRUE, decreasing = TRUE)]
-    x[c(1L, 4L, 3L, 5L, 2L)]
+    #x[order(x, na.last = FALSE, decreasing = TRUE)]
+    x[c(5L, 2L, 1L, 4L, 3L)]
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "smallest", direction = "desc")],
     #x[order(x, na.last = FALSE, decreasing = TRUE)]
-    x[c(5L, 2L, 1L, 4L, 3L)]
+    x[c(1L, 4L, 3L, 5L, 2L)]
   )
 })
 
@@ -538,11 +538,11 @@ test_that("all combinations of `direction` and `na_value` work", {
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "largest", direction = "desc")],
-    x[order(x, na.last = TRUE, decreasing = TRUE)]
+    x[order(x, na.last = FALSE, decreasing = TRUE)]
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "smallest", direction = "desc")],
-    x[order(x, na.last = FALSE, decreasing = TRUE)]
+    x[order(x, na.last = TRUE, decreasing = TRUE)]
   )
 })
 
@@ -599,13 +599,13 @@ test_that("can order when in expected order", {
   x <- c("a", "a", "b", NA, NA)
   expect_identical(vec_order_radix(x, direction = "asc", na_value = "largest"), 1:5)
 
-  x <- c("c", "c", "b", NA, NA)
+  x <- c(NA, NA, "c", "c", "b")
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "largest"), 1:5)
 
   x <- c(NA, NA, "a", "a", "b")
   expect_identical(vec_order_radix(x, direction = "asc", na_value = "smallest"), 1:5)
 
-  x <- c(NA, NA, "c", "c", "b")
+  x <- c("c", "c", "b", NA, NA)
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "smallest"), 1:5)
 })
 
@@ -613,13 +613,13 @@ test_that("can order when in strictly opposite of expected order (no ties)", {
   x <- c(NA, "b", "a")
   expect_identical(vec_order_radix(x, direction = "asc", na_value = "largest"), 3:1)
 
-  x <- c(NA, "a", "b")
+  x <- c("a", "b", NA)
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "largest"), 3:1)
 
   x <- c("b", "a", NA)
   expect_identical(vec_order_radix(x, direction = "asc", na_value = "smallest"), 3:1)
 
-  x <- c("a", "b", NA)
+  x <- c(NA, "a", "b")
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "smallest"), 3:1)
 })
 
@@ -670,11 +670,11 @@ test_that("all combinations of `direction` and `na_value` work", {
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "largest", direction = "desc")],
-    x[base_order(x, na.last = TRUE, decreasing = TRUE)]
+    x[base_order(x, na.last = FALSE, decreasing = TRUE)]
   )
   expect_identical(
     x[vec_order_radix(x, na_value = "smallest", direction = "desc")],
-    x[base_order(x, na.last = FALSE, decreasing = TRUE)]
+    x[base_order(x, na.last = TRUE, decreasing = TRUE)]
   )
 })
 
@@ -767,10 +767,10 @@ test_that("`na_value` is recycled", {
 
 test_that("`direction` can be a vector", {
   df <- data.frame(
-    x = c(1L, 1L, 2L, 2L),
-    y = c(3L, 2L, 4L, 1L)
+    x = c(1L, 1L, 2L, 2L, NA, 1L),
+    y = c(3L, 2L, 4L, 1L, 3L, NA)
   )
-  expect_identical(vec_order_radix(df, direction = c("desc", "asc")), c(4L, 3L, 2L, 1L))
+  expect_identical(vec_order_radix(df, direction = c("desc", "asc")), c(5L, 4L, 3L, 2L, 1L, 6L))
 })
 
 test_that("`na_value` can be a vector", {
@@ -789,7 +789,7 @@ test_that("`na_value` and `direction` can both be vectors", {
 
   expect_identical(
     vec_order_radix(df, direction = c("desc", "asc"), na_value = c("smallest", "largest")),
-    6:1
+    c(4:1, 6:5)
   )
 })
 
@@ -980,10 +980,10 @@ test_that("`chr_transform` can result in keys being seen as identical", {
 
 test_that("can request NAs sorted first", {
   expect_equal(vec_order_radix(c(1, NA), "asc", "largest"), 1:2)
-  expect_equal(vec_order_radix(c(1, NA), "desc", "largest"), 1:2)
+  expect_equal(vec_order_radix(c(1, NA), "desc", "largest"), 2:1)
 
   expect_equal(vec_order_radix(c(1, NA), "asc", "smallest"), 2:1)
-  expect_equal(vec_order_radix(c(1, NA), "desc", "smallest"), 2:1)
+  expect_equal(vec_order_radix(c(1, NA), "desc", "smallest"), 1:2)
 })
 
 test_that("can sort data frames", {


### PR DESCRIPTION
I'm not entirely sure how I did this, but this bit of `order_proxy()` wasn't faithfully translated over to `vec_order_radix()`

https://github.com/r-lib/vctrs/blob/f255bca3cf118e85701966ffca0c4692c29ca5f3/R/order.R#L53-L55

That resulted in this inconsistency when `direction = "desc"`

``` r
x <- c(1, 2, NA)
x[vctrs::vec_order(x, direction = "desc", na_value = "smallest")]
#> [1]  2  1 NA
x[vctrs:::vec_order_radix(x, direction = "desc", na_value = "smallest")]
#> [1] NA  2  1
```

We now flip the `na_last` argument (parsed from `na_value`) depending on the `decreasing` value (parsed from `direction`), being careful to recycle them in case the user does `direction = c("desc", "asc"), na_value = "smallest"`.

Luckily there were a large number of tests for this, they were just coded incorrectly. Fixing those tests makes me confident that this is working correctly now.