### PR TITLE
Fix memory leak of strings_posixt

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1667,7 +1667,7 @@ void vctrs_init_utils(SEXP ns) {
   SET_STRING_ELT(strings, 4, strings_posixlt);
 
   strings_posixt = Rf_mkChar("POSIXt");
-  SET_STRING_ELT(strings, 5, strings_posixlt);
+  SET_STRING_ELT(strings, 5, strings_posixt);
 
   strings_none = Rf_mkChar("none");
   SET_STRING_ELT(strings, 6, strings_none);


### PR DESCRIPTION
This PR fixes #1384 - correctly insert `strings_posixt` into `strings` so that it is protected against garbage collection.