### PR TITLE
Return `logical()` from `vec_equal_na(NULL)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `vec_equal_na(NULL)` now returns `logical(0)` rather than erroring (#1494).
+
 * `vec_as_location(missing = "error")` now fails with `NA` and `NA_character_`
   in addition to `NA_integer_` (#1420, @krlmlr).
 

--- a/src/equal.c
+++ b/src/equal.c
@@ -475,6 +475,10 @@ SEXP vec_equal_na(SEXP x) {
     UNPROTECT(1);
     return out;
   }
+  case vctrs_type_null: {
+    UNPROTECT(1);
+    return vctrs_shared_empty_lgl;
+  }
   case vctrs_type_scalar:    Rf_errorcall(R_NilValue, "Can't detect `NA` values in scalars with `vctrs_equal_na()`.");
   default:                   Rf_error("Unimplemented type in `vctrs_equal_na()`.");
   }

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -303,6 +303,10 @@ test_that("works recursively with data frame columns", {
   expect_equal(vec_equal_na(df), c(FALSE, FALSE, FALSE, TRUE))
 })
 
+test_that("works with `NULL` input (#1494)", {
+  expect_identical(vec_equal_na(NULL), logical())
+})
+
 test_that("NA propagate symmetrically (#204)", {
   exp <- c(NA, NA)
 


### PR DESCRIPTION
Closes #1494 