### PR TITLE
Use `vec_cast_common()` rather than `map()` in `list_of()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `list_of()` is now much faster when many values are provided.
+
 * `vec_as_location()` evaluates `arg` only in case of error, for performance
   (#1150, @krlmlr).
 

--- a/R/type-list-of.R
+++ b/R/type-list-of.R
@@ -26,8 +26,9 @@ list_of <- function(..., .ptype = NULL) {
     abort("Could not find common type for elements of `x`.")
   }
 
-  x <- map(args, vec_cast, to = ptype)
-  new_list_of(x, ptype)
+  args <- vec_cast_common(!!!args, .to = ptype)
+
+  new_list_of(args, ptype)
 }
 
 #' @export


### PR DESCRIPTION
Small but meaningful upgrade

```r
library(vctrs)

x <- rep(list(1), 1e6)

bench::mark(
  list_of(!!!x, .ptype = double()),
  iterations = 5
)

# CRAN
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression                            min  median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                       <bch:tm> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 list_of(!!!x, .ptype = double())    1.09s   1.12s     0.878    30.6MB     19.1

# This PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression                            min  median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                       <bch:tm> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 list_of(!!!x, .ptype = double())     71ms  75.7ms      12.3    38.3MB     17.3
```