### PR TITLE
Avoid overly large default group size allocation

### DIFF
--- a/src/order-groups.c
+++ b/src/order-groups.c
@@ -108,11 +108,6 @@ void groups_size_push(r_ssize size, struct group_infos* p_group_infos) {
  */
 static
 void group_realloc(r_ssize size, struct group_info* p_group_info) {
-  // First allocation
-  if (size == 0) {
-    size = GROUP_DATA_SIZE_DEFAULT;
-  }
-
   // Reallocate
   p_group_info->data = int_resize(
     p_group_info->data,
@@ -134,8 +129,15 @@ void group_realloc(r_ssize size, struct group_info* p_group_info) {
 
 static
 r_ssize groups_realloc_size(r_ssize data_size, r_ssize max_data_size) {
-  // Avoid potential overflow when doubling size
-  uint64_t new_data_size = ((uint64_t) data_size) * 2;
+  uint64_t new_data_size;
+
+  if (data_size == 0) {
+    // First allocation
+    new_data_size = GROUP_DATA_SIZE_DEFAULT;
+  } else {
+    // Avoid potential overflow when doubling size
+    new_data_size = ((uint64_t) data_size) * 2;
+  }
 
   // Clamp maximum allocation size to the size of the input
   if (new_data_size > max_data_size) {

--- a/src/order-groups.h
+++ b/src/order-groups.h
@@ -19,7 +19,7 @@
 
 // This seems to be a reasonable default to start with for tracking group sizes
 // and is what base R uses. It is expanded by 2x every time we need to
-// reallocate.
+// reallocate. It is also capped to the size of `x`.
 #define GROUP_DATA_SIZE_DEFAULT 100000
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Previously, we accidentally always defaulted to a group size of 100,000 when groups were requested (like they are in `vec_order_info()`) even if the input was much smaller than that. The default group size should always get capped to the size of the input. This PR ensures that that is now the case.

Related to #1361 discussion about sort based methods being slower than hash based methods for small input. They should be a little closer now for very small input.

``` r
library(vctrs)
vec_order_info <- vctrs:::vec_order_info

x <- 1L

# before (look at memory allocated)
bench::mark(vec_order_info(x), iterations = 1000000)
#> # A tibble: 1 x 6
#>   expression             min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_order_info(x)    2.2µs   3.06µs   316627.     391KB    2513.

# after
bench::mark(vec_order_info(x), iterations = 1000000)
#> # A tibble: 1 x 6
#>   expression             min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_order_info(x)   2.02µs   2.51µs   375323.      240B     53.3
```

<sup>Created on 2021-04-15 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>