### PR TITLE
stop_vctrs(call = )

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -56,8 +56,8 @@
 #' @name vctrs-conditions
 NULL
 
-stop_vctrs <- function(message = NULL, class = NULL, ...) {
-  abort(message, class = c(class, "vctrs_error"), ...)
+stop_vctrs <- function(message = NULL, class = NULL, call = caller_env(), ...) {
+  abort(message, class = c(class, "vctrs_error"), call = call, ...)
 }
 warn_vctrs <- function(message = NULL, class = NULL, ...) {
   warn(message, class = c(class, "vctrs_warning"), ...)

--- a/tests/testthat/_snaps/assert.md
+++ b/tests/testthat/_snaps/assert.md
@@ -162,11 +162,11 @@
       (expect_error(vec_assert(1, size = 1.5)))
     Output
       <error/vctrs_error_cast_lossy>
-      Error in `stop_vctrs()`: Can't convert from `size` <double> to <integer> due to loss of precision.
+      Error in `stop_lossy_cast()`: Can't convert from `size` <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
       (expect_error(vec_assert(1, size = "x")))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't convert `size` <character> to <integer>.
+      Error in `stop_incompatible()`: Can't convert `size` <character> to <integer>.
 

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -187,7 +187,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
+      Error in `stop_incompatible()`: Can't combine `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
       i See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
@@ -201,7 +201,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `..1` <vctrs_Counts> and `..2` <vctrs:::common_class_fallback>.
+      Error in `stop_incompatible()`: Can't combine `..1` <vctrs_Counts> and `..2` <vctrs:::common_class_fallback>.
 
 # row-binding performs expected allocations
 

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -27,7 +27,7 @@
       (expect_error(vec_c(x, y), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
+      Error in `stop_incompatible()`: Can't combine `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
       i See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
@@ -40,7 +40,7 @@
       (expect_error(vec_c(joe, jane), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `..1` <vctrs_Counts> and `..2` <vctrs_Counts>.
+      Error in `stop_incompatible()`: Can't combine `..1` <vctrs_Counts> and `..2` <vctrs_Counts>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
       i See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
@@ -59,7 +59,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't convert <vctrs_foobar> to <character>.
+      Error in `stop_incompatible()`: Can't convert <vctrs_foobar> to <character>.
 
 # can ignore names in `vec_c()` by providing a `zap()` name-spec (#232)
 
@@ -68,7 +68,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `a` <character> and `b` <double>.
+      Error in `stop_incompatible()`: Can't combine `a` <character> and `b` <double>.
 
 # concatenation performs expected allocations
 

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -42,13 +42,13 @@
       (expect_error(vec_slice(foobar(list(1)), 1), class = "vctrs_error_scalar_type"))
     Output
       <error/vctrs_error_scalar_type>
-      Error in `stop_vctrs()`: Input must be a vector, not a <vctrs_foobar> object.
+      Error in `stop_scalar_type()`: Input must be a vector, not a <vctrs_foobar> object.
     Code
       (expect_error(stop_scalar_type(foobar(list(1)), arg = "foo"), class = "vctrs_error_scalar_type")
       )
     Output
       <error/vctrs_error_scalar_type>
-      Error in `stop_vctrs()`: `foo` must be a vector, not a <vctrs_foobar> object.
+      Error in `stop_scalar_type()`: `foo` must be a vector, not a <vctrs_foobar> object.
 
 # empty names errors are informative
 
@@ -57,21 +57,21 @@
       )
     Output
       <error/vctrs_error_names_cannot_be_empty>
-      Error in `stop_vctrs()`: Names can't be empty.
+      Error in `stop_names()`: Names can't be empty.
       x Empty name found at location 2.
     Code
       (expect_error(vec_as_names(c("x", "", "y", ""), repair = "check_unique"),
       class = "vctrs_error_names_cannot_be_empty"))
     Output
       <error/vctrs_error_names_cannot_be_empty>
-      Error in `stop_vctrs()`: Names can't be empty.
+      Error in `stop_names()`: Names can't be empty.
       x Empty names found at locations 2 and 4.
     Code
       (expect_error(vec_as_names(rep("", 10), repair = "check_unique"), class = "vctrs_error_names_cannot_be_empty")
       )
     Output
       <error/vctrs_error_names_cannot_be_empty>
-      Error in `stop_vctrs()`: Names can't be empty.
+      Error in `stop_names()`: Names can't be empty.
       x Empty names found at locations 1, 2, 3, 4, 5, etc.
 
 # dot dot names errors are informative
@@ -81,7 +81,7 @@
       class = "vctrs_error_names_cannot_be_dot_dot"))
     Output
       <error/vctrs_error_names_cannot_be_dot_dot>
-      Error in `stop_vctrs()`: Names can't be of the form `...` or `..j`.
+      Error in `stop_names()`: Names can't be of the form `...` or `..j`.
       x These names are invalid:
         * "..1" at locations 1, 2, and 3.
         * "..." at location 4.
@@ -91,7 +91,7 @@
       )
     Output
       <error/vctrs_error_names_cannot_be_dot_dot>
-      Error in `stop_vctrs()`: Names can't be of the form `...` or `..j`.
+      Error in `stop_names()`: Names can't be of the form `...` or `..j`.
       x These names are invalid:
         * "..1" at locations 1, 2, 3, 4, 5, etc.
         * "..2" at locations 21 and 26.
@@ -107,7 +107,7 @@
       class = "vctrs_error_names_must_be_unique"))
     Output
       <error/vctrs_error_names_must_be_unique>
