### PR TITLE
Move comparison helpers to `compare.h`

### DIFF
--- a/src/compare.c
+++ b/src/compare.c
@@ -6,7 +6,7 @@
 #include <strings.h>
 
 static void stop_not_comparable(SEXP x, SEXP y, const char* message) {
-  Rf_errorcall(R_NilValue, "`x` and `y` are not comparable: %s", message);
+  r_abort("`x` and `y` are not comparable: %s", message);
 }
 
 // -----------------------------------------------------------------------------
@@ -56,9 +56,9 @@ SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal_) {
     case vctrs_type_integer:   COMPARE(int, INTEGER_RO, int_compare_na_equal);
     case vctrs_type_double:    COMPARE(double, REAL_RO, dbl_compare_na_equal);
     case vctrs_type_character: COMPARE(SEXP, STRING_PTR_RO, chr_compare_na_equal);
-    case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
-    case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
-    default:                   Rf_error("Unimplemented type in `vctrs_compare()`");
+    case vctrs_type_scalar:    r_abort("Can't compare scalars with `vctrs_compare()`");
+    case vctrs_type_list:      r_abort("Can't compare lists with `vctrs_compare()`");
+    default:                   stop_unimplemented_vctrs_type("vctrs_compare", type);
     }
   } else {
     switch (type) {
@@ -66,9 +66,9 @@ SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal_) {
     case vctrs_type_integer:   COMPARE(int, INTEGER_RO, int_compare_na_propagate);
     case vctrs_type_double:    COMPARE(double, REAL_RO, dbl_compare_na_propagate);
     case vctrs_type_character: COMPARE(SEXP, STRING_PTR_RO, chr_compare_na_propagate);
-    case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
-    case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
-    default:                   Rf_error("Unimplemented type in `vctrs_compare()`");
+    case vctrs_type_scalar:    r_abort("Can't compare scalars with `vctrs_compare()`");
+    case vctrs_type_list:      r_abort("Can't compare lists with `vctrs_compare()`");
+    default:                   stop_unimplemented_vctrs_type("vctrs_compare", type);
     }
   }
 }
@@ -182,9 +182,9 @@ static void vec_compare_col(int* p_out,
     case vctrs_type_integer:   COMPARE_COL(int, INTEGER_RO, int_compare_na_equal); break;
     case vctrs_type_double:    COMPARE_COL(double, REAL_RO, dbl_compare_na_equal); break;
     case vctrs_type_character: COMPARE_COL(SEXP, STRING_PTR_RO, chr_compare_na_equal); break;
-    case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
-    case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
-    default:                   Rf_error("Unimplemented type in `vctrs_compare()`");
+    case vctrs_type_scalar:    r_abort("Can't compare scalars with `vctrs_compare()`");
+    case vctrs_type_list:      r_abort("Can't compare lists with `vctrs_compare()`");
+    default:                   stop_unimplemented_vctrs_type("vec_compare_col", type);
     }
   } else {
     switch (type) {
@@ -192,9 +192,9 @@ static void vec_compare_col(int* p_out,
     case vctrs_type_integer:   COMPARE_COL(int, INTEGER_RO, int_compare_na_propagate); break;
     case vctrs_type_double:    COMPARE_COL(double, REAL_RO, dbl_compare_na_propagate); break;
     case vctrs_type_character: COMPARE_COL(SEXP, STRING_PTR_RO, chr_compare_na_propagate); break;
-    case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
-    case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
-    default:                   Rf_error("Unimplemented type in `vctrs_compare()`");
+    case vctrs_type_scalar:    r_abort("Can't compare scalars with `vctrs_compare()`");
+    case vctrs_type_list:      r_abort("Can't compare lists with `vctrs_compare()`");
+    default:                   stop_unimplemented_vctrs_type("vec_compare_col", type);
     }
   }
 }

--- a/src/compare.c
+++ b/src/compare.c
@@ -107,56 +107,6 @@ static inline int chr_compare_scalar(const SEXP* x, const SEXP* y, bool na_equal
   }
 }
 
