### PR TITLE
Implement `vec_rank()`

### DIFF
--- a/R/order-radix.R
+++ b/R/order-radix.R
@@ -36,13 +36,12 @@
 #'     respectively.
 #'   - For data frames, a length `1` or `ncol(x)` character vector containing
 #'     only `"asc"` or `"desc"`, specifying the direction for each column.
-#' @param na_value Treatment of `NA` values. `NaN` values are treated as
-#'   equivalent to `NA` values.
-#'   - A single `"largest"` or `"smallest"` for treating `NA` values as the
+#' @param na_value Treatment of missing values.
+#'   - A single `"largest"` or `"smallest"` for treating missing values as the
 #'     largest or smallest values respectively.
 #'   - For data frames, a length `1` or `ncol(x)` character vector containing
-#'     only `"largest"` or `"smallest"`, specifying how `NA`s should be treated
-#'     in each column.
+#'     only `"largest"` or `"smallest"`, specifying how missing values should
+#'     be treated in each column.
 #' @param nan_distinct A single logical specifying whether or not `NaN` should
 #'   be considered distinct from `NA` for double and complex vectors. If `TRUE`,
 #'   `NaN` will always be ordered between `NA` and non-missing numbers.

--- a/R/rank.R
+++ b/R/rank.R
@@ -2,11 +2,21 @@ vec_rank <- function(x,
                      ...,
                      ties = c("min", "max", "sequential", "dense"),
                      na_propagate = FALSE,
+                     direction = "asc",
                      na_value = "largest",
                      nan_distinct = FALSE,
                      chr_transform = NULL) {
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
-  .Call(vctrs_rank, x, ties, na_propagate, na_value, nan_distinct, chr_transform)
+  .Call(
+    vctrs_rank,
+    x,
+    ties,
+    na_propagate,
+    direction,
+    na_value,
+    nan_distinct,
+    chr_transform
+  )
 }

