### PR TITLE
Use `local_reproducible_output()` to force no unicode

### DIFF
--- a/tests/testthat/test-list_of-print.txt
+++ b/tests/testthat/test-list_of-print.txt
@@ -6,7 +6,7 @@
 [1] 2 3
 
 
-# A tibble: 2 × 1
+# A tibble: 2 x 1
             x
   <list<dbl>>
 1         [1]

--- a/tests/testthat/test-type-list-of.R
+++ b/tests/testthat/test-type-list-of.R
@@ -41,8 +41,10 @@ test_that("is_list_of as expected", {
 test_that("print method gives human friendly output", {
   skip_on_cran() # Depends on tibble
 
-  # FIXME: Disable crayon until we switch to testthat 3e
-  local_options(crayon.enabled = FALSE)
+  # FIXME:
+  # Disable crayon until we switch to testthat 3e
+  # Disable unicode in tibble header until we switch to testthat 3e
+  local_reproducible_output(crayon = FALSE, unicode = FALSE)
 
   x <- list_of(1, 2:3)
 


### PR DESCRIPTION
Followup to https://github.com/r-lib/vctrs/commit/fdd274d91993cda888189aed906b041bdfc2942d where I tried to fix the failing test related to the fact that tibble now uses a unicode "times" symbol in the header.

Once we switch to testthat 3e this should be easier to do, but hopefully it passes everywhere now...