### PR TITLE
Ensure `vec_proxy_order.list()` propagates missing values in the proxy

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* The `na_value` argument of `vec_order()` and `vec_sort()` now correctly
+  respect missing values in lists (#1401).
+
 * `vec_rep()` and `vec_rep_each()` are much faster for `times = 0` and
   `times = 1` (@mgirlich, #1392).
 

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -354,7 +354,11 @@ vec_proxy_order.raw <- function(x, ...) {
 vec_proxy_order.list <- function(x, ...) {
   # Order lists by first appearance.
   # This allows list elements to be grouped in `vec_order()`.
-  vec_duplicate_id(x)
+  # Have to separately ensure missing values are propagated.
+  out <- vec_duplicate_id(x)
+  na <- vec_equal_na(x)
+  out <- vec_assign(out, na, NA_integer_)
+  out
 }
 
 #' @export

--- a/tests/testthat/test-order-radix.R
+++ b/tests/testthat/test-order-radix.R
@@ -771,6 +771,12 @@ test_that("list elements are ordered by first appearance", {
   expect_identical(vec_order_radix(list(1:2, "a", 1:2)), c(1L, 3L, 2L))
 })
 
+test_that("missing values in lists are respected (#1401)", {
+  x <- list(1, NULL, 2, NULL)
+  expect_identical(vec_order_radix(x, na_value = "largest"), c(1L, 3L, 2L, 4L))
+  expect_identical(vec_order_radix(x, na_value = "smallest"), c(2L, 4L, 1L, 3L))
+})
+
 # ------------------------------------------------------------------------------
 # vec_order_radix(<data.frame>) - insertion
 

--- a/tests/testthat/test-order.R
+++ b/tests/testthat/test-order.R
@@ -94,3 +94,10 @@ test_that("can order data frames that don't allow removing the column names (#12
 
   expect_silent(expect_identical(vec_order(df), 1L))
 })
+
+test_that("missing values in lists are respected (#1401)", {
+  x <- list(1, NULL, 2, NULL)
+  expect_identical(vec_order(x, na_value = "largest"), c(1L, 3L, 2L, 4L))
+  expect_identical(vec_order(x, na_value = "smallest"), c(2L, 4L, 1L, 3L))
+})
+


### PR DESCRIPTION
Closes #1401 

I've decided to just patch this with `vec_equal_na()` for now.

In the long run, it might be nice if `vec_duplicate_id()` had a `na_propagate` argument to control this, but that would require changes to the hash and dictionary internals, as the hash code will actually only use `HASH_MISSING` for _incomplete_ data frame rows, not _missing_ data frame rows (this is why we can use it in vec-match, but it doesn't make sense here).