### PR TITLE
Revise `vec_detect_complete()` to treat rcrds like data frames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # vctrs (development version)
 
+* `vec_detect_complete()` now computes completeness for `vctrs_rcrd` types in
+  the same way as data frames, which means that if any field is missing, the
+  entire record is considered incomplete (#1386).
+  
 * The `na_value` argument of `vec_order()` and `vec_sort()` now correctly
   respect missing values in lists (#1401).
 

--- a/R/complete.R
+++ b/R/complete.R
@@ -10,8 +10,8 @@
 #' rows that are partially complete (they have at least one non-missing value).
 #'
 #' @details
-#' A [record][new_rcrd] type vector is considered complete if any field is
-#' non-missing.
+#' A [record][new_rcrd] type vector is similar to a data frame, and is only
+#' considered complete if all fields are non-missing.
 #'
 #' @param x A vector
 #'
@@ -49,8 +49,4 @@ vec_slice_complete <- function(x) {
 
 vec_locate_complete <- function(x) {
   .Call(vctrs_locate_complete, x)
-}
-
-vec_proxy_complete <- function(x) {
-  .Call(vctrs_proxy_complete, x)
 }

--- a/man/vec_detect_complete.Rd
+++ b/man/vec_detect_complete.Rd
@@ -22,8 +22,8 @@ elements of that row are non-missing. To compare, \code{!vec_equal_na(x)} detect
 rows that are partially complete (they have at least one non-missing value).
 }
 \details{
-A \link[=new_rcrd]{record} type vector is considered complete if any field is
-non-missing.
+A \link[=new_rcrd]{record} type vector is similar to a data frame, and is only
+considered complete if all fields are non-missing.
 }
 \examples{
 x <- c(1, 2, NA, 4, NA)

--- a/src/complete.c
+++ b/src/complete.c
@@ -50,7 +50,7 @@ static inline void vec_detect_complete_switch(SEXP x, R_len_t size, int* p_out);
 
 // [[ include("complete.h") ]]
 SEXP vec_detect_complete(SEXP x) {
-  SEXP proxy = PROTECT(vec_proxy_complete(x));
+  SEXP proxy = PROTECT(vec_proxy_equal(x));
 
   R_len_t size = vec_size(proxy);
 

--- a/src/init.c
+++ b/src/init.c
@@ -59,7 +59,6 @@ extern SEXP vec_proxy(SEXP);
 extern SEXP vec_proxy_equal(SEXP);
 extern SEXP vec_proxy_compare(SEXP);
 extern SEXP vec_proxy_order(SEXP);
-extern SEXP vec_proxy_complete(SEXP);
 extern SEXP vctrs_df_proxy(SEXP, SEXP);
 extern SEXP vctrs_unspecified(SEXP);
 extern SEXP vctrs_ptype(SEXP, SEXP);
@@ -213,7 +212,6 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_proxy_equal",                (DL_FUNC) &vec_proxy_equal, 1},
   {"vctrs_proxy_compare",              (DL_FUNC) &vec_proxy_compare, 1},
   {"vctrs_proxy_order",                (DL_FUNC) &vec_proxy_order, 1},
-  {"vctrs_proxy_complete",             (DL_FUNC) &vec_proxy_complete, 1},
   {"vctrs_df_proxy",                   (DL_FUNC) &vctrs_df_proxy, 2},
   {"vctrs_unspecified",                (DL_FUNC) &vctrs_unspecified, 1},
   {"vctrs_ptype",                      (DL_FUNC) &vctrs_ptype, 2},

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -73,52 +73,6 @@ SEXP vec_proxy_order(SEXP x) {
   return out;
 }
 
-static SEXP df_proxy(SEXP x, enum vctrs_proxy_kind kind);
-
-/*
- * Specialized internal variant of `vec_proxy_equal()` that returns an
- * alternative proxy for non data frame input that has a data frame proxy.
- * These are special cased under the heuristic that the entire row has to be
- * missing to be considered "incomplete". The easiest way to generate a
- * completeness proxy following this heuristic is to generate a logical vector
- * marked with `NA` where that row is completely missing.
- */
-// [[ register() ]]
-SEXP vec_proxy_complete(SEXP x) {
-  if (is_data_frame(x)) {
-    return df_proxy(x, VCTRS_PROXY_KIND_complete);
-  }
-
-  SEXP proxy = PROTECT(vec_proxy_equal(x));
-
-  // Arrays have stopgap data frame proxies,
-  // but their completeness rules match normal data frames
-  if (has_dim(x)) {
-    UNPROTECT(1);
-    return proxy;
-  }
-
-  if (!is_data_frame(proxy)) {
-    UNPROTECT(1);
-    return proxy;
-  }
-
-  SEXP out = PROTECT(vec_equal_na(proxy));
-  int* p_out = LOGICAL(out);
-
-  r_ssize size = r_length(out);
-
-  for (r_ssize i = 0; i < size; ++i) {
-    if (p_out[i]) {
-      p_out[i] = NA_LOGICAL;
-    }
-  }
-
-  UNPROTECT(2);
-  return out;
-}
-
-
 SEXP vec_proxy_method(SEXP x) {
   return s3_find_method("vec_proxy", x, vctrs_method_table);
 }
@@ -217,7 +171,6 @@ SEXP df_proxy(SEXP x, enum vctrs_proxy_kind kind) {
   case VCTRS_PROXY_KIND_equal: DF_PROXY(vec_proxy_equal); break;
   case VCTRS_PROXY_KIND_compare: DF_PROXY(vec_proxy_compare); break;
   case VCTRS_PROXY_KIND_order: DF_PROXY(vec_proxy_order); break;
-  case VCTRS_PROXY_KIND_complete: DF_PROXY(vec_proxy_complete); break;
   }
 
   x = PROTECT(df_flatten(x));

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -352,15 +352,13 @@ enum vctrs_proxy_kind {
   VCTRS_PROXY_KIND_default,
   VCTRS_PROXY_KIND_equal,
   VCTRS_PROXY_KIND_compare,
-  VCTRS_PROXY_KIND_order,
-  VCTRS_PROXY_KIND_complete
+  VCTRS_PROXY_KIND_order
 };
 
 SEXP vec_proxy(SEXP x);
 SEXP vec_proxy_equal(SEXP x);
 SEXP vec_proxy_compare(SEXP x);
 SEXP vec_proxy_order(SEXP x);
-SEXP vec_proxy_complete(SEXP x);
 SEXP vec_restore(SEXP x, SEXP to, SEXP n, const enum vctrs_owned owned);
 SEXP vec_restore_default(SEXP x, SEXP to, const enum vctrs_owned owned);
 R_len_t vec_size(SEXP x);

--- a/tests/testthat/test-complete.R
+++ b/tests/testthat/test-complete.R
@@ -78,14 +78,14 @@ test_that("takes the equality proxy", {
   expect_identical(vec_detect_complete(df), expect)
 })
 
-test_that("columns with a data frame proxy are only incomplete if all rows are incomplete", {
+test_that("columns with a data frame proxy are incomplete if any columns of the proxy are incomplete", {
   df <- data_frame(
-    x = c(NA, 1, 2, 3),
-    y = new_rcrd(list(a = c(1, 1, NA, NA), b = c(2, 2, 2, NA))),
-    z = new_rcrd(list(a = c(1, NA, 1, 1), b = c(2, NA, NA, 1)))
+    x = c(NA, 0, 1, 2, 3),
+    y = new_rcrd(list(a = c(1, 1, 1, NA, NA), b = c(2, 2, 2, 2, NA))),
+    z = new_rcrd(list(a = c(1, 1, NA, 1, 1), b = c(2, 2, NA, NA, 1)))
   )
 
-  expect_identical(vec_detect_complete(df), c(FALSE, FALSE, TRUE, FALSE))
+  expect_identical(vec_detect_complete(df), c(FALSE, TRUE, FALSE, FALSE, FALSE))
 })
 
 test_that("can have rcrd fields of all types", {
@@ -112,39 +112,4 @@ test_that("works with arrays", {
 
   expect_identical(vec_detect_complete(x), c(TRUE, FALSE))
   expect_identical(vec_detect_complete(y), c(TRUE, FALSE))
-})
-
-# vec_proxy_complete -----------------------------------------------------------
-
-test_that("generally returns equality proxy", {
-  x <- 1:5
-  y <- as.POSIXlt("2019-01-01") + 1:5
-
-  expect_identical(vec_proxy_complete(x), vec_proxy_equal(x))
-  expect_identical(vec_proxy_complete(y), vec_proxy_equal(y))
-  expect_identical(vec_proxy_complete(mtcars), vec_proxy_equal(mtcars))
-})
-
-test_that("returns equality proxy with arrays", {
-  x <- array(1)
-  y <- array(1, c(2, 2))
-  z <- array(1, c(2, 2, 2))
-
-  expect_identical(vec_proxy_complete(x), vec_proxy_equal(x))
-  expect_identical(vec_proxy_complete(y), vec_proxy_equal(y))
-  expect_identical(vec_proxy_complete(z), vec_proxy_equal(z))
-})
-
-test_that("non data frame input that has a data frame equality proxy has the correct completeness proxy", {
-  x <- 1:2
-  y <- new_rcrd(list(a = c(NA, 1), b = c(NA, NA)))
-  z <- data_frame(c = 1:2, d = 3:4)
-
-  df <- data_frame(x = x, y = y, z = z)
-
-  y_expect <- c(NA, FALSE)
-  df_expect <- data_frame(x = x, y = y_expect, z)
-
-  expect_identical(vec_proxy_complete(y), y_expect)
-  expect_identical(vec_proxy_complete(df), df_expect)
 })

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -300,6 +300,14 @@ test_that("can propagate missing values while matching", {
   expect_identical(vec_match(raw2(0, 1, 0, 2), raw2(2, 0, 1), na_equal = FALSE), c(2L, 3L, 2L, 1L))
 })
 
+test_that("can propagate missingness of incomplete rcrd observations (#1386)", {
+  x <- new_rcrd(list(x = c(1, 1, NA, NA), y = c(1, NA, 1, NA)))
+  expect_identical(vec_match(x, x, na_equal = FALSE), c(1L, NA, NA, NA))
+
+  # Matches `vec_detect_complete()` results
+  expect_identical(vec_detect_complete(x), c(TRUE, FALSE, FALSE, FALSE))
+})
+
 test_that("can propagate NaN as a missing value (#1252)", {
   expect_identical(vec_match(dbl(NaN, NA), c(NaN, NA), na_equal = FALSE), int(NA, NA))
   expect_identical(vec_in(dbl(NaN, NA), c(NaN, NA), na_equal = FALSE), lgl(NA, NA))

--- a/tests/testthat/test-rank.R
+++ b/tests/testthat/test-rank.R
@@ -78,7 +78,7 @@ test_that("can control the direction per column", {
   )
 })
 
-test_that("NA propagation occurs if ANY row has a missing value (i.e. uses `vec_detect_complete()`)", {
+test_that("NA propagation occurs if the observation is incomplete (i.e. uses `vec_detect_complete()`)", {
   df <- data_frame(
     x = c(1, NA, NA, 1),
     y = c(NA, NA, 1, 1)
@@ -86,6 +86,13 @@ test_that("NA propagation occurs if ANY row has a missing value (i.e. uses `vec_
 
   expect_identical(vec_rank(df, na_propagate = TRUE), c(NA, NA, NA, 1L))
   expect_identical(vec_rank(df, na_propagate = TRUE, direction = "desc"), c(NA, NA, NA, 1L))
+
+  x <- new_rcrd(list(
+    x = c(1, 1, NA, NA, 1),
+    y = c(1, NA, 1, NA, 1)
+  ))
+
+  expect_identical(vec_rank(x, na_propagate = TRUE), c(1L, NA, NA, NA, 1L))
 })
 
 test_that("can control `na_value` per column", {


### PR DESCRIPTION
Closes #1386 

This PR aligns the way `vec_detect_complete()` computes completeness for rcrds and data frames. Previously:

For data frames:
- A row is missing if all columns are missing
- A row is incomplete if any columns are missing

For rcrd data frame proxies:
- A row is missing if all columns are missing
- A row is incomplete if all columns are missing

Now, both consider a row as incomplete if _any_ columns are missing.

This makes C level coding around these conventions a bit easier, in particular with functions like `vec_match()` which try to detect completeness on the fly by iterating across the columns of the equality proxy looking to see if any columns are missing. Since rcrd types aren't treated specially anymore, the way this works now aligns with `vec_detect_complete()`.

I believe this also makes a bit more sense in general. I'd argue that the definition of "missing" is what you get from `vec_init(x)`, but the definition of "incomplete" is when any component of your observation has missing information. For example:

- From the vignette, the rational rcrd class has a numerator and denominator. If either one is missing, I’d argue that you have an incomplete record.
- A similar argument can be made for the decimal2 rcrd class, which stores the numbers to the left and right of the decimal as separate integers.
- In base R, the complex type is considered incomplete (by complete.cases()) if either the real or imaginary part is NA.
- I’d argue that if any component of the POSIXlt list is missing, you have an incomplete record because you can’t tell what time it actually is.
- I could make similar arguments for clock types (although in clock I worked hard to ensure that if any field was set to NA, then all were, so I didn’t have to deal with this)