### PR TITLE
Expand upon our minimal `vec_assert()` C API

### DIFF
--- a/R/assert.R
+++ b/R/assert.R
@@ -93,18 +93,35 @@ vec_assert <- function(x, ptype = NULL, size = NULL, arg = as_label(substitute(x
     size <- vec_recycle(vec_cast(size, integer()), 1L)
     x_size <- vec_size(x)
     if (!identical(x_size, size)) {
-      msg <- paste0("`", arg, "` must have size ", size, ", not size ", x_size, ".")
-      abort(
-        msg,
-        class = c("vctrs_error_assert_size", "vctrs_error_assert"),
-        required = size,
-        actual = x_size
-      )
+      stop_assert_size(x_size, size, arg)
     }
   }
 
   invisible(x)
 }
+
+# Also thrown from C
+stop_assert_size <- function(actual, required, arg) {
+  if (!nzchar(arg)) {
+    arg <- "Input"
+  } else {
+    arg <- glue::backtick(arg)
+  }
+
+  message <- glue::glue("{arg} must have size {required}, not size {actual}.")
+
+  stop_assert(
+    message,
+    class = "vctrs_error_assert_size",
+    actual = actual,
+    required = required
+  )
+}
+
+stop_assert <- function(message = NULL, class = NULL, ...) {
+  stop_vctrs(message, class = c(class, "vctrs_error_assert"), ...)
+}
+
 #' @rdname vec_assert
 #' @export
 vec_is <- function(x, ptype = NULL, size = NULL) {

--- a/src/assert.c
+++ b/src/assert.c
@@ -1,0 +1,27 @@
+#include "assert.h"
+
+// [[ include("assert.h") ]]
+void vec_assert(r_obj* x, r_ssize size, struct vctrs_arg* arg) {
+  vec_assert_vector(x, arg);
+
+  if (size != -1) {
+    // `size == -1` makes no assertion about size
+    vec_assert_size(x, size, arg);
+  }
+}
+
+// [[ include("assert.h") ]]
+void vec_assert_vector(r_obj* x, struct vctrs_arg* arg) {
+  if (!vec_is_vector(x)) {
+    stop_scalar_type(x, arg);
+  }
+}
+
+// [[ include("assert.h") ]]
+void vec_assert_size(r_obj* x, r_ssize size, struct vctrs_arg* arg) {
+  r_ssize x_size = vec_size(x);
+
+  if (x_size != size) {
+    stop_assert_size(x_size, size, arg);
+  }
+}

--- a/src/assert.h
+++ b/src/assert.h
@@ -1,0 +1,11 @@
+#ifndef VCTRS_ASSERT_H
+#define VCTRS_ASSERT_H
+
+#include <rlang.h>
+#include "vctrs.h"
+
+void vec_assert(r_obj* x, r_ssize size, struct vctrs_arg* arg);
+void vec_assert_vector(r_obj* x, struct vctrs_arg* arg);
+void vec_assert_size(r_obj* x, r_ssize size, struct vctrs_arg* arg);
+
+#endif

--- a/src/cast.c
+++ b/src/cast.c
@@ -6,6 +6,7 @@
 #include "ptype-common.h"
 #include "type-data-frame.h"
 #include "utils.h"
+#include "assert.h"
 
 static
 SEXP vec_cast_switch_native(const struct cast_opts* opts,
@@ -32,13 +33,13 @@ SEXP vec_cast_opts(const struct cast_opts* opts) {
 
   if (x == R_NilValue) {
     if (!vec_is_partial(to)) {
-      vec_assert(to, to_arg);
+      vec_assert_vector(to, to_arg);
     }
     return x;
   }
   if (to == R_NilValue) {
     if (!vec_is_partial(x)) {
-      vec_assert(x, x_arg);
+      vec_assert_vector(x, x_arg);
     }
     return x;
   }

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -2,7 +2,7 @@
 #include "vctrs.h"
 #include "utils.h"
 
-
+// [[ include("vctrs.h") ]]
 void stop_scalar_type(SEXP x, struct vctrs_arg* arg) {
   SEXP call = PROTECT(Rf_lang3(Rf_install("stop_scalar_type"),
                                PROTECT(r_protect(x)),
@@ -11,10 +11,27 @@ void stop_scalar_type(SEXP x, struct vctrs_arg* arg) {
   never_reached("stop_scalar_type");
 }
 
-void vec_assert(SEXP x, struct vctrs_arg* arg) {
-  if (!vec_is_vector(x)) {
-    stop_scalar_type(x, arg);
-  }
+// [[ include("vctrs.h") ]]
+void stop_assert_size(r_ssize actual,
+                      r_ssize required,
+                      struct vctrs_arg* arg) {
+  r_obj* syms[4] = {
+   syms_actual,
+   syms_required,
+   syms_arg,
+   NULL
+  };
+  r_obj* args[4] = {
+    KEEP(r_int(actual)),
+    KEEP(r_int(required)),
+    KEEP(vctrs_arg(arg)),
+    NULL
+  };
+
+  r_obj* call = KEEP(r_call_n(syms_stop_assert_size, syms, args));
+  r_eval(call, vctrs_ns_env);
+
+  never_reached("stop_assert_size");
 }
 
 // [[ include("vctrs.h") ]]

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -6,6 +6,7 @@
 #include "slice-assign.h"
 #include "subscript-loc.h"
 #include "utils.h"
+#include "assert.h"
 
 // Initialised at load time
 SEXP syms_vec_assign_fallback = NULL;
@@ -33,8 +34,8 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
     return R_NilValue;
   }
 
-  vec_assert(x, opts->x_arg);
-  vec_assert(value, opts->value_arg);
+  vec_assert_vector(x, opts->x_arg);
+  vec_assert_vector(value, opts->value_arg);
 
   index = PROTECT(vec_as_location_opts(index,
                                        vec_size(x),

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -6,6 +6,7 @@
 #include "type-data-frame.h"
 #include "owned.h"
 #include "utils.h"
+#include "assert.h"
 
 /*
  * @member proxy_info The result of `vec_proxy_info(x)`.
@@ -173,7 +174,7 @@ static SEXP vec_chop_base(SEXP x, SEXP indices, struct vctrs_chop_info info) {
     return chop_df(x, indices, info);
   }
   default:
-    vec_assert(x, args_empty);
+    vec_assert_vector(x, args_empty);
     stop_unimplemented_vctrs_type("vec_chop_base", proxy_info.type);
   }
 }

--- a/src/slice.c
+++ b/src/slice.c
@@ -7,6 +7,7 @@
 #include "owned.h"
 #include "utils.h"
 #include "dim.h"
+#include "assert.h"
 
 // Initialised at load time
 SEXP syms_vec_slice_fallback = NULL;
@@ -347,7 +348,7 @@ SEXP vec_slice_impl(SEXP x, SEXP subscript) {
   // to be maximally compatible with existing classes.
   if (vec_requires_fallback(x, info)) {
     if (info.type == vctrs_type_scalar) {
-      vec_assert(x, NULL);
+      vec_assert_vector(x, NULL);
     }
 
     if (is_compact(subscript)) {
@@ -452,7 +453,7 @@ bool vec_is_restored(SEXP x, SEXP to) {
 
 // [[ include("vctrs.h"); register() ]]
 SEXP vec_slice(SEXP x, SEXP subscript) {
-  vec_assert(x, args_empty);
+  vec_assert_vector(x, args_empty);
 
   subscript = PROTECT(vec_as_location(subscript, vec_size(x), PROTECT(vec_names(x))));
   SEXP out = vec_slice_impl(x, subscript);
@@ -463,7 +464,7 @@ SEXP vec_slice(SEXP x, SEXP subscript) {
 
 // [[ include("vctrs.h") ]]
 SEXP vec_init(SEXP x, R_len_t n) {
-  vec_assert(x, NULL);
+  vec_assert_vector(x, NULL);
 
   SEXP i = PROTECT(compact_rep(NA_INTEGER, n));
 

--- a/src/type.c
+++ b/src/type.c
@@ -5,6 +5,7 @@
 #include "ptype2.h"
 #include "type-data-frame.h"
 #include "utils.h"
+#include "assert.h"
 #include "decl/ptype-decl.h"
 
 // Initialised at load time
@@ -85,7 +86,7 @@ static SEXP s3_type(SEXP x, struct vctrs_arg* x_arg) {
   SEXP out;
 
   if (method == r_null) {
-    vec_assert(x, x_arg);
+    vec_assert_vector(x, x_arg);
     out = vec_slice(x, r_null);
   } else {
     out = vec_ptype_invoke(x, method);
@@ -136,7 +137,7 @@ SEXP vec_ptype_finalise(SEXP x) {
   }
 
   if (!OBJECT(x)) {
-    vec_assert(x, args_empty);
+    vec_assert_vector(x, args_empty);
     return x;
   }
 
@@ -148,7 +149,7 @@ SEXP vec_ptype_finalise(SEXP x) {
     return vec_ptype_finalise_dispatch(x);
   }
 
-  vec_assert(x, args_empty);
+  vec_assert_vector(x, args_empty);
 
   switch (class_type(x)) {
   case vctrs_class_bare_tibble:

--- a/src/utils.c
+++ b/src/utils.c
@@ -1584,12 +1584,15 @@ SEXP syms_df_fallback = NULL;
 SEXP syms_s3_fallback = NULL;
 SEXP syms_stop_incompatible_type = NULL;
 SEXP syms_stop_incompatible_size = NULL;
+SEXP syms_stop_assert_size = NULL;
 SEXP syms_action = NULL;
 SEXP syms_vctrs_common_class_fallback = NULL;
 SEXP syms_fallback_class = NULL;
 SEXP syms_abort = NULL;
 SEXP syms_message = NULL;
 SEXP syms_chr_transform = NULL;
+SEXP syms_actual = NULL;
+SEXP syms_required = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -1847,12 +1850,15 @@ void vctrs_init_utils(SEXP ns) {
   syms_s3_fallback = Rf_install("vctrs:::s3_fallback");
   syms_stop_incompatible_type = Rf_install("stop_incompatible_type");
   syms_stop_incompatible_size = Rf_install("stop_incompatible_size");
+  syms_stop_assert_size = Rf_install("stop_assert_size");
   syms_action = Rf_install("action");
   syms_vctrs_common_class_fallback = Rf_install(c_strs_vctrs_common_class_fallback);
   syms_fallback_class = Rf_install("fallback_class");
   syms_abort = Rf_install("abort");
   syms_message = Rf_install("message");
   syms_chr_transform = Rf_install("chr_transform");
+  syms_actual = Rf_install("actual");
+  syms_required = Rf_install("required");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.h
+++ b/src/utils.h
@@ -500,12 +500,15 @@ extern SEXP syms_df_fallback;
 extern SEXP syms_s3_fallback;
 extern SEXP syms_stop_incompatible_type;
 extern SEXP syms_stop_incompatible_size;
+extern SEXP syms_stop_assert_size;
 extern SEXP syms_action;
 extern SEXP syms_vctrs_common_class_fallback;
 extern SEXP syms_fallback_class;
 extern SEXP syms_abort;
 extern SEXP syms_message;
 extern SEXP syms_chr_transform;
+extern SEXP syms_actual;
+extern SEXP syms_required;
 
 static const char * const c_strs_vctrs_common_class_fallback = "vctrs:::common_class_fallback";
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -598,7 +598,10 @@ static inline void growable_push_int(struct growable* g, int i) {
 // Conditions ---------------------------------------------------
 
 void stop_scalar_type(SEXP x, struct vctrs_arg* arg) __attribute__((noreturn));
-void vec_assert(SEXP x, struct vctrs_arg* arg);
+__attribute__((noreturn))
+void stop_assert_size(r_ssize actual,
+                      r_ssize required,
+                      struct vctrs_arg* arg);
 __attribute__((noreturn))
 void stop_incompatible_size(SEXP x, SEXP y,
                             R_len_t x_size, R_len_t y_size,


### PR DESCRIPTION
As requested by https://github.com/r-lib/vctrs/pull/1427#discussion_r690433667

It now includes an optional check for size assertion, as well as separate helpers for each check.

I think having separate helpers is useful. We often just check for vector-ness, so `vec_assert_vector(x, arg)` is going to be cleaner than having `vec_assert(x, -1, arg)` everywhere. Similarly, we might just want to check the size (as in `vec_init()`, since I will have already run `vec_cast()` on `n`).