### PR TITLE
Return the maximum group size from `vec_order_info()`

### DIFF
--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -299,10 +299,11 @@ SEXP vec_order_locs(SEXP x, SEXP direction, SEXP na_value, bool nan_distinct, SE
 // -----------------------------------------------------------------------------
 
 /*
- * Returns a list of size two.
+ * Returns a list of size three.
  * - The first element of the list contains the ordering as an integer vector.
  * - The second element of the list contains the group sizes as an integer
  *   vector.
+ * - The third element of the list contains the max group size as an integer.
  */
 // [[ include("order-radix.h") ]]
 SEXP vec_order_info(SEXP x,
@@ -456,7 +457,7 @@ SEXP vec_order_info_impl(SEXP x,
     p_truelength_info
   );
 
-  SEXP out = PROTECT_N(r_alloc_list(2), &n_prot);
+  SEXP out = PROTECT_N(r_alloc_list(3), &n_prot);
   r_list_poke(out, 0, p_order->data);
 
   if (group_sizes) {
@@ -464,6 +465,7 @@ SEXP vec_order_info_impl(SEXP x,
     SEXP sizes = p_group_info->data;
     sizes = r_int_resize(sizes, p_group_info->n_groups);
     r_list_poke(out, 1, sizes);
+    r_list_poke(out, 2, r_int((int) p_group_info->max_group_size));
   }
 
   UNPROTECT(n_prot);

--- a/tests/testthat/test-order-radix.R
+++ b/tests/testthat/test-order-radix.R
@@ -1108,6 +1108,7 @@ test_that("can order character vectors in appearance order", {
 
   expect_identical(info[[1]], c(1L, 2L, 5L, 3L, 4L))
   expect_identical(info[[2]], c(1L, 2L, 2L))
+  expect_identical(info[[3]], 2L)
 })
 
 test_that("using appearance order means `direction` has no effect", {
@@ -1118,6 +1119,7 @@ test_that("using appearance order means `direction` has no effect", {
 
   expect_identical(info1[[1]], info2[[1]])
   expect_identical(info1[[2]], info2[[2]])
+  expect_identical(info1[[3]], info2[[3]])
 })
 
 test_that("appearance order works with NA - `na_value` has no effect", {
@@ -1126,6 +1128,7 @@ test_that("appearance order works with NA - `na_value` has no effect", {
 
   expect_identical(info[[1]], c(1L, 3L, 2L, 4L))
   expect_identical(info[[2]], c(2L, 1L, 1L))
+  expect_identical(info[[3]], 2L)
 })
 
 test_that("appearance order can be mixed with regular ordering", {
@@ -1138,4 +1141,17 @@ test_that("appearance order can be mixed with regular ordering", {
 
   expect_identical(info[[1]], c(1L, 5L, 2L, 6L, 3L, 4L))
   expect_identical(info[[2]], c(1L, 1L, 2L, 1L, 1L))
+  expect_identical(info[[3]], 2L)
+})
+
+# ------------------------------------------------------------------------------
+# `vec_order_info(nan_distinct = FALSE)`
+
+test_that("Indistinct NA and NaN are reported in the same group", {
+  x <- c(NA, NaN)
+  info <- vec_order_info(x, nan_distinct = FALSE)
+
+  expect_identical(info[[1]], c(1L, 2L))
+  expect_identical(info[[2]], 2L)
+  expect_identical(info[[3]], 2L)
 })


### PR DESCRIPTION
This is useful since it is a proxy for whether or not there are duplicate values in the data.