### PR TITLE
Reexport `s3_register()` from rlang if available

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,3 +1,23 @@
+on_load <- function(expr, env = parent.frame()) {
+  ns <- topenv(env)
+  expr <- substitute(expr)
+  callback <- function() eval_bare(expr, env)
+  ns$.__rlang_hook__. <- c(ns$.__rlang_hook__., list(callback))
+}
+
+run_on_load <- function(env = caller_env()) {
+  ns <- topenv(env)
+
+  hook <- ns$.__rlang_hook__.
+  env_unbind(ns, ".__rlang_hook__.")
+
+  for (callback in hook) {
+    callback()
+  }
+
+  ns$.__rlang_hook__. <- NULL
+}
+
 
 # nocov start
 

--- a/R/register-s3.R
+++ b/R/register-s3.R
@@ -112,6 +112,14 @@ s3_register <- function(generic, class, method = NULL) {
   invisible()
 }
 
+# Replace by rlang's version once it is available
+on_load({
+  if ("s3_register" %in% getNamespaceImports("vctrs")$rlang) {
+    s3_register <- rlang::s3_register
+  }
+})
+
+
 knitr_defer <- function(expr, env = caller_env()) {
   roxy_caller <- detect(sys.frames(), env_inherits, ns_env("knitr"))
   if (is_null(roxy_caller)) {

--- a/R/register-s3.R
+++ b/R/register-s3.R
@@ -115,7 +115,7 @@ s3_register <- function(generic, class, method = NULL) {
 # Replace by rlang's version once it is available
 on_load({
   if ("s3_register" %in% getNamespaceImports("vctrs")$rlang) {
-    s3_register <- rlang::s3_register
+    s3_register <- evalq(s3_register, ns_env("rlang"))
   }
 })
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,6 +13,8 @@ on_package_load <- function(pkg, expr) {
   check_linked_version(pkgname)
   ns <- ns_env("vctrs")
 
+  run_on_load()
+
   on_package_load("testthat", {
     s3_register("testthat::is_informative_error", "vctrs_error_cast_lossy")
     s3_register("testthat::is_informative_error", "vctrs_error_cast_lossy_dropped")


### PR DESCRIPTION
In prevision of exporting `s3_register()` from rlang (r-lib/rlang#1161).

The `s3_register()` binding in the vctrs namespace is replaced by the one in rlang but only if rlang exports it. The goal is to avoid this sort of conflict warning:

```r
invisible(rlang::is_installed("funs"))
#> Warning message:
#> replacing previous import ‘rlang::s3_register’ by ‘vctrs::s3_register’ when loading ‘funs’
```

Unfortunately the warning will still appear if rlang is updated but not vctrs, so we should probably wait for a while before going through with the export @hadley?