### PR TITLE
Always materialize ALTREP vectors in `vec_chop()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* `vec_chop()` now materializes ALTREP vectors before chopping, which is more
+  efficient than creating many small ALTREP pieces (#1450).
+
 * New `list_drop_empty()` for removing empty elements from a list (#1395).
 
 * `list_sizes()` now propagates the names of the list onto the result.

--- a/R/altrep.R
+++ b/R/altrep.R
@@ -1,0 +1,3 @@
+is_altrep <- function(x) {
+  .Call(vctrs_is_altrep, x)
+}

--- a/src/altrep-rle.c
+++ b/src/altrep-rle.c
@@ -9,6 +9,11 @@
 
 void vctrs_init_altrep_rle(DllInfo* dll) { }
 
+SEXP altrep_rle_is_materialized(SEXP x) {
+  Rf_error("Need R 3.5+ for Altrep support.");
+  return R_NilValue;
+}
+
 SEXP altrep_rle_Make(SEXP input) {
   Rf_error("Need R 3.5+ for Altrep support.");
   return R_NilValue;
@@ -20,6 +25,9 @@ SEXP altrep_rle_Make(SEXP input) {
 // Initialised at load time
 R_altrep_class_t altrep_rle_class;
 
+SEXP altrep_rle_is_materialized(SEXP x) {
+  return Rf_ScalarLogical(R_altrep_data2(x) != R_NilValue);
+}
 
 SEXP altrep_rle_Make(SEXP input) {
   SEXP res = R_new_altrep(altrep_rle_class, input, R_NilValue);

--- a/src/altrep.c
+++ b/src/altrep.c
@@ -1,0 +1,7 @@
+#include <rlang.h>
+#include "altrep.h"
+
+// [[ register() ]]
+r_obj* vctrs_is_altrep(r_obj* x) {
+  return r_lgl(ALTREP(x));
+}

--- a/src/init.c
+++ b/src/init.c
@@ -161,6 +161,7 @@ SEXP vctrs_init_library(SEXP);
 
 // Defined in altrep-rle.h
 extern SEXP altrep_rle_Make(SEXP);
+extern SEXP altrep_rle_is_materialized(SEXP);
 void vctrs_init_altrep_rle(DllInfo* dll);
 
 static const R_CallMethodDef CallEntries[] = {
@@ -242,6 +243,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_apply_name_spec",            (DL_FUNC) &vctrs_apply_name_spec, 4},
   {"vctrs_unset_s4",                   (DL_FUNC) &vctrs_unset_s4, 1},
   {"vctrs_altrep_rle_Make",            (DL_FUNC) &altrep_rle_Make, 1},
+  {"vctrs_altrep_rle_is_materialized", (DL_FUNC) &altrep_rle_is_materialized, 1},
   {"vctrs_validate_name_repair_arg",   (DL_FUNC) &vctrs_validate_name_repair_arg, 1},
   {"vctrs_validate_minimal_names",     (DL_FUNC) &vctrs_validate_minimal_names, 2},
   {"vctrs_as_names",                   (DL_FUNC) &vctrs_as_names, 4},

--- a/src/init.c
+++ b/src/init.c
@@ -137,6 +137,7 @@ extern r_obj* vctrs_rank(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*)
 extern r_obj* vctrs_integer64_proxy(r_obj*);
 extern r_obj* vctrs_integer64_restore(r_obj*);
 extern r_obj* vctrs_list_drop_empty(r_obj*);
+extern r_obj* vctrs_is_altrep(r_obj* x);
 
 
 // Maturing
@@ -292,6 +293,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_integer64_proxy",            (DL_FUNC) &vctrs_integer64_proxy, 1},
   {"vctrs_integer64_restore",          (DL_FUNC) &vctrs_integer64_restore, 1},
   {"vctrs_list_drop_empty",            (DL_FUNC) &vctrs_list_drop_empty, 1},
+  {"vctrs_is_altrep",                  (DL_FUNC) &vctrs_is_altrep, 1},
   {NULL, NULL, 0}
 };
 

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -192,7 +192,10 @@ static SEXP chop(SEXP x, SEXP indices, struct vctrs_chop_info info) {
     }
 
     // Always materialize ALTREP vectors when chopping to avoid inefficiently
-    // creating a large amount of small ALTREP objects (#1450)
+    // creating a large amount of small ALTREP objects that are used downstream.
+    // This is a heuristic and we should also be on the lookout for cases where
+    // we chop to create a small amount of large ALTREP objects that are
+    // quickly discarded (#1450).
     SEXP elt = PROTECT(vec_slice_base(
       info.proxy_info.type,
       proxy,

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -191,7 +191,14 @@ static SEXP chop(SEXP x, SEXP indices, struct vctrs_chop_info info) {
       ++(*info.p_index);
     }
 
-    SEXP elt = PROTECT(vec_slice_base(info.proxy_info.type, proxy, info.index));
+    // Always materialize ALTREP vectors when chopping to avoid inefficiently
+    // creating a large amount of small ALTREP objects (#1450)
+    SEXP elt = PROTECT(vec_slice_base(
+      info.proxy_info.type,
+      proxy,
+      info.index,
+      VCTRS_MATERIALIZE_true
+    ));
 
     if (names != R_NilValue) {
       SEXP elt_names = PROTECT(slice_names(names, info.index));

--- a/src/slice.h
+++ b/src/slice.h
@@ -4,9 +4,18 @@
 extern SEXP syms_vec_slice_dispatch_integer64;
 extern SEXP fns_vec_slice_dispatch_integer64;
 
+enum vctrs_materialize {
+  VCTRS_MATERIALIZE_false = 0,
+  VCTRS_MATERIALIZE_true
+};
+
+SEXP vec_slice_base(enum vctrs_type type,
+                    SEXP x,
+                    SEXP subscript,
+                    enum vctrs_materialize materialize);
+
 SEXP slice_names(SEXP names, SEXP subscript);
 SEXP slice_rownames(SEXP names, SEXP subscript);
-SEXP vec_slice_base(enum vctrs_type type, SEXP x, SEXP subscript);
 SEXP vec_slice_fallback(SEXP x, SEXP subscript);
 
 bool vec_is_restored(SEXP x, SEXP to);

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -192,6 +192,26 @@ test_that("vec_chop() with data frame proxies always uses the proxy's length inf
   expect_identical(proxy_deref(result2), proxy_deref(expect2))
 })
 
+test_that("ALTREP objects always generate materialized chops (#1450)", {
+  skip_if(getRversion() <= "3.5.0")
+
+  x <- .Call(vctrs_altrep_rle_Make, c(foo = 10L, bar = 5L))
+
+  # `x` starts in compact form
+  expect_false(.Call(vctrs_altrep_rle_is_materialized, x))
+
+  result <- vec_chop(x)
+
+  # Chopping materializes `x`
+  expect_true(.Call(vctrs_altrep_rle_is_materialized, x))
+
+  # And chopped elements are not ALTREP vectors
+  expect_false(any(map_lgl(result, is_altrep)))
+
+  expect <- vec_chop(c(rep("foo", 10), rep("bar", 5)))
+  expect_identical(result, expect)
+})
+
 # vec_chop + compact_seq --------------------------------------------------
 
 # `start` is 0-based


### PR DESCRIPTION
Closes #1450

We now signal to `vec_slice_base()` that we would like it to materialize any ALTREP vectors by skipping the special ALTREP handling and instead dropping into the standard slicing behavior, which naturally forces materialization. This has large performance benefits downstream from `vec_chop()`, since manipulating many small ALTREP vectors can have a large amount of overhead.

The original example from tidyverse/dplyr#6015 is below. Notice that the benchmark associated with this PR allocates more memory than before, which makes sense because it will now materialize the ALTREP columns mentioned in the `summarize()` expressions.

``` r
library(readr)
library(dplyr)

