### PR TITLE
Add the capability to differentiate `NaN` from `NA_real_` in `vec_order_radix()`

### DIFF
--- a/R/order-radix.R
+++ b/R/order-radix.R
@@ -43,6 +43,9 @@
 #'   - For data frames, a length `1` or `ncol(x)` character vector containing
 #'     only `"largest"` or `"smallest"`, specifying how `NA`s should be treated
 #'     in each column.
+#' @param nan_distinct A single logical specifying whether or not `NaN` should
+#'   be considered distinct from `NA` for double and complex vectors. If `TRUE`,
+#'   `NaN` will always be ordered between `NA` and non-missing numbers.
 #' @param chr_transform Transformation of character vectors for sorting in
 #'   alternate locales.
 #'   - If `NULL`, no transformation is done.
@@ -100,8 +103,9 @@
 vec_order_radix <- function(x,
                             direction = "asc",
                             na_value = "largest",
+                            nan_distinct = FALSE,
                             chr_transform = NULL) {
-  .Call(vctrs_order, x, direction, na_value, chr_transform)
+  .Call(vctrs_order, x, direction, na_value, nan_distinct, chr_transform)
 }
 
 #' Identify ordered groups
@@ -139,6 +143,7 @@ vec_order_radix <- function(x,
 vec_order_locs <- function(x,
                            direction = "asc",
                            na_value = "largest",
+                           nan_distinct = FALSE,
                            chr_transform = NULL) {
-  .Call(vctrs_order_locs, x, direction, na_value, chr_transform)
+  .Call(vctrs_order_locs, x, direction, na_value, nan_distinct, chr_transform)
 }

--- a/src/init.c
+++ b/src/init.c
@@ -129,8 +129,8 @@ extern SEXP vctrs_slice_complete(SEXP);
 extern SEXP vctrs_locate_complete(SEXP);
 extern SEXP vctrs_detect_complete(SEXP);
 extern SEXP vctrs_normalize_encoding(SEXP);
-extern SEXP vctrs_order(SEXP, SEXP, SEXP, SEXP);
-extern SEXP vctrs_order_locs(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_order(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_order_locs(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_unrep(SEXP);
 extern SEXP vctrs_fill_missing(SEXP, SEXP, SEXP);
 extern SEXP vctrs_chr_paste_prefix(SEXP, SEXP, SEXP);
@@ -280,8 +280,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_locate_complete",            (DL_FUNC) &vctrs_locate_complete, 1},
   {"vctrs_detect_complete",            (DL_FUNC) &vctrs_detect_complete, 1},
   {"vctrs_normalize_encoding",         (DL_FUNC) &vctrs_normalize_encoding, 1},
-  {"vctrs_order",                      (DL_FUNC) &vctrs_order, 4},
-  {"vctrs_order_locs",                 (DL_FUNC) &vctrs_order_locs, 4},
+  {"vctrs_order",                      (DL_FUNC) &vctrs_order, 5},
+  {"vctrs_order_locs",                 (DL_FUNC) &vctrs_order_locs, 5},
   {"vctrs_unrep",                      (DL_FUNC) &vctrs_unrep, 1},
   {"vctrs_fill_missing",               (DL_FUNC) &vctrs_fill_missing, 3},
   {"vctrs_chr_paste_prefix",           (DL_FUNC) &vctrs_chr_paste_prefix, 3},

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -184,38 +184,59 @@
 
 // -----------------------------------------------------------------------------
 
-static SEXP vec_order(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform);
+static inline bool parse_nan_distinct(SEXP nan_distinct);
+
+static SEXP vec_order(SEXP x,
+                      SEXP direction,
+                      SEXP na_value,
+                      bool nan_distinct,
+                      SEXP chr_transform);
 
 // [[ register() ]]
-SEXP vctrs_order(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform) {
-  return vec_order(x, direction, na_value, chr_transform);
+SEXP vctrs_order(SEXP x,
+                 SEXP direction,
+                 SEXP na_value,
+                 SEXP nan_distinct,
+                 SEXP chr_transform) {
+  bool c_nan_distinct = parse_nan_distinct(nan_distinct);
+  return vec_order(x, direction, na_value, c_nan_distinct, chr_transform);
 }
 
 
 static SEXP vec_order_impl(SEXP x,
                            SEXP direction,
                            SEXP na_value,
+                           bool nan_distinct,
                            SEXP chr_transform,
                            bool locations);
 
 static
-SEXP vec_order(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform) {
-  return vec_order_impl(x, direction, na_value, chr_transform, false);
+SEXP vec_order(SEXP x, SEXP direction, SEXP na_value, bool nan_distinct, SEXP chr_transform) {
+  return vec_order_impl(x, direction, na_value, nan_distinct, chr_transform, false);
 }
 
 // -----------------------------------------------------------------------------
 
-static SEXP vec_order_locs(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform);
+static SEXP vec_order_locs(SEXP x,
+                           SEXP direction,
+                           SEXP na_value,
+                           bool nan_distinct,
+                           SEXP chr_transform);
 
 // [[ register() ]]
-SEXP vctrs_order_locs(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform) {
-  return vec_order_locs(x, direction, na_value, chr_transform);
+SEXP vctrs_order_locs(SEXP x,
+                      SEXP direction,
+                      SEXP na_value,
+                      SEXP nan_distinct,
+                      SEXP chr_transform) {
+  bool c_nan_distinct = parse_nan_distinct(nan_distinct);
+  return vec_order_locs(x, direction, na_value, c_nan_distinct, chr_transform);
 }
 
 
 static
-SEXP vec_order_locs(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform) {
-  return vec_order_impl(x, direction, na_value, chr_transform, true);
+SEXP vec_order_locs(SEXP x, SEXP direction, SEXP na_value, bool nan_distinct, SEXP chr_transform) {
+  return vec_order_impl(x, direction, na_value, nan_distinct, chr_transform, true);
 }
 
 // -----------------------------------------------------------------------------
@@ -236,6 +257,7 @@ static SEXP vec_order_flip_na_last(SEXP na_last, SEXP decreasing);
 static void vec_order_switch(SEXP x,
                              SEXP decreasing,
                              SEXP na_last,
+                             bool nan_distinct,
                              r_ssize size,
                              const enum vctrs_type type,
                              struct order* p_order,
@@ -255,7 +277,12 @@ static void vec_order_switch(SEXP x,
  * the locations in `x` corresponding to each key.
  */
 static
-SEXP vec_order_impl(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform, bool locations) {
+SEXP vec_order_impl(SEXP x,
+                    SEXP direction,
+                    SEXP na_value,
+                    bool nan_distinct,
+                    SEXP chr_transform,
+                    bool locations) {
   int n_prot = 0;
 
   SEXP decreasing = PROTECT_N(parse_direction(direction), &n_prot);
@@ -339,6 +366,7 @@ SEXP vec_order_impl(SEXP x, SEXP direction, SEXP na_value, SEXP chr_transform, b
     proxy,
     decreasing,
     na_last,
+    nan_distinct,
     size,
     type,
     p_order,
@@ -425,6 +453,7 @@ SEXP vec_order_locs_impl(SEXP x,
 static void df_order(SEXP x,
                      SEXP decreasing,
                      SEXP na_last,
+                     bool nan_distinct,
                      r_ssize size,
                      struct order* p_order,
                      struct lazy_raw* p_lazy_x_chunk,
@@ -438,6 +467,7 @@ static void df_order(SEXP x,
 static void vec_order_base_switch(SEXP x,
                                   bool decreasing,
                                   bool na_last,
+                                  bool nan_distinct,
                                   r_ssize size,
                                   const enum vctrs_type type,
                                   struct order* p_order,
@@ -453,6 +483,7 @@ static
 void vec_order_switch(SEXP x,
                       SEXP decreasing,
                       SEXP na_last,
+                      bool nan_distinct,
                       r_ssize size,
                       const enum vctrs_type type,
                       struct order* p_order,
@@ -468,6 +499,7 @@ void vec_order_switch(SEXP x,
       x,
       decreasing,
       na_last,
+      nan_distinct,
       size,
       p_order,
       p_lazy_x_chunk,
@@ -505,6 +537,7 @@ void vec_order_switch(SEXP x,
     x,
     c_decreasing,
     c_na_last,
+    nan_distinct,
     size,
     type,
     p_order,
@@ -547,6 +580,7 @@ static void lgl_order(SEXP x,
 static void dbl_order(SEXP x,
                       bool decreasing,
                       bool na_last,
+                      bool nan_distinct,
                       r_ssize size,
                       struct order* p_order,
                       struct lazy_raw* p_lazy_x_chunk,
@@ -559,6 +593,7 @@ static void dbl_order(SEXP x,
 static void cpl_order(SEXP x,
                       bool decreasing,
                       bool na_last,
+                      bool nan_distinct,
                       r_ssize size,
                       struct order* p_order,
                       struct lazy_raw* p_lazy_x_chunk,
@@ -586,6 +621,7 @@ static
 void vec_order_base_switch(SEXP x,
                            bool decreasing,
                            bool na_last,
+                           bool nan_distinct,
                            r_ssize size,
                            const enum vctrs_type type,
                            struct order* p_order,
@@ -636,6 +672,7 @@ void vec_order_base_switch(SEXP x,
       x,
       decreasing,
       na_last,
+      nan_distinct,
       size,
       p_order,
       p_lazy_x_chunk,
@@ -653,6 +690,7 @@ void vec_order_base_switch(SEXP x,
       x,
       decreasing,
       na_last,
+      nan_distinct,
       size,
       p_order,
       p_lazy_x_chunk,
@@ -1722,6 +1760,7 @@ void lgl_order(SEXP x,
 
 static void dbl_order_chunk_impl(bool decreasing,
                                  bool na_last,
+                                 bool nan_distinct,
                                  r_ssize size,
                                  void* p_x,
                                  int* p_o,
@@ -1752,6 +1791,7 @@ static void dbl_order_chunk_impl(bool decreasing,
 static
 void dbl_order_chunk(bool decreasing,
                      bool na_last,
+                     bool nan_distinct,
                      r_ssize size,
                      int* p_o,
                      struct lazy_raw* p_lazy_x_chunk,
@@ -1765,6 +1805,7 @@ void dbl_order_chunk(bool decreasing,
   dbl_order_chunk_impl(
     decreasing,
     na_last,
+    nan_distinct,
     size,
     p_x_chunk,
     p_o,
@@ -1780,6 +1821,7 @@ void dbl_order_chunk(bool decreasing,
 static void dbl_order_impl(const double* p_x,
                            bool decreasing,
                            bool na_last,
+                           bool nan_distinct,
                            r_ssize size,
                            bool copy,
                            struct order* p_order,
@@ -1794,6 +1836,7 @@ static
 void dbl_order(SEXP x,
                bool decreasing,
                bool na_last,
+               bool nan_distinct,
                r_ssize size,
                struct order* p_order,
                struct lazy_raw* p_lazy_x_chunk,
@@ -1808,6 +1851,7 @@ void dbl_order(SEXP x,
     p_x,
     decreasing,
     na_last,
+    nan_distinct,
     size,
     true,
     p_order,
@@ -1823,6 +1867,7 @@ void dbl_order(SEXP x,
 
 static void dbl_adjust(const bool decreasing,
                        const bool na_last,
+                       const bool nan_distinct,
                        const r_ssize size,
                        void* p_x);
 
@@ -1850,6 +1895,7 @@ static void dbl_order_radix(const r_ssize size,
 static
 void dbl_order_chunk_impl(bool decreasing,
                           bool na_last,
+                          bool nan_distinct,
                           r_ssize size,
                           void* p_x,
                           int* p_o,
@@ -1863,6 +1909,7 @@ void dbl_order_chunk_impl(bool decreasing,
     size,
     decreasing,
     na_last,
+    nan_distinct,
     p_group_infos
   );
 
@@ -1871,7 +1918,7 @@ void dbl_order_chunk_impl(bool decreasing,
     return;
   }
 
-  dbl_adjust(decreasing, na_last, size, p_x);
+  dbl_adjust(decreasing, na_last, nan_distinct, size, p_x);
 
   if (size <= ORDER_INSERTION_BOUNDARY) {
     dbl_order_insertion(size, p_x, p_o, p_group_infos);
@@ -1914,6 +1961,7 @@ static
 void dbl_order_impl(const double* p_x,
                     bool decreasing,
                     bool na_last,
+                    bool nan_distinct,
                     r_ssize size,
                     bool copy,
                     struct order* p_order,
@@ -1928,6 +1976,7 @@ void dbl_order_impl(const double* p_x,
     size,
     decreasing,
     na_last,
+    nan_distinct,
     p_group_infos
   );
 
@@ -1949,7 +1998,7 @@ void dbl_order_impl(const double* p_x,
     p_x_chunk = p_lazy_x_chunk->p_data;
   }
 
-  dbl_adjust(decreasing, na_last, size, p_x_chunk);
+  dbl_adjust(decreasing, na_last, nan_distinct, size, p_x_chunk);
 
   if (size <= ORDER_INSERTION_BOUNDARY) {
     dbl_order_insertion(size, p_x_chunk, p_o, p_group_infos);
@@ -1979,7 +2028,17 @@ void dbl_order_impl(const double* p_x,
 
 // -----------------------------------------------------------------------------
 
-static inline uint64_t dbl_map_to_uint64(double x);
+static inline void dbl_adjust_nan_identical(const bool decreasing,
+                                            const bool na_last,
+                                            const r_ssize size,
+                                            double* p_x_dbl,
+                                            uint64_t* p_x_u64);
+
+static inline void dbl_adjust_nan_distinct(const bool decreasing,
+                                           const bool na_last,
+                                           const r_ssize size,
+                                           double* p_x_dbl,
+                                           uint64_t* p_x_u64);
 
 /*
  * When mapping double -> uint64_t:
@@ -1996,34 +2055,87 @@ static inline uint64_t dbl_map_to_uint64(double x);
  * One smaller is:
  * dbl_map_to_uint64(.Machine$double.xmax) -> 18442240474082181119
  *
- * This gives us room to manually map (depending on `na_last`):
- * dbl_map_to_uint64(NA_real_) -> UINT64_MAX (or 0 if `na_last = false`)
- * dbl_map_to_uint64(NaN) -> UINT64_MAX (or 0 if `na_last = false`)
+ * This gives us room to manually map:
+ * If (!nan_distinct):
+ *   dbl_map_to_uint64(NA_real_) -> UINT64_MAX (or 0 if `na_last = false`)
+ *   dbl_map_to_uint64(NaN) -> UINT64_MAX (or 0 if `na_last = false`)
+ * If (nan_distinct):
+ *   dbl_map_to_uint64(NA_real_) -> UINT64_MAX (or 0 if `na_last = false`)
+ *   dbl_map_to_uint64(NaN) -> UINT64_MAX - 1 (or 1 if `na_last = false`)
+ * When using `nan_distinct`, NaN is always ordered between NA_real_ and
+ * non-missing numbers, regardless of `decreasing`.
  */
 static
 void dbl_adjust(const bool decreasing,
                 const bool na_last,
+                const bool nan_distinct,
                 const r_ssize size,
                 void* p_x) {
-  const int direction = decreasing ? -1 : 1;
-  const uint64_t na_u64 = na_last ? UINT64_MAX : 0;
-
   double* p_x_dbl = (double*) p_x;
   uint64_t* p_x_u64 = (uint64_t*) p_x;
 
+  if (nan_distinct) {
+    dbl_adjust_nan_distinct(decreasing, na_last, size, p_x_dbl, p_x_u64);
+  } else {
+    dbl_adjust_nan_identical(decreasing, na_last, size, p_x_dbl, p_x_u64);
+  }
+}
+
+static inline uint64_t dbl_map_to_uint64(double x);
+
+static inline
+void dbl_adjust_nan_identical(const bool decreasing,
+                              const bool na_last,
+                              const r_ssize size,
+                              double* p_x_dbl,
+                              uint64_t* p_x_u64) {
+  const int direction = decreasing ? -1 : 1;
+  const uint64_t na_u64 = na_last ? UINT64_MAX : 0;
+
   for (r_ssize i = 0; i < size; ++i) {
-    // Flip direction ahead of time. Won't affect `NA_real`, `NaN` values.
-    double elt = p_x_dbl[i] * direction;
+    double elt = p_x_dbl[i];
 
     if (isnan(elt)) {
       p_x_u64[i] = na_u64;
       continue;
     }
 
+    elt = elt * direction;
     p_x_u64[i] = dbl_map_to_uint64(elt);
   }
 }
 
+static inline
+void dbl_adjust_nan_distinct(const bool decreasing,
+                             const bool na_last,
+                             const r_ssize size,
+                             double* p_x_dbl,
+                             uint64_t* p_x_u64) {
+  const int direction = decreasing ? -1 : 1;
+  const uint64_t na_u64 = na_last ? UINT64_MAX : 0;
+  const uint64_t nan_u64 = na_last ? UINT64_MAX - 1 : 1;
+
+  for (r_ssize i = 0; i < size; ++i) {
+    double elt = p_x_dbl[i];
+    const enum vctrs_dbl_class type = dbl_classify(elt);
+
+    switch (type) {
+    case vctrs_dbl_number: {
+      elt = elt * direction;
+      p_x_u64[i] = dbl_map_to_uint64(elt);
+      break;
+    }
+    case vctrs_dbl_missing: {
+      p_x_u64[i] = na_u64;
+      break;
+    }
+    case vctrs_dbl_nan: {
+      p_x_u64[i] = nan_u64;
+      break;
+    }
+    }
+  }
+}
 
 static inline uint64_t dbl_flip_uint64(uint64_t x);
 
@@ -2465,6 +2577,7 @@ static
 void cpl_order(SEXP x,
                bool decreasing,
                bool na_last,
+               bool nan_distinct,
                r_ssize size,
                struct order* p_order,
                struct lazy_raw* p_lazy_x_chunk,
@@ -2509,6 +2622,7 @@ void cpl_order(SEXP x,
     p_x_chunk_dbl,
     decreasing,
     na_last,
+    nan_distinct,
     size,
     false,
     p_order,
@@ -2564,6 +2678,7 @@ void cpl_order(SEXP x,
     dbl_order_chunk_impl(
       decreasing,
       na_last,
+      nan_distinct,
       group_size,
       p_x_chunk_dbl,
       p_o,
@@ -3281,6 +3396,7 @@ struct df_order_info {
   SEXP x;
   SEXP decreasing;
   SEXP na_last;
+  bool nan_distinct;
   r_ssize size;
   struct order* p_order;
   struct lazy_raw* p_lazy_x_chunk;
@@ -3321,6 +3437,7 @@ static
 void df_order(SEXP x,
               SEXP decreasing,
               SEXP na_last,
+              bool nan_distinct,
               r_ssize size,
               struct order* p_order,
               struct lazy_raw* p_lazy_x_chunk,
@@ -3334,6 +3451,7 @@ void df_order(SEXP x,
     .x = x,
     .decreasing = decreasing,
     .na_last = na_last,
+    .nan_distinct = nan_distinct,
     .size = size,
     .p_order = p_order,
     .p_lazy_x_chunk = p_lazy_x_chunk,
@@ -3360,6 +3478,7 @@ void df_order(SEXP x,
 static void df_order_internal(SEXP x,
                               SEXP decreasing,
                               SEXP na_last,
+                              bool nan_distinct,
                               r_ssize size,
                               struct order* p_order,
                               struct lazy_raw* p_lazy_x_chunk,
@@ -3378,6 +3497,7 @@ SEXP df_order_exec(void* p_data) {
     p_info->x,
     p_info->decreasing,
     p_info->na_last,
+    p_info->nan_distinct,
     p_info->size,
     p_info->p_order,
     p_info->p_lazy_x_chunk,
@@ -3401,6 +3521,7 @@ void df_order_cleanup(void* p_data) {
 
 static void vec_order_chunk_switch(bool decreasing,
                                    bool na_last,
+                                   bool nan_distinct,
                                    r_ssize size,
                                    const enum vctrs_type type,
                                    int* p_o,
@@ -3450,6 +3571,7 @@ static
 void df_order_internal(SEXP x,
                        SEXP decreasing,
                        SEXP na_last,
+                       bool nan_distinct,
                        r_ssize size,
                        struct order* p_order,
                        struct lazy_raw* p_lazy_x_chunk,
@@ -3512,6 +3634,7 @@ void df_order_internal(SEXP x,
     col,
     col_decreasing,
     col_na_last,
+    nan_distinct,
     size,
     type,
     p_order,
@@ -3613,6 +3736,7 @@ void df_order_internal(SEXP x,
       vec_order_chunk_switch(
         col_decreasing,
         col_na_last,
+        nan_distinct,
         group_size,
         type,
         p_o_col,
@@ -3646,6 +3770,7 @@ void df_order_internal(SEXP x,
 static
 void vec_order_chunk_switch(bool decreasing,
                             bool na_last,
+                            bool nan_distinct,
                             r_ssize size,
                             const enum vctrs_type type,
                             int* p_o,
@@ -3692,6 +3817,7 @@ void vec_order_chunk_switch(bool decreasing,
     dbl_order_chunk(
       decreasing,
       na_last,
+      nan_distinct,
       size,
       p_o,
       p_lazy_x_chunk,
@@ -3709,6 +3835,7 @@ void vec_order_chunk_switch(bool decreasing,
     dbl_order_chunk(
       decreasing,
       na_last,
+      nan_distinct,
       size,
       p_o,
       p_lazy_x_chunk,
@@ -4176,4 +4303,22 @@ int parse_direction_one(SEXP x) {
     R_NilValue,
     "`direction` must contain only \"asc\" or \"desc\"."
   );
+}
+
+static inline
+bool parse_nan_distinct(SEXP nan_distinct) {
+  if (TYPEOF(nan_distinct) != LGLSXP) {
+    Rf_errorcall(R_NilValue, "`nan_distinct` must be a logical vector.");
+  }
+  if (Rf_length(nan_distinct) != 1) {
+    Rf_errorcall(R_NilValue, "`nan_distinct` must be length 1.");
+  }
+
+  int c_nan_distinct = LOGICAL_RO(nan_distinct)[0];
+
+  if (c_nan_distinct == NA_LOGICAL) {
+    Rf_errorcall(R_NilValue, "`nan_distinct` can't be missing.");
+  }
+
+  return (bool) c_nan_distinct;
 }

--- a/src/order-sortedness.c
+++ b/src/order-sortedness.c
@@ -21,7 +21,7 @@ static inline int dbl_cmp(double x,
                           enum vctrs_dbl_class y_type,
                           int direction,
                           int na_order,
-                          int na_nan_cmp);
+                          int na_nan_order);
 
 /*
  * Check if a double vector is ordered, handling `decreasing`, `na_last`, and
@@ -51,7 +51,7 @@ enum vctrs_sortedness dbl_sortedness(const double* p_x,
 
   const int direction = decreasing ? -1 : 1;
   const int na_order = na_last ? 1 : -1;
-  const int na_nan_cmp = nan_distinct ? na_order : 0;
+  const int na_nan_order = nan_distinct ? na_order : 0;
 
   double previous = p_x[0];
   enum vctrs_dbl_class previous_type = dbl_classify(previous);
@@ -71,7 +71,7 @@ enum vctrs_sortedness dbl_sortedness(const double* p_x,
       previous_type,
       direction,
       na_order,
-      na_nan_cmp
+      na_nan_order
     );
 
     if (cmp >= 0) {
@@ -117,7 +117,7 @@ enum vctrs_sortedness dbl_sortedness(const double* p_x,
       previous_type,
       direction,
       na_order,
-      na_nan_cmp
+      na_nan_order
     );
 
     // Not expected ordering
@@ -150,7 +150,7 @@ enum vctrs_sortedness dbl_sortedness(const double* p_x,
 static inline int dbl_cmp_numbers(double x, double y, int direction);
 
 /*
- * Compare two doubles, handling `na_order`, `direction`, and `na_nan_cmp`
+ * Compare two doubles, handling `na_order`, `direction`, and `na_nan_order`
  */
 static inline
 int dbl_cmp(double x,
@@ -159,7 +159,7 @@ int dbl_cmp(double x,
             enum vctrs_dbl_class y_type,
             int direction,
             int na_order,
-            int na_nan_cmp) {
+            int na_nan_order) {
   switch (x_type) {
   case vctrs_dbl_number:
     switch (y_type) {
@@ -171,12 +171,12 @@ int dbl_cmp(double x,
     switch (y_type) {
     case vctrs_dbl_number: return na_order;
     case vctrs_dbl_missing: return 0;
-    case vctrs_dbl_nan: return na_nan_cmp;
+    case vctrs_dbl_nan: return na_nan_order;
     }
   case vctrs_dbl_nan:
     switch (y_type) {
     case vctrs_dbl_number: return na_order;
-    case vctrs_dbl_missing: return -na_nan_cmp;
+    case vctrs_dbl_missing: return -na_nan_order;
     case vctrs_dbl_nan: return 0;
     }
   }

--- a/src/order-sortedness.c
+++ b/src/order-sortedness.c
@@ -15,13 +15,13 @@
 
 // -----------------------------------------------------------------------------
 
-static inline int dbl_cmp(const double x,
-                          const double y,
-                          const enum vctrs_dbl_class x_type,
-                          const enum vctrs_dbl_class y_type,
-                          const int direction,
-                          const int na_order,
-                          const int na_nan_cmp);
+static inline int dbl_cmp(double x,
+                          double y,
+                          enum vctrs_dbl_class x_type,
+                          enum vctrs_dbl_class y_type,
+                          int direction,
+                          int na_order,
+                          int na_nan_cmp);
 
 /*
  * Check if a double vector is ordered, handling `decreasing`, `na_last`, and
@@ -147,19 +147,19 @@ enum vctrs_sortedness dbl_sortedness(const double* p_x,
   return VCTRS_SORTEDNESS_sorted;
 }
 
-static inline int dbl_cmp_numbers(double x, double y, const int direction);
+static inline int dbl_cmp_numbers(double x, double y, int direction);
 
 /*
  * Compare two doubles, handling `na_order`, `direction`, and `na_nan_cmp`
  */
 static inline
-int dbl_cmp(const double x,
-            const double y,
-            const enum vctrs_dbl_class x_type,
-            const enum vctrs_dbl_class y_type,
-            const int direction,
-            const int na_order,
-            const int na_nan_cmp) {
+int dbl_cmp(double x,
+            double y,
+            enum vctrs_dbl_class x_type,
+            enum vctrs_dbl_class y_type,
+            int direction,
+            int na_order,
+            int na_nan_cmp) {
   switch (x_type) {
   case vctrs_dbl_number:
     switch (y_type) {
@@ -184,7 +184,7 @@ int dbl_cmp(const double x,
 }
 
 static inline
-int dbl_cmp_numbers(const double x, const double y, const int direction) {
+int dbl_cmp_numbers(double x, double y, int direction) {
   const int cmp = (x > y) - (x < y);
   return cmp * direction;
 }

--- a/src/order-sortedness.c
+++ b/src/order-sortedness.c
@@ -180,6 +180,7 @@ int dbl_cmp(const double x,
     case vctrs_dbl_nan: return 0;
     }
   }
+  never_reached("dbl_cmp");
 }
 
 static inline

--- a/src/order-sortedness.c
+++ b/src/order-sortedness.c
@@ -17,6 +17,8 @@
 
 static inline int dbl_cmp(const double x,
                           const double y,
+                          const enum vctrs_dbl_class x_type,
+                          const enum vctrs_dbl_class y_type,
                           const int direction,
                           const int na_order,
                           const int na_nan_cmp);
@@ -52,6 +54,7 @@ enum vctrs_sortedness dbl_sortedness(const double* p_x,
   const int na_nan_cmp = nan_distinct ? na_order : 0;
 
   double previous = p_x[0];
+  enum vctrs_dbl_class previous_type = dbl_classify(previous);
 
   r_ssize count = 0;
 
@@ -59,10 +62,13 @@ enum vctrs_sortedness dbl_sortedness(const double* p_x,
   // (ties are not allowed so we can reverse the vector stably)
   for (r_ssize i = 1; i < size; ++i, ++count) {
     double current = p_x[i];
+    enum vctrs_dbl_class current_type = dbl_classify(current);
 
     int cmp = dbl_cmp(
       current,
       previous,
+      current_type,
+      previous_type,
       direction,
       na_order,
       na_nan_cmp
@@ -73,6 +79,7 @@ enum vctrs_sortedness dbl_sortedness(const double* p_x,
     }
 
     previous = current;
+    previous_type = current_type;
   }
 
   // Was in strictly opposite of expected order.
@@ -101,10 +108,13 @@ enum vctrs_sortedness dbl_sortedness(const double* p_x,
   // reverse the ordering.
   for (r_ssize i = 1; i < size; ++i) {
     double current = p_x[i];
+    enum vctrs_dbl_class current_type = dbl_classify(current);
 
     int cmp = dbl_cmp(
       current,
       previous,
+      current_type,
+      previous_type,
       direction,
       na_order,
       na_nan_cmp
@@ -117,6 +127,7 @@ enum vctrs_sortedness dbl_sortedness(const double* p_x,
     }
 
     previous = current;
+    previous_type = current_type;
 
     // Continue group run
     if (cmp == 0) {
@@ -144,12 +155,11 @@ static inline int dbl_cmp_numbers(double x, double y, const int direction);
 static inline
 int dbl_cmp(const double x,
             const double y,
+            const enum vctrs_dbl_class x_type,
+            const enum vctrs_dbl_class y_type,
             const int direction,
             const int na_order,
             const int na_nan_cmp) {
-  const enum vctrs_dbl_class x_type = dbl_classify(x);
-  const enum vctrs_dbl_class y_type = dbl_classify(y);
-
   switch (x_type) {
   case vctrs_dbl_number:
     switch (y_type) {

--- a/src/order-sortedness.h
+++ b/src/order-sortedness.h
@@ -30,6 +30,7 @@ enum vctrs_sortedness dbl_sortedness(const double* p_x,
                                      r_ssize size,
                                      bool decreasing,
                                      bool na_last,
+                                     bool nan_distinct,
                                      struct group_infos* p_group_infos);
 
 enum vctrs_sortedness int_sortedness(const int* p_x,

--- a/tests/testthat/test-order-radix.R
+++ b/tests/testthat/test-order-radix.R
@@ -331,6 +331,20 @@ test_that("can order when in expected order", {
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "smallest"), 1:5)
 })
 
+test_that("can order when in expected order - using distinct NaN values", {
+  x <- c(1, 1, 2, NaN, NA)
+  expect_identical(vec_order_radix(x, direction = "asc", na_value = "largest", nan_distinct = TRUE), 1:5)
+
+  x <- c(NA, NaN, 3, 3, 2)
+  expect_identical(vec_order_radix(x, direction = "desc", na_value = "largest", nan_distinct = TRUE), 1:5)
+
+  x <- c(NA, NaN, 1, 1, 2)
+  expect_identical(vec_order_radix(x, direction = "asc", na_value = "smallest", nan_distinct = TRUE), 1:5)
+
+  x <- c(3, 3, 2, NaN, NA)
+  expect_identical(vec_order_radix(x, direction = "desc", na_value = "smallest", nan_distinct = TRUE), 1:5)
+})
+
 test_that("can order when in strictly opposite of expected order (no ties)", {
   x <- c(NA, 2, 1)
   expect_identical(vec_order_radix(x, direction = "asc", na_value = "largest"), 3:1)
@@ -343,6 +357,29 @@ test_that("can order when in strictly opposite of expected order (no ties)", {
 
   x <- c(NA, 1, 2)
   expect_identical(vec_order_radix(x, direction = "desc", na_value = "smallest"), 3:1)
+})
+
+test_that("can order when in strictly opposite of expected order (no ties) - using distinct NaN values", {
+  x <- c(NA, NaN, 2, 1)
+  expect_identical(vec_order_radix(x, direction = "asc", na_value = "largest", nan_distinct = TRUE), 4:1)
+
+  x <- c(1, 2, NaN, NA)
+  expect_identical(vec_order_radix(x, direction = "desc", na_value = "largest", nan_distinct = TRUE), 4:1)
+
+  x <- c(2, 1, NaN, NA)
+  expect_identical(vec_order_radix(x, direction = "asc", na_value = "smallest", nan_distinct = TRUE), 4:1)
+
+  x <- c(NA, NaN, 1, 2)
+  expect_identical(vec_order_radix(x, direction = "desc", na_value = "smallest", nan_distinct = TRUE), 4:1)
+})
+
+test_that("NaN is always placed next to numbers when treated as distinct", {
+  x <- c(1, 2, NA, NaN)
+
+  expect_identical(vec_order_radix(x, direction = "asc", na_value = "largest", nan_distinct = TRUE), c(1L, 2L, 4L, 3L))
+  expect_identical(vec_order_radix(x, direction = "asc", na_value = "smallest", nan_distinct = TRUE), c(3L, 4L, 1L, 2L))
+  expect_identical(vec_order_radix(x, direction = "desc", na_value = "largest", nan_distinct = TRUE), c(3L, 4L, 2L, 1L))
+  expect_identical(vec_order_radix(x, direction = "desc", na_value = "smallest", nan_distinct = TRUE), c(2L, 1L, 4L, 3L))
 })
 
 # ------------------------------------------------------------------------------
@@ -392,10 +429,20 @@ test_that("all `NA` values works", {
   expect_identical(vec_order_radix(x), order(x))
 })
 
-test_that("NA_real_ and NaN look identical for ordering", {
+test_that("NA_real_ and NaN generally look identical for ordering", {
   x <- rep(c(NA_real_, NaN), ORDER_INSERTION_BOUNDARY + 1L)
   expect_identical(vec_order_radix(x, na_value = "largest"), seq_along(x))
   expect_identical(vec_order_radix(x, na_value = "smallest"), seq_along(x))
+})
+
+test_that("NA_real_ and NaN can be considered distinct with `nan_distinct`", {
+  x <- rep(c(NA_real_, NaN), ORDER_INSERTION_BOUNDARY + 1L)
+
+  loc_nan <- seq(2L, length(x), by = 2L)
+  loc_na <- seq(1L, length(x), by = 2L)
+
+  expect_identical(vec_order_radix(x, na_value = "largest", nan_distinct = TRUE), c(loc_nan, loc_na))
+  expect_identical(vec_order_radix(x, na_value = "smallest", nan_distinct = TRUE), c(loc_na, loc_nan))
 })
 
 test_that("-Inf / Inf order correctly", {
@@ -485,6 +532,15 @@ test_that("all combinations of `direction` and `na_value` work", {
     #x[order(x, na.last = FALSE, decreasing = TRUE)]
     x[c(1L, 4L, 3L, 5L, 2L)]
   )
+})
+
+test_that("can treat NaN and NA_real_ as distinct values", {
+  x <- complex(real = c(NA, NA, NaN, NaN), imaginary = c(NA, NaN, NaN, NA))
+
+  expect_identical(vec_order_radix(x, direction = "asc", na_value = "largest", nan_distinct = TRUE), c(3L, 4L, 2L, 1L))
+  expect_identical(vec_order_radix(x, direction = "asc", na_value = "smallest", nan_distinct = TRUE), c(1L, 2L, 4L, 3L))
+  expect_identical(vec_order_radix(x, direction = "desc", na_value = "largest", nan_distinct = TRUE), c(1L, 2L, 4L, 3L))
+  expect_identical(vec_order_radix(x, direction = "desc", na_value = "smallest", nan_distinct = TRUE), c(3L, 4L, 2L, 1L))
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
~Requires #1342 to be merged, and some changes will have to be done here after that~ Done

Dictionary functions generally treat `NA_real_` different from `NaN` for double and complex vectors:

``` r
x <- c(NA_real_, NaN)
vctrs::vec_unique(x)
#> [1]  NA NaN
vctrs::vec_match(x, x, na_equal = TRUE)
#> [1] 1 2

x <- complex(real = c(NA, NA, NaN, NaN), imaginary = c(NA, NaN, NaN, NA))
vctrs::vec_unique(x)
#> [1]       NA       NA NaN+NaNi       NA
```

If we are thinking about using `vec_order_radix()` for these internally, we will need to allow `NaN` to look different from `NA_real_` in the ordering code.

I've added a boolean `nan_distinct` argument to `vec_order_radix()` to control this. If `TRUE`, `NaN` values are always placed between `NA_real_` and non-missing numbers. Because there is no obvious ordering between `NA_real_` and `NaN`, this seems like a reasonable heuristic, and is also what data.table does (unconditionally, I might add).

Unfortunately, we do have to thread this `nan_distinct` argument all the way through to `dbl_adjust()`. I don't see any way around that, but it isn't too bad. It also gets threaded through the complex (`cpl_*()`) calls.

``` r
vec_order_radix <- vctrs:::vec_order_radix

x <- c(NaN, 1, 2, NA_real_, NaN, NA_real_)

x[vec_order_radix(x, direction = "asc", na_value = "largest", nan_distinct = TRUE)]
#> [1]   1   2 NaN NaN  NA  NA
x[vec_order_radix(x, direction = "asc", na_value = "smallest", nan_distinct = TRUE)]
#> [1]  NA  NA NaN NaN   1   2
x[vec_order_radix(x, direction = "desc", na_value = "largest", nan_distinct = TRUE)]
#> [1]  NA  NA NaN NaN   2   1
x[vec_order_radix(x, direction = "desc", na_value = "smallest", nan_distinct = TRUE)]
#> [1]   2   1 NaN NaN  NA  NA
```