### PR TITLE
Implement `chr_appearance()` for character vectors

### DIFF
--- a/R/order-radix.R
+++ b/R/order-radix.R
@@ -152,6 +152,7 @@ vec_order_info <- function(x,
                            direction = "asc",
                            na_value = "largest",
                            nan_distinct = FALSE,
-                           chr_transform = NULL) {
-  .Call(vctrs_order_info, x, direction, na_value, nan_distinct, chr_transform)
+                           chr_transform = NULL,
+                           chr_ordered = TRUE) {
+  .Call(vctrs_order_info, x, direction, na_value, nan_distinct, chr_transform, chr_ordered)
 }

--- a/src/init.c
+++ b/src/init.c
@@ -130,7 +130,7 @@ extern SEXP vctrs_detect_complete(SEXP);
 extern SEXP vctrs_normalize_encoding(SEXP);
 extern SEXP vctrs_order(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_order_locs(SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP vctrs_order_info(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_order_info(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_unrep(SEXP);
 extern SEXP vctrs_fill_missing(SEXP, SEXP, SEXP);
 extern SEXP vctrs_chr_paste_prefix(SEXP, SEXP, SEXP);
@@ -282,7 +282,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_normalize_encoding",         (DL_FUNC) &vctrs_normalize_encoding, 1},
   {"vctrs_order",                      (DL_FUNC) &vctrs_order, 5},
   {"vctrs_order_locs",                 (DL_FUNC) &vctrs_order_locs, 5},
-  {"vctrs_order_info",                 (DL_FUNC) &vctrs_order_info, 5},
+  {"vctrs_order_info",                 (DL_FUNC) &vctrs_order_info, 6},
   {"vctrs_unrep",                      (DL_FUNC) &vctrs_unrep, 1},
   {"vctrs_fill_missing",               (DL_FUNC) &vctrs_fill_missing, 3},
   {"vctrs_chr_paste_prefix",           (DL_FUNC) &vctrs_chr_paste_prefix, 3},

--- a/src/order-radix.h
+++ b/src/order-radix.h
@@ -21,7 +21,8 @@ SEXP vec_order_info(SEXP x,
                     SEXP direction,
                     SEXP na_value,
                     bool nan_distinct,
-                    SEXP chr_transform);
+                    SEXP chr_transform,
+                    bool chr_ordered);
 
 // -----------------------------------------------------------------------------
 

--- a/tests/testthat/test-order-radix.R
+++ b/tests/testthat/test-order-radix.R
@@ -1098,3 +1098,44 @@ test_that("can order data frames (and subclasses) with matrix columns", {
   df$x <- tibble::tibble(y = matrix(1:2, 2))
   expect_identical(vec_order_radix(df), 1:2)
 })
+
+# ------------------------------------------------------------------------------
+# `vec_order_info(chr_ordered = FALSE)`
+
+test_that("can order character vectors in appearance order", {
+  x <- c("b", "a", "B", "B", "a")
+  info <- vec_order_info(x, chr_ordered = FALSE)
+
+  expect_identical(info[[1]], c(1L, 2L, 5L, 3L, 4L))
+  expect_identical(info[[2]], c(1L, 2L, 2L))
+})
+
+test_that("using appearance order means `direction` has no effect", {
+  x <- c("b", "a", "B", "B", "a")
+
+  info1 <- vec_order_info(x, direction = "asc", chr_ordered = FALSE)
+  info2 <- vec_order_info(x, direction = "desc", chr_ordered = FALSE)
+
+  expect_identical(info1[[1]], info2[[1]])
+  expect_identical(info1[[2]], info2[[2]])
+})
+
+test_that("appearance order works with NA - `na_value` has no effect", {
+  x <- c(NA, "foo", NA, "bar")
+  info <- vec_order_info(x, chr_ordered = FALSE)
+
+  expect_identical(info[[1]], c(1L, 3L, 2L, 4L))
+  expect_identical(info[[2]], c(2L, 1L, 1L))
+})
+
+test_that("appearance order can be mixed with regular ordering", {
+  x <- c("b", "a", "B", "B", "a", "a")
+  y <- c(1, 2, 3, 4, 1, 2)
+  df <- data_frame(x = x, y = y)
+
+  # `y` breaks ties
+  info <- vec_order_info(df, chr_ordered = FALSE)
+
+  expect_identical(info[[1]], c(1L, 5L, 2L, 6L, 3L, 4L))
+  expect_identical(info[[2]], c(1L, 1L, 2L, 1L, 1L))
+})


### PR DESCRIPTION
This PR adds `chr_appearance()` for ordering character vectors in appearance order, accessible through `vec_order_info(chr_ordered = FALSE)`. Ordering character vectors in appearance order is often much faster than actually sorting them, especially when there are many unique values.

This is a bit of an odd idea, but here is the rationale:

- For dictionary functions, we have to return results in order of appearance
- To get order of appearance with `vec_order_radix()`, we end up having to call it twice

In the first call to `vec_order_radix()`, we can optimize ordering of character vectors by using appearance order, while still computing the regular ordering for any other atomic types. The second call to `vec_order_radix()` on the result will still always allow us to compute an overall appearance order (even if we had a data frame with character columns mixed with other column types).

This finally gets us much closer to the current performance of the dictionary functions with character vectors. This is an approximate comparison, as there is a bit more work to do on top of that `vec_order_info(x, chr_ordered = FALSE)` call, but the improvements definitely seem worth it.

```r
set.seed(123)
library(vctrs)
vec_order_info <- vctrs:::vec_order_info

random_strings <- function(size, min_length, max_length) {
  lengths <- rlang::seq2(min_length, max_length)
  stringi::stri_rand_strings(
    size,
    sample(lengths, size = size, replace = TRUE)
  )
}

# all unique strings!
x <- random_strings(size = 1e7, min_length = 5, max_length = 20)

bench::mark(
  vec_order_info(x, chr_ordered = TRUE), 
  vec_order_info(x, chr_ordered = FALSE), 
  vec_unique_loc(x), # as a reference
  iterations = 10,
  check = FALSE
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 3 x 6
#>   expression                                  min   median `itr/sec` mem_alloc
#>   <bch:expr>                             <bch:tm> <bch:tm>     <dbl> <bch:byt>
#> 1 vec_order_info(x, chr_ordered = TRUE)     5.25s    6.24s     0.146     634MB
#> 2 vec_order_info(x, chr_ordered = FALSE) 498.42ms    1.13s     1.05      279MB
#> 3 vec_unique_loc(x)                      678.08ms 989.17ms     0.991     268MB
#> # … with 1 more variable: gc/sec <dbl>

# two unique strings!
dict <- random_strings(size = 2, min_length = 5, max_length = 20)
x <- sample(dict, 1e7, replace = TRUE)

bench::mark(
  vec_order_info(x, chr_ordered = TRUE), 
  vec_order_info(x, chr_ordered = FALSE), 
  vec_unique_loc(x), # as a reference
  iterations = 20,
  check = FALSE
)
#> # A tibble: 3 x 6
#>   expression                                  min   median `itr/sec` mem_alloc
#>   <bch:expr>                             <bch:tm> <bch:tm>     <dbl> <bch:byt>
#> 1 vec_order_info(x, chr_ordered = TRUE)   111.5ms  115.5ms      8.48   124.5MB
#> 2 vec_order_info(x, chr_ordered = FALSE)   79.6ms   82.8ms     11.8     38.6MB
#> 3 vec_unique_loc(x)                        72.5ms   80.5ms     12.5    102.1MB
#> # … with 1 more variable: gc/sec <dbl>
```