### PR TITLE
Fix `min()`, `max()` and `range()` where `na.rm = TRUE` and all values are `NA`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,13 @@
 # vctrs (development version)
 
+* `min()`, `max()` and `range()` no longer throw an error if `na.rm = TRUE` is
+  set and all values are `NA` (@gorcha, #1357). In this case, and where an empty
+  input is given, it will return `Inf`/`-Inf`, or `NA` if `Inf` can't be cast
+  to the input type.
+
 * `vec_group_loc()`, used for grouping in dplyr, now correctly handles
   vectors with billions of elements (up to `.Machine$integer.max`) (#1133).
+
 
 # vctrs 0.3.7
 

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -477,7 +477,7 @@ quantile.vctrs_vctr <- function(x, ..., type = 1, na.rm = FALSE) {
 
 vec_cast_or_na <- function(x, to, ...) {
   tryCatch(
-    vctrs_error_incompatible_type = function(...) vec_cast(rep(NA, length(x)), to),
+    vctrs_error_incompatible_type = function(...) vec_init(to, length(x)),
     vec_cast(x, to)
   )
 }

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -475,10 +475,17 @@ quantile.vctrs_vctr <- function(x, ..., type = 1, na.rm = FALSE) {
   # nocov end
 }
 
+vec_cast_or_na <- function(x, to, ...) {
+  tryCatch(
+    vctrs_error_incompatible_type = function(...) vec_cast(rep(NA, length(x)), to),
+    vec_cast(x, to)
+  )
+}
+
 #' @export
 min.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
   if (vec_is_empty(x)) {
-    return(vec_cast(Inf, x))
+    return(vec_cast_or_na(Inf, x))
   }
 
   # TODO: implement to do vec_arg_min()
@@ -486,6 +493,9 @@ min.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
 
   if (isTRUE(na.rm)) {
     idx <- which.min(rank)
+    if (vec_is_empty(idx)) {
+      return(vec_cast_or_na(Inf, x))
+    }
   } else {
     idx <- which(vec_equal(rank, min(rank), na_equal = TRUE))
   }
@@ -496,7 +506,7 @@ min.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
 #' @export
 max.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
   if (vec_is_empty(x)) {
-    return(vec_cast(-Inf, x))
+    return(vec_cast_or_na(-Inf, x))
   }
 
   # TODO: implement to do vec_arg_max()
@@ -504,6 +514,9 @@ max.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
 
   if (isTRUE(na.rm)) {
     idx <- which.max(rank)
+    if (vec_is_empty(idx)) {
+      return(vec_cast_or_na(-Inf, x))
+    }
   } else {
     idx <- which(vec_equal(rank, max(rank), na_equal = TRUE))
   }
@@ -514,7 +527,7 @@ max.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
 #' @export
 range.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
   if (vec_is_empty(x)) {
-    return(vec_cast(c(Inf, -Inf), x))
+    return(vec_cast_or_na(c(Inf, -Inf), x))
   }
 
   # Inline `min()` / `max()` to only call `xtfrm()` once
@@ -523,6 +536,9 @@ range.vctrs_vctr <- function(x, ..., na.rm = FALSE) {
   if (isTRUE(na.rm)) {
     idx_min <- which.min(rank)
     idx_max <- which.max(rank)
+    if (vec_is_empty(idx_min) && vec_is_empty(idx_max)) {
+      return(vec_cast_or_na(c(Inf, -Inf), x))
+    }
   } else {
     idx_min <- which(vec_equal(rank, min(rank), na_equal = TRUE))
     idx_max <- which(vec_equal(rank, max(rank), na_equal = TRUE))

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -585,25 +585,38 @@ test_that("xtfrm() works with character subclass", {
   expect_identical(xtfrm(new_vctr(chr())), int())
 })
 
-test_that("Summary generics behave identically to base if na.rm = TRUE and all values are NA (#1357)", {
-  expect_warning(
-    expect_identical(
-      min(new_vctr(NA_real_), na.rm = TRUE),
-      new_vctr(min(NA_real_, na.rm = TRUE))
-    )
-  )
+test_that("Summary generics behave as expected if na.rm = TRUE and all values are NA (#1357)", {
+  expect_identical(min(new_vctr(NA_real_), na.rm = TRUE), new_vctr(Inf))
+  expect_identical(max(new_vctr(NA_real_), na.rm = TRUE), new_vctr(-Inf))
+  expect_identical(range(new_vctr(NA_real_), na.rm = TRUE), new_vctr(c(Inf, -Inf)))
 
-  expect_warning(
-    expect_identical(
-      max(new_vctr(NA_real_), na.rm = TRUE),
-      new_vctr(max(NA_real_, na.rm = TRUE))
-    )
-  )
+  expect_identical(min(new_vctr(NA_integer_), na.rm = TRUE), new_vctr(NA_integer_))
+  expect_identical(max(new_vctr(NA_integer_), na.rm = TRUE), new_vctr(NA_integer_))
+  expect_identical(range(new_vctr(NA_integer_), na.rm = TRUE), new_vctr(c(NA_integer_, NA_integer_)))
 
-  expect_warning(
-    expect_identical(
-      range(new_vctr(NA_real_), na.rm = TRUE),
-      new_vctr(range(NA_real_, na.rm = TRUE))
-    )
-  )
+  expect_identical(min(new_vctr(NA_character_), na.rm = TRUE), new_vctr(NA_character_))
+  expect_identical(max(new_vctr(NA_character_), na.rm = TRUE), new_vctr(NA_character_))
+  expect_identical(range(new_vctr(NA_character_), na.rm = TRUE), new_vctr(c(NA_character_, NA_character_)))
+
+  expect_identical(min(new_vctr(NA), na.rm = TRUE), new_vctr(NA))
+  expect_identical(max(new_vctr(NA), na.rm = TRUE), new_vctr(NA))
+  expect_identical(range(new_vctr(NA), na.rm = TRUE), new_vctr(c(NA, NA)))
+})
+
+test_that("Summary generics behave as expected for empty vctrs (#1357)", {
+  expect_identical(min(new_vctr(numeric()), na.rm = TRUE), new_vctr(Inf))
+  expect_identical(max(new_vctr(numeric()), na.rm = TRUE), new_vctr(-Inf))
+  expect_identical(range(new_vctr(numeric()), na.rm = TRUE), new_vctr(c(Inf, -Inf)))
+
+  expect_identical(min(new_vctr(integer()), na.rm = TRUE), new_vctr(NA_integer_))
+  expect_identical(max(new_vctr(integer()), na.rm = TRUE), new_vctr(NA_integer_))
+  expect_identical(range(new_vctr(integer()), na.rm = TRUE), new_vctr(c(NA_integer_, NA_integer_)))
+
+  expect_identical(min(new_vctr(character()), na.rm = TRUE), new_vctr(NA_character_))
+  expect_identical(max(new_vctr(character()), na.rm = TRUE), new_vctr(NA_character_))
+  expect_identical(range(new_vctr(character()), na.rm = TRUE), new_vctr(c(NA_character_, NA_character_)))
+
+  expect_identical(min(new_vctr(logical()), na.rm = TRUE), new_vctr(NA))
+  expect_identical(max(new_vctr(logical()), na.rm = TRUE), new_vctr(NA))
+  expect_identical(range(new_vctr(logical()), na.rm = TRUE), new_vctr(c(NA, NA)))
 })

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -584,3 +584,26 @@ test_that("xtfrm() returns a bare vector", {
 test_that("xtfrm() works with character subclass", {
   expect_identical(xtfrm(new_vctr(chr())), int())
 })
+
+test_that("Summary generics behave identically to base if na.rm = TRUE and all values are NA (#1357)", {
+  expect_warning(
+    expect_identical(
+      min(new_vctr(NA_real_), na.rm = TRUE),
+      new_vctr(min(NA_real_, na.rm = TRUE))
+    )
+  )
+
+  expect_warning(
+    expect_identical(
+      max(new_vctr(NA_real_), na.rm = TRUE),
+      new_vctr(max(NA_real_, na.rm = TRUE))
+    )
+  )
+
+  expect_warning(
+    expect_identical(
+      range(new_vctr(NA_real_), na.rm = TRUE),
+      new_vctr(range(NA_real_, na.rm = TRUE))
+    )
+  )
+})


### PR DESCRIPTION
This PR fixes #1357. Where `na.rm = TRUE` and all values are `NA`, these functions now return `Inf`/`-Inf` or `NA` depending on the input type.

As noted in #1004, base R returns `Inf`/`-Inf` for numeric types, and `NA_character_` for character vectors, so it should do so in vctrs as well. I've followed almost the same rules here.

If `Inf`/`-Inf` can be successfully cast to the input type that will be the return value. Otherwise it will return `NA` cast to the appropriate type. This is kind of the same as base R in theory, but in vctrs doubles can't be cast to integer or logical, so these return `Inf` in base R but `NA` here.

This behaviour has been extended to empty vectors as well, so they no longer throw an error if `Inf` can't be cast to the input type.

I'm thinking that #1004 is right, and it should just be `NA` in all cases, but I've left `Inf` as the default where possible to match existing behaviour.

``` r
library(vctrs)

# Integer
min(integer())
#> Warning in min(integer()): no non-missing arguments to min; returning Inf
#> [1] Inf
min(new_vctr(integer()))
#> <vctrs_vctr[1]>
#> [1] NA

min(NA_integer_, na.rm = TRUE)
#> Warning in min(NA_integer_, na.rm = TRUE): no non-missing arguments to min;
#> returning Inf
#> [1] Inf
min(new_vctr(NA_integer_), na.rm = TRUE)
#> <vctrs_vctr[1]>
#> [1] NA

# Double
min(numeric())
#> Warning in min(numeric()): no non-missing arguments to min; returning Inf
#> [1] Inf
min(new_vctr(numeric()))
#> <vctrs_vctr[1]>
#> [1] Inf

min(NA_real_, na.rm = TRUE)
#> Warning in min(NA_real_, na.rm = TRUE): no non-missing arguments to min;
#> returning Inf
#> [1] Inf
min(new_vctr(NA_real_), na.rm = TRUE)
#> <vctrs_vctr[1]>
#> [1] Inf

# Character
min(character())
#> Warning in min(character()): no non-missing arguments, returning NA
#> [1] NA
min(new_vctr(character()))
#> <vctrs_vctr[1]>
#> [1] NA

min(NA_character_, na.rm = TRUE)
#> Warning in min(NA_character_, na.rm = TRUE): no non-missing arguments, returning
#> NA
#> [1] NA
min(new_vctr(NA_character_), na.rm = TRUE)
#> <vctrs_vctr[1]>
#> [1] NA

# Logical
min(logical())
#> Warning in min(logical()): no non-missing arguments to min; returning Inf
#> [1] Inf
min(new_vctr(logical()))
#> <vctrs_vctr[1]>
#> [1] NA

min(NA, na.rm = TRUE)
#> Warning in min(NA, na.rm = TRUE): no non-missing arguments to min; returning Inf
#> [1] Inf
min(new_vctr(NA), na.rm = TRUE)
#> <vctrs_vctr[1]>
#> [1] NA
```

<sup>Created on 2021-04-10 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

