### PR TITLE
Modularize TRUELENGTH saving/reallocating helpers

### DIFF
--- a/src/order-truelength.c
+++ b/src/order-truelength.c
@@ -29,23 +29,28 @@
  *
  * Pair with `PROTECT_TRUELENGTH_INFO()` in the caller
  */
-struct truelength_info* new_truelength_info(r_ssize max_size_alloc) {
+struct truelength_info* new_truelength_info(r_ssize n_max) {
   SEXP self = PROTECT(r_new_raw(sizeof(struct truelength_info)));
   struct truelength_info* p_truelength_info = (struct truelength_info*) RAW(self);
 
   p_truelength_info->self = self;
 
   p_truelength_info->strings = vctrs_shared_empty_chr;
-  p_truelength_info->lengths = vctrs_shared_empty_raw;
+  p_truelength_info->truelengths = vctrs_shared_empty_raw;
+  p_truelength_info->n_strings_alloc = 0;
+  p_truelength_info->n_strings_used = 0;
+
   p_truelength_info->uniques = vctrs_shared_empty_chr;
+  p_truelength_info->n_uniques_alloc = 0;
+  p_truelength_info->n_uniques_used = 0;
+
   p_truelength_info->sizes = vctrs_shared_empty_int;
   p_truelength_info->sizes_aux = vctrs_shared_empty_int;
-
-  p_truelength_info->size_alloc = 0;
-  p_truelength_info->max_size_alloc = max_size_alloc;
-  p_truelength_info->size_used = 0;
-
+  p_truelength_info->n_sizes_alloc = 0;
+  p_truelength_info->n_sizes_used = 0;
   p_truelength_info->max_string_size = 0;
+
+  p_truelength_info->n_max = n_max;
 
   UNPROTECT(1);
   return p_truelength_info;
@@ -54,112 +59,79 @@ struct truelength_info* new_truelength_info(r_ssize max_size_alloc) {
 // -----------------------------------------------------------------------------
 
 /*
- * Reset the truelengths of all unique strings captured in `strings` using
- * the original truelengths in `lengths`.
+ * First, reset the TRUELENGTHs of all unique CHARSXPs in `uniques` to 0, which
+ * is the default used by R.
  *
- * Will be called after each character data frame column is processed, and
+ * Then, reset the TRUELENGTHs of all CHARSXPs in `strings` to their original
+ * value contained in `truelengths`. There should be very few of these,
+ * if any, as R doesn't typically use the TRUELENGTH slot of CHARSXPs. One
+ * exception seems to be very simple strings, such as `"a"`, which R probably
+ * adds to the cache at startup, and sets their TRUELENGTH value for some
+ * reason.
+ *
+ * It is important to reset `uniques` first, then `strings`, as the CHARSXPs
+ * in `strings` are, by definition, also in `uniques`.
+ *
+ * This will be called after each character data frame column is processed, and
  * at the end of `chr_order()` for a single character vector.
  */
 void truelength_reset(struct truelength_info* p_truelength_info) {
-  r_ssize size = p_truelength_info->size_used;
+  r_ssize n_uniques_used = p_truelength_info->n_uniques_used;
+  r_ssize n_strings_used = p_truelength_info->n_strings_used;
 
-  for (r_ssize i = 0; i < size; ++i) {
+  // First reset uniques
+  for (r_ssize i = 0; i < n_uniques_used; ++i) {
+    SEXP unique = p_truelength_info->p_uniques[i];
+    SET_TRUELENGTH(unique, 0);
+  }
+
+  // Then reset strings
+  for (r_ssize i = 0; i < n_strings_used; ++i) {
     SEXP string = p_truelength_info->p_strings[i];
-    r_ssize length = p_truelength_info->p_lengths[i];
-
-    SET_TRUELENGTH(string, length);
+    r_ssize truelength = p_truelength_info->p_truelengths[i];
+    SET_TRUELENGTH(string, truelength);
   }
 
   // Also reset vector specific details
-  p_truelength_info->size_used = 0;
+  p_truelength_info->n_uniques_used = 0;
+  p_truelength_info->n_strings_used = 0;
+  p_truelength_info->n_sizes_used = 0;
   p_truelength_info->max_string_size = 0;
 }
 
 // -----------------------------------------------------------------------------
 
-static void truelength_realloc(struct truelength_info* p_truelength_info);
+static r_ssize truelength_realloc_size(r_ssize n_x, r_ssize n_max);
 
-/*
- * Saves a unique CHARSXP `x` along with its original truelength and
- * its "size" (i.e the number of characters). Will be reset later with
- * `truelength_reset()`.
- */
-void truelength_save(SEXP x,
-                     r_ssize truelength,
-                     r_ssize size,
-                     struct truelength_info* p_truelength_info) {
-  // Reallocate as needed
-  if (p_truelength_info->size_used == p_truelength_info->size_alloc) {
-    truelength_realloc(p_truelength_info);
-  }
+static inline SEXP truelengths_resize(SEXP x, r_ssize x_size, r_ssize size);
 
-  p_truelength_info->p_strings[p_truelength_info->size_used] = x;
-  p_truelength_info->p_lengths[p_truelength_info->size_used] = truelength;
-  p_truelength_info->p_uniques[p_truelength_info->size_used] = x;
-  p_truelength_info->p_sizes[p_truelength_info->size_used] = size;
-
-  ++p_truelength_info->size_used;
-}
-
-// -----------------------------------------------------------------------------
-
-static r_ssize truelength_realloc_size(struct truelength_info* p_truelength_info);
-
-static inline SEXP lengths_resize(SEXP x, r_ssize x_size, r_ssize size);
-
-/*
- * Extend the vectors in `truelength_info`.
- * Reprotects itself.
- */
-static
-void truelength_realloc(struct truelength_info* p_truelength_info) {
-  r_ssize size = truelength_realloc_size(p_truelength_info);
+void truelength_realloc_strings(struct truelength_info* p_truelength_info) {
+  r_ssize size = truelength_realloc_size(
+    p_truelength_info->n_strings_alloc,
+    p_truelength_info->n_max
+  );
 
   p_truelength_info->strings = chr_resize(
     p_truelength_info->strings,
-    p_truelength_info->size_used,
+    p_truelength_info->n_strings_alloc,
     size
   );
   REPROTECT(p_truelength_info->strings, p_truelength_info->strings_pi);
   p_truelength_info->p_strings = STRING_PTR(p_truelength_info->strings);
 
-  p_truelength_info->lengths = lengths_resize(
-    p_truelength_info->lengths,
-    p_truelength_info->size_used,
+  p_truelength_info->truelengths = truelengths_resize(
+    p_truelength_info->truelengths,
+    p_truelength_info->n_strings_alloc,
     size
   );
-  REPROTECT(p_truelength_info->lengths, p_truelength_info->lengths_pi);
-  p_truelength_info->p_lengths = (r_ssize*) RAW(p_truelength_info->lengths);
+  REPROTECT(p_truelength_info->truelengths, p_truelength_info->truelengths_pi);
+  p_truelength_info->p_truelengths = (r_ssize*) RAW(p_truelength_info->truelengths);
 
-  p_truelength_info->uniques = chr_resize(
-    p_truelength_info->uniques,
-    p_truelength_info->size_used,
-    size
-  );
-  REPROTECT(p_truelength_info->uniques, p_truelength_info->uniques_pi);
-  p_truelength_info->p_uniques = STRING_PTR(p_truelength_info->uniques);
-
-  p_truelength_info->sizes = int_resize(
-    p_truelength_info->sizes,
-    p_truelength_info->size_used,
-    size
-  );
-  REPROTECT(p_truelength_info->sizes, p_truelength_info->sizes_pi);
-  p_truelength_info->p_sizes = INTEGER(p_truelength_info->sizes);
-
-  p_truelength_info->sizes_aux = int_resize(
-    p_truelength_info->sizes_aux,
-    p_truelength_info->size_used,
-    size
-  );
-  REPROTECT(p_truelength_info->sizes_aux, p_truelength_info->sizes_aux_pi);
-  p_truelength_info->p_sizes_aux = INTEGER(p_truelength_info->sizes_aux);
-
-  p_truelength_info->size_alloc = size;
+  p_truelength_info->n_strings_alloc = size;
 }
 
 static inline
-SEXP lengths_resize(SEXP x, r_ssize x_size, r_ssize size) {
+SEXP truelengths_resize(SEXP x, r_ssize x_size, r_ssize size) {
   return raw_resize(
     x,
     x_size * sizeof(r_ssize),
@@ -169,28 +141,71 @@ SEXP lengths_resize(SEXP x, r_ssize x_size, r_ssize size) {
 
 // -----------------------------------------------------------------------------
 
-static
-r_ssize truelength_realloc_size(struct truelength_info* p_truelength_info) {
-  r_ssize size_alloc = p_truelength_info->size_alloc;
-  r_ssize max_size_alloc = p_truelength_info->max_size_alloc;
+void truelength_realloc_uniques(struct truelength_info* p_truelength_info) {
+  r_ssize size = truelength_realloc_size(
+    p_truelength_info->n_uniques_alloc,
+    p_truelength_info->n_max
+  );
 
+  p_truelength_info->uniques = chr_resize(
+    p_truelength_info->uniques,
+    p_truelength_info->n_uniques_alloc,
+    size
+  );
+  REPROTECT(p_truelength_info->uniques, p_truelength_info->uniques_pi);
+  p_truelength_info->p_uniques = STRING_PTR(p_truelength_info->uniques);
+
+  p_truelength_info->n_uniques_alloc = size;
+}
+
+// -----------------------------------------------------------------------------
+
+void truelength_realloc_sizes(struct truelength_info* p_truelength_info) {
+  r_ssize size = truelength_realloc_size(
+    p_truelength_info->n_sizes_alloc,
+    p_truelength_info->n_max
+  );
+
+  p_truelength_info->sizes = int_resize(
+    p_truelength_info->sizes,
+    p_truelength_info->n_sizes_alloc,
+    size
+  );
+  REPROTECT(p_truelength_info->sizes, p_truelength_info->sizes_pi);
+  p_truelength_info->p_sizes = INTEGER(p_truelength_info->sizes);
+
+  p_truelength_info->sizes_aux = int_resize(
+    p_truelength_info->sizes_aux,
+    p_truelength_info->n_sizes_alloc,
+    size
+  );
+  REPROTECT(p_truelength_info->sizes_aux, p_truelength_info->sizes_aux_pi);
+  p_truelength_info->p_sizes_aux = INTEGER(p_truelength_info->sizes_aux);
+
+  p_truelength_info->n_sizes_alloc = size;
+}
+
+// -----------------------------------------------------------------------------
+
+static
+r_ssize truelength_realloc_size(r_ssize n_x, r_ssize n_max) {
   // First allocation
-  if (size_alloc == 0) {
-    if (TRUELENGTH_SIZE_ALLOC_DEFAULT < max_size_alloc) {
+  if (n_x == 0) {
+    if (TRUELENGTH_SIZE_ALLOC_DEFAULT < n_max) {
       return TRUELENGTH_SIZE_ALLOC_DEFAULT;
     } else {
-      return max_size_alloc;
+      return n_max;
     }
   }
 
   // Avoid potential overflow when doubling size
-  uint64_t new_size_alloc = ((uint64_t) size_alloc) * 2;
+  uint64_t n_new = ((uint64_t) n_x) * 2;
 
   // Clamp maximum allocation size to the size of the input
-  if (new_size_alloc > max_size_alloc) {
-    return max_size_alloc;
+  if (n_new > n_max) {
+    return n_max;
   }
 
   // Can now safely cast back to `r_ssize`
-  return (r_ssize) new_size_alloc;
+  return (r_ssize) n_new;
 }

--- a/src/order-truelength.h
+++ b/src/order-truelength.h
@@ -17,54 +17,70 @@
 
 // -----------------------------------------------------------------------------
 
-// This seems to be a reasonable default to start with for tracking the original
-// truelengths of the unique strings, and is what base R uses. It is expanded
-// by 2x every time we need to reallocate.
+// This seems to be a reasonable default to start with for tracking the unique
+// strings, and is what base R uses. It is expanded by 2x every time we need to
+// reallocate.
 #define TRUELENGTH_SIZE_ALLOC_DEFAULT 10000
 
 // -----------------------------------------------------------------------------
 
 /*
- * Struct of information required to track truelengths of character vectors
+ * Struct of information required to track unique strings and their truelengths
  * when ordering them
  *
  * @member self A RAWSXP for the struct memory.
  *
- * @members strings,p_strings,strings_pi The unique CHARSXP seen during
- *   ordering.
- * @members lengths,p_lengths,lengths_pi The original truelengths of the
- *   `strings`.
- * @members uniques,p_uniques,uniques_pi At first, this is the same as `strings`
- *   until `chr_mark_sorted_uniques()` is called, which reorders them in place
- *   and sorts them.
+ * @members strings,p_strings,strings_pi CHARSXPs originally containing a
+ *   TRUELENGTH value >0, implying that base R was already using it and we
+ *   need to reset it. These are rare.
+ * @members truelengths,p_truelengths,truelengths_pi The original TRUELENGTHs
+ *   of `strings`.
+ * @member n_strings_alloc The allocated length of `strings`
+ *   (and `truelengths`).
+ * @member n_strings_used The number of `strings` currently in use.
+ *
+ * @members uniques,p_uniques,uniques_pi Unique CHARSXPs. Will be sorted in
+ *   place by `chr_mark_sorted_uniques()`. We reset the TRUELENGTH of these
+ *   to 0 (R's default) after ordering, then reset the TRUELENGTH of `strings`.
+ * @member n_uniques_alloc The allocated length of `uniques`.
+ * @member n_uniques_used The number of `uniques` currently in use.
+ *
  * @members sizes,p_sizes,sizes_pi The sizes of each individual CHARSXP in
  *   `uniques`. Kept in the same ordering as `uniques` while sorting.
  * @members sizes_aux, p_sizes_aux, sizes_aux_pi Auxiliary vector of sizes
- *   that is used as working memory when sorting `uniques`.
- *
- * @member size_alloc The current allocated size of the SEXP objects in this
- *   struct
- * @member max_size_alloc The maximum allowed allocation size for the SEXP
- *   objects in this struct. Set to the size of `x`, which would occur if
- *   all strings were unique.
- * @member size_used The number of unique strings currently in `strings`.
+ *   that is used as working memory when sorting `sizes`.
+ * @member n_sizes_alloc The allocated length of `sizes` (and `sizes_aux`).
+ * @member n_sizes_used The number of `sizes` currently in use.
  * @member max_string_size The maximum string size of the unique strings stored
- *   in `strings`. This controls the depth of recursion in `chr_radix_order()`.
+ *   in `uniques`. This controls the depth of recursion in `chr_radix_order()`.
+ *
+ * @member n_max The maximum allowed allocation size for the SEXP
+ *   objects in this struct. Always set to the size of `x`, which would occur if
+ *   all strings were unique.
  */
 struct truelength_info {
   SEXP self;
+
 
   SEXP strings;
   SEXP* p_strings;
   PROTECT_INDEX strings_pi;
 
-  SEXP lengths;
-  r_ssize* p_lengths;
-  PROTECT_INDEX lengths_pi;
+  SEXP truelengths;
+  r_ssize* p_truelengths;
+  PROTECT_INDEX truelengths_pi;
+
+  r_ssize n_strings_alloc;
+  r_ssize n_strings_used;
+
 
   SEXP uniques;
   SEXP* p_uniques;
   PROTECT_INDEX uniques_pi;
+
+  r_ssize n_uniques_alloc;
+  r_ssize n_uniques_used;
+
 
   SEXP sizes;
   int* p_sizes;
@@ -74,31 +90,63 @@ struct truelength_info {
   int* p_sizes_aux;
   PROTECT_INDEX sizes_aux_pi;
 
-  r_ssize size_alloc;
-  r_ssize max_size_alloc;
-  r_ssize size_used;
+  r_ssize n_sizes_alloc;
+  r_ssize n_sizes_used;
+  int max_string_size;
 
-  r_ssize max_string_size;
+
+  r_ssize n_max;
 };
 
-#define PROTECT_TRUELENGTH_INFO(p_info, p_n) do {                   \
-  PROTECT((p_info)->self);                                          \
-  PROTECT_WITH_INDEX((p_info)->strings, &(p_info)->strings_pi);     \
-  PROTECT_WITH_INDEX((p_info)->lengths, &(p_info)->lengths_pi);     \
-  PROTECT_WITH_INDEX((p_info)->uniques, &(p_info)->uniques_pi);     \
-  PROTECT_WITH_INDEX((p_info)->sizes, &(p_info)->sizes_pi);         \
-  PROTECT_WITH_INDEX((p_info)->sizes_aux, &(p_info)->sizes_aux_pi); \
-  *(p_n) += 6;                                                      \
+#define PROTECT_TRUELENGTH_INFO(p_info, p_n) do {                       \
+  PROTECT((p_info)->self);                                              \
+  PROTECT_WITH_INDEX((p_info)->strings, &(p_info)->strings_pi);         \
+  PROTECT_WITH_INDEX((p_info)->truelengths, &(p_info)->truelengths_pi); \
+  PROTECT_WITH_INDEX((p_info)->uniques, &(p_info)->uniques_pi);         \
+  PROTECT_WITH_INDEX((p_info)->sizes, &(p_info)->sizes_pi);             \
+  PROTECT_WITH_INDEX((p_info)->sizes_aux, &(p_info)->sizes_aux_pi);     \
+  *(p_n) += 6;                                                          \
 } while(0)
 
 
-struct truelength_info* new_truelength_info(r_ssize max_size_alloc);
+struct truelength_info* new_truelength_info(r_ssize n_max);
 void truelength_reset(struct truelength_info* p_truelength_info);
 
-void truelength_save(SEXP x,
-                     r_ssize truelength,
-                     r_ssize size,
-                     struct truelength_info* p_truelength_info);
+void truelength_realloc_strings(struct truelength_info* p_truelength_info);
+void truelength_realloc_uniques(struct truelength_info* p_truelength_info);
+void truelength_realloc_sizes(struct truelength_info* p_truelength_info);
+
+static inline
+void truelength_save_string(SEXP string,
+                            r_ssize truelength,
+                            struct truelength_info* p_truelength_info) {
+  if (p_truelength_info->n_strings_used == p_truelength_info->n_strings_alloc) {
+    truelength_realloc_strings(p_truelength_info);
+  }
+  p_truelength_info->p_strings[p_truelength_info->n_strings_used] = string;
+  p_truelength_info->p_truelengths[p_truelength_info->n_strings_used] = truelength;
+  ++p_truelength_info->n_strings_used;
+}
+
+static inline
+void truelength_save_unique(SEXP unique,
+                            struct truelength_info* p_truelength_info) {
+  if (p_truelength_info->n_uniques_used == p_truelength_info->n_uniques_alloc) {
+    truelength_realloc_uniques(p_truelength_info);
+  }
+  p_truelength_info->p_uniques[p_truelength_info->n_uniques_used] = unique;
+  ++p_truelength_info->n_uniques_used;
+}
+
+static inline
+void truelength_save_size(int size,
+                          struct truelength_info* p_truelength_info) {
+  if (p_truelength_info->n_sizes_used == p_truelength_info->n_sizes_alloc) {
+    truelength_realloc_sizes(p_truelength_info);
+  }
+  p_truelength_info->p_sizes[p_truelength_info->n_sizes_used] = size;
+  ++p_truelength_info->n_sizes_used;
+}
 
 // -----------------------------------------------------------------------------
 #endif


### PR DESCRIPTION
For `vec_order_radix()`'s `struct truelength_info`, we only have to store the original TRUELENGTH value in `strings` / `truelengths` if R is actually using it, i.e. the value is >0, otherwise we can always reset it to the default value of 0. It is rare for R to use the TRUELENGTH, so we should rarely have to reallocate the `strings` and `truelengths` vectors. This saves us some time with large vectors when most of the strings are unique, because we previously saved every unique value and its TRUELENGTH.

Base R actually does this optimization too, I just didn't see the benefit of it until now.

I've also separated out the saving/reallocating of individual CHARSXP `sizes` into its own helper as well. I've got an upcoming PR that allows for ordering character vectors by appearance, which doesn't require the `sizes` vector, so this is preparation for that. That PR will be used for reimplementing the dictionary functions.

In the numbers below, I'm mainly interested in the big drop in memory usage required to sort a character vector with lots of unique values

``` r
set.seed(123)

vec_order_radix <- vctrs:::vec_order_radix

random_strings <- function(size, min_length, max_length) {
  lengths <- rlang::seq2(min_length, max_length)
  stringi::stri_rand_strings(
    size,
    sample(lengths, size = size, replace = TRUE)
  )
}

# all unique strings!
x <- random_strings(size = 1e7, min_length = 5, max_length = 20)

# before
bench::mark(vec_order_radix(x), iterations = 20)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_order_radix(x)    5.86s    5.97s     0.162     856MB    0.341

# after
bench::mark(vec_order_radix(x), iterations = 20)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_order_radix(x)    5.12s    5.23s     0.185     547MB    0.222
```