### PR TITLE
Change `vec_rank(na_propagate = TRUE)` to use completeness

### DIFF
--- a/R/rank.R
+++ b/R/rank.R
@@ -10,6 +10,9 @@
 #' `nan_distinct = FALSE`, `NaN` values are given the same rank as `NA`,
 #' otherwise they are given a rank that differentiates them from `NA`.
 #'
+#' For data frames, `na_propagate = TRUE` will propagate a missing value if
+#' any row is incomplete, as determined by [vec_detect_complete()].
+#'
 #' Like [vec_order_radix()], ordering is done in the C-locale. This can affect
 #' the ranks of character vectors, especially regarding how uppercase and
 #' lowercase letters are ranked. See the Details section of [vec_order_radix()]

--- a/src/complete.c
+++ b/src/complete.c
@@ -1,5 +1,4 @@
-#include <rlang.h>
-#include "vctrs.h"
+#include "complete.h"
 #include "equal.h"
 #include "type-data-frame.h"
 
@@ -32,8 +31,6 @@ SEXP vctrs_locate_complete(SEXP x) {
   return vec_locate_complete(x);
 }
 
-static SEXP vec_detect_complete(SEXP x);
-
 static
 SEXP vec_locate_complete(SEXP x) {
   SEXP where = PROTECT(vec_detect_complete(x));
@@ -51,7 +48,7 @@ SEXP vctrs_detect_complete(SEXP x) {
 
 static inline void vec_detect_complete_switch(SEXP x, R_len_t size, int* p_out);
 
-static
+// [[ include("complete.h") ]]
 SEXP vec_detect_complete(SEXP x) {
   SEXP proxy = PROTECT(vec_proxy_complete(x));
 

--- a/src/complete.h
+++ b/src/complete.h
@@ -1,0 +1,9 @@
+#ifndef VCTRS_COMPLETE_H
+#define VCTRS_COMPLETE_H
+
+#include <rlang.h>
+#include "vctrs.h"
+
+SEXP vec_detect_complete(SEXP x);
+
+#endif

--- a/src/decl/rank-decl.h
+++ b/src/decl/rank-decl.h
@@ -1,6 +1,6 @@
 static inline enum ties parse_ties(r_obj* ties);
 
-static inline bool r_lgl_any(r_obj* x);
+static inline bool r_lgl_all(r_obj* x);
 
 static r_obj* vec_rank(r_obj* x,
                        enum ties ties_type,

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -98,7 +98,8 @@ test_that("C code doesn't crash with bad inputs", {
 
 test_that("xtfrm.vctrs_vctr works for variety of base classes", {
   df <- data.frame(x = c(NA, 1, 1), y = c(1, 2, 1))
-  expect_equal(xtfrm.vctrs_vctr(df), c(3, 2, 1))
+  # Internally uses `vec_rank()`, which propagates rows if not "complete"
+  expect_equal(xtfrm.vctrs_vctr(df), c(NA, 2, 1))
 
   x <- c(2, 3, 1)
   expect_equal(xtfrm.vctrs_vctr(x), x)

--- a/tests/testthat/test-rank.R
+++ b/tests/testthat/test-rank.R
@@ -78,17 +78,17 @@ test_that("can control the direction per column", {
   )
 })
 
-test_that("completely missing rows can propagate NA", {
+test_that("NA propagation occurs if ANY row has a missing value (i.e. uses `vec_detect_complete()`)", {
   df <- data_frame(
-    x = c(1, NA, NA),
-    y = c(NA, NA, 1)
+    x = c(1, NA, NA, 1),
+    y = c(NA, NA, 1, 1)
   )
 
-  expect_identical(vec_rank(df, na_propagate = TRUE), c(1L, NA, 2L))
-  expect_identical(vec_rank(df, na_propagate = TRUE, direction = "desc"), c(2L, NA, 1L))
+  expect_identical(vec_rank(df, na_propagate = TRUE), c(NA, NA, NA, 1L))
+  expect_identical(vec_rank(df, na_propagate = TRUE, direction = "desc"), c(NA, NA, NA, 1L))
 })
 
-test_that("partially missing rows are controlled by `na_value`", {
+test_that("can control `na_value` per column", {
   df <- data_frame(
     x = c(1, 1, NA, NA, NA),
     y = c(3, NA, NA, 2, 1)
@@ -99,17 +99,18 @@ test_that("partially missing rows are controlled by `na_value`", {
     c(2L, 1L, 3L, 5L, 4L)
   )
   expect_identical(
-    vec_rank(df, na_value = c("largest", "smallest"), na_propagate = TRUE),
-    c(2L, 1L, NA, 4L, 3L)
-  )
-
-  expect_identical(
     vec_rank(df, na_value = c("largest", "smallest"), direction = "desc"),
     c(4L, 5L, 3L, 1L, 2L)
   )
+
+  # But `na_propagate = TRUE` overrules it
+  expect_identical(
+    vec_rank(df, na_value = c("largest", "smallest"), na_propagate = TRUE),
+    c(1L, NA, NA, NA, NA)
+  )
   expect_identical(
     vec_rank(df, na_value = c("largest", "smallest"), na_propagate = TRUE, direction = "desc"),
-    c(3L, 4L, NA, 1L, 2L)
+    c(1L, NA, NA, NA, NA)
   )
 })
 


### PR DESCRIPTION
As discussed over slack, it generally makes more sense for `vec_rank()` to use completeness for determining whether or not to propagate NA. This makes it more in line with `vec_match()`, which will allow us to use `vec_rank()` for `vec_matches()`.

``` r
df <- data.frame(x = c(1, NA, NA), y = c(NA, 1, NA))
df
#>    x  y
#> 1  1 NA
#> 2 NA  1
#> 3 NA NA

# Before
vctrs:::vec_rank(df, na_propagate = TRUE)
#> [1]  1  2 NA

# After
vctrs:::vec_rank(df, na_propagate = TRUE)
#> [1] NA NA NA
```

<sup>Created on 2021-06-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>