### PR TITLE
Add `...` to the signature of radix ordering functions

### DIFF
--- a/R/order-radix.R
+++ b/R/order-radix.R
@@ -30,6 +30,8 @@
 #' Character vectors are always translated to UTF-8 before ordering, and before
 #' any transform is applied by `chr_transform`.
 #'
+#' @inheritParams ellipsis::dots_empty
+#'
 #' @param x A vector
 #' @param direction Direction to sort in.
 #'   - A single `"asc"` or `"desc"` for ascending or descending order
@@ -100,10 +102,14 @@
 #' vec_sort(y, chr_transform = tolower)
 #' @noRd
 vec_order_radix <- function(x,
+                            ...,
                             direction = "asc",
                             na_value = "largest",
                             nan_distinct = FALSE,
                             chr_transform = NULL) {
+  if (!missing(...)) {
+    ellipsis::check_dots_empty()
+  }
   .Call(vctrs_order, x, direction, na_value, nan_distinct, chr_transform)
 }
 
@@ -140,18 +146,26 @@ vec_order_radix <- function(x,
 #' vec_group_loc(df)
 #' @noRd
 vec_order_locs <- function(x,
+                           ...,
                            direction = "asc",
                            na_value = "largest",
                            nan_distinct = FALSE,
                            chr_transform = NULL) {
+  if (!missing(...)) {
+    ellipsis::check_dots_empty()
+  }
   .Call(vctrs_order_locs, x, direction, na_value, nan_distinct, chr_transform)
 }
 
 vec_order_info <- function(x,
+                           ...,
                            direction = "asc",
                            na_value = "largest",
                            nan_distinct = FALSE,
                            chr_transform = NULL,
                            chr_ordered = TRUE) {
+  if (!missing(...)) {
+    ellipsis::check_dots_empty()
+  }
   .Call(vctrs_order_info, x, direction, na_value, nan_distinct, chr_transform, chr_ordered)
 }

--- a/tests/testthat/test-order-radix.R
+++ b/tests/testthat/test-order-radix.R
@@ -1035,11 +1035,11 @@ test_that("`chr_transform` can result in keys being seen as identical", {
 # `vec_order_radix()` - Pre-existing tests
 
 test_that("can request NAs sorted first", {
-  expect_equal(vec_order_radix(c(1, NA), "asc", "largest"), 1:2)
-  expect_equal(vec_order_radix(c(1, NA), "desc", "largest"), 2:1)
+  expect_equal(vec_order_radix(c(1, NA), direction = "asc", na_value = "largest"), 1:2)
+  expect_equal(vec_order_radix(c(1, NA), direction = "desc", na_value = "largest"), 2:1)
 
-  expect_equal(vec_order_radix(c(1, NA), "asc", "smallest"), 2:1)
-  expect_equal(vec_order_radix(c(1, NA), "desc", "smallest"), 1:2)
+  expect_equal(vec_order_radix(c(1, NA), direction = "asc", na_value = "smallest"), 2:1)
+  expect_equal(vec_order_radix(c(1, NA), direction = "desc", na_value = "smallest"), 1:2)
 })
 
 test_that("can sort data frames", {


### PR DESCRIPTION
I think this is good practice. It's easier to read code if these optional args are always named, and will be less error prone if we add more optional arguments in the future