### PR TITLE
Move `vec_init()`'s checks on `n` to C

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `vec_init()` is now slightly faster (#1423).
+
 * `vec_set_names()` no longer corrupts `vctrs_rcrd` types (#1419).
 
 * `vec_detect_complete()` now computes completeness for `vctrs_rcrd` types in

--- a/R/slice.R
+++ b/R/slice.R
@@ -232,9 +232,6 @@ vec_index <- function(x, i, ...) {
 #' vec_init(Sys.Date(), 5)
 #' vec_init(mtcars, 2)
 vec_init <- function(x, n = 1L) {
-  n <- vec_cast(n, integer())
-  vec_assert(n, size = 1L)
-
   .Call(vctrs_init, x, n)
 }
 

--- a/src/slice.c
+++ b/src/slice.c
@@ -477,11 +477,7 @@ SEXP vec_init(SEXP x, R_len_t n) {
 // [[ register() ]]
 SEXP vctrs_init(SEXP x, SEXP n) {
   n = PROTECT(vec_cast(n, vctrs_shared_empty_int, args_n, args_empty));
-
-  if (r_length(n) != 1) {
-    r_abort("`n` must have size 1, not size %i.", r_length(n));
-  }
-
+  vec_assert_size(n, 1, args_n);
   R_len_t n_ = r_int_get(n, 0);
 
   SEXP out = vec_init(x, n_);

--- a/src/slice.c
+++ b/src/slice.c
@@ -466,6 +466,10 @@ SEXP vec_slice(SEXP x, SEXP subscript) {
 SEXP vec_init(SEXP x, R_len_t n) {
   vec_assert_vector(x, NULL);
 
+  if (n < 0) {
+    r_abort("`n` must be a positive integer.");
+  }
+
   SEXP i = PROTECT(compact_rep(NA_INTEGER, n));
 
   SEXP out = vec_slice_impl(x, i);

--- a/src/slice.c
+++ b/src/slice.c
@@ -476,8 +476,18 @@ SEXP vec_init(SEXP x, R_len_t n) {
 
 // [[ register() ]]
 SEXP vctrs_init(SEXP x, SEXP n) {
+  n = PROTECT(vec_cast(n, vctrs_shared_empty_int, args_n, args_empty));
+
+  if (r_length(n) != 1) {
+    r_abort("`n` must have size 1, not size %i.", r_length(n));
+  }
+
   R_len_t n_ = r_int_get(n, 0);
-  return vec_init(x, n_);
+
+  SEXP out = vec_init(x, n_);
+
+  UNPROTECT(1);
+  return out;
 }
 
 // Exported for testing

--- a/src/utils.c
+++ b/src/utils.c
@@ -1601,6 +1601,7 @@ SEXP fns_names = NULL;
 SEXP result_attrib = NULL;
 
 struct vctrs_arg args_empty_;
+struct vctrs_arg args_n_;
 struct vctrs_arg args_dot_ptype_;
 struct vctrs_arg args_max_fill_;
 
@@ -1871,6 +1872,7 @@ void vctrs_init_utils(SEXP ns) {
   new_env__size_node = CDR(new_env__parent_node);
 
   args_empty_ = new_wrapper_arg(NULL, "");
+  args_n_ = new_wrapper_arg(NULL, "n");
   args_dot_ptype_ = new_wrapper_arg(NULL, ".ptype");
   args_max_fill_ = new_wrapper_arg(NULL, "max_fill");
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -157,6 +157,9 @@ SEXP node_compact_d(SEXP xs);
 extern struct vctrs_arg args_empty_;
 static struct vctrs_arg* const args_empty = &args_empty_;
 
+extern struct vctrs_arg args_n_;
+static struct vctrs_arg* const args_n = &args_n_;
+
 extern struct vctrs_arg args_dot_ptype_;
 static struct vctrs_arg* const args_dot_ptype = &args_dot_ptype_;
 

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -507,6 +507,8 @@ test_that("vec_init() works with Altrep classes", {
 test_that("vec_init() validates `n`", {
   expect_error(vec_init(1L, 1.5), class = "vctrs_error_cast_lossy")
   expect_error(vec_init(1L, c(1, 2)), "`n` must have size 1, not size 2.")
+  expect_error(vec_init(1L, -1L), "positive integer")
+  expect_error(vec_init(1L, NA_integer_), "positive integer")
 })
 
 # vec_slice + compact_rep -------------------------------------------------

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -504,6 +504,11 @@ test_that("vec_init() works with Altrep classes", {
   expect_equal(vec_init(x, 2), rep(NA_character_, 2))
 })
 
+test_that("vec_init() validates `n`", {
+  expect_error(vec_init(1L, 1.5), class = "vctrs_error_cast_lossy")
+  expect_error(vec_init(1L, c(1, 2)), "`n` must have size 1, not size 2.")
+})
+
 # vec_slice + compact_rep -------------------------------------------------
 
 # `i` is 1-based


### PR DESCRIPTION
Closes #1423 

It is now about as fast as the equivalent `vec_slice(x, NA_integer_)` syntax

```r
library(vctrs)

x <- rep(list(1), times = 10000)

bench::mark(
  lapply(x, vec_init, n = 1L),
  lapply(x, vec_slice, i = NA_integer_)
)

# Before
#> # A tibble: 2 × 6
#>   expression                                 min   median `itr/sec` mem_alloc
#>   <bch:expr>                            <bch:tm> <bch:tm>     <dbl> <bch:byt>
#> 1 lapply(x, vec_init, n = 1L)             71.3ms   73.4ms      11.7   117.5KB
#> 2 lapply(x, vec_slice, i = NA_integer_)    9.9ms   11.4ms      86.3    80.5KB
#> # … with 1 more variable: gc/sec <dbl>

# After
#> # A tibble: 2 × 6
#>   expression                                 min   median `itr/sec` mem_alloc
#>   <bch:expr>                            <bch:tm> <bch:tm>     <dbl> <bch:byt>
#> 1 lapply(x, vec_init, n = 1L)             7.68ms   9.36ms      108.    84.6KB
#> 2 lapply(x, vec_slice, i = NA_integer_)   7.91ms   9.85ms      103.    82.2KB
#> # … with 1 more variable: gc/sec <dbl>
```