### PR TITLE
fast path for edge cases times = 0 or 1 or x_size = 1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* `vec_rep()` and `vec_rep_each()` are much faster for `times = 0` and
+  `times = 1` (@mgirlich, #1392).
+
 * `vec_equal_na()` and `vec_fill_missing()` now work with integer64 vectors
   (#1304).
 

--- a/src/rep.c
+++ b/src/rep.c
@@ -39,8 +39,16 @@ SEXP vctrs_rep(SEXP x, SEXP times) {
 static SEXP vec_rep(SEXP x, int times) {
   check_rep_times(times);
 
+  if (times == 1) {
+    return x;
+  }
+
   const R_len_t times_ = (R_len_t) times;
   const R_len_t x_size = vec_size(x);
+
+  if (x_size == 1) {
+    return vec_recycle(x, times_, args_empty);
+  }
 
   if (multiply_would_overflow(x_size, times_)) {
     stop_rep_size_oob();
@@ -86,7 +94,14 @@ static SEXP vec_rep_each(SEXP x, SEXP times) {
 
   if (times_size == 1) {
     const int times_ = r_int_get(times, 0);
-    out = vec_rep_each_uniform(x, times_);
+
+    if (times_ == 1) {
+      out = x;
+    } else if (times_ == 0) {
+      out = vec_ptype(x, args_empty);
+    } else {
+      out = vec_rep_each_uniform(x, times_);
+    }
   } else {
     out = vec_rep_each_impl(x, times, times_size);
   }

--- a/tests/testthat/test-rep.R
+++ b/tests/testthat/test-rep.R
@@ -15,6 +15,14 @@ test_that("`vec_rep()` can repeat 0 `times`", {
   expect_identical(vec_rep(1, 0), numeric())
 })
 
+test_that("`vec_rep()` can repeat 1 `time`", {
+  expect_identical(vec_rep(1:3, 1), 1:3)
+})
+
+test_that("`vec_rep()` can repeat `x` of size 1", {
+  expect_identical(vec_rep(1, 2), c(1, 1))
+})
+
 test_that("`vec_rep()` errors on long vector output", {
   # Exact error message may be platform specific
   expect_error(vec_rep(1:2, .Machine$integer.max), "output size must be less than")
@@ -46,6 +54,10 @@ test_that("`vec_rep_each()` repeats data frames row wise", {
 
 test_that("`vec_rep_each()` can repeat 0 `times`", {
   expect_identical(vec_rep_each(1:2, 0), integer())
+})
+
+test_that("`vec_rep_each()` can repeat 1 `time`", {
+  expect_identical(vec_rep_each(1:2, 1), 1:2)
 })
 
 test_that("`vec_rep_each()` errors on long vector output", {


### PR DESCRIPTION
Fixes #1392 

## Benchmarks
```r
library(vctrs)

x <- 1L + seq(10e6)

bench::mark(
  vec_rep1 = vec_rep(x, 1),
  vec_rep0 = vec_rep(x, 0),
  vec_rep_each1 = vec_rep_each(x, 1),
  vec_rep_each0 = vec_rep_each(x, 0),
  vec_rep_x1 = vec_rep(1L, 100e6),
  rep_x1 = rep(1L, 100e6),
  rep.int_x1 = rep.int(1L, 100e6),
  check = FALSE
)

# This PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 7 x 13
#>   expression        min  median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result
#>   <bch:expr>    <bch:t> <bch:t>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>
#> 1 vec_rep1        772ns   882ns 928978.          0B     0    10000     0     10.8ms <NULL>
#> 2 vec_rep0        800ns   890ns 966806.          0B     0    10000     0     10.3ms <NULL>
#> 3 vec_rep_each1   767ns   876ns 982103.          0B     0    10000     0     10.2ms <NULL>
#> 4 vec_rep_each0   796ns   894ns 801876.          0B     0    10000     0     12.5ms <NULL>
#> 5 vec_rep_x1      127ms   134ms      7.31     381MB     7.31     4     4      547ms <NULL>
#> 6 rep_x1          126ms   131ms      7.62     381MB     7.62     4     4    525.2ms <NULL>

# CRAN
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 7 x 13
#>   expression         min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm>
#> 1 vec_rep1       11.84ms  14.66ms     44.0     76.3MB    11.5     23     6    522.4ms
#> 2 vec_rep0         834ns    911ns 921936.          0B     0    10000     0     10.8ms
#> 3 vec_rep_each1  19.52ms  21.02ms     29.7     76.3MB     5.93    15     3    505.8ms
#> 4 vec_rep_each0   5.61ms   5.81ms    172.          0B     0       86     0    500.2ms
#> 5 vec_rep_x1    206.72ms 228.49ms      4.46   762.9MB     4.46     3     3      672ms
#> 6 rep_x1         97.12ms 138.09ms      7.40   381.5MB     3.70     4     2    540.8ms
```