### PR TITLE
Lazy evaluation of `arg` in `vec_as_location()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* `vec_as_location()` evaluates `arg` only in case of error, for performance
+  (#1150, @krlmlr).
+
 * `vec_assert()` produces a more informative error when `size` is invalid
   (#1470).
 

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -70,7 +70,7 @@ vec_as_location <- function(i,
     loc_oob = "error",
     loc_zero = "remove",
     missing = missing,
-    arg = arg
+    env = environment()
   )
 }
 #' @rdname vec_as_location
@@ -105,7 +105,7 @@ num_as_location <- function(i,
     loc_oob = oob,
     loc_zero = zero,
     missing = missing,
-    arg = arg
+    env = environment()
   )
 }
 

--- a/R/vctrs-deprecated.R
+++ b/R/vctrs-deprecated.R
@@ -72,6 +72,9 @@ vec_as_index <- function(i, n, names = NULL) {
   vec_assert(n, integer(), 1L)
   i <- vec_as_subscript(i)
 
+  # Picked up from the environment at the C level
+  arg <- NULL
+
   .Call(
     vctrs_as_location,
     i = i,
@@ -81,7 +84,7 @@ vec_as_index <- function(i, n, names = NULL) {
     loc_oob = "error",
     loc_zero = "remove",
     missing = "propagate",
-    arg = NULL
+    env = environment()
   )
 }
 

--- a/src/arg.c
+++ b/src/arg.c
@@ -107,6 +107,56 @@ static r_ssize wrapper_arg_fill(void* data, char* buf, r_ssize remaining) {
 }
 
 
+// Wrapper that accesses a symbol in an environment, for lazy evaluation
+static r_ssize lazy_arg_fill(void* data, char* buf, r_ssize remaining);
+
+struct vctrs_arg new_lazy_arg(struct arg_data_lazy* data) {
+  return (struct vctrs_arg) {
+    .parent = NULL,
+    .fill = &lazy_arg_fill,
+    .data = data
+  };
+}
+
+struct arg_data_lazy new_lazy_arg_data(SEXP environment, const char* arg_name) {
+  if (environment == R_NilValue) {
+    r_stop_internal("new_lazy_arg_data", "`env` can't be NULL.");
+  }
+
+  return (struct arg_data_lazy) {
+    .environment = environment,
+    .arg_name = arg_name
+  };
+}
+
+static r_ssize lazy_arg_fill(void* data_, char* buf, r_ssize remaining) {
+  struct arg_data_lazy* data = (struct arg_data_lazy*) data_;
+
+  SEXP arg_name = Rf_install(data->arg_name);
+  SEXP value = PROTECT(r_env_get(data->environment, arg_name));
+  const char* c_value;
+
+  if (value == R_NilValue) {
+    c_value = "";
+  } else {
+    c_value = r_chr_get_c_string(value, 0);
+  }
+
+  size_t len = strlen(c_value);
+
+  if (len >= remaining) {
+    UNPROTECT(1);
+    return -1;
+  }
+
+  memcpy(buf, c_value, len);
+  buf[len] = '\0';
+
+  UNPROTECT(1);
+  return len;
+}
+
+
 // Wrapper around a counter representing the current position of the
 // argument
 

--- a/src/arg.c
+++ b/src/arg.c
@@ -2,6 +2,8 @@
 #include "vctrs.h"
 #include "utils.h"
 
+#include "decl/arg-decl.h"
+
 
 // Materialising argument tags ------------------------------------------
 
@@ -162,8 +164,6 @@ static r_ssize lazy_arg_fill(void* data_, char* buf, r_ssize remaining) {
 
 // Wrapper around a counter representing the current position of the
 // argument
-
-static r_ssize counter_arg_fill(void* data, char* buf, r_ssize remaining);
 
 struct vctrs_arg new_counter_arg(struct vctrs_arg* parent,
                                  struct arg_data_counter* data) {

--- a/src/arg.c
+++ b/src/arg.c
@@ -136,7 +136,10 @@ static r_ssize lazy_arg_fill(void* data_, char* buf, r_ssize remaining) {
   SEXP value = PROTECT(r_env_get(data->environment, arg_name));
   const char* c_value;
 
-  if (value == R_NilValue) {
+  // NULL values are mapped to an empty string. We also silently ignore
+  // non-character values or zero-length vectors and take the first element of a
+  // character vector. We could do better with a warning or a combined error.
+  if (!r_is_string(value) || r_length(value) < 1) {
     c_value = "";
   } else {
     c_value = r_chr_get_c_string(value, 0);

--- a/src/arg.c
+++ b/src/arg.c
@@ -132,7 +132,7 @@ struct arg_data_lazy new_lazy_arg_data(SEXP environment, const char* arg_name) {
 static r_ssize lazy_arg_fill(void* data_, char* buf, r_ssize remaining) {
   struct arg_data_lazy* data = (struct arg_data_lazy*) data_;
 
-  SEXP arg_name = Rf_install(data->arg_name);
+  SEXP arg_name = r_sym(data->arg_name);
   SEXP value = PROTECT(r_env_get(data->environment, arg_name));
   const char* c_value;
 

--- a/src/arg.h
+++ b/src/arg.h
@@ -27,6 +27,17 @@ struct vctrs_arg new_wrapper_arg(struct vctrs_arg* parent,
                                  const char* arg);
 
 
+// Wrapper that accesses a symbol in an environment, for lazy evaluation
+struct arg_data_lazy {
+  SEXP environment;
+  const char* arg_name;
+};
+
+struct vctrs_arg new_lazy_arg(struct arg_data_lazy* data);
+
+struct arg_data_lazy new_lazy_arg_data(SEXP environment, const char* arg_name);
+
+
 // Wrapper around a counter representing the current position of the
 // argument
 struct arg_data_counter {

--- a/src/decl/arg-decl.h
+++ b/src/decl/arg-decl.h
@@ -1,0 +1,1 @@
+static r_ssize counter_arg_fill(void* data, char* buf, r_ssize remaining);

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -406,7 +406,7 @@ static enum num_loc_zero parse_loc_zero(SEXP x) {
 // [[ register() ]]
 SEXP vctrs_as_location(SEXP subscript, SEXP n_, SEXP names,
                        SEXP loc_negative, SEXP loc_oob, SEXP loc_zero,
-                       SEXP missing, SEXP arg_) {
+                       SEXP missing, SEXP env) {
   R_len_t n = 0;
 
   if (n_ == R_NilValue && TYPEOF(subscript) == STRSXP) {
@@ -425,7 +425,8 @@ SEXP vctrs_as_location(SEXP subscript, SEXP n_, SEXP names,
     UNPROTECT(1);
   }
 
-  struct vctrs_arg arg = vec_as_arg(arg_);
+  struct arg_data_lazy arg_ = new_lazy_arg_data(env, "arg");
+  struct vctrs_arg arg = new_lazy_arg(&arg_);
 
   struct subscript_opts subscript_opts = {
     .subscript_arg  = &arg

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -241,6 +241,10 @@ test_that("arg is evaluated lazily (#1150)", {
   expect_silent(vec_as_location(1, 1, arg = { writeLines("oof"); "boo" }))
 })
 
+test_that("arg works for complex expressions (#1150)", {
+  expect_error(vec_as_location(mean, 1, arg = paste0("foo", "bar")), "foobar")
+})
+
 test_that("can optionally extend beyond the end", {
   expect_error(num_as_location(1:5, 3), class = "vctrs_error_subscript_oob")
 

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -245,12 +245,6 @@ test_that("arg works for complex expressions (#1150)", {
   expect_error(vec_as_location(mean, 1, arg = paste0("foo", "bar")), "foobar")
 })
 
-test_that("arg works with the byte compiler (#1150)", {
-  eval(compiler::compile(
-      expect_error(vec_as_location(mean, 1, arg = paste0("foo", "bar"), "foobar"))
-  ))
-})
-
 test_that("can optionally extend beyond the end", {
   expect_error(num_as_location(1:5, 3), class = "vctrs_error_subscript_oob")
 

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -237,6 +237,10 @@ test_that("character subscripts require named vectors", {
   })
 })
 
+test_that("arg is evaluated lazily (#1150)", {
+  expect_silent(vec_as_location(1, 1, arg = { writeLines("oof"); "boo" }))
+})
+
 test_that("can optionally extend beyond the end", {
   expect_error(num_as_location(1:5, 3), class = "vctrs_error_subscript_oob")
 

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -245,6 +245,12 @@ test_that("arg works for complex expressions (#1150)", {
   expect_error(vec_as_location(mean, 1, arg = paste0("foo", "bar")), "foobar")
 })
 
+test_that("arg works with the byte compiler (#1150)", {
+  eval(compiler::compile(
+      expect_error(vec_as_location(mean, 1, arg = paste0("foo", "bar"), "foobar"))
+  ))
+})
+
 test_that("can optionally extend beyond the end", {
   expect_error(num_as_location(1:5, 3), class = "vctrs_error_subscript_oob")
 


### PR DESCRIPTION
We can easily adapt all other functions that use `vec_as_arg()` today.

For #1150.