-static inline int df_compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal, int n_col) {
-  int cmp;
-
-  for (int k = 0; k < n_col; ++k) {
-    SEXP col_x = VECTOR_ELT(x, k);
-    SEXP col_y = VECTOR_ELT(y, k);
-
-    cmp = compare_scalar(col_x, i, col_y, j, na_equal);
-
-    if (cmp != 0) {
-      return cmp;
-    }
-  }
-
-  return cmp;
-}
-
-// -----------------------------------------------------------------------------
-
-// [[ include("vctrs.h") ]]
-int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal) {
-  switch (TYPEOF(x)) {
-  case LGLSXP: return lgl_compare_scalar(LOGICAL_RO(x) + i, LOGICAL_RO(y) + j, na_equal);
-  case INTSXP: return int_compare_scalar(INTEGER_RO(x) + i, INTEGER_RO(y) + j, na_equal);
-  case REALSXP: return dbl_compare_scalar(REAL_RO(x) + i, REAL_RO(y) + j, na_equal);
-  case STRSXP: return chr_compare_scalar(STRING_PTR_RO(x) + i, STRING_PTR_RO(y) + j, na_equal);
-  default: break;
-  }
-
-  switch (vec_proxy_typeof(x)) {
-  case vctrs_type_list: stop_not_comparable(x, y, "lists are not comparable");
-  case vctrs_type_dataframe: {
-    int n_col = Rf_length(x);
-
-    if (n_col != Rf_length(y)) {
-      stop_not_comparable(x, y, "must have the same number of columns");
-    }
-
-    if (n_col == 0) {
-      stop_not_comparable(x, y, "data frame with zero columns");
-    }
-
-    return df_compare_scalar(x, i, y, j, na_equal, n_col);
-  }
-  default: break;
-  }
-
-  Rf_errorcall(R_NilValue, "Unsupported type %s", Rf_type2char(TYPEOF(x)));
-}
-
 // -----------------------------------------------------------------------------
 
 static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t size);

--- a/src/compare.c
+++ b/src/compare.c
@@ -1,110 +1,12 @@
 #include <rlang.h>
 #include "vctrs.h"
 #include "utils.h"
+#include "compare.h"
 #include "translate.h"
 #include <strings.h>
 
 static void stop_not_comparable(SEXP x, SEXP y, const char* message) {
   Rf_errorcall(R_NilValue, "`x` and `y` are not comparable: %s", message);
-}
-
-// https://stackoverflow.com/questions/10996418
-static inline int icmp(int x, int y) {
-  return (x > y) - (x < y);
-}
-int qsort_icmp(const void* x, const void* y) {
-  return icmp(*((int*) x), *((int*) y));
-}
-
-static int dcmp(double x, double y) {
-  return (x > y) - (x < y);
-}
-
-// Assume translation handled by `vec_normalize_encoding()`
-static inline int scmp(SEXP x, SEXP y) {
-  if (x == y) {
-    return 0;
-  }
-
-  int cmp = strcmp(CHAR(x), CHAR(y));
-  return cmp / abs(cmp);
-}
-
-// -----------------------------------------------------------------------------
-
-static inline int lgl_compare_scalar(const int* x, const int* y, bool na_equal) {
-  int xi = *x;
-  int yj = *y;
-
-  if (na_equal) {
-    return icmp(xi, yj);
-  } else {
-    return (xi == NA_LOGICAL || yj == NA_LOGICAL) ? NA_INTEGER : icmp(xi, yj);
-  }
-}
-
-static inline int int_compare_scalar(const int* x, const int* y, bool na_equal) {
-  int xi = *x;
-  int yj = *y;
-
-  if (na_equal) {
-    return icmp(xi, yj);
-  } else {
-    return (xi == NA_INTEGER || yj == NA_INTEGER) ? NA_INTEGER : icmp(xi, yj);
-  }
-}
-
-static inline int dbl_compare_scalar(const double* x, const double* y, bool na_equal) {
-  double xi = *x;
-  double yj = *y;
-
-  if (na_equal) {
-    enum vctrs_dbl_class x_class = dbl_classify(xi);
-    enum vctrs_dbl_class y_class = dbl_classify(yj);
-
-    switch (x_class) {
-    case vctrs_dbl_number: {
-      switch (y_class) {
-      case vctrs_dbl_number: return dcmp(xi, yj);
-      case vctrs_dbl_missing: return 1;
-      case vctrs_dbl_nan: return 1;
-      }
-    }
-    case vctrs_dbl_missing: {
-      switch (y_class) {
-      case vctrs_dbl_number: return -1;
-      case vctrs_dbl_missing: return 0;
-      case vctrs_dbl_nan: return 1;
-      }
-    }
-    case vctrs_dbl_nan: {
-      switch (y_class) {
-      case vctrs_dbl_number: return -1;
-      case vctrs_dbl_missing: return -1;
-      case vctrs_dbl_nan: return 0;
-      }
-    }
-    }
-  } else {
-    return (isnan(xi) || isnan(yj)) ? NA_INTEGER : dcmp(xi, yj);
-  }
-
-  never_reached("dbl_compare_scalar");
-}
-
-static inline int chr_compare_scalar(const SEXP* x, const SEXP* y, bool na_equal) {
-  const SEXP xi = *x;
-  const SEXP yj = *y;
-
-  if (na_equal) {
-    if (xi == NA_STRING) {
-      return (yj == NA_STRING) ? 0 : -1;
-    } else {
-      return (yj == NA_STRING) ? 1 : scmp(xi, yj);
-    }
-  } else {
-    return (xi == NA_STRING || yj == NA_STRING) ? NA_INTEGER : scmp(xi, yj);
-  }
 }
 
 // -----------------------------------------------------------------------------
