### PR TITLE
Use `names_inform_repair()` for name repair messages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # vctrs (development version)
 
+* Name repair messages are now signaled by `rlang::names_inform_repair()`. This
+  means that the messages are now sent to stdout rather than stderr, resulting
+  in prettier messages. Additionally, name repair messages can now be silenced
+  through the global option `rlib_name_repair_verbosity`, which is useful
+  for testing purposes. See `?names_inform_repair` for more information (#1429).
+  
 * `vctrs_vctr` methods for `na.omit()`, `na.exclude()`, and `na.fail()` have
   been added (#1413).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,11 @@
 # vctrs (development version)
 
 * Name repair messages are now signaled by `rlang::names_inform_repair()`. This
-  means that the messages are now sent to stdout rather than stderr, resulting
-  in prettier messages. Additionally, name repair messages can now be silenced
-  through the global option `rlib_name_repair_verbosity`, which is useful
-  for testing purposes. See `?names_inform_repair` for more information (#1429).
+  means that the messages are now sent to stdout by default rather than to
+  stderr, resulting in prettier messages. Additionally, name repair messages can
+  now be silenced through the global option `rlib_name_repair_verbosity`, which
+  is useful for testing purposes. See `?names_inform_repair` for more
+  information (#1429).
   
 * `vctrs_vctr` methods for `na.omit()`, `na.exclude()`, and `na.fail()` have
   been added (#1413).

--- a/R/names.R
+++ b/R/names.R
@@ -404,25 +404,7 @@ re_match <- function(text, pattern, perl = TRUE, ...) {
 
 
 describe_repair <- function(orig_names, names) {
-  if (is_null(orig_names)) {
-    orig_names <- rep_along(names, "")
-  }
-  if (length(orig_names) != length(names)) {
-    stop("Internal error: New names and old names don't have same length")
-  }
-
-  new_names <- names != as_minimal_names(orig_names)
-  if (any(new_names)) {
-    msg <- bullets(
-      header = "New names:",
-      paste0(
-        tick_if_needed(orig_names[new_names]),
-        " -> ",
-        tick_if_needed(names[new_names])
-      )
-    )
-    message(msg)
-  }
+  names_inform_repair(orig_names, names)
 }
 
 bullets <- function(..., header = NULL) {
@@ -451,12 +433,6 @@ is_syntactic <- function(x) {
   ret <- (make_syntactic(x) == x)
   ret[is.na(x)] <- FALSE
   ret
-}
-
-tick_if_needed <- function(x) {
-  needs_ticks <- !is_syntactic(x)
-  x[needs_ticks] <- tick(x[needs_ticks])
-  x
 }
 
 # Used in names.c

--- a/R/names.R
+++ b/R/names.R
@@ -425,16 +425,6 @@ bullets <- function(..., header = NULL) {
   info
 }
 
-tick <- function(x) {
-  ifelse(is.na(x), "NA", encodeString(x, quote = "`"))
-}
-
-is_syntactic <- function(x) {
-  ret <- (make_syntactic(x) == x)
-  ret[is.na(x)] <- FALSE
-  ret
-}
-
 # Used in names.c
 set_rownames_fallback <- function(x, names) {
   rownames(x) <- names

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -203,7 +203,7 @@
       # Integers as rows
       suppressMessages(with_memory_prof(vec_rbind_list(ints)))
     Output
-      [1] 22.1KB
+      [1] 2.53KB
     Code
       suppressMessages(with_memory_prof(vec_rbind_list(named_ints)))
     Output

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -1,36 +1,58 @@
+# duplicate names are de-deduplicated
+
+    Code
+      (expect_named(vec_cbind(x = 1, x = 1), c("x...1", "x...2")))
+    Message <rlib_message_name_repair>
+      New names:
+      * `x` -> `x...1`
+      * `x` -> `x...2`
+    Output
+        x...1 x...2
+      1     1     1
+    Code
+      (expect_named(vec_cbind(data.frame(x = 1), data.frame(x = 1)), c("x...1",
+        "x...2")))
+    Message <rlib_message_name_repair>
+      New names:
+      * `x` -> `x...1`
+      * `x` -> `x...2`
+    Output
+        x...1 x...2
+      1     1     1
+
 # vec_rbind() name repair messages are useful
 
     Code
       vec_rbind(1, 2)
-    Message <simpleMessage>
+    Message <rlib_message_name_repair>
       New names:
-      * `` -> ...1
+      * `` -> `...1`
       New names:
-      * `` -> ...1
+      * `` -> `...1`
     Output
         ...1
       1    1
       2    2
     Code
       vec_rbind(1, 2, .names_to = NULL)
-    Message <simpleMessage>
+    Message <rlib_message_name_repair>
       New names:
-      * `` -> ...1
+      * `` -> `...1`
       New names:
-      * `` -> ...1
+      * `` -> `...1`
     Output
         ...1
       1    1
       2    2
     Code
       vec_rbind(1, 2, ...10 = 3)
-    Message <simpleMessage>
+    Message <rlib_message_name_repair>
       New names:
-      * `` -> ...1
+      * `` -> `...1`
       New names:
-      * `` -> ...1
+      * `` -> `...1`
       New names:
-      * `` -> ...1
+      * `` -> `...1`
     Output
         ...1
       1    1
@@ -38,13 +60,13 @@
       3    3
     Code
       vec_rbind(1, 2, ...10 = 3, .names_to = NULL)
-    Message <simpleMessage>
+    Message <rlib_message_name_repair>
       New names:
-      * `` -> ...1
+      * `` -> `...1`
       New names:
-      * `` -> ...1
+      * `` -> `...1`
       New names:
-      * `` -> ...1
+      * `` -> `...1`
     Output
            ...1
       ...1    1
@@ -52,22 +74,22 @@
       ...3    3
     Code
       vec_rbind(a = 1, b = 2)
-    Message <simpleMessage>
+    Message <rlib_message_name_repair>
       New names:
-      * `` -> ...1
+      * `` -> `...1`
       New names:
-      * `` -> ...1
+      * `` -> `...1`
     Output
         ...1
       1    1
       2    2
     Code
       vec_rbind(a = 1, b = 2, .names_to = NULL)
-    Message <simpleMessage>
+    Message <rlib_message_name_repair>
       New names:
-      * `` -> ...1
+      * `` -> `...1`
       New names:
-      * `` -> ...1
+      * `` -> `...1`
     Output
         ...1
       a    1
@@ -116,20 +138,20 @@
 
     Code
       vec_cbind(1, 2)
-    Message <simpleMessage>
+    Message <rlib_message_name_repair>
       New names:
-      * `` -> ...1
-      * `` -> ...2
+      * `` -> `...1`
+      * `` -> `...2`
     Output
         ...1 ...2
       1    1    2
     Code
       vec_cbind(1, 2, ...10 = 3)
-    Message <simpleMessage>
+    Message <rlib_message_name_repair>
       New names:
-      * `` -> ...1
-      * `` -> ...2
-      * ...10 -> ...3
+      * `` -> `...1`
+      * `` -> `...2`
+      * `...10` -> `...3`
     Output
         ...1 ...2 ...3
       1    1    2    3
@@ -140,10 +162,10 @@
       1 1 2
     Code
       vec_cbind(c(a = 1), c(b = 2))
-    Message <simpleMessage>
+    Message <rlib_message_name_repair>
       New names:
-      * `` -> ...1
-      * `` -> ...2
+      * `` -> `...1`
+      * `` -> `...2`
     Output
         ...1 ...2
       1    1    2
@@ -181,7 +203,7 @@
       # Integers as rows
       suppressMessages(with_memory_prof(vec_rbind_list(ints)))
     Output
-      [1] 2.53KB
+      [1] 22.1KB
     Code
       suppressMessages(with_memory_prof(vec_rbind_list(named_ints)))
     Output

--- a/tests/testthat/_snaps/names.md
+++ b/tests/testthat/_snaps/names.md
@@ -2,10 +2,10 @@
 
     Code
       vec_as_names(c("x", "x"), repair = "unique")
-    Message <simpleMessage>
+    Message <rlib_message_name_repair>
       New names:
-      * x -> x...1
-      * x -> x...2
+      * `x` -> `x...1`
+      * `x` -> `x...2`
     Output
       [1] "x...1" "x...2"
     Code
@@ -21,4 +21,59 @@
       x These names are duplicated:
         * "x" at locations 1 and 2.
       i Use argument `repair` to specify repair strategy.
+
+# unique_names() and as_unique_names() are verbose or silent
+
+    Code
+      unique_names(1:2)
+    Message <rlib_message_name_repair>
+      New names:
+      * `` -> `...1`
+      * `` -> `...2`
+    Output
+      [1] "...1" "...2"
+
+---
+
+    Code
+      as_unique_names(c("", ""))
+    Message <rlib_message_name_repair>
+      New names:
+      * `` -> `...1`
+      * `` -> `...2`
+    Output
+      [1] "...1" "...2"
+
+# message
+
+    Code
+      as_universal_names(c("a b", "b c"))
+    Message <rlib_message_name_repair>
+      New names:
+      * a b -> `a.b`
+      * b c -> `b.c`
+    Output
+      [1] "a.b" "b.c"
+
+# messages by default
+
+    Code
+      vec_repair_names(set_names(1, "a:b"), "universal")
+    Message <rlib_message_name_repair>
+      New names:
+      * a:b -> `a.b`
+    Output
+      a.b 
+        1 
+
+---
+
+    Code
+      vec_repair_names(set_names(1, "a:b"), ~ make.names(.))
+    Message <rlib_message_name_repair>
+      New names:
+      * a:b -> `a.b`
+    Output
+      a.b 
+        1 
 

--- a/tests/testthat/_snaps/names.md
+++ b/tests/testthat/_snaps/names.md
@@ -50,8 +50,8 @@
       as_universal_names(c("a b", "b c"))
     Message <rlib_message_name_repair>
       New names:
-      * a b -> `a.b`
-      * b c -> `b.c`
+      * `a b` -> `a.b`
+      * `b c` -> `b.c`
     Output
       [1] "a.b" "b.c"
 
@@ -61,7 +61,7 @@
       vec_repair_names(set_names(1, "a:b"), "universal")
     Message <rlib_message_name_repair>
       New names:
-      * a:b -> `a.b`
+      * `a:b` -> `a.b`
     Output
       a.b 
         1 
@@ -72,7 +72,7 @@
       vec_repair_names(set_names(1, "a:b"), ~ make.names(.))
     Message <rlib_message_name_repair>
       New names:
-      * a:b -> `a.b`
+      * `a:b` -> `a.b`
     Output
       a.b 
         1 

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -405,12 +405,10 @@ test_that("matrix becomes data frame", {
 })
 
 test_that("duplicate names are de-deduplicated", {
-  expect_message(
-    expect_named(vec_cbind(x = 1, x = 1), c("x...1", "x...2")),
-    "x -> x...1",
-    fixed = TRUE
-  )
-  expect_named(vec_cbind(data.frame(x = 1), data.frame(x = 1)), c("x...1", "x...2"))
+  expect_snapshot({
+    (expect_named(vec_cbind(x = 1, x = 1), c("x...1", "x...2")))
+    (expect_named(vec_cbind(data.frame(x = 1), data.frame(x = 1)), c("x...1", "x...2")))
+  })
 })
 
 test_that("rows recycled to longest", {

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -426,8 +426,8 @@ test_that("unique-ification has an 'algebraic'-y property", {
 })
 
 test_that("unique_names() and as_unique_names() are verbose or silent", {
-  expect_message(unique_names(1:2), "-> ...1", fixed = TRUE)
-  expect_message(as_unique_names(c("", "")), "-> ...1", fixed = TRUE)
+  expect_snapshot(unique_names(1:2))
+  expect_snapshot(as_unique_names(c("", "")))
 
   expect_message(regexp = NA, unique_names(1:2, quiet = TRUE))
   expect_message(regexp = NA, as_unique_names(c("", ""), quiet = TRUE))
@@ -514,11 +514,7 @@ test_that("complicated inputs", {
 })
 
 test_that("message", {
-  expect_message(
-    as_universal_names(c("a b", "b c")),
-    "New names:\n* `a b` -> a.b\n* `b c` -> b.c\n",
-    fixed = TRUE
-  )
+  expect_snapshot(as_universal_names(c("a b", "b c")))
 })
 
 test_that("quiet", {
@@ -550,17 +546,8 @@ test_that("unnamed input gives uniquely named output", {
 })
 
 test_that("messages by default", {
-  expect_message(
-    vec_repair_names(set_names(1, "a:b"), "universal"),
-    "New names:\n* `a:b` -> a.b\n",
-    fixed = TRUE
-  )
-
-  expect_message(
-    vec_repair_names(set_names(1, "a:b"), ~ make.names(.)),
-    "New names:\n* `a:b` -> a.b\n",
-    fixed = TRUE
-  )
+  expect_snapshot(vec_repair_names(set_names(1, "a:b"), "universal"))
+  expect_snapshot(vec_repair_names(set_names(1, "a:b"), ~ make.names(.)))
 })
 
 test_that("quiet = TRUE", {


### PR DESCRIPTION
Closes #1429 
Closes #1317 

I've updated the failing tests to use `expect_snapshot()`, which should be a little more forgiving if the rlang implementation changes