### PR TITLE
Ensure that missing complex values are always grouped together

### DIFF
--- a/R/order-radix.R
+++ b/R/order-radix.R
@@ -30,6 +30,9 @@
 #' Character vectors are always translated to UTF-8 before ordering, and before
 #' any transform is applied by `chr_transform`.
 #'
+#' For complex vectors, if either the real or imaginary component is `NA` or
+#' `NaN`, then the entire observation is considered missing.
+#'
 #' @inheritParams ellipsis::dots_empty
 #'
 #' @param x A vector

--- a/src/order-radix.c
+++ b/src/order-radix.c
@@ -2624,7 +2624,7 @@ uint8_t dbl_extract_uint64_byte(uint64_t x, uint8_t shift) {
 // -----------------------------------------------------------------------------
 
 static inline
-r_complex_t cpl_normalise(r_complex_t x);
+r_complex_t cpl_normalise_missing(r_complex_t x);
 
 /*
  * `cpl_order()` uses the fact that Rcomplex is really just a rcrd
@@ -2670,7 +2670,7 @@ void cpl_order(SEXP x,
 
   // Handle the real portion first
   for (r_ssize i = 0; i < size; ++i) {
-    p_x_chunk_dbl[i] = cpl_normalise(p_x_cpl[i]).r;
+    p_x_chunk_dbl[i] = cpl_normalise_missing(p_x_cpl[i]).r;
   }
 
   /*
@@ -2723,7 +2723,7 @@ void cpl_order(SEXP x,
   // Uses updated ordering to place it in sequential order.
   for (r_ssize i = 0; i < size; ++i) {
     const int loc = p_o[i] - 1;
-    p_x_chunk_dbl[i] = cpl_normalise(p_x_cpl[loc]).i;
+    p_x_chunk_dbl[i] = cpl_normalise_missing(p_x_cpl[loc]).i;
   }
 
   // Iterate over the group chunks from the first pass
@@ -2767,7 +2767,7 @@ void cpl_order(SEXP x,
  * See issue #1403 for more information.
  */
 static inline
-r_complex_t cpl_normalise(r_complex_t x) {
+r_complex_t cpl_normalise_missing(r_complex_t x) {
   const double na = r_globals.na_dbl;
   const double nan = R_NaN;
 
@@ -2795,7 +2795,7 @@ r_complex_t cpl_normalise(r_complex_t x) {
     }
   }
 
-  never_reached("cpl_normalise");
+  never_reached("cpl_normalise_missing");
 }
 
 // -----------------------------------------------------------------------------
@@ -3936,7 +3936,7 @@ static void vec_order_chunk_switch(bool decreasing,
     /* First pass - real */                                    \
     for (r_ssize j = 0; j < group_size; ++j) {                 \
       const int loc = p_o_col[j] - 1;                          \
-      p_x_chunk_col[j] = cpl_normalise(p_col[loc]).r;          \
+      p_x_chunk_col[j] = cpl_normalise_missing(p_col[loc]).r;  \
     }                                                          \
                                                                \
     /* Decrement `i` to rerun column */                        \
@@ -3945,7 +3945,7 @@ static void vec_order_chunk_switch(bool decreasing,
     /* Second pass - imaginary */                              \
     for (r_ssize j = 0; j < group_size; ++j) {                 \
       const int loc = p_o_col[j] - 1;                          \
-      p_x_chunk_col[j] = cpl_normalise(p_col[loc]).i;          \
+      p_x_chunk_col[j] = cpl_normalise_missing(p_col[loc]).i;  \
     }                                                          \
   }                                                            \
 } while (0)


### PR DESCRIPTION
Closes #1403 

Rather than adding a new proxy method, I've fixed this directly in `vec_order_radix()`, as I think that is more appropriate.

In #1403 I mentioned:

> For `nan_distinct = TRUE` combined with the case where you have something like `NaN+NAi` or `NA+NaNi`, we would follow base R's lead of letting `NA` be more infectious than `NaN` - so those two values would both become `NA+NAi`.

I have changed my mind since then. I'm now allowing `NA+NAi`, `NA+NaNi`, `NaN+NAi` and `NaN+NaNi` to all be distinct values, as I think that aligns better with what that argument is generally trying to achieve anyways. I don't think this is that important of a distinction, the main thing is that all 4 types of missingness get grouped together either before any or after all of the non-missing values have appeared.