### PR TITLE
Use an argument label when casting and recycling `size`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* `vec_assert()` produces a more informative error when `size` is invalid
+  (#1470).
+
 * `vec_duplicate_detect()` is a bit faster when there are many unique values.
 
 * New `vec_rank()` to compute various types of sample ranks.

--- a/R/assert.R
+++ b/R/assert.R
@@ -91,7 +91,12 @@ vec_assert <- function(x, ptype = NULL, size = NULL, arg = as_label(substitute(x
 
   if (!is_null(size)) {
     size <- vec_cast(size, integer(), x_arg = "size")
-    size <- vec_recycle(size, 1L, x_arg = "size")
+
+    n_size <- length(size)
+    if (n_size != 1L) {
+      abort(glue::glue("`size` must be length 1, not length {n_size}."))
+    }
+
     x_size <- vec_size(x)
     if (!identical(x_size, size)) {
       stop_assert_size(x_size, size, arg)

--- a/R/assert.R
+++ b/R/assert.R
@@ -61,7 +61,7 @@
 #'   class, its [vec_ptype()] is compared to that of `x` with
 #'   `identical()`. Otherwise, its [typeof()] is compared to that of
 #'   `x` with `==`.
-#' @param size A single integer size to compare against.
+#' @param size A single integer size against which to compare.
 #' @param arg Name of argument being checked. This is used in error
 #'   messages. The label of the expression passed as `x` is taken as
 #'   default.

--- a/R/assert.R
+++ b/R/assert.R
@@ -61,7 +61,7 @@
 #'   class, its [vec_ptype()] is compared to that of `x` with
 #'   `identical()`. Otherwise, its [typeof()] is compared to that of
 #'   `x` with `==`.
-#' @param size Size to compare against
+#' @param size A single integer size to compare against.
 #' @param arg Name of argument being checked. This is used in error
 #'   messages. The label of the expression passed as `x` is taken as
 #'   default.

--- a/R/assert.R
+++ b/R/assert.R
@@ -90,7 +90,8 @@ vec_assert <- function(x, ptype = NULL, size = NULL, arg = as_label(substitute(x
   }
 
   if (!is_null(size)) {
-    size <- vec_recycle(vec_cast(size, integer()), 1L)
+    size <- vec_cast(size, integer(), x_arg = "size")
+    size <- vec_recycle(size, 1L, x_arg = "size")
     x_size <- vec_size(x)
     if (!identical(x_size, size)) {
       stop_assert_size(x_size, size, arg)

--- a/man/vec_assert.Rd
+++ b/man/vec_assert.Rd
@@ -17,7 +17,7 @@ class, its \code{\link[=vec_ptype]{vec_ptype()}} is compared to that of \code{x}
 \code{identical()}. Otherwise, its \code{\link[=typeof]{typeof()}} is compared to that of
 \code{x} with \code{==}.}
 
-\item{size}{A single integer size to compare against.}
+\item{size}{A single integer size against which to compare.}
 
 \item{arg}{Name of argument being checked. This is used in error
 messages. The label of the expression passed as \code{x} is taken as

--- a/man/vec_assert.Rd
+++ b/man/vec_assert.Rd
@@ -17,7 +17,7 @@ class, its \code{\link[=vec_ptype]{vec_ptype()}} is compared to that of \code{x}
 \code{identical()}. Otherwise, its \code{\link[=typeof]{typeof()}} is compared to that of
 \code{x} with \code{==}.}
 
-\item{size}{Size to compare against}
+\item{size}{A single integer size to compare against.}
 
 \item{arg}{Name of argument being checked. This is used in error
 messages. The label of the expression passed as \code{x} is taken as

--- a/tests/testthat/_snaps/assert.md
+++ b/tests/testthat/_snaps/assert.md
@@ -151,3 +151,25 @@
           y: double
         >>
 
+# vec_assert() validates `size` (#1470)
+
+    Code
+      vec_assert(1, size = c(2, 3))
+    Error <vctrs_error_incompatible_size>
+      Can't recycle `size` (size 2) to size 1.
+
+---
+
+    Code
+      vec_assert(1, size = 1.5)
+    Error <vctrs_error_cast_lossy>
+      Can't convert from `size` <double> to <integer> due to loss of precision.
+      * Locations: 1
+
+---
+
+    Code
+      vec_assert(1, size = "x")
+    Error <vctrs_error_incompatible_type>
+      Can't convert `size` <character> to <integer>.
+

--- a/tests/testthat/_snaps/assert.md
+++ b/tests/testthat/_snaps/assert.md
@@ -154,22 +154,19 @@
 # vec_assert() validates `size` (#1470)
 
     Code
-      vec_assert(1, size = c(2, 3))
-    Error <rlang_error>
-      `size` must be length 1, not length 2.
-
----
-
+      (expect_error(vec_assert(1, size = c(2, 3))))
+    Output
+      <error/rlang_error>
+      Error in `vec_assert()`: `size` must be length 1, not length 2.
     Code
-      vec_assert(1, size = 1.5)
-    Error <vctrs_error_cast_lossy>
-      Can't convert from `size` <double> to <integer> due to loss of precision.
+      (expect_error(vec_assert(1, size = 1.5)))
+    Output
+      <error/vctrs_error_cast_lossy>
+      Error in `stop_vctrs()`: Can't convert from `size` <double> to <integer> due to loss of precision.
       * Locations: 1
-
----
-
     Code
-      vec_assert(1, size = "x")
-    Error <vctrs_error_incompatible_type>
-      Can't convert `size` <character> to <integer>.
+      (expect_error(vec_assert(1, size = "x")))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `stop_vctrs()`: Can't convert `size` <character> to <integer>.
 

--- a/tests/testthat/_snaps/assert.md
+++ b/tests/testthat/_snaps/assert.md
@@ -155,8 +155,8 @@
 
     Code
       vec_assert(1, size = c(2, 3))
-    Error <vctrs_error_incompatible_size>
-      Can't recycle `size` (size 2) to size 1.
+    Error <rlang_error>
+      `size` must be length 1, not length 2.
 
 ---
 

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -218,6 +218,12 @@ test_that("assertion failures are explained", {
   expect_snapshot(error = TRUE, vec_assert(data.frame(x = 1, y = 2), data.frame(x = "foo", y = 2)))
 })
 
+test_that("vec_assert() validates `size` (#1470)", {
+  expect_snapshot(error = TRUE, vec_assert(1, size = c(2, 3)))
+  expect_snapshot(error = TRUE, vec_assert(1, size = 1.5))
+  expect_snapshot(error = TRUE, vec_assert(1, size = "x"))
+})
+
 test_that("NULL is not a vector", {
   expect_false(vec_is_vector(NULL))
   expect_false(vec_is(NULL))

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -219,9 +219,11 @@ test_that("assertion failures are explained", {
 })
 
 test_that("vec_assert() validates `size` (#1470)", {
-  expect_snapshot(error = TRUE, vec_assert(1, size = c(2, 3)))
-  expect_snapshot(error = TRUE, vec_assert(1, size = 1.5))
-  expect_snapshot(error = TRUE, vec_assert(1, size = "x"))
+  expect_snapshot({
+    (expect_error(vec_assert(1, size = c(2, 3))))
+    (expect_error(vec_assert(1, size = 1.5)))
+    (expect_error(vec_assert(1, size = "x")))
+  })
 })
 
 test_that("NULL is not a vector", {


### PR DESCRIPTION
Closes #1470 

@MichaelChirico With this change you get the more informative:

``` r
testthat::expect_vector(matrix(1:10, 2, 5), ptype = rbind(integer(5)), size = c(2, 5))
#> Error: Can't recycle `size` (size 2) to size 1.
```