### PR TITLE
Mention why we have an `as.character()` method for list-of

### DIFF
--- a/R/type-list-of.R
+++ b/R/type-list-of.R
@@ -139,6 +139,7 @@ as.list.vctrs_list_of <- function(x, ...) {
 }
 #' @export
 as.character.vctrs_list_of <- function(x, ...) {
+  # For compatibility with the RStudio Viewer. See tidyverse/tidyr#654.
   map_chr(x, function(elt) paste0("<", vec_ptype_abbr(elt), ">"))
 }
 


### PR DESCRIPTION
Closes #1490 

It turns out we have this for compatibility with the RStudio Viewer, i.e. tidyverse/tidyr#654. So I'm adding a note about that.

A little over a year ago, the IDE switched to checking for a `format()` method first before calling `as.character()` and it would have used that instead if a `format()` method existed. We do have a `format.vctrs_list_of()` method. But that IDE feature is a little broken https://github.com/rstudio/rstudio/issues/10073, plus we'd probably need to keep this to support older versions of the IDE anyways.