### PR TITLE
Fix dictionary function overflow with long input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* `vec_group_loc()`, used for grouping in dplyr, now correctly handles
+  vectors with billions of elements (up to `.Machine$integer.max`) (#1133).
+
 # vctrs 0.3.7
 
 * `vec_ptype_abbr()` gains arguments to control whether to indicate

--- a/src/decl/dictionary-decl.h
+++ b/src/decl/dictionary-decl.h
@@ -1,0 +1,6 @@
+#ifndef VCTRS_DICTIONARY_DECL_H
+#define VCTRS_DICTIONARY_DECL_H
+
+static inline uint32_t dict_key_size(SEXP x);
+
+#endif

--- a/src/decl/dictionary-decl.h
+++ b/src/decl/dictionary-decl.h
@@ -1,6 +1,1 @@
-#ifndef VCTRS_DICTIONARY_DECL_H
-#define VCTRS_DICTIONARY_DECL_H
-
 static inline uint32_t dict_key_size(SEXP x);
-
-#endif

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -13,7 +13,7 @@ struct vctrs_arg args_haystack;
 
 
 // http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
-int32_t ceil2(int32_t x) {
+uint32_t ceil2(uint32_t x) {
   x--;
   x |= x >> 1;
   x |= x >> 2;
@@ -79,7 +79,7 @@ static struct dictionary* new_dictionary_opts(SEXP x, struct dictionary_opts* op
     // of at most 77%. We round up to power of 2 to ensure quadratic probing
     // strategy works.
     // Rprintf("size: %i\n", size);
-    R_len_t size = ceil2(vec_size(x) / 0.77);
+    uint32_t size = ceil2(vec_size(x) / 0.77);
     size = (size < 16) ? 16 : size;
 
     d->key = (R_len_t*) R_alloc(size, sizeof(R_len_t));
@@ -492,7 +492,7 @@ SEXP vctrs_count(SEXP x) {
   int* p_val = INTEGER(val);
 
   for (int i = 0; i < n; ++i) {
-    int32_t hash = dict_hash_scalar(d, i);
+    uint32_t hash = dict_hash_scalar(d, i);
 
     if (d->key[hash] == DICT_EMPTY) {
       dict_put(d, hash, i);
@@ -508,7 +508,7 @@ SEXP vctrs_count(SEXP x) {
   int* p_out_val = INTEGER(out_val);
 
   int i = 0;
-  for (int hash = 0; hash < d->size; ++hash) {
+  for (uint32_t hash = 0; hash < d->size; ++hash) {
     if (d->key[hash] == DICT_EMPTY)
       continue;
 
@@ -544,7 +544,7 @@ SEXP vctrs_duplicated(SEXP x) {
   int* p_val = INTEGER(val);
 
   for (int i = 0; i < n; ++i) {
-    int32_t hash = dict_hash_scalar(d, i);
+    uint32_t hash = dict_hash_scalar(d, i);
 
     if (d->key[hash] == DICT_EMPTY) {
       dict_put(d, hash, i);
@@ -558,7 +558,7 @@ SEXP vctrs_duplicated(SEXP x) {
   int* p_out = LOGICAL(out);
 
   for (int i = 0; i < n; ++i) {
-    int32_t hash = dict_hash_scalar(d, i);
+    uint32_t hash = dict_hash_scalar(d, i);
     p_out[i] = p_val[hash] != 1;
   }
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -174,7 +174,13 @@ uint32_t dict_key_size(SEXP x) {
     stop_internal("dict_key_size", "Dictionary functions do not support long vectors.");
   }
 
-  uint32_t size = (uint32_t)(x_size / 0.77);
+  const double load_adjusted_size = x_size / 0.77;
+
+  if (load_adjusted_size > UINT32_MAX) {
+    stop_internal("dict_key_size", "Can't safely cast load adjusted size to a `uint32_t`.");
+  }
+
+  uint32_t size = (uint32_t)load_adjusted_size;
   size = size > INT_MAX ? INT_MAX : size;
   size = u32_ceil2(size);
   size = (size < 16) ? 16 : size;

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -1,12 +1,13 @@
 #include <rlang.h>
 #include "vctrs.h"
 #include "dictionary.h"
-#include "decl/dictionary-decl.h"
 #include "translate.h"
 #include "equal.h"
 #include "hash.h"
 #include "ptype2.h"
 #include "utils.h"
+
+#include "decl/dictionary-decl.h"
 
 // Initialised at load time
 struct vctrs_arg args_needles;

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -1,6 +1,7 @@
 #include <rlang.h>
 #include "vctrs.h"
 #include "dictionary.h"
+#include "decl/dictionary-decl.h"
 #include "translate.h"
 #include "equal.h"
 #include "hash.h"
@@ -52,8 +53,6 @@ static struct dictionary* new_dictionary_params(SEXP x, bool partial, bool na_eq
   opts.na_equal = na_equal;
   return new_dictionary_opts(x, &opts);
 }
-
-static inline uint32_t dict_key_size(SEXP x);
 
 static struct dictionary* new_dictionary_opts(SEXP x, struct dictionary_opts* opts) {
   int nprot = 0;

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -15,7 +15,7 @@ struct vctrs_arg args_haystack;
 
 // http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
 static inline
-uint32_t ceil2(uint32_t x) {
+uint32_t u32_ceil2(uint32_t x) {
   x--;
   x |= x >> 1;
   x |= x >> 2;
@@ -169,7 +169,7 @@ static inline
 uint32_t dict_key_size(SEXP x) {
   uint32_t size = (uint32_t)(vec_size(x) / 0.77);
   size = size > (uint32_t)INT_MAX ? (uint32_t)INT_MAX : size;
-  size = ceil2(size);
+  size = u32_ceil2(size);
   size = (size < 16) ? 16 : size;
   // Rprintf("size: %u\n", size);
   return size;

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -169,7 +169,7 @@ void dict_put(struct dictionary* d, uint32_t hash, R_len_t i) {
 static inline
 uint32_t dict_key_size(SEXP x) {
   uint32_t size = (uint32_t)(vec_size(x) / 0.77);
-  size = size > (uint32_t)INT_MAX ? (uint32_t)INT_MAX : size;
+  size = size > INT_MAX ? INT_MAX : size;
   size = u32_ceil2(size);
   size = (size < 16) ? 16 : size;
   // Rprintf("size: %u\n", size);

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -168,10 +168,17 @@ void dict_put(struct dictionary* d, uint32_t hash, R_len_t i) {
 // it can run.
 static inline
 uint32_t dict_key_size(SEXP x) {
-  uint32_t size = (uint32_t)(vec_size(x) / 0.77);
+  const R_len_t x_size = vec_size(x);
+
+  if (x_size > R_LEN_T_MAX) {
+    stop_internal("dict_key_size", "Dictionary functions do not support long vectors.");
+  }
+
+  uint32_t size = (uint32_t)(x_size / 0.77);
   size = size > INT_MAX ? INT_MAX : size;
   size = u32_ceil2(size);
   size = (size < 16) ? 16 : size;
+
   // Rprintf("size: %u\n", size);
   return size;
 }

--- a/src/group.c
+++ b/src/group.c
@@ -23,7 +23,7 @@ SEXP vctrs_group_id(SEXP x) {
   R_len_t g = 1;
 
   for (int i = 0; i < n; ++i) {
-    int32_t hash = dict_hash_scalar(d, i);
+    uint32_t hash = dict_hash_scalar(d, i);
     R_len_t key = d->key[hash];
 
     if (key == DICT_EMPTY) {
@@ -77,7 +77,7 @@ SEXP vctrs_group_rle(SEXP x) {
   int* p_map = INTEGER(map);
 
   // Initialize first value
-  int32_t hash = dict_hash_scalar(d, 0);
+  uint32_t hash = dict_hash_scalar(d, 0);
   dict_put(d, hash, 0);
   p_map[hash] = 0;
   *p_g = 1;
@@ -95,7 +95,7 @@ SEXP vctrs_group_rle(SEXP x) {
     *p_l = 1;
 
     // Check if we have seen this value before
-    int32_t hash = dict_hash_scalar(d, i);
+    uint32_t hash = dict_hash_scalar(d, i);
 
     if (d->key[hash] == DICT_EMPTY) {
       dict_put(d, hash, i);
@@ -158,7 +158,7 @@ SEXP vec_group_loc(SEXP x) {
 
   // Identify groups, this is essentially `vec_group_id()`
   for (int i = 0; i < n; ++i) {
-    const int32_t hash = dict_hash_scalar(d, i);
+    const uint32_t hash = dict_hash_scalar(d, i);
     const R_len_t key = d->key[hash];
 
     if (key == DICT_EMPTY) {


### PR DESCRIPTION
Closes https://github.com/r-lib/vctrs/issues/1133

I am very happy to report that I figured out how to fix #1133. It turns out that we just needed to consistently use `uint32_t` for the `size` and `hash` value results.

As mentioned in #1133, when `x` has size `1e9`, this resulted in our `ceil2()` call of `ceil2(vec_size(x) / 0.77)` overflowing, since it tried to compute `2 ^ 31 = 2147483648`, which is 1 larger than `INT_MAX`. Since `ceil2()` takes and returns `int32_t`, it overflowed. Really it should take and return a `uint32_t`, since that is what the `size` member of the dictionary is stored as. This prevents us from overflowing, since the max `uint32_t` value is `2 ^ 32 - 1`.

Additionally, if a vector has a size greater than `2147483648 * .77 = 1653562409`, we'd have an additional issue where `ceil2(vec_size(x) / 0.77)` would try to theoretically compute and return `2 ^ 32`, which is 1 larger than `UINT_MAX`. To fix this, I've capped the `vec_size(x) / 0.77` value to `INT_MAX`, meaning that the maximum key size that can be computed is `2 ^ 31`. Since we only support short vectors right now, this should never be an issue, it just means that the maximum load factor will be greater than 77% for those vectors.

Here is a reprex for the original issue, which works now:

```r
library(vctrs)

N <- 1e9
K <- 1e2L

set.seed(108)

x <- sample(sprintf("id%03d",1:K), N, TRUE)

tictoc::tic()
zz <- vec_group_loc(x)
tictoc::toc()
#> 30.779 sec elapsed
```

I also rented an EC2 instance with 60gb of RAM to test out this much beefier example of using a vector with the maximum "short" length, and a _lot_ of groups. It also works now (but it takes a loooong time to run). The second commit here regarding capping the key size was required to allow this to work.

```r
library(vctrs)

N <- .Machine$integer.max
K <- 1e8L

set.seed(108)

x <- sample(1:K, N, TRUE)

zz <- vec_group_loc(x)
```