@@ -119,8 +21,8 @@ do {                                                    \
   const CTYPE* p_x = CONST_DEREF(x);                    \
   const CTYPE* p_y = CONST_DEREF(y);                    \
                                                         \
-  for (R_len_t i = 0; i < size; ++i, ++p_x, ++p_y) {    \
-    p_out[i] = SCALAR_COMPARE(p_x, p_y, na_equal);      \
+  for (R_len_t i = 0; i < size; ++i) {                  \
+    p_out[i] = SCALAR_COMPARE(p_x[i], p_y[i]);          \
   }                                                     \
                                                         \
   UNPROTECT(3);                                         \
@@ -142,19 +44,32 @@ SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal_) {
   x = PROTECT(vec_normalize_encoding(x));
   y = PROTECT(vec_normalize_encoding(y));
 
-  switch (type) {
-  case vctrs_type_logical:   COMPARE(int, LOGICAL_RO, lgl_compare_scalar);
-  case vctrs_type_integer:   COMPARE(int, INTEGER_RO, int_compare_scalar);
-  case vctrs_type_double:    COMPARE(double, REAL_RO, dbl_compare_scalar);
-  case vctrs_type_character: COMPARE(SEXP, STRING_PTR_RO, chr_compare_scalar);
-  case vctrs_type_dataframe: {
+  if (type == vctrs_type_dataframe) {
     SEXP out = df_compare(x, y, na_equal, size);
     UNPROTECT(2);
     return out;
   }
-  case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
-  case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
-  default:                   Rf_error("Unimplemented type in `vctrs_compare()`");
+
+  if (na_equal) {
+    switch (type) {
+    case vctrs_type_logical:   COMPARE(int, LOGICAL_RO, lgl_compare_na_equal);
+    case vctrs_type_integer:   COMPARE(int, INTEGER_RO, int_compare_na_equal);
+    case vctrs_type_double:    COMPARE(double, REAL_RO, dbl_compare_na_equal);
+    case vctrs_type_character: COMPARE(SEXP, STRING_PTR_RO, chr_compare_na_equal);
+    case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
+    case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
+    default:                   Rf_error("Unimplemented type in `vctrs_compare()`");
+    }
+  } else {
+    switch (type) {
+    case vctrs_type_logical:   COMPARE(int, LOGICAL_RO, lgl_compare_na_propagate);
+    case vctrs_type_integer:   COMPARE(int, INTEGER_RO, int_compare_na_propagate);
+    case vctrs_type_double:    COMPARE(double, REAL_RO, dbl_compare_na_propagate);
+    case vctrs_type_character: COMPARE(SEXP, STRING_PTR_RO, chr_compare_na_propagate);
+    case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
+    case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
+    default:                   Rf_error("Unimplemented type in `vctrs_compare()`");
+    }
   }
 }
 
@@ -224,29 +139,29 @@ static void df_compare_impl(int* p_out,
 
 // -----------------------------------------------------------------------------
 
-#define COMPARE_COL(CTYPE, CONST_DEREF, SCALAR_COMPARE)              \
-do {                                                                 \
-  const CTYPE* p_x = CONST_DEREF(x);                                 \
-  const CTYPE* p_y = CONST_DEREF(y);                                 \
-                                                                     \
-  for (R_len_t i = 0; i < p_info->size; ++i, ++p_x, ++p_y) {         \
-    if (p_info->p_row_known[i]) {                                    \
-      continue;                                                      \
-    }                                                                \
-                                                                     \
-    int cmp = SCALAR_COMPARE(p_x, p_y, na_equal);                    \
-                                                                     \
-    if (cmp != 0) {                                                  \
-      p_out[i] = cmp;                                                \
-      p_info->p_row_known[i] = true;                                 \
-      --p_info->remaining;                                           \
-                                                                     \
-      if (p_info->remaining == 0) {                                  \
-        break;                                                       \
-      }                                                              \
-    }                                                                \
-  }                                                                  \
-}                                                                    \
+#define COMPARE_COL(CTYPE, CONST_DEREF, SCALAR_COMPARE) \
+do {                                                    \
+  const CTYPE* p_x = CONST_DEREF(x);                    \
+  const CTYPE* p_y = CONST_DEREF(y);                    \
+                                                        \
+  for (R_len_t i = 0; i < p_info->size; ++i) {          \
+    if (p_info->p_row_known[i]) {                       \
+      continue;                                         \
+    }                                                   \
+                                                        \
+    int cmp = SCALAR_COMPARE(p_x[i], p_y[i]);           \
+                                                        \
+    if (cmp != 0) {                                     \
+      p_out[i] = cmp;                                   \
+      p_info->p_row_known[i] = true;                    \
+      --p_info->remaining;                              \
+                                                        \
+      if (p_info->remaining == 0) {                     \
+        break;                                          \
+      }                                                 \
+    }                                                   \
+  }                                                     \
+}                                                       \
 while (0)
 
 static void vec_compare_col(int* p_out,
@@ -254,15 +169,33 @@ static void vec_compare_col(int* p_out,
                             SEXP x,
                             SEXP y,
                             bool na_equal) {
-  switch (vec_proxy_typeof(x)) {
-  case vctrs_type_logical:   COMPARE_COL(int, LOGICAL_RO, lgl_compare_scalar); break;
-  case vctrs_type_integer:   COMPARE_COL(int, INTEGER_RO, int_compare_scalar); break;
-  case vctrs_type_double:    COMPARE_COL(double, REAL_RO, dbl_compare_scalar); break;
-  case vctrs_type_character: COMPARE_COL(SEXP, STRING_PTR_RO, chr_compare_scalar); break;
-  case vctrs_type_dataframe: df_compare_impl(p_out, p_info, x, y, na_equal); break;
-  case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
-  case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
-  default:                   Rf_error("Unimplemented type in `vctrs_compare()`");
+  enum vctrs_type type = vec_proxy_typeof(x);
+
+  if (type == vctrs_type_dataframe) {
+    df_compare_impl(p_out, p_info, x, y, na_equal);
+    return;
+  }
+
+  if (na_equal) {
+    switch (type) {
+    case vctrs_type_logical:   COMPARE_COL(int, LOGICAL_RO, lgl_compare_na_equal); break;
+    case vctrs_type_integer:   COMPARE_COL(int, INTEGER_RO, int_compare_na_equal); break;
+    case vctrs_type_double:    COMPARE_COL(double, REAL_RO, dbl_compare_na_equal); break;
+    case vctrs_type_character: COMPARE_COL(SEXP, STRING_PTR_RO, chr_compare_na_equal); break;
+    case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
+    case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
+    default:                   Rf_error("Unimplemented type in `vctrs_compare()`");
+    }
+  } else {
+    switch (type) {
+    case vctrs_type_logical:   COMPARE_COL(int, LOGICAL_RO, lgl_compare_na_propagate); break;
+    case vctrs_type_integer:   COMPARE_COL(int, INTEGER_RO, int_compare_na_propagate); break;
+    case vctrs_type_double:    COMPARE_COL(double, REAL_RO, dbl_compare_na_propagate); break;
+    case vctrs_type_character: COMPARE_COL(SEXP, STRING_PTR_RO, chr_compare_na_propagate); break;
+    case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't compare scalars with `vctrs_compare()`");
+    case vctrs_type_list:      Rf_errorcall(R_NilValue, "Can't compare lists with `vctrs_compare()`");
+    default:                   Rf_error("Unimplemented type in `vctrs_compare()`");
+    }
   }
 }
 

--- a/src/compare.h
+++ b/src/compare.h
@@ -72,6 +72,8 @@ int dbl_compare_na_equal(double x, double y) {
     }
   }
   }
+
+  r_stop_unreached("dbl_compare_na_equal");
 }
 static inline
 int cpl_compare_na_equal(Rcomplex x, Rcomplex y) {

--- a/src/compare.h
+++ b/src/compare.h
@@ -1,6 +1,7 @@
 #ifndef VCTRS_COMPARE_H
 #define VCTRS_COMPARE_H
 
+#include <rlang.h>
 #include "vctrs.h"
 #include "equal.h"
 
@@ -16,9 +17,9 @@ int dbl_compare_scalar(double x, double y) {
   return (x > y) - (x < y);
 }
 static inline
-int chr_compare_scalar(SEXP x, SEXP y) {
+int chr_compare_scalar(r_obj* x, r_obj* y) {
   // Assume translation handled by `vec_normalize_encoding()`
-  int cmp = strcmp(CHAR(x), CHAR(y));
+  int cmp = strcmp(r_str_c_string(x), r_str_c_string(y));
   return cmp / abs(cmp);
 }
 
@@ -32,8 +33,8 @@ int qsort_int_compare_scalar(const void* x, const void* y) {
 // -----------------------------------------------------------------------------
 
 static inline
-int nil_compare_na_equal(SEXP x, SEXP y) {
-  stop_internal("nil_compare_na_equal", "Can't compare NULL values.");
+int nil_compare_na_equal(r_obj* x, r_obj* y) {
+  r_stop_internal("nil_compare_na_equal", "Can't compare NULL values.");
 }
 static inline
 int lgl_compare_na_equal(int x, int y) {
@@ -74,10 +75,10 @@ int dbl_compare_na_equal(double x, double y) {
 }
 static inline
 int cpl_compare_na_equal(Rcomplex x, Rcomplex y) {
-  stop_internal("cpl_compare_na_equal", "Can't compare complex types.");
+  r_stop_internal("cpl_compare_na_equal", "Can't compare complex types.");
 }
 static inline
-int chr_compare_na_equal(SEXP x, SEXP y) {
+int chr_compare_na_equal(r_obj* x, r_obj* y) {
   if (chr_equal_na_equal(x, y)) {
     return 0;
   } else if (chr_is_missing(x)) {
@@ -90,22 +91,22 @@ int chr_compare_na_equal(SEXP x, SEXP y) {
 }
 static inline
 int raw_compare_na_equal(Rbyte x, Rbyte y) {
-  stop_internal("raw_compare_na_equal", "Can't compare raw types.");
+  r_stop_internal("raw_compare_na_equal", "Can't compare raw types.");
 }
 static inline
-int list_compare_na_equal(SEXP x, SEXP y) {
-  stop_internal("list_compare_na_equal", "Can't compare list types.");
+int list_compare_na_equal(r_obj* x, r_obj* y) {
+  r_stop_internal("list_compare_na_equal", "Can't compare list types.");
 }
 
 // -----------------------------------------------------------------------------
 
 #define P_COMPARE_NA_EQUAL(CTYPE, COMPARE_NA_EQUAL) do {                     \
-  return COMPARE_NA_EQUAL(((const CTYPE*) p_x)[i], ((const CTYPE*) p_y)[j]); \
+  return COMPARE_NA_EQUAL(((CTYPE const*) p_x)[i], ((CTYPE const*) p_y)[j]); \
 } while (0)
 
 static inline
 int p_nil_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
-  P_COMPARE_NA_EQUAL(SEXP, nil_compare_na_equal);
+  P_COMPARE_NA_EQUAL(r_obj*, nil_compare_na_equal);
 }
 static inline
 int p_lgl_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
@@ -125,7 +126,7 @@ int p_cpl_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize 
 }
 static inline
 int p_chr_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
-  P_COMPARE_NA_EQUAL(SEXP, chr_compare_na_equal);
+  P_COMPARE_NA_EQUAL(r_obj*, chr_compare_na_equal);
 }
 static inline
 int p_raw_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
@@ -133,7 +134,7 @@ int p_raw_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize 
 }
 static inline
 int p_list_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
-  P_COMPARE_NA_EQUAL(SEXP, list_compare_na_equal);
+  P_COMPARE_NA_EQUAL(r_obj*, list_compare_na_equal);
 }
 
 #undef P_COMPARE_NA_EQUAL
@@ -160,8 +161,8 @@ bool p_compare_na_equal(const void* p_x,
 // -----------------------------------------------------------------------------
 
 static inline
-int nil_compare_na_propagate(SEXP x, SEXP y) {
-  stop_internal("nil_compare_na_propagate", "Can't compare NULL values.");
+int nil_compare_na_propagate(r_obj* x, r_obj* y) {
+  r_stop_internal("nil_compare_na_propagate", "Can't compare NULL values.");
 }
 static inline
 int lgl_compare_na_propagate(int x, int y) {
@@ -189,10 +190,10 @@ int dbl_compare_na_propagate(double x, double y) {
 }
 static inline
 int cpl_compare_na_propagate(Rcomplex x, Rcomplex y) {
-  stop_internal("cpl_compare_na_propagate", "Can't compare complex types.");
+  r_stop_internal("cpl_compare_na_propagate", "Can't compare complex types.");
 }
 static inline
-int chr_compare_na_propagate(SEXP x, SEXP y) {
+int chr_compare_na_propagate(r_obj* x, r_obj* y) {
   if (chr_is_missing(x) || chr_is_missing(y)) {
     return r_globals.na_int;
   } else if (chr_equal_na_equal(x, y)) {
@@ -203,22 +204,22 @@ int chr_compare_na_propagate(SEXP x, SEXP y) {
 }
 static inline
 int raw_compare_na_propagate(Rbyte x, Rbyte y) {
-  stop_internal("raw_compare_na_propagate", "Can't compare raw types.");
+  r_stop_internal("raw_compare_na_propagate", "Can't compare raw types.");
 }
 static inline
-int list_compare_na_propagate(SEXP x, SEXP y) {
-  stop_internal("list_compare_na_propagate", "Can't compare list types.");
+int list_compare_na_propagate(r_obj* x, r_obj* y) {
+  r_stop_internal("list_compare_na_propagate", "Can't compare list types.");
 }
 
 // -----------------------------------------------------------------------------
 
 #define P_COMPARE_NA_PROPAGATE(CTYPE, COMPARE_NA_PROPAGATE) do {               \
-return COMPARE_NA_PROPAGATE(((const CTYPE*) p_x)[i], ((const CTYPE*) p_y)[j]); \
+return COMPARE_NA_PROPAGATE(((CTYPE const*) p_x)[i], ((CTYPE const*) p_y)[j]); \
 } while (0)
 
 static inline
 int p_nil_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
-  P_COMPARE_NA_PROPAGATE(SEXP, nil_compare_na_propagate);
+  P_COMPARE_NA_PROPAGATE(r_obj*, nil_compare_na_propagate);
 }
 static inline
 int p_lgl_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
@@ -238,7 +239,7 @@ int p_cpl_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ss
 }
 static inline
 int p_chr_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
-  P_COMPARE_NA_PROPAGATE(SEXP, chr_compare_na_propagate);
+  P_COMPARE_NA_PROPAGATE(r_obj*, chr_compare_na_propagate);
 }
 static inline
 int p_raw_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
@@ -246,7 +247,7 @@ int p_raw_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ss
 }
 static inline
 int p_list_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
-  P_COMPARE_NA_PROPAGATE(SEXP, list_compare_na_propagate);
+  P_COMPARE_NA_PROPAGATE(r_obj*, list_compare_na_propagate);
 }
 
 #undef P_COMPARE_NA_PROPAGATE

--- a/src/compare.h
+++ b/src/compare.h
@@ -1,0 +1,274 @@
+#ifndef VCTRS_COMPARE_H
+#define VCTRS_COMPARE_H
+
+#include "vctrs.h"
+#include "equal.h"
+
+// -----------------------------------------------------------------------------
+
+// https://stackoverflow.com/questions/10996418
+static inline
+int int_compare_scalar(int x, int y) {
+  return (x > y) - (x < y);
+}
+static inline
+int dbl_compare_scalar(double x, double y) {
+  return (x > y) - (x < y);
+}
+static inline
+int chr_compare_scalar(SEXP x, SEXP y) {
+  // Assume translation handled by `vec_normalize_encoding()`
+  int cmp = strcmp(CHAR(x), CHAR(y));
+  return cmp / abs(cmp);
+}
+
+// -----------------------------------------------------------------------------
+
+static inline
+int qsort_int_compare_scalar(const void* x, const void* y) {
+  return int_compare_scalar(*((int*) x), *((int*) y));
+}
+
+// -----------------------------------------------------------------------------
+
+static inline
+int nil_compare_na_equal(SEXP x, SEXP y) {
+  stop_internal("nil_compare_na_equal", "Can't compare NULL values.");
+}
+static inline
+int lgl_compare_na_equal(int x, int y) {
+  return int_compare_scalar(x, y);
+}
+static inline
+int int_compare_na_equal(int x, int y) {
+  return int_compare_scalar(x, y);
+}
+static inline
+int dbl_compare_na_equal(double x, double y) {
+  enum vctrs_dbl_class x_class = dbl_classify(x);
+  enum vctrs_dbl_class y_class = dbl_classify(y);
+
+  switch (x_class) {
+  case vctrs_dbl_number: {
+    switch (y_class) {
+    case vctrs_dbl_number: return dbl_compare_scalar(x, y);
+    case vctrs_dbl_missing: return 1;
+    case vctrs_dbl_nan: return 1;
+    }
+  }
+  case vctrs_dbl_missing: {
+    switch (y_class) {
+    case vctrs_dbl_number: return -1;
+    case vctrs_dbl_missing: return 0;
+    case vctrs_dbl_nan: return 1;
+    }
+  }
+  case vctrs_dbl_nan: {
+    switch (y_class) {
+    case vctrs_dbl_number: return -1;
+    case vctrs_dbl_missing: return -1;
+    case vctrs_dbl_nan: return 0;
+    }
+  }
+  }
+}
+static inline
+int cpl_compare_na_equal(Rcomplex x, Rcomplex y) {
+  stop_internal("cpl_compare_na_equal", "Can't compare complex types.");
+}
+static inline
+int chr_compare_na_equal(SEXP x, SEXP y) {
+  if (chr_equal_na_equal(x, y)) {
+    return 0;
+  } else if (chr_is_missing(x)) {
+    return -1;
+  } else if (chr_is_missing(y)) {
+    return 1;
+  } else {
+    return chr_compare_scalar(x, y);
+  }
+}
+static inline
+int raw_compare_na_equal(Rbyte x, Rbyte y) {
+  stop_internal("raw_compare_na_equal", "Can't compare raw types.");
+}
+static inline
+int list_compare_na_equal(SEXP x, SEXP y) {
+  stop_internal("list_compare_na_equal", "Can't compare list types.");
+}
+
+// -----------------------------------------------------------------------------
+
+#define P_COMPARE_NA_EQUAL(CTYPE, COMPARE_NA_EQUAL) do {                     \
+  return COMPARE_NA_EQUAL(((const CTYPE*) p_x)[i], ((const CTYPE*) p_y)[j]); \
+} while (0)
+
+static inline
+int p_nil_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_EQUAL(SEXP, nil_compare_na_equal);
+}
+static inline
+int p_lgl_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_EQUAL(int, lgl_compare_na_equal);
+}
+static inline
+int p_int_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_EQUAL(int, int_compare_na_equal);
+}
+static inline
+int p_dbl_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_EQUAL(double, dbl_compare_na_equal);
+}
+static inline
+int p_cpl_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_EQUAL(Rcomplex, cpl_compare_na_equal);
+}
+static inline
+int p_chr_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_EQUAL(SEXP, chr_compare_na_equal);
+}
+static inline
+int p_raw_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_EQUAL(Rbyte, raw_compare_na_equal);
+}
+static inline
+int p_list_compare_na_equal(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_EQUAL(SEXP, list_compare_na_equal);
+}
+
+#undef P_COMPARE_NA_EQUAL
+
+static inline
+bool p_compare_na_equal(const void* p_x,
+                        r_ssize i,
+                        const void* p_y,
+                        r_ssize j,
+                        const enum vctrs_type type) {
+  switch (type) {
+  case vctrs_type_null: return p_nil_compare_na_equal(p_x, i, p_y, j);
+  case vctrs_type_logical: return p_lgl_compare_na_equal(p_x, i, p_y, j);
+  case vctrs_type_integer: return p_int_compare_na_equal(p_x, i, p_y, j);
+  case vctrs_type_double: return p_dbl_compare_na_equal(p_x, i, p_y, j);
+  case vctrs_type_complex: return p_cpl_compare_na_equal(p_x, i, p_y, j);
+  case vctrs_type_character: return p_chr_compare_na_equal(p_x, i, p_y, j);
+  case vctrs_type_raw: return p_raw_compare_na_equal(p_x, i, p_y, j);
+  case vctrs_type_list: return p_list_compare_na_equal(p_x, i, p_y, j);
+  default: stop_unimplemented_vctrs_type("p_compare_na_equal", type);
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+static inline
+int nil_compare_na_propagate(SEXP x, SEXP y) {
+  stop_internal("nil_compare_na_propagate", "Can't compare NULL values.");
+}
+static inline
+int lgl_compare_na_propagate(int x, int y) {
+  if (lgl_is_missing(x) || lgl_is_missing(y)) {
+    return r_globals.na_int;
+  } else {
+    return int_compare_scalar(x, y);
+  }
+}
+static inline
+int int_compare_na_propagate(int x, int y) {
+  if (int_is_missing(x) || int_is_missing(y)) {
+    return r_globals.na_int;
+  } else {
+    return int_compare_scalar(x, y);
+  }
+}
+static inline
+int dbl_compare_na_propagate(double x, double y) {
+  if (dbl_is_missing(x) || dbl_is_missing(y)) {
+    return r_globals.na_int;
+  } else {
+    return dbl_compare_scalar(x, y);
+  }
+}
+static inline
+int cpl_compare_na_propagate(Rcomplex x, Rcomplex y) {
+  stop_internal("cpl_compare_na_propagate", "Can't compare complex types.");
+}
+static inline
+int chr_compare_na_propagate(SEXP x, SEXP y) {
+  if (chr_is_missing(x) || chr_is_missing(y)) {
+    return r_globals.na_int;
+  } else if (chr_equal_na_equal(x, y)) {
+    return 0;
+  } else {
+    return chr_compare_scalar(x, y);
+  }
+}
+static inline
+int raw_compare_na_propagate(Rbyte x, Rbyte y) {
+  stop_internal("raw_compare_na_propagate", "Can't compare raw types.");
+}
+static inline
+int list_compare_na_propagate(SEXP x, SEXP y) {
+  stop_internal("list_compare_na_propagate", "Can't compare list types.");
+}
+
+// -----------------------------------------------------------------------------
+
+#define P_COMPARE_NA_PROPAGATE(CTYPE, COMPARE_NA_PROPAGATE) do {               \
+return COMPARE_NA_PROPAGATE(((const CTYPE*) p_x)[i], ((const CTYPE*) p_y)[j]); \
+} while (0)
+
+static inline
+int p_nil_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_PROPAGATE(SEXP, nil_compare_na_propagate);
+}
+static inline
+int p_lgl_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_PROPAGATE(int, lgl_compare_na_propagate);
+}
+static inline
+int p_int_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_PROPAGATE(int, int_compare_na_propagate);
+}
+static inline
+int p_dbl_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_PROPAGATE(double, dbl_compare_na_propagate);
+}
+static inline
+int p_cpl_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_PROPAGATE(Rcomplex, cpl_compare_na_propagate);
+}
+static inline
+int p_chr_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_PROPAGATE(SEXP, chr_compare_na_propagate);
+}
+static inline
+int p_raw_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_PROPAGATE(Rbyte, raw_compare_na_propagate);
+}
+static inline
+int p_list_compare_na_propagate(const void* p_x, r_ssize i, const void* p_y, r_ssize j) {
+  P_COMPARE_NA_PROPAGATE(SEXP, list_compare_na_propagate);
+}
+
+#undef P_COMPARE_NA_PROPAGATE
+
+static inline
+bool p_compare_na_propagate(const void* p_x,
+                            r_ssize i,
+                            const void* p_y,
+                            r_ssize j,
+                            const enum vctrs_type type) {
+  switch (type) {
+  case vctrs_type_null: return p_nil_compare_na_propagate(p_x, i, p_y, j);
+  case vctrs_type_logical: return p_lgl_compare_na_propagate(p_x, i, p_y, j);
+  case vctrs_type_integer: return p_int_compare_na_propagate(p_x, i, p_y, j);
+  case vctrs_type_double: return p_dbl_compare_na_propagate(p_x, i, p_y, j);
+  case vctrs_type_complex: return p_cpl_compare_na_propagate(p_x, i, p_y, j);
+  case vctrs_type_character: return p_chr_compare_na_propagate(p_x, i, p_y, j);
+  case vctrs_type_raw: return p_raw_compare_na_propagate(p_x, i, p_y, j);
+  case vctrs_type_list: return p_list_compare_na_propagate(p_x, i, p_y, j);
+  default: stop_unimplemented_vctrs_type("p_compare_na_propagate", type);
+  }
+}
+
+// -----------------------------------------------------------------------------
+#endif // VCTRS_COMPARE_H

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -1,6 +1,7 @@
 #include <rlang.h>
 #include "vctrs.h"
 #include "utils.h"