-      Error in `stop_vctrs()`: Names must be unique.
+      Error in `stop_names()`: Names must be unique.
       x These names are duplicated:
         * "x" at locations 1, 2, and 3.
         * "y" at locations 4 and 5.
@@ -116,7 +116,7 @@
       repair = "check_unique"), class = "vctrs_error_names_must_be_unique"))
     Output
       <error/vctrs_error_names_must_be_unique>
-      Error in `stop_vctrs()`: Names must be unique.
+      Error in `stop_names()`: Names must be unique.
       x These names are duplicated:
         * "x" at locations 1, 2, 3, 4, 5, etc.
         * "a" at locations 21 and 26.
@@ -131,7 +131,7 @@
       (expect_error(vec_cast("a", factor("b")), class = "vctrs_error_cast_lossy"))
     Output
       <error/vctrs_error_cast_lossy>
-      Error in `stop_vctrs()`: Can't convert from <character> to <factor<9b7e3>> due to loss of generality.
+      Error in `stop_lossy_cast()`: Can't convert from <character> to <factor<9b7e3>> due to loss of generality.
       * Locations: 1
 
 # ordered cast failures mention conversion
@@ -141,7 +141,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't convert <ordered<bf275>> to <ordered<fd1ad>>.
+      Error in `stop_incompatible()`: Can't convert <ordered<bf275>> to <ordered<fd1ad>>.
 
 # incompatible size errors
 
@@ -149,23 +149,23 @@
       (expect_error(stop_incompatible_size(1:2, 3:5, 2L, 3L, x_arg = "", y_arg = "")))
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`: Can't recycle input of size 2 to size 3.
+      Error in `stop_incompatible()`: Can't recycle input of size 2 to size 3.
     Code
       (expect_error(stop_incompatible_size(1:2, 3:5, 2L, 3L, x_arg = quote(foo),
       y_arg = "")))
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`: Can't recycle `foo` (size 2) to size 3.
+      Error in `stop_incompatible()`: Can't recycle `foo` (size 2) to size 3.
     Code
       (expect_error(stop_incompatible_size(1:2, 3:5, 2L, 3L, x_arg = "", y_arg = "bar"))
       )
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`: Can't recycle input of size 2 to match `bar` (size 3).
+      Error in `stop_incompatible()`: Can't recycle input of size 2 to match `bar` (size 3).
     Code
       (expect_error(stop_incompatible_size(1:2, 3:5, 2L, 3L, x_arg = quote(foo),
       y_arg = quote(bar))))
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`: Can't recycle `foo` (size 2) to match `bar` (size 3).
+      Error in `stop_incompatible()`: Can't recycle `foo` (size 2) to match `bar` (size 3).
 