--- a/R/rank.R
+++ b/R/rank.R
@@ -87,6 +87,9 @@ vec_rank <- function(x,
   if (!missing(...)) {
     ellipsis::check_dots_empty()
   }
+
+  ties <- arg_match0(ties, c("min", "max", "sequential", "dense"), "ties")
+
   .Call(
     vctrs_rank,
     x,

--- a/R/rank.R
+++ b/R/rank.R
@@ -1,0 +1,12 @@
+vec_rank <- function(x,
+                     ...,
+                     ties = c("min", "max", "sequential", "dense"),
+                     na_propagate = FALSE,
+                     na_value = "largest",
+                     nan_distinct = FALSE,
+                     chr_transform = NULL) {
+  if (!missing(...)) {
+    ellipsis::check_dots_empty()
+  }
+  .Call(vctrs_rank, x, ties, na_propagate, na_value, nan_distinct, chr_transform)
+}

--- a/R/rank.R
+++ b/R/rank.R
@@ -1,3 +1,81 @@
+#' Rank vectors
+#'
+#' `vec_rank()` computes the sample ranks of a vector. For data frames, ranks
+#' are computed along the rows, using all columns after the first to break
+#' ties.
+#'
+#' @details
+#' Unlike [base::rank()], when `na_propagate = FALSE` all `NA` values are
+#' given the same rank, rather than an increasing sequence of ranks. When
+#' `nan_distinct = FALSE`, `NaN` values are given the same rank as `NA`,
+#' otherwise they are given a rank that differentiates them from `NA`.
+#'
+#' Like [vec_order_radix()], ordering is done in the C-locale. This can affect
+#' the ranks of character vectors, especially regarding how uppercase and
+#' lowercase letters are ranked. See the Details section of [vec_order_radix()]
+#' for more information.
+#'
+#' @inheritParams vec_order_radix
+#' @inheritParams ellipsis::dots_empty
+#'
+#' @param ties Treatment of duplicate values.
+#'   - `"min"`: Use the current rank for all duplicates. The next non-duplicate
+#'   value will have a rank incremented by the number of duplicates present.
+#'
+#'   - `"max"`: Use the current rank `+ n_duplicates - 1` for all duplicates.
+#'   The next non-duplicate value will have a rank incremented by the number of
+#'   duplicates present.
+#'
+#'   - `"sequential"`: Use an increasing sequence of ranks starting at the
+#'   current rank, applied to duplicates in order of appearance.
+#'
+#'   - `"dense"`: Use the current rank for all duplicates. The next
+#'   non-duplicate value will have a rank incremented by `1`, effectively
+#'   removing any gaps in the ranking.
+#'
+#' @param na_propagate A single logical specifying whether or not missing
+#'   values should be propagated. If `TRUE`, all missing values are given
+#'   the rank `NA`.
+#'
+#' @section Dependencies of `vec_rank()`:
+#'
+#' - `vec_order()`
+#'
+#' - `vec_slice()`
+#'
+#' @examples
+#' x <- c(5L, 6L, 3L, 3L, 5L, 3L)
+#'
+#' vec_rank(x, ties = "min")
+#' vec_rank(x, ties = "max")
+#'
+#' # Sequential ranks use an increasing sequence for duplicates
+#' vec_rank(x, ties = "sequential")
+#'
+#' # Dense ranks remove gaps between distinct values,
+#' # even if there are duplicates
+#' vec_rank(x, ties = "dense")
+#'
+#' y <- c(NA, x, NA, NaN)
+#'
+#' # Missing values match other missing values
+#' vec_rank(y, na_value = "largest")
+#' vec_rank(y, na_value = "smallest")
+#'
+#' # NaN can be ranked separately from NA if required
+#' vec_rank(y, nan_distinct = TRUE)
+#'
+#' # Rank in descending order. Since missing values are the largest value,
+#' # they are given a rank of `1` when ranking in descending order.
+#' vec_rank(y, direction = "desc", na_value = "largest")
+#'
+#' # Can also rank data frames, using columns after the first to break ties
+#' z <- c(2L, 3L, 4L, 4L, 5L, 2L)
+#' df <- data_frame(x = x, z = z)
+#' df
+#'
+#' vec_rank(df)
+#' @noRd
 vec_rank <- function(x,
                      ...,
                      ties = c("min", "max", "sequential", "dense"),

--- a/src/decl/rank-decl.h
+++ b/src/decl/rank-decl.h
@@ -14,6 +14,7 @@ static inline bool r_lgl_any(sexp* x);
 static sexp* vec_rank(sexp* x,
                       enum ties ties_type,
                       bool na_propagate,
+                      sexp* direction,
                       sexp* na_value,
                       bool nan_distinct,
                       sexp* chr_transform);

--- a/src/decl/rank-decl.h
+++ b/src/decl/rank-decl.h
@@ -1,12 +1,6 @@
 #ifndef VCTRS_RANK_DECL_H
 #define VCTRS_RANK_DECL_H
 
-enum ties {
-  TIES_min,
-  TIES_max,
-  TIES_sequential,
-  TIES_dense
-};
 static inline enum ties parse_ties(r_obj* ties);
 
 static inline bool r_lgl_any(r_obj* x);

--- a/src/decl/rank-decl.h
+++ b/src/decl/rank-decl.h
@@ -9,8 +9,7 @@ enum ties {
 };
 static inline enum ties parse_ties(sexp* ties);
 
-static sexp* r_lgl_negate(sexp* x, bool na_propagate);
-static bool r_lgl_any(sexp* x);
+static inline bool r_lgl_any(sexp* x);
 
 static sexp* vec_rank(sexp* x,
                       enum ties ties_type,
@@ -21,34 +20,22 @@ static sexp* vec_rank(sexp* x,
 
 static void vec_rank_min(const int* v_order,
                          const int* v_group_sizes,
-                         const int* v_locs,
-                         r_ssize size,
                          r_ssize n_groups,
-                         bool na_propagate,
-                         int* v_out);
+                         int* v_rank);
 
 static void vec_rank_max(const int* v_order,
                          const int* v_group_sizes,
-                         const int* v_locs,
-                         r_ssize size,
                          r_ssize n_groups,
-                         bool na_propagate,
-                         int* v_out);
+                         int* v_rank);
 
 static void vec_rank_sequential(const int* v_order,
                                 const int* v_group_sizes,
-                                const int* v_locs,
-                                r_ssize size,
                                 r_ssize n_groups,
-                                bool na_propagate,
-                                int* v_out);
+                                int* v_rank);
 
 static void vec_rank_dense(const int* v_order,
                            const int* v_group_sizes,
-                           const int* v_locs,
-                           r_ssize size,
                            r_ssize n_groups,
-                           bool na_propagate,
-                           int* v_out);
+                           int* v_rank);
 
 #endif

--- a/src/decl/rank-decl.h
+++ b/src/decl/rank-decl.h
@@ -1,6 +1,3 @@
-#ifndef VCTRS_RANK_DECL_H
-#define VCTRS_RANK_DECL_H
-
 static inline enum ties parse_ties(r_obj* ties);
 
 static inline bool r_lgl_any(r_obj* x);
@@ -32,5 +29,3 @@ static void vec_rank_dense(const int* v_order,
                            const int* v_group_sizes,
                            r_ssize n_groups,
                            int* v_rank);
-
-#endif

--- a/src/decl/rank-decl.h
+++ b/src/decl/rank-decl.h
@@ -7,17 +7,17 @@ enum ties {
   TIES_sequential,
   TIES_dense
 };
-static inline enum ties parse_ties(sexp* ties);
+static inline enum ties parse_ties(r_obj* ties);
 
-static inline bool r_lgl_any(sexp* x);
+static inline bool r_lgl_any(r_obj* x);
 
-static sexp* vec_rank(sexp* x,
-                      enum ties ties_type,
-                      bool na_propagate,
-                      sexp* direction,
-                      sexp* na_value,
-                      bool nan_distinct,
-                      sexp* chr_transform);
+static r_obj* vec_rank(r_obj* x,
+                       enum ties ties_type,
+                       bool na_propagate,
+                       r_obj* direction,
+                       r_obj* na_value,
+                       bool nan_distinct,
+                       r_obj* chr_transform);
 
 static void vec_rank_min(const int* v_order,
                          const int* v_group_sizes,

--- a/src/decl/rank-decl.h
+++ b/src/decl/rank-decl.h
@@ -1,0 +1,54 @@
+#ifndef VCTRS_RANK_DECL_H
+#define VCTRS_RANK_DECL_H
+
+enum ties {
+  TIES_min,
+  TIES_max,
+  TIES_sequential,
+  TIES_dense
+};
+static inline enum ties parse_ties(sexp* ties);
+
+static sexp* r_lgl_negate(sexp* x, bool na_propagate);
+static bool r_lgl_any(sexp* x);
+
+static sexp* vec_rank(sexp* x,
+                      enum ties ties_type,
+                      bool na_propagate,
+                      sexp* na_value,
+                      bool nan_distinct,
+                      sexp* chr_transform);
+
+static void vec_rank_min(const int* v_order,
+                         const int* v_group_sizes,
+                         const int* v_locs,
+                         r_ssize size,
+                         r_ssize n_groups,
+                         bool na_propagate,
+                         int* v_out);
+
+static void vec_rank_max(const int* v_order,
+                         const int* v_group_sizes,
+                         const int* v_locs,
+                         r_ssize size,
+                         r_ssize n_groups,
+                         bool na_propagate,
+                         int* v_out);
+
+static void vec_rank_sequential(const int* v_order,
+                                const int* v_group_sizes,
+                                const int* v_locs,
+                                r_ssize size,
+                                r_ssize n_groups,
+                                bool na_propagate,
+                                int* v_out);
+
+static void vec_rank_dense(const int* v_order,
+                           const int* v_group_sizes,
+                           const int* v_locs,
+                           r_ssize size,
+                           r_ssize n_groups,
+                           bool na_propagate,
+                           int* v_out);
+
+#endif

--- a/src/init.c
+++ b/src/init.c
@@ -134,7 +134,7 @@ extern SEXP vctrs_order_info(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_unrep(SEXP);
 extern SEXP vctrs_fill_missing(SEXP, SEXP, SEXP);
 extern SEXP vctrs_chr_paste_prefix(SEXP, SEXP, SEXP);
-extern sexp* vctrs_rank(sexp*, sexp*, sexp*, sexp*, sexp*, sexp*);
+extern sexp* vctrs_rank(sexp*, sexp*, sexp*, sexp*, sexp*, sexp*, sexp*);
 
 
 // Maturing
@@ -287,7 +287,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_unrep",                      (DL_FUNC) &vctrs_unrep, 1},
   {"vctrs_fill_missing",               (DL_FUNC) &vctrs_fill_missing, 3},
   {"vctrs_chr_paste_prefix",           (DL_FUNC) &vctrs_chr_paste_prefix, 3},
-  {"vctrs_rank",                       (DL_FUNC) &vctrs_rank, 6},
+  {"vctrs_rank",                       (DL_FUNC) &vctrs_rank, 7},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -134,6 +134,7 @@ extern SEXP vctrs_order_info(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_unrep(SEXP);
 extern SEXP vctrs_fill_missing(SEXP, SEXP, SEXP);
 extern SEXP vctrs_chr_paste_prefix(SEXP, SEXP, SEXP);
+extern sexp* vctrs_rank(sexp*, sexp*, sexp*, sexp*, sexp*, sexp*);
 
 
 // Maturing
@@ -286,6 +287,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_unrep",                      (DL_FUNC) &vctrs_unrep, 1},
   {"vctrs_fill_missing",               (DL_FUNC) &vctrs_fill_missing, 3},
   {"vctrs_chr_paste_prefix",           (DL_FUNC) &vctrs_chr_paste_prefix, 3},
+  {"vctrs_rank",                       (DL_FUNC) &vctrs_rank, 6},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -134,7 +134,7 @@ extern SEXP vctrs_order_info(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_unrep(SEXP);
 extern SEXP vctrs_fill_missing(SEXP, SEXP, SEXP);
 extern SEXP vctrs_chr_paste_prefix(SEXP, SEXP, SEXP);
-extern sexp* vctrs_rank(sexp*, sexp*, sexp*, sexp*, sexp*, sexp*, sexp*);
+extern r_obj* vctrs_rank(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 
 
 // Maturing

--- a/src/rank.c
+++ b/src/rank.c
@@ -8,6 +8,7 @@
 sexp* vctrs_rank(sexp* x,
                  sexp* ties,
                  sexp* na_propagate,
+                 sexp* direction,
                  sexp* na_value,
                  sexp* nan_distinct,
                  sexp* chr_transform) {
@@ -19,6 +20,7 @@ sexp* vctrs_rank(sexp* x,
     x,
     c_ties,
     c_na_propagate,
+    direction,
     na_value,
     c_nan_distinct,
     chr_transform
@@ -29,6 +31,7 @@ static
 sexp* vec_rank(sexp* x,
                enum ties ties_type,
                bool na_propagate,
+               sexp* direction,
                sexp* na_value,
                bool nan_distinct,
                sexp* chr_transform) {
@@ -84,7 +87,6 @@ sexp* vec_rank(sexp* x,
   sexp* rank = KEEP(r_alloc_integer(rank_size));
   int* v_rank = r_int_deref(rank);
 
-  sexp* direction = KEEP(r_chr("asc"));
   sexp* info = KEEP(vec_order_info(x, direction, na_value, nan_distinct, chr_transform));
 
   sexp* order = r_list_get(info, 0);
@@ -118,7 +120,7 @@ sexp* vec_rank(sexp* x,
     out = rank;
   }
 
-  FREE(7);
+  FREE(6);
   return out;
 }
 

--- a/src/rank.c
+++ b/src/rank.c
@@ -2,6 +2,14 @@
 #include "vctrs.h"
 #include "equal.h"
 #include "order-radix.h"
+
+enum ties {
+  TIES_min,
+  TIES_max,
+  TIES_sequential,
+  TIES_dense
+};
+
 #include "decl/rank-decl.h"
 
 // [[ register() ]]

--- a/src/rank.c
+++ b/src/rank.c
@@ -241,7 +241,7 @@ enum ties parse_ties(r_obj* ties) {
 static inline
 bool r_lgl_any(r_obj* x) {
   if (r_typeof(x) != R_TYPE_logical) {
-    r_abort("Internal error: Expected logical vector in `r_lgl_any()`.");
+    r_stop_internal("r_lgl_any", "`x` must be a logical vector.");
   }
 
   const int* v_x = r_lgl_cbegin(x);

--- a/src/rank.c
+++ b/src/rank.c
@@ -58,7 +58,7 @@ r_obj* vec_rank(r_obj* x,
   KEEP_HERE(not_missing, &pi_not_missing);
   int* v_not_missing = NULL;
 
-  r_ssize rank_size = -1;
+  r_ssize rank_size = size;
 
   if (na_propagate) {
     // Slice out non-missing values of `x` to rank.
@@ -68,28 +68,25 @@ r_obj* vec_rank(r_obj* x,
     v_missing = r_lgl_begin(missing);
 
     bool any_missing = r_lgl_any(missing);
-    if (!any_missing) {
+
+    if (any_missing) {
+      for (r_ssize i = 0; i < size; ++i) {
+        v_missing[i] = !v_missing[i];
+      }
+
+      not_missing = missing;
+      KEEP_AT(not_missing, pi_not_missing);
+      v_not_missing = v_missing;
+      missing = NULL;
+      v_missing = NULL;
+
+      x = vec_slice(x, not_missing);
+      KEEP_AT(x, pi_x);
+
+      rank_size = vec_size(x);
+    } else {
       na_propagate = false;
-      goto skip_propagate;
     }
-
-    for (r_ssize i = 0; i < size; ++i) {
-      v_missing[i] = !v_missing[i];
-    }
-
-    not_missing = missing;
-    KEEP_AT(not_missing, pi_not_missing);
-    v_not_missing = v_missing;
-    missing = NULL;
-    v_missing = NULL;
-
-    x = vec_slice(x, not_missing);
-    KEEP_AT(x, pi_x);
-
-    rank_size = vec_size(x);
-  } else {
-    skip_propagate:;
-    rank_size = size;
   }
 
   r_obj* rank = KEEP(r_alloc_integer(rank_size));

--- a/src/rank.c
+++ b/src/rank.c
@@ -218,11 +218,8 @@ void vec_rank_dense(const int* v_order,
 
 static inline
 enum ties parse_ties(r_obj* ties) {
-  if (r_typeof(ties) != R_TYPE_character) {
-    r_abort("`ties` must be a character vector.");
-  }
-  if (r_length(ties) < 1) {
-    r_abort("`ties` must be at least length 1.");
+  if (!r_is_string(ties)) {
+    r_stop_internal("parse_ties", "`ties` must be a string.");
   }
 
   const char* c_ties = r_chr_get_c_string(ties, 0);
@@ -232,7 +229,10 @@ enum ties parse_ties(r_obj* ties) {
   if (!strcmp(c_ties, "sequential")) return TIES_sequential;
   if (!strcmp(c_ties, "dense")) return TIES_dense;
 
-  r_abort("`ties` must be one of: \"min\", \"max\", \"sequential\", or \"dense\".");
+  r_stop_internal(
+    "parse_ties",
+    "`ties` must be one of: \"min\", \"max\", \"sequential\", or \"dense\"."
+  );
 }
 
 // -----------------------------------------------------------------------------

--- a/src/rank.c
+++ b/src/rank.c
@@ -232,7 +232,7 @@ enum ties parse_ties(r_obj* ties) {
   if (!strcmp(c_ties, "sequential")) return TIES_sequential;
   if (!strcmp(c_ties, "dense")) return TIES_dense;
 
-  r_abort("`ties` must be one of: 'min', 'max', 'sequential', or 'dense'.");
+  r_abort("`ties` must be one of: \"min\", \"max\", \"sequential\", or \"dense\".");
 }
 
 // -----------------------------------------------------------------------------

--- a/src/rank.c
+++ b/src/rank.c
@@ -1,0 +1,274 @@
+#include <rlang.h>
+#include "vctrs.h"
+#include "equal.h"
+#include "order-radix.h"
+#include "decl/rank-decl.h"
+
+// [[ register() ]]
+sexp* vctrs_rank(sexp* x,
+                 sexp* ties,
+                 sexp* na_propagate,
+                 sexp* na_value,
+                 sexp* nan_distinct,
+                 sexp* chr_transform) {
+  const enum ties c_ties = parse_ties(ties);
+  const bool c_na_propagate = r_bool_as_int(na_propagate);
+  const bool c_nan_distinct = r_bool_as_int(nan_distinct);
+
+  return vec_rank(
+    x,
+    c_ties,
+    c_na_propagate,
+    na_value,
+    c_nan_distinct,
+    chr_transform
+  );
+}
+
+static
+sexp* vec_rank(sexp* x,
+               enum ties ties_type,
+               bool na_propagate,
+               sexp* na_value,
+               bool nan_distinct,
+               sexp* chr_transform) {
+  r_ssize size = vec_size(x);
+
+  sexp* out = KEEP(r_alloc_integer(size));
+  int* v_out = r_int_deref(out);
+
+  r_keep_t pi_x;
+  KEEP_HERE(x, &pi_x);
+
+  sexp* locs = R_NilValue;
+  r_keep_t pi_locs;
+  KEEP_HERE(locs, &pi_locs);
+  const int* v_locs = NULL;
+
+  if (na_propagate) {
+    // Locate non-missing values and slice them out of `x`,
+    // retaining their locations in `locs` for later placement in `out`
+    locs = vec_equal_na(x);
+    KEEP_AT(locs, pi_locs);
+
+    bool any_missing = r_lgl_any(locs);
+    if (!any_missing) {
+      // Skipping random access into `v_locs` in `vec_rank_*()` when not
+      // required greatly improves performance
+      na_propagate = false;
+      goto skip_propagate;
+    }
+
+    locs = r_lgl_negate(locs, false);
+    KEEP_AT(locs, pi_locs);
+    locs = r_lgl_which(locs, false);
+    KEEP_AT(locs, pi_locs);
+
+    v_locs = r_int_deref_const(locs);
+
+    x = vec_slice_impl(x, locs);
+    KEEP_AT(x, pi_x);
+
+    // Initialize to `NA` to "propagate" it
+    r_int_fill(out, r_globals.na_int, size);
+  } else {
+    skip_propagate:;
+  }
+
+  sexp* direction = KEEP(r_chr("asc"));
+  sexp* info = KEEP(vec_order_info(x, direction, na_value, nan_distinct, chr_transform));
+
+  sexp* order = r_list_get(info, 0);
+  const int* v_order = r_int_deref_const(order);
+
+  sexp* group_sizes = r_list_get(info, 1);
+  const int* v_group_sizes = r_int_deref_const(group_sizes);
+  r_ssize n_groups = r_length(group_sizes);
+
+  switch (ties_type) {
+  case TIES_min: vec_rank_min(v_order, v_group_sizes, v_locs, size, n_groups, na_propagate, v_out); break;
+  case TIES_max: vec_rank_max(v_order, v_group_sizes, v_locs, size, n_groups, na_propagate, v_out); break;
+  case TIES_sequential: vec_rank_sequential(v_order, v_group_sizes, v_locs, size, n_groups, na_propagate, v_out); break;
+  case TIES_dense: vec_rank_dense(v_order, v_group_sizes, v_locs, size, n_groups, na_propagate, v_out); break;
+  }
+
+  FREE(5);
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+
+static
+void vec_rank_min(const int* v_order,
+                  const int* v_group_sizes,
+                  const int* v_locs,
+                  r_ssize size,
+                  r_ssize n_groups,
+                  bool na_propagate,
+                  int* v_out) {
+  r_ssize k = 0;
+  r_ssize rank = 1;
+
+  for (r_ssize i = 0; i < n_groups; ++i) {
+    const r_ssize group_size = v_group_sizes[i];
+
+    for (r_ssize j = 0; j < group_size; ++j) {
+      r_ssize loc = v_order[k] - 1;
+      if (na_propagate) {
+        loc = v_locs[loc] - 1;
+      }
+      v_out[loc] = rank;
+      ++k;
+    }
+
+    rank += group_size;
+  }
+}
+
+static
+void vec_rank_max(const int* v_order,
+                  const int* v_group_sizes,
+                  const int* v_locs,
+                  r_ssize size,
+                  r_ssize n_groups,
+                  bool na_propagate,
+                  int* v_out) {
+  r_ssize k = 0;
+  r_ssize rank = 0;
+
+  for (r_ssize i = 0; i < n_groups; ++i) {
+    const r_ssize group_size = v_group_sizes[i];
+    rank += group_size;
+
+    for (r_ssize j = 0; j < group_size; ++j) {
+      r_ssize loc = v_order[k] - 1;
+      if (na_propagate) {
+        loc = v_locs[loc] - 1;
+      }
+      v_out[loc] = rank;
+      ++k;
+    }
+  }
+}
+
+static
+void vec_rank_sequential(const int* v_order,
+                         const int* v_group_sizes,
+                         const int* v_locs,
+                         r_ssize size,
+                         r_ssize n_groups,
+                         bool na_propagate,
+                         int* v_out) {
+  r_ssize k = 0;
+  r_ssize rank = 1;
+
+  for (r_ssize i = 0; i < n_groups; ++i) {
+    const r_ssize group_size = v_group_sizes[i];
+
+    for (r_ssize j = 0; j < group_size; ++j) {
+      r_ssize loc = v_order[k] - 1;
+      if (na_propagate) {
+        loc = v_locs[loc] - 1;
+      }
+      v_out[loc] = rank;
+      ++k;
+      ++rank;
+    }
+  }
+}
+
+static
+void vec_rank_dense(const int* v_order,
+                    const int* v_group_sizes,
+                    const int* v_locs,
+                    r_ssize size,
+                    r_ssize n_groups,
+                    bool na_propagate,
+                    int* v_out) {
+  r_ssize k = 0;
+  r_ssize rank = 1;
+
+  for (r_ssize i = 0; i < n_groups; ++i) {
+    const r_ssize group_size = v_group_sizes[i];
+
+    for (r_ssize j = 0; j < group_size; ++j) {
+      r_ssize loc = v_order[k] - 1;
+      if (na_propagate) {
+        loc = v_locs[loc] - 1;
+      }
+      v_out[loc] = rank;
+      ++k;
+    }
+
+    ++rank;
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+static inline
+enum ties parse_ties(sexp* ties) {
+  if (r_typeof(ties) != R_TYPE_character) {
+    r_abort("`ties` must be a character vector.");
+  }
+  if (r_length(ties) < 1) {
+    r_abort("`ties` must be at least length 1.");
+  }
+
+  const char* c_ties = r_chr_get_c_string(ties, 0);
+
+  if (!strcmp(c_ties, "min")) return TIES_min;
+  if (!strcmp(c_ties, "max")) return TIES_max;
+  if (!strcmp(c_ties, "sequential")) return TIES_sequential;
+  if (!strcmp(c_ties, "dense")) return TIES_dense;
+
+  r_abort("`ties` must be one of: 'min', 'max', 'sequential', or 'dense'.");
+}
+
+// -----------------------------------------------------------------------------
+
+static
+sexp* r_lgl_negate(sexp* x, bool na_propagate) {
+  if (r_typeof(x) != R_TYPE_logical) {
+    r_abort("Internal error: Expected logical vector in `r_lgl_negate()`.");
+  }
+
+  const int* v_x = r_lgl_deref_const(x);
+  r_ssize size = r_length(x);
+
+  sexp* out = KEEP(r_new_logical(size));
+  int* v_out = r_lgl_deref(out);
+
+  if (na_propagate) {
+    for (r_ssize i = 0; i < size; ++i) {
+      const int elt = v_x[i];
+      v_out[i] = (elt == r_globals.na_lgl) ? r_globals.na_lgl : !elt;
+    }
+  } else {
+    for (r_ssize i = 0; i < size; ++i) {
+      v_out[i] = !v_x[i];
+    }
+  }
+
+  FREE(1);
+  return out;
+}
+
+// Treats missing values as `true`
+static
+bool r_lgl_any(sexp* x) {
+  if (r_typeof(x) != R_TYPE_logical) {
+    r_abort("Internal error: Expected logical vector in `r_lgl_any()`.");
+  }
+
+  const int* v_x = r_lgl_deref_const(x);
+  r_ssize size = r_length(x);
+
+  for (r_ssize i = 0; i < size; ++i) {
+    if (v_x[i]) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/rank.c
+++ b/src/rank.c
@@ -111,23 +111,22 @@ r_obj* vec_rank(r_obj* x,
   }
 
   r_obj* out = r_null;
-  r_keep_t pi_out;
-  KEEP_HERE(out, &pi_out);
 
   if (na_propagate) {
-    out = r_alloc_integer(size);
-    KEEP_AT(out, pi_out);
+    out = KEEP(r_alloc_integer(size));
     int* v_out = r_int_begin(out);
     r_ssize j = 0;
 
     for (r_ssize i = 0; i < size; ++i) {
       v_out[i] = v_not_missing[i] ? v_rank[j++] : r_globals.na_int;
     }
+
+    FREE(1);
   } else {
     out = rank;
   }
 
-  FREE(6);
+  FREE(5);
   return out;
 }
 

--- a/src/rank.c
+++ b/src/rank.c
@@ -21,8 +21,8 @@ r_obj* vctrs_rank(r_obj* x,
                   r_obj* nan_distinct,
                   r_obj* chr_transform) {
   const enum ties c_ties = parse_ties(ties);
-  const bool c_na_propagate = r_bool_as_int(na_propagate);
-  const bool c_nan_distinct = r_bool_as_int(nan_distinct);
+  const bool c_na_propagate = r_as_bool(na_propagate);
+  const bool c_nan_distinct = r_as_bool(nan_distinct);
 
   return vec_rank(
     x,

--- a/tests/testthat/test-rank.R
+++ b/tests/testthat/test-rank.R
@@ -123,7 +123,7 @@ test_that("`ties` is validated", {
 })
 
 test_that("`na_propagate` is validated", {
-  expect_error(vec_rank(1, na_propagate = NA), "single `TRUE` or `FALSE`")
-  expect_error(vec_rank(1, na_propagate = c(TRUE, FALSE)), "single `TRUE` or `FALSE`")
-  expect_error(vec_rank(1, na_propagate = "foo"), "single `TRUE` or `FALSE`")
+  expect_error(vec_rank(1, na_propagate = NA), "must be a logical value")
+  expect_error(vec_rank(1, na_propagate = c(TRUE, FALSE)), "must be a logical value")
+  expect_error(vec_rank(1, na_propagate = "foo"), "must be a logical value")
 })

--- a/tests/testthat/test-rank.R
+++ b/tests/testthat/test-rank.R
@@ -1,0 +1,129 @@
+test_that("can rank with different types of `ties`", {
+  x <- c(2L, 5L, 1L, 1L, 2L)
+
+  expect_identical(vec_rank(x, ties = "min"), rank(x, ties.method = "min"))
+  expect_identical(vec_rank(x, ties = "max"), rank(x, ties.method = "max"))
+  expect_identical(vec_rank(x, ties = "sequential"), rank(x, ties.method = "first"))
+  expect_identical(vec_rank(x, ties = "dense"), c(2L, 3L, 1L, 1L, 2L))
+})
+
+test_that("can rank in descending order", {
+  x <- c(2L, 5L, 1L, 1L, 2L)
+
+  expect_identical(vec_rank(x, ties = "min", direction = "desc"), rank(-x, ties.method = "min"))
+  expect_identical(vec_rank(x, ties = "max", direction = "desc"), rank(-x, ties.method = "max"))
+  expect_identical(vec_rank(x, ties = "sequential", direction = "desc"), rank(-x, ties.method = "first"))
+  expect_identical(vec_rank(x, ties = "dense", direction = "desc"), c(2L, 1L, 3L, 3L, 2L))
+})
+
+test_that("can propagate missing values", {
+  x <- c(2, NA, 4, NaN, 4, 2, NA)
+
+  expect_identical(vec_rank(x, ties = "min", na_propagate = TRUE), rank(x, ties.method = "min", na.last = "keep"))
+  expect_identical(vec_rank(x, ties = "max", na_propagate = TRUE), rank(x, ties.method = "max", na.last = "keep"))
+  expect_identical(vec_rank(x, ties = "sequential", na_propagate = TRUE), rank(x, ties.method = "first", na.last = "keep"))
+  expect_identical(vec_rank(x, ties = "dense", na_propagate = TRUE), c(1L, NA, 2L, NA, 2L, 1L, NA))
+
+  # NaN are treated as missing, regardless of whether or not they are distinct from NA_real_
+  expect_identical(
+    vec_rank(x, ties = "min", na_propagate = TRUE, nan_distinct = TRUE),
+    vec_rank(x, ties = "min", na_propagate = TRUE, nan_distinct = FALSE)
+  )
+})
+
+test_that("works correctly when `na_propagate = TRUE` with no missing values", {
+  x <- c(1, 2, 1, 5, 2)
+  expect_identical(vec_rank(x, na_propagate = TRUE), rank(x, ties.method = "min"))
+})
+
+test_that("when `na_propagate = FALSE`, all NA (or NaN) values get the same rank", {
+  # this is in contrast to rank(), which treats all NA (NaN) as different
+  x <- c(1, NA, 3, NaN, NA, 1, NaN)
+
+  expect_identical(vec_rank(x, na_value = "largest"), c(1L, 4L, 3L, 4L, 4L, 1L, 4L))
+  expect_identical(vec_rank(x, na_value = "smallest"), c(5L, 1L, 7L, 1L, 1L, 5L, 1L))
+
+  # If distinct, NaN are always ranked between real numbers and NA_real_
+  expect_identical(vec_rank(x, na_value = "largest", nan_distinct = TRUE), c(1L, 6L, 3L, 4L, 6L, 1L, 4L))
+  expect_identical(vec_rank(x, na_value = "smallest", nan_distinct = TRUE), c(5L, 1L, 7L, 3L, 1L, 5L, 3L))
+})
+
+test_that("ranks character vectors in the C locale", {
+  x <- c("B", "b", "a")
+  expect_identical(vec_rank(x), c(1L, 3L, 2L))
+})
+
+test_that("works with data frames", {
+  df <- data_frame(
+    x = c(1, 2, 1, 2, 2),
+    y = c(2, 2, 1, 2, 5)
+  )
+
+  expect_identical(vec_rank(df, ties = "min"), c(2L, 3L, 1L, 3L, 5L))
+  expect_identical(vec_rank(df, ties = "sequential"), c(2L, 3L, 1L, 4L, 5L))
+})
+
+test_that("can control the direction per column", {
+  df <- data_frame(
+    x = c(1, 2, 1, 2, 2),
+    y = c(2, 2, 1, 2, 5)
+  )
+
+  df2 <- df
+  df2$y <- -df2$y
+
+  expect_identical(
+    vec_rank(df, direction = c("asc", "desc")),
+    vec_rank(df2, direction = "asc")
+  )
+})
+
+test_that("completely missing rows can propagate NA", {
+  df <- data_frame(
+    x = c(1, NA, NA),
+    y = c(NA, NA, 1)
+  )
+
+  expect_identical(vec_rank(df, na_propagate = TRUE), c(1L, NA, 2L))
+  expect_identical(vec_rank(df, na_propagate = TRUE, direction = "desc"), c(2L, NA, 1L))
+})
+
+test_that("partially missing rows are controlled by `na_value`", {
+  df <- data_frame(
+    x = c(1, 1, NA, NA, NA),
+    y = c(3, NA, NA, 2, 1)
+  )
+
+  expect_identical(
+    vec_rank(df, na_value = c("largest", "smallest")),
+    c(2L, 1L, 3L, 5L, 4L)
+  )
+  expect_identical(
+    vec_rank(df, na_value = c("largest", "smallest"), na_propagate = TRUE),
+    c(2L, 1L, NA, 4L, 3L)
+  )
+
+  expect_identical(
+    vec_rank(df, na_value = c("largest", "smallest"), direction = "desc"),
+    c(4L, 5L, 3L, 1L, 2L)
+  )
+  expect_identical(
+    vec_rank(df, na_value = c("largest", "smallest"), na_propagate = TRUE, direction = "desc"),
+    c(3L, 4L, NA, 1L, 2L)
+  )
+})
+
+test_that("`x` must be a vector", {
+  expect_error(vec_rank(identity), class = "vctrs_error_scalar_type")
+})
+
+test_that("`ties` is validated", {
+  expect_error(vec_rank(1, ties = "foo"), "must be one of")
+  expect_error(vec_rank(1, ties = 1), "must be a character")
+})
+
+test_that("`na_propagate` is validated", {
+  expect_error(vec_rank(1, na_propagate = NA), "single `TRUE` or `FALSE`")
+  expect_error(vec_rank(1, na_propagate = c(TRUE, FALSE)), "single `TRUE` or `FALSE`")
+  expect_error(vec_rank(1, na_propagate = "foo"), "single `TRUE` or `FALSE`")
+})

--- a/tests/testthat/test-rank.R
+++ b/tests/testthat/test-rank.R
@@ -118,7 +118,7 @@ test_that("`x` must be a vector", {
 })
 
 test_that("`ties` is validated", {
-  expect_error(vec_rank(1, ties = "foo"), 'must be one of: "min", "max", "sequential", or "dense".')
+  expect_error(vec_rank(1, ties = "foo"), 'must be one of "min", "max", "sequential", or "dense", not "foo".')
   expect_error(vec_rank(1, ties = 1), "must be a character")
 })
 

--- a/tests/testthat/test-rank.R
+++ b/tests/testthat/test-rank.R
@@ -118,7 +118,7 @@ test_that("`x` must be a vector", {
 })
 
 test_that("`ties` is validated", {
-  expect_error(vec_rank(1, ties = "foo"), "must be one of")
+  expect_error(vec_rank(1, ties = "foo"), 'must be one of: "min", "max", "sequential", or "dense".')
   expect_error(vec_rank(1, ties = 1), "must be a character")
 })
 


### PR DESCRIPTION
Closes #1251 

Currently unexported because `vec_order_radix()` isn't either, but all docs / tests are there.

Can power these dplyr functions:

```r
row_number(x)
min_rank(x)
dense_rank(x)
percent_rank(x)
cume_dist(x)
```

There are 4 ties methods: `"min"`, `"max"`, `"sequential"`, and `"dense"`. Once we have the order and group sizes, these are all just slight variations of one another.

The hardest bit is `na_propagate`. The easiest way to handle this is to just slice out the non-missing values, rank those, and then construct the output using the locations of the missing values and the non-missing value ranks. If I've used `goto` in a horrible way please let me know 😬  but it seemed like a nice solution

Ranking in descending order seems like a somewhat common question, so this implementation allows a user-defined `direction` to be passed through to `vec_order()`. https://stats.stackexchange.com/questions/3321/rank-in-r-descending-order/3322

This ranks character vectors in the C locale