+#include "compare.h"
 #include "subscript.h"
 #include "subscript-loc.h"
 
@@ -150,9 +151,6 @@ static SEXP int_filter_zero(SEXP subscript, R_len_t n_zero) {
   return out;
 }
 
-// From compare.c
-int qsort_icmp(const void* x, const void* y);
-
 static void int_check_consecutive(SEXP subscript, R_len_t n, R_len_t n_extend,
                                   const struct location_opts* opts) {
 
@@ -196,7 +194,7 @@ static void int_check_consecutive(SEXP subscript, R_len_t n, R_len_t n_extend,
 
   // Only the first i_extend entries of the array are populated,
   // the rest is never touched.
-  qsort(p_extended, i_extend, sizeof(int), &qsort_icmp);
+  qsort(p_extended, i_extend, sizeof(int), &qsort_int_compare_scalar);
 
   for (R_len_t i = 0; i < i_extend; ++i) {
     int elt = p_extended[i];

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -422,8 +422,6 @@ bool equal_object(SEXP x, SEXP y);
 bool equal_object_normalized(SEXP x, SEXP y);
 bool equal_names(SEXP x, SEXP y);
 
-int compare_scalar(SEXP x, R_len_t i, SEXP y, R_len_t j, bool na_equal);
-
 uint32_t hash_object(SEXP x);
 void hash_fill(uint32_t* p, R_len_t n, SEXP x, bool na_equal);
 


### PR DESCRIPTION
Generally cleans up the comparison code. Also allows for a `poly-op.c` addition for fast comparisons, which I'm thinking about using soon