### PR TITLE
Use `vec_rank()` within `xtfrm.vctrs_vctr()` to avoid breaking ties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* The `xtfrm()` method for vctrs_vctr objects no longer accidentally breaks
+  ties (#1354).
+
 * `min()`, `max()` and `range()` no longer throw an error if `na.rm = TRUE` is
   set and all values are `NA` (@gorcha, #1357). In this case, and where an empty
   input is given, it will return `Inf`/`-Inf`, or `NA` if `Inf` can't be cast

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -446,17 +446,20 @@ anyDuplicated.vctrs_vctr <- function(x, incomparables = FALSE, ...) {
 #' @export
 xtfrm.vctrs_vctr <- function(x) {
   proxy <- vec_proxy_order(x)
+  type <- typeof(proxy)
 
-  if (is.object(proxy) && typeof(proxy) %in% c("integer", "double", "character")) {
+  if (type == "logical") {
     proxy <- unstructure(proxy)
+    proxy <- as.integer(proxy)
+    return(proxy)
   }
 
-  # order(order(x)) ~= rank(x)
-  if (typeof(proxy) %in% c("integer", "double")) {
-    proxy
-  } else {
-    vec_order(vec_order(proxy))
+  if (type %in% c("integer", "double")) {
+    proxy <- unstructure(proxy)
+    return(proxy)
   }
+
+  vec_rank(proxy, ties = "dense", na_propagate = TRUE)
 }
 
 #' @importFrom stats median

--- a/tests/testthat/test-type-vctr.R
+++ b/tests/testthat/test-type-vctr.R
@@ -577,12 +577,37 @@ test_that("generic predicates return logical vectors (#251)", {
   expect_identical(all(x), TRUE)
 })
 
-test_that("xtfrm() returns a bare vector", {
+test_that("xtfrm() converts logical types to integer", {
+  expect_identical(xtfrm(new_vctr(c(TRUE, FALSE, NA), foo = "bar")), c(1L, 0L, NA))
+})
+
+test_that("xtfrm() unwraps integer and double atomic types", {
   expect_identical(xtfrm(new_vctr(1:3, foo = "bar")), 1:3)
+  expect_identical(xtfrm(new_vctr(1:3 + 0, foo = "bar")), 1:3 + 0)
 })
 
 test_that("xtfrm() works with character subclass", {
   expect_identical(xtfrm(new_vctr(chr())), int())
+})
+
+test_that("xtfrm() maintains ties when falling through to vec_rank() (#1354)", {
+  x <- new_vctr(c("F", "F", "M", "A", "M", "A"))
+  expect_identical(xtfrm(x), c(2L, 2L, 3L, 1L, 3L, 1L))
+})
+
+test_that("xtfrm() propagates NAs when falling through to vec_rank()", {
+  x <- new_vctr(c("F", NA))
+  expect_identical(xtfrm(x), c(1L, NA))
+})
+
+test_that("xtfrm() uses C locale ordering with character proxies", {
+  x <- new_vctr(c("A", "a", "B"))
+  expect_identical(xtfrm(x), c(1L, 3L, 2L))
+})
+
+test_that("xtfrm() works on rcrd types", {
+  x <- new_rcrd(list(x = c(1, 2, 1, NA), y = c(2, 1, 1, NA)))
+  expect_identical(xtfrm(x), c(2L, 3L, 1L, NA))
 })
 
 test_that("Summary generics behave as expected if na.rm = TRUE and all values are NA (#1357)", {


### PR DESCRIPTION
Closes #1354 

Refactored a little, but mainly we switch from:

```r
vec_order(vec_order(proxy))
```

to

```r
vec_rank(proxy, ties = "dense", na_propagate = TRUE)
```

to ensure that we don't break ties when computing the xtfrm proxy (as described in https://github.com/r-lib/vctrs/issues/1354#issuecomment-815155065)