### PR TITLE
Improve performance of `vec_duplicate_detect()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `vec_duplicate_detect()` is a bit faster when there are many unique values.
+
 * New `vec_rank()` to compute various types of sample ranks.
 
 * `vec_chop()` now materializes ALTREP vectors before chopping, which is more


### PR DESCRIPTION
I recently realized that `vec_duplicate_detect()` could probably be improved with an alternate algorithm, and it does seem to improve performance by around 2x in a few cases, and is never slower than the current algorithm. It also uses a little less memory.

The new algorithm essentially does `duplicated(x) & duplicated(x, fromLast = TRUE)`, which is generally what people do in base R when they want "all" the duplicates.

I think it is faster for two reasons:
- More sequential access. The previous algorithm used a random access to access the `hash` location in a few more places.
- Caching of the hash keys in `p_hashes`. This doesn't use any more memory than the old algorithm (since we don't need `val` anymore), and not recomputing the hash in the reverse loop seems to improve the performance.

This new approach is also a bit nicer if we are eventually going to implement `ignore = c("none", "first", "last")` as suggested in https://github.com/r-lib/vctrs/issues/1239. `"first"` is just the forward loop, and `"last"` is just the reverse loop. 

I haven't refreshed the code to use the rlang lib, as I wanted to limit the changes to just the algorithmic changes for now.

``` r
library(vctrs)
set.seed(123)

# 10 unique, 100 values
x <- sample(10, 100, replace = TRUE)

bench::mark(vec_duplicate_detect(x), iterations = 10000)
# CRAN
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_duplicate_detect(x)    2.4µs   4.65µs   196549.     5.2KB        0

# PR
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_duplicate_detect(x)   1.86µs   3.42µs   264995.    9.09KB        0

# all unique, 100 values
x <- sample(100, 100, replace = FALSE)

bench::mark(vec_duplicate_detect(x), iterations = 10000)
# CRAN
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_duplicate_detect(x)   2.58µs   4.46µs   215469.    2.98KB     21.5

# PR
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_duplicate_detect(x)   1.79µs   3.27µs   286884.    2.38KB        0

# 2 unique values, 10 mil total size
x <- sample(2, 1e7, replace = TRUE)

bench::mark(vec_duplicate_detect(x), iterations = 30)
# CRAN
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_duplicate_detect(x)     94ms    102ms      8.90     204MB     9.49

# PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_duplicate_detect(x)     91ms   98.2ms      9.44     178MB     10.1

# all unique, 10 mil total size
x <- sample(1e7, 1e7, replace = FALSE)

bench::mark(vec_duplicate_detect(x), iterations = 10)
# CRAN
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_duplicate_detect(x)    1.31s    1.37s     0.733     204MB    0.733

# PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_duplicate_detect(x)    779ms    791ms      1.25     178MB     1.38

# ~1 mil unique, 10 mil total size
x <- sample(1e6, 1e7, replace = TRUE)

bench::mark(vec_duplicate_detect(x), iterations = 10)
# CRAN
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_duplicate_detect(x)    1.19s    1.26s     0.789     204MB    0.789

# PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_duplicate_detect(x)    714ms    737ms      1.36     178MB     1.36

# more complex object
# 10 mil rows, ~300k unique rows. hashing probably dominates time here
x <- dplyr::sample_n(nycflights13::flights[1:5], 1e7, replace = TRUE)

bench::mark(vec_duplicate_detect(x), iterations = 20)
# CRAN
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_duplicate_detect(x)    2.92s    2.96s     0.336     204MB    0.353

# PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_duplicate_detect(x)    1.38s    1.43s     0.700     178MB    0.700
```