url <- url("https://media.githubusercontent.com/media/matanmazor/thesis/main/index/data/RC/RC.csv")

df <- read_csv(url)

gdf <- df %>%
  mutate(
    confidence = confidence / 1000,
    direction = ifelse(direction == 3,1,0)
  ) %>%
  group_by(subj_id, trial_id)

gdf
#> # A tibble: 1,488,000 × 15
#> # Groups:   subj_id, trial_id [24,000]
#>    subj_id trial_id trial_number timepoint detection direction signal response
#>      <dbl>    <dbl>        <dbl>     <dbl>     <dbl>     <dbl>  <dbl>    <dbl>
#>  1       1        1            1         1         1         0      1        0
#>  2       1        1            1         2         1         0      1        0
#>  3       1        1            1         3         1         0      1        0
#>  4       1        1            1         4         1         0      1        0
#>  5       1        1            1         5         1         0      1        0
#>  6       1        1            1         6         1         0      1        0
#>  7       1        1            1         7         1         0      1        0
#>  8       1        1            1         8         1         0      1        0
#>  9       1        1            1         9         1         0      1        0
#> 10       1        1            1        10         1         0      1        0
#> # … with 1,487,990 more rows, and 7 more variables: RT <dbl>, confidence <dbl>,
#> #   correct <dbl>, energyRight <dbl>, energyLeft <dbl>, energyDown <dbl>,
#> #   energyUp <dbl>

bench::mark(
  dplyr_summarise = summarise(
    gdf,
    detection = detection[timepoint == 1],
    RT = RT[timepoint == 1] - 700,
    .groups = "drop"
  )
)

# CRAN vctrs
#> # A tibble: 1 × 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 dplyr_summarise    14.9s    14.9s    0.0672    44.4MB    0.134

# This PR
#> # A tibble: 1 × 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 dplyr_summarise    172ms    187ms      5.34     103MB     5.34
```

<sup>Created on 2021-09-21 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0.9000)</sup>