--- a/tests/testthat/_snaps/dictionary.md
+++ b/tests/testthat/_snaps/dictionary.md
@@ -6,22 +6,22 @@
       (expect_error(vec_match(df1, df2), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `x$foo` <double> and `x$foo` <character>.
+      Error in `stop_incompatible()`: Can't combine `x$foo` <double> and `x$foo` <character>.
     Code
       (expect_error(vec_match(df1, df2, needles_arg = "n", haystack_arg = "h"),
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `n$x$foo` <double> and `h$x$foo` <character>.
+      Error in `stop_incompatible()`: Can't combine `n$x$foo` <double> and `h$x$foo` <character>.
     Code
       (expect_error(vec_in(df1, df2), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `x$foo` <double> and `x$foo` <character>.
+      Error in `stop_incompatible()`: Can't combine `x$foo` <double> and `x$foo` <character>.
     Code
       (expect_error(vec_in(df1, df2, needles_arg = "n", haystack_arg = "h"), class = "vctrs_error_incompatible_type")
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `n$x$foo` <double> and `h$x$foo` <character>.
+      Error in `stop_incompatible()`: Can't combine `n$x$foo` <double> and `h$x$foo` <character>.
 

--- a/tests/testthat/_snaps/names.md
+++ b/tests/testthat/_snaps/names.md
@@ -17,7 +17,7 @@
       )
     Output
       <error/vctrs_error_names_must_be_unique>
-      Error in `stop_vctrs()`: Names must be unique.
+      Error in `stop_names()`: Names must be unique.
       x These names are duplicated:
         * "x" at locations 1 and 2.
       i Use argument `repair` to specify repair strategy.

--- a/tests/testthat/_snaps/recycle.md
+++ b/tests/testthat/_snaps/recycle.md
@@ -5,7 +5,8 @@
       )
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`: Can't recycle input of size 2 to size 1.
+      Error in `stop_recycle_incompatible_size()`: 
+      Can't recycle input of size 2 to size 1.
 
 # incompatible recycling size has informative error
 

--- a/tests/testthat/_snaps/recycle.md
+++ b/tests/testthat/_snaps/recycle.md
@@ -5,7 +5,7 @@
       )
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_recycle_incompatible_size()`: 
+      Error in `stop_recycle_incompatible_size()`:
       Can't recycle input of size 2 to size 1.
 
 # incompatible recycling size has informative error

--- a/tests/testthat/_snaps/shape.md
+++ b/tests/testthat/_snaps/shape.md
@@ -5,14 +5,14 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine <integer[,0,5]> and <integer[,5,1]>.
+      Error in `stop_incompatible()`: Can't combine <integer[,0,5]> and <integer[,5,1]>.
       x Incompatible sizes 0 and 5 along axis 2.
     Code
       (expect_error(vec_shape2(shaped_int(1, 5, 0), shaped_int(1, 1, 5)), class = "vctrs_error_incompatible_type")
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine <integer[,5,0]> and <integer[,1,5]>.
+      Error in `stop_incompatible()`: Can't combine <integer[,5,0]> and <integer[,1,5]>.
       x Incompatible sizes 0 and 5 along axis 3.
 
 # can override error args
@@ -22,6 +22,6 @@
       y_arg = "bar"), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `foo` <integer[,0,5]> and `bar` <integer[,5,1]>.
+      Error in `stop_incompatible()`: Can't combine `foo` <integer[,0,5]> and `bar` <integer[,5,1]>.
       x Incompatible sizes 0 and 5 along axis 2.
 

--- a/tests/testthat/_snaps/slice-assign.md
+++ b/tests/testthat/_snaps/slice-assign.md
@@ -5,7 +5,7 @@
       )
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_recycle_incompatible_size()`: 
+      Error in `stop_recycle_incompatible_size()`:
       Can't recycle input of size 2 to size 3.
 
 # logical subscripts must match size of indexed vector
@@ -91,6 +91,6 @@
       )
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_recycle_incompatible_size()`: 
+      Error in `stop_recycle_incompatible_size()`:
       Can't recycle `bar` (size 2) to size 1.
 

--- a/tests/testthat/_snaps/slice-assign.md
+++ b/tests/testthat/_snaps/slice-assign.md
@@ -5,7 +5,8 @@
       )
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`: Can't recycle input of size 2 to size 3.
+      Error in `stop_recycle_incompatible_size()`: 
+      Can't recycle input of size 2 to size 3.
 
 # logical subscripts must match size of indexed vector
 
@@ -84,11 +85,12 @@
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't convert `bar` <character> to match type of `foo` <integer>.
+      Error in `stop_incompatible()`: Can't convert `bar` <character> to match type of `foo` <integer>.
     Code
       (expect_error(vec_assign(1:2, 1L, 1:2, value_arg = "bar"), class = "vctrs_error_recycle_incompatible_size")
       )
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`: Can't recycle `bar` (size 2) to size 1.
+      Error in `stop_recycle_incompatible_size()`: 
+      Can't recycle `bar` (size 2) to size 1.
 

--- a/tests/testthat/_snaps/slice-chop.md
+++ b/tests/testthat/_snaps/slice-chop.md
@@ -24,7 +24,7 @@
       (expect_error(vec_unchop(list(x, y)), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
+      Error in `stop_incompatible()`: Can't combine `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
       i See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
@@ -38,7 +38,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `..1` <vctrs_Counts> and `..2` <vctrs_Counts>.
+      Error in `stop_incompatible()`: Can't combine `..1` <vctrs_Counts> and `..2` <vctrs_Counts>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
       i See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
@@ -50,7 +50,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `..1` <vctrs_Counts> and `..2` <double>.
+      Error in `stop_incompatible()`: Can't combine `..1` <vctrs_Counts> and `..2` <double>.
 
 # vec_unchop() fallback doesn't support `name_spec` or `ptype`
 
@@ -68,7 +68,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't convert <vctrs_foobar> to <character>.
+      Error in `stop_incompatible()`: Can't convert <vctrs_foobar> to <character>.
 
 # vec_unchop() does not support non-numeric S3 indices
 
@@ -96,11 +96,11 @@
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `a` <character> and `b` <integer>.
+      Error in `stop_incompatible()`: Can't combine `a` <character> and `b` <integer>.
     Code
       (expect_error(vec_unchop(list(a = c(foo = 1:2), b = c(bar = "")), indices = list(
         2:1, 3), name_spec = zap()), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine `a` <integer> and `b` <character>.
+      Error in `stop_incompatible()`: Can't combine `a` <integer> and `b` <character>.
 

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -5,11 +5,11 @@
       )
     Output
       <error/vctrs_error_subscript_type>
-      Error: 
+      Error:
         Must extract element with a single valid subscript.
         x Subscript has the wrong type `logical`.
         i It must be numeric or character.
-      Caused by error: 
+      Caused by error:
         Must extract element with a single valid subscript.
         x Subscript has the wrong type `logical`.
         i It must be numeric or character.
@@ -18,7 +18,7 @@
       )
     Output
       <error/vctrs_error_subscript_type>
-      Error: 
+      Error:
         Must extract element with a single valid subscript.
         x Subscript has the wrong type `data.frame<
           mpg : double
@@ -34,7 +34,7 @@
           carb: double
         >`.
         i It must be numeric or character.
-      Caused by error: 
+      Caused by error:
         Must extract element with a single valid subscript.
         x Subscript has the wrong type `data.frame<
           mpg : double
@@ -55,11 +55,11 @@
       )
     Output
       <error/vctrs_error_subscript_type>
-      Error: 
+      Error:
         Must extract element with a single valid subscript.
         x Subscript has the wrong type `environment`.
         i It must be numeric or character.
-      Caused by error: 
+      Caused by error:
         Must extract element with a single valid subscript.
         x Subscript has the wrong type `environment`.
         i It must be numeric or character.
@@ -68,11 +68,11 @@
       )
     Output
       <error/vctrs_error_subscript_type>
-      Error: 
+      Error:
         Must extract element with a single valid subscript.
         x Subscript has the wrong type `vctrs_foobar`.
         i It must be numeric or character.
-      Caused by error: 
+      Caused by error:
         Must extract element with a single valid subscript.
         x Subscript has the wrong type `vctrs_foobar`.
         i It must be numeric or character.
@@ -80,26 +80,26 @@
       (expect_error(vec_as_location2(2.5, 10L), class = "vctrs_error_subscript_type"))
     Output
       <error/vctrs_error_subscript_type>
-      Error: 
+      Error:
         Must extract element with a single valid subscript.
         x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error: 
+      Caused by error:
         Must extract element with a single valid subscript.
         x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `stop_lossy_cast()`: 
+      Caused by error in `stop_lossy_cast()`:
         Can't convert from <double> to <integer> due to loss of precision.
         * Locations: 1
     Code
       (expect_error(vec_as_location2(Inf, 10L), class = "vctrs_error_subscript_type"))
     Output
       <error/vctrs_error_subscript_type>
-      Error: 
+      Error:
         Must extract element with a single valid subscript.
         x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error: 
+      Caused by error:
         Must extract element with a single valid subscript.
         x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `stop_lossy_cast()`: 
+      Caused by error in `stop_lossy_cast()`:
         Can't convert from <double> to <integer> due to loss of precision.
         * Locations: 1
     Code
@@ -107,13 +107,13 @@
       )
     Output
       <error/vctrs_error_subscript_type>
-      Error: 
+      Error:
         Must extract element with a single valid subscript.
         x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error: 
+      Caused by error:
         Must extract element with a single valid subscript.
         x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `stop_lossy_cast()`: 
+      Caused by error in `stop_lossy_cast()`:
         Can't convert from <double> to <integer> due to loss of precision.
         * Locations: 1
     Code
@@ -122,11 +122,11 @@
       )
     Output
       <error/vctrs_error_subscript_type>
-      Error: 
+      Error:
         Must extract element with a single valid subscript.
         x Subscript `foo` has the wrong type `vctrs_foobar`.
         i It must be numeric or character.
-      Caused by error: 
+      Caused by error:
         Must extract element with a single valid subscript.
         x Subscript `foo` has the wrong type `vctrs_foobar`.
         i It must be numeric or character.
@@ -135,13 +135,13 @@
       )
     Output
       <error/vctrs_error_subscript_type>
-      Error: 
+      Error:
         Must extract element with a single valid subscript.
         x Can't convert from `foo` <double> to <integer> due to loss of precision.
-      Caused by error: 
+      Caused by error:
         Must extract element with a single valid subscript.
         x Can't convert from `foo` <double> to <integer> due to loss of precision.
-      Caused by error in `stop_lossy_cast()`: 
+      Caused by error in `stop_lossy_cast()`:
         Can't convert from `foo` <double> to <integer> due to loss of precision.
         * Locations: 1
     Code
@@ -149,11 +149,11 @@
       )
     Output
       <error/vctrs_error_subscript_type>
-      Error: 
+      Error:
         Must remove row with a single valid subscript.
         x Subscript `foo(bar)` has the wrong type `logical`.
         i It must be numeric or character.
-      Caused by error: 
+      Caused by error:
         Must extract element with a single valid subscript.
         x Subscript has the wrong type `logical`.
         i It must be numeric or character.
@@ -200,10 +200,10 @@
       (expect_error(vec_as_location(2.5, 10L), class = "vctrs_error_subscript_type"))
     Output
       <error/vctrs_error_subscript_type>
-      Error: 
+      Error:
         Must subset elements with a valid subscript vector.
         x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `stop_lossy_cast()`: 
+      Caused by error in `stop_lossy_cast()`:
         Can't convert from <double> to <integer> due to loss of precision.
         * Locations: 1
     Code
@@ -252,10 +252,10 @@
       )
     Output
       <error/vctrs_error_subscript_type>
-      Error: 
+      Error:
         Must subset elements with a valid subscript vector.
         x Can't convert from `foo` <double> to <integer> due to loss of precision.
-      Caused by error in `stop_lossy_cast()`: 
+      Caused by error in `stop_lossy_cast()`:
         Can't convert from `foo` <double> to <integer> due to loss of precision.
         * Locations: 1
 
@@ -327,7 +327,7 @@
       )
     Output
       <error/vctrs_error_subscript_type>
-      Error: 
+      Error:
         Must extract element with a single valid subscript.
         x Subscript `foo` has the wrong type `data.frame<
           mpg : double
@@ -343,7 +343,7 @@
           carb: double
         >`.
         i It must be numeric or character.
-      Caused by error: 
+      Caused by error:
         Must extract element with a single valid subscript.
         x Subscript `foo` has the wrong type `data.frame<
           mpg : double

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -86,7 +86,7 @@
       Caused by error: 
         Must extract element with a single valid subscript.
         x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `stop_vctrs()`: 
+      Caused by error in `stop_lossy_cast()`: 
         Can't convert from <double> to <integer> due to loss of precision.
         * Locations: 1
     Code
@@ -99,7 +99,7 @@
       Caused by error: 
         Must extract element with a single valid subscript.
         x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `stop_vctrs()`: 
+      Caused by error in `stop_lossy_cast()`: 
         Can't convert from <double> to <integer> due to loss of precision.
         * Locations: 1
     Code
@@ -113,7 +113,7 @@
       Caused by error: 
         Must extract element with a single valid subscript.
         x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `stop_vctrs()`: 
+      Caused by error in `stop_lossy_cast()`: 
         Can't convert from <double> to <integer> due to loss of precision.
         * Locations: 1
     Code
@@ -141,7 +141,7 @@
       Caused by error: 
         Must extract element with a single valid subscript.
         x Can't convert from `foo` <double> to <integer> due to loss of precision.
-      Caused by error in `stop_vctrs()`: 
+      Caused by error in `stop_lossy_cast()`: 
         Can't convert from `foo` <double> to <integer> due to loss of precision.
         * Locations: 1
     Code
@@ -203,7 +203,7 @@
       Error: 
         Must subset elements with a valid subscript vector.
         x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `stop_vctrs()`: 
+      Caused by error in `stop_lossy_cast()`: 
         Can't convert from <double> to <integer> due to loss of precision.
         * Locations: 1
     Code
@@ -255,7 +255,7 @@
       Error: 
         Must subset elements with a valid subscript vector.
         x Can't convert from `foo` <double> to <integer> due to loss of precision.
-      Caused by error in `stop_vctrs()`: 
+      Caused by error in `stop_lossy_cast()`: 
         Can't convert from `foo` <double> to <integer> due to loss of precision.
         * Locations: 1
 

--- a/tests/testthat/_snaps/type-asis.md
+++ b/tests/testthat/_snaps/type-asis.md
@@ -5,7 +5,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine <double> and <character>.
+      Error in `stop_incompatible()`: Can't combine <double> and <character>.
 
 # AsIs objects throw cast errors with their underlying types
 
@@ -14,5 +14,5 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't convert <double> to <factor<bf275>>.
+      Error in `stop_incompatible()`: Can't convert <double> to <factor<bf275>>.
 

--- a/tests/testthat/_snaps/type2.md
+++ b/tests/testthat/_snaps/type2.md
@@ -34,13 +34,13 @@
       )
     Output
       <error/vctrs_error_scalar_type>
-      Error in `stop_vctrs()`: `foo` must be a vector, not a symbol.
+      Error in `stop_scalar_type()`: `foo` must be a vector, not a symbol.
     Code
       (expect_error(vec_ptype2(quote(x), NULL, x_arg = "foo"), class = "vctrs_error_scalar_type")
       )
     Output
       <error/vctrs_error_scalar_type>
-      Error in `stop_vctrs()`: `foo` must be a vector, not a symbol.
+      Error in `stop_scalar_type()`: `foo` must be a vector, not a symbol.
 
 # can override scalar vector error message for S3 types
 
@@ -49,13 +49,13 @@
       )
     Output
       <error/vctrs_error_scalar_type>
-      Error in `stop_vctrs()`: `foo` must be a vector, not a <vctrs_foobar> object.
+      Error in `stop_scalar_type()`: `foo` must be a vector, not a <vctrs_foobar> object.
     Code
       (expect_error(vec_ptype2(foobar(), NULL, x_arg = "foo"), class = "vctrs_error_scalar_type")
       )
     Output
       <error/vctrs_error_scalar_type>
-      Error in `stop_vctrs()`: `foo` must be a vector, not a <vctrs_foobar> object.
+      Error in `stop_scalar_type()`: `foo` must be a vector, not a <vctrs_foobar> object.
 
 # ptype2 and cast errors when same class fallback is impossible are informative
 
@@ -64,7 +64,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't convert <vctrs_foobar> to <vctrs_foobar>.
+      Error in `stop_incompatible()`: Can't convert <vctrs_foobar> to <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
       i See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
@@ -73,7 +73,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine <vctrs_foobar> and <vctrs_foobar>.
+      Error in `stop_incompatible()`: Can't combine <vctrs_foobar> and <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
       i See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
@@ -95,13 +95,13 @@
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't convert <vctrs_foobar> to <vctrs_foobar>.
+      Error in `stop_incompatible()`: Can't convert <vctrs_foobar> to <vctrs_foobar>.
     Code
       (expect_error(with_foobar_ptype2(vec_ptype2(foobar(1, bar = TRUE), foobar(2,
         baz = TRUE))), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine <vctrs_foobar> and <vctrs_foobar>.
+      Error in `stop_incompatible()`: Can't combine <vctrs_foobar> and <vctrs_foobar>.
 
 # common type errors don't mention columns if they are compatible
 
@@ -113,7 +113,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't convert <vctrs_foo> to <vctrs_bar>.
+      Error in `stop_incompatible()`: Can't convert <vctrs_foo> to <vctrs_bar>.
 
 # common type warnings for data frames take attributes into account
 
@@ -141,7 +141,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`: Can't combine <vctrs_foobar> and <vctrs_foobaz>.
+      Error in `stop_incompatible()`: Can't combine <vctrs_foobar> and <vctrs_foobaz>.
 
 # For reference, warning for incompatible classes
 


### PR DESCRIPTION
Because it's never useful to see 

```
Error in `stop_vctrs()`: <...>
```

Although the caller is not what we would ideally want to see, it's still more useful IMO. 

I think this is a good first step, maybe this should propagate further, e.g. `stop_incompatible(call=)` etc ... but then some functions are exported so I'm not sure it's ok to have them have a `call=` argument. 
