### PR TITLE
Fix OOB detection in `r__intmax_subtract()`

### DIFF
--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -1268,7 +1268,7 @@ void int_compute_range(const int* p_x,
    * - We need to go up to `intmax_t` to avoid intermediate overflow.
    * - `+ 1` to get an inclusive range on both ends.
    */
-  range = (uint32_t) intmax_add(intmax_subtract(x_max, x_min), 1);
+  range = (uint32_t) r__intmax_add(r__intmax_subtract(x_max, x_min), 1);
 
   *p_x_min = x_min;
   *p_range = range;

--- a/src/rlang/c-utils.h
+++ b/src/rlang/c-utils.h
@@ -34,7 +34,7 @@ intmax_t r__intmax_add(intmax_t x, intmax_t y) {
 static inline
 intmax_t r__intmax_subtract(intmax_t x, intmax_t y) {
   if ((y > 0 && x < (INTMAX_MIN + y)) ||
-      (y < 0 && x < (INTMAX_MAX + y))) {
+      (y < 0 && x > (INTMAX_MAX + y))) {
     r_stop_internal("intmax_subtract", "Subtraction resulted in overflow or underflow.");
   }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -393,26 +393,6 @@ static inline const void* vec_type_missing_value(enum vctrs_type type) {
 void c_print_backtrace();
 
 
-// Adapted from CERT C coding standards
-static inline
-intmax_t intmax_add(intmax_t x, intmax_t y) {
-  if ((y > 0 && x > (INTMAX_MAX - y)) ||
-      (y < 0 && x < (INTMAX_MIN - y))) {
-    r_stop_internal("intmax_add", "Values too large to be added.");
-  }
-
-  return x + y;
-}
-static inline
-intmax_t intmax_subtract(intmax_t x, intmax_t y) {
-  if ((y > 0 && x < (INTMAX_MIN + y)) ||
-      (y < 0 && x < (INTMAX_MAX + y))) {
-    r_stop_internal("intmax_subtract", "Subtraction resulted in overflow or underflow.");
-  }
-
-  return x - y;
-}
-
 SEXP chr_c(SEXP x, SEXP y);
 
 

--- a/tests/testthat/test-order-radix.R
+++ b/tests/testthat/test-order-radix.R
@@ -199,6 +199,11 @@ test_that("can order with many NAs first", {
   expect_identical(vec_order_radix(x, na_value = "smallest"), base_order(x, na.last = FALSE))
 })
 
+test_that("subtraction in counting order range computation works correctly (#1399)", {
+  x <- c(rep(1L, ORDER_INSERTION_BOUNDARY), -2147483647L)
+  expect_identical(vec_order_radix(x), base_order(x))
+})
+
 # ------------------------------------------------------------------------------
 # vec_order_radix(<logical>)
 


### PR DESCRIPTION
Closes #1399 

Also removes our current intmax utilities in favor of the rlang ones