### PR TITLE
Refactor `vec_order_impl()` to expose `vec_order_info()`

### DIFF
--- a/R/order-radix.R
+++ b/R/order-radix.R
@@ -147,3 +147,11 @@ vec_order_locs <- function(x,
                            chr_transform = NULL) {
   .Call(vctrs_order_locs, x, direction, na_value, nan_distinct, chr_transform)
 }
+
+vec_order_info <- function(x,
+                           direction = "asc",
+                           na_value = "largest",
+                           nan_distinct = FALSE,
+                           chr_transform = NULL) {
+  .Call(vctrs_order_info, x, direction, na_value, nan_distinct, chr_transform)
+}

--- a/src/init.c
+++ b/src/init.c
@@ -130,6 +130,7 @@ extern SEXP vctrs_detect_complete(SEXP);
 extern SEXP vctrs_normalize_encoding(SEXP);
 extern SEXP vctrs_order(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_order_locs(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_order_info(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_unrep(SEXP);
 extern SEXP vctrs_fill_missing(SEXP, SEXP, SEXP);
 extern SEXP vctrs_chr_paste_prefix(SEXP, SEXP, SEXP);
@@ -281,6 +282,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_normalize_encoding",         (DL_FUNC) &vctrs_normalize_encoding, 1},
   {"vctrs_order",                      (DL_FUNC) &vctrs_order, 5},
   {"vctrs_order_locs",                 (DL_FUNC) &vctrs_order_locs, 5},
+  {"vctrs_order_info",                 (DL_FUNC) &vctrs_order_info, 5},
   {"vctrs_unrep",                      (DL_FUNC) &vctrs_unrep, 1},
   {"vctrs_fill_missing",               (DL_FUNC) &vctrs_fill_missing, 3},
   {"vctrs_chr_paste_prefix",           (DL_FUNC) &vctrs_chr_paste_prefix, 3},

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -213,10 +213,8 @@ static SEXP vec_order_info_impl(SEXP x,
 static
 SEXP vec_order(SEXP x, SEXP direction, SEXP na_value, bool nan_distinct, SEXP chr_transform) {
   const bool group_sizes = false;
-  SEXP info = PROTECT(vec_order_info_impl(x, direction, na_value, nan_distinct, chr_transform, group_sizes));
-  SEXP out = VECTOR_ELT(info, 0);
-  UNPROTECT(1);
-  return out;
+  SEXP info = vec_order_info_impl(x, direction, na_value, nan_distinct, chr_transform, group_sizes);
+  return r_list_get(info, 0);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -453,18 +453,8 @@ SEXP vec_order_info_impl(SEXP x,
 
   if (group_sizes) {
     struct group_info* p_group_info = groups_current(p_group_infos);
-
     SEXP sizes = p_group_info->data;
-
-    // TODO: Replace with `r_int_resize()` from the rlang lib
-#if R_VERSION >= R_Version(3, 4, 0)
-    SETLENGTH(sizes, p_group_info->n_groups);
-    SET_TRUELENGTH(sizes, p_group_info->data_size);
-    SET_GROWABLE_BIT(sizes);
-#else
-    sizes = Rf_xlengthgets(sizes, p_group_info->n_groups);
-#endif
-
+    sizes = r_int_resize(sizes, p_group_info->n_groups);
     SET_VECTOR_ELT(out, 1, sizes);
   }
 

--- a/src/order-radix.h
+++ b/src/order-radix.h
@@ -17,6 +17,14 @@
 
 // -----------------------------------------------------------------------------
 
+SEXP vec_order_info(SEXP x,
+                    SEXP direction,
+                    SEXP na_value,
+                    bool nan_distinct,
+                    SEXP chr_transform);
+
+// -----------------------------------------------------------------------------
+
 /*
  * `order` is an integer vector intended to hold the ordering vector
  * in `vec_order()`. It is allocated eagerly, but the initialization of its


### PR DESCRIPTION
Closes #1266, which is highly optimized for performance by reusing allocated data where possible, but gets extremely confusing very quickly

This PR exposes `vec_order_info()`, which returns a list of size two.
- The first element contains the ordering
- The second element contains the group sizes

``` r
vctrs:::vec_order_info(c(1, 2, 1, 1, 4, 3, 4))
#> [[1]]
#> [1] 1 3 4 2 6 5 7
#> 
#> [[2]]
#> [1] 3 1 1 2
```

Being able to access both the ordering and the group sizes is a step towards implementing `vec_rank()` and reimplementing dictionary functions.