### PR TITLE
Propagate list names onto the result of `list_sizes()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `list_sizes()` now propagates the names of the list onto the result.
+
 * `vec_order()` and `vec_sort()` now use a custom radix sort algorithm, rather
    than relying on `order()`. The implementation is based on data.table’s
    `forder()` and their earlier contribution to R’s `order()`. There are four

--- a/src/size.c
+++ b/src/size.c
@@ -73,6 +73,8 @@ SEXP list_sizes(SEXP x) {
   SEXP out = PROTECT(Rf_allocVector(INTSXP, size));
   int* v_out = INTEGER(out);
 
+  r_poke_names(out, vec_names(x));
+
   for (R_len_t i = 0; i < size; ++i) {
     v_out[i] = vec_size(v_x[i]);
   }

--- a/tests/testthat/test-size.R
+++ b/tests/testthat/test-size.R
@@ -106,6 +106,19 @@ test_that("computes element sizes", {
   expect_identical(list_sizes(list(1, 1:3, c("a", "b"))), c(1L, 3L, 2L))
 })
 
+test_that("retains list names", {
+  x <- list(1, x = 2, a = 3)
+  expect_named(list_sizes(x), c("", "x", "a"))
+
+  x <- list_of(y = 1, x = 2, a = 3)
+  expect_named(list_sizes(x), c("y", "x", "a"))
+})
+
+test_that("retains names of empty lists", {
+  x <- structure(list(), names = character())
+  expect_named(list_sizes(x), character())
+})
+
 # sequences ---------------------------------------------------------------
 
 test_that("vec_seq_along returns size-0 output for size-0 input", {


### PR DESCRIPTION
Since `lengths()` does this, I figure we should too. `lengths()` has a `use.names` argument that defaults to `TRUE`, but I don't see any reason why we shouldn't do this unconditionally.