### PR TITLE
Add a `no_repair_opts` object to avoid name repair

### DIFF
--- a/src/names.c
+++ b/src/names.c
@@ -933,6 +933,7 @@ SEXP vctrs_validate_minimal_names(SEXP names, SEXP n_) {
 
 struct name_repair_opts unique_repair_default_opts;
 struct name_repair_opts unique_repair_silent_opts;
+struct name_repair_opts no_repair_opts;
 
 void vctrs_init_names(SEXP ns) {
   syms_set_rownames_fallback = Rf_install("set_rownames_fallback");
@@ -956,4 +957,8 @@ void vctrs_init_names(SEXP ns) {
   unique_repair_silent_opts.type = name_repair_unique;
   unique_repair_silent_opts.fn = R_NilValue;
   unique_repair_silent_opts.quiet = true;
+
+  no_repair_opts.type = name_repair_none;
+  no_repair_opts.fn = R_NilValue;
+  no_repair_opts.quiet = true;
 }

--- a/src/names.h
+++ b/src/names.h
@@ -19,9 +19,11 @@ struct name_repair_opts {
 
 extern struct name_repair_opts unique_repair_default_opts;
 extern struct name_repair_opts unique_repair_silent_opts;
+extern struct name_repair_opts no_repair_opts;
 
 static struct name_repair_opts const * const p_unique_repair_default_opts = &unique_repair_default_opts;
 static struct name_repair_opts const * const p_unique_repair_silent_opts = &unique_repair_silent_opts;
+static struct name_repair_opts const * const p_no_repair_opts = &no_repair_opts;
 
 #define PROTECT_NAME_REPAIR_OPTS(opts) PROTECT((opts)->fn)
 


### PR DESCRIPTION
For #1387 