### PR TITLE
Preliminary support for error calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # vctrs (development version)
 
+* Starting with rlang 1.0.0, errors are displayed with the contextual
+  function call. Several vctrs operations gain a `call` argument that
+  makes it possible to report the correct context in error messages.
+  This concerns:
+
+  - `vec_cast()` and `vec_ptype2()`
+  - `vec_default_cast()` and `vec_default_ptype2()`
+  - `vec_assert()`
+  - `vec_as_names()`
+  - `stop_` constructors like `stop_incompatible_type()`
+
+  Note that default `vec_cast()` and `vec_ptype2()` methods
+  automatically support this if they pass `...` to the corresponding
+  `vec_default_` functions. If you throw a non-internal error from a
+  non-default method add a `call = caller_env()` argument in the
+  method and pass it to `rlang::abort()`.
+
 * If `NA_character_` is specified as a name for `vctrs_vctr` objects, it is
   now automatically repaired to `""` (#780).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
   Note that default `vec_cast()` and `vec_ptype2()` methods
   automatically support this if they pass `...` to the corresponding
   `vec_default_` functions. If you throw a non-internal error from a
-  non-default method add a `call = caller_env()` argument in the
+  non-default method, add a `call = caller_env()` argument in the
   method and pass it to `rlang::abort()`.
 
 * If `NA_character_` is specified as a name for `vctrs_vctr` objects, it is

--- a/R/assert.R
+++ b/R/assert.R
@@ -56,6 +56,8 @@
 #'
 #' Both errors inherit from `"vctrs_error_assert"`.
 #'
+#' @inheritParams rlang::args_error_context
+#'
 #' @param x A vector argument to check.
 #' @param ptype Prototype to compare against. If the prototype has a
 #'   class, its [vec_ptype()] is compared to that of `x` with
@@ -70,9 +72,13 @@
 #'   throws a typed error (see section on error types) or returns `x`,
 #'   invisibly.
 #' @export
-vec_assert <- function(x, ptype = NULL, size = NULL, arg = as_label(substitute(x))) {
+vec_assert <- function(x,
+                       ptype = NULL,
+                       size = NULL,
+                       arg = caller_arg(x),
+                       call = caller_env()) {
   if (!vec_is_vector(x)) {
-    stop_scalar_type(x, arg)
+    stop_scalar_type(x, arg, call = call)
   }
 
   if (!is_null(ptype)) {
@@ -84,7 +90,8 @@ vec_assert <- function(x, ptype = NULL, size = NULL, arg = as_label(substitute(x
         msg,
         class = c("vctrs_error_assert_ptype", "vctrs_error_assert"),
         required = ptype,
-        actual = x_type
+        actual = x_type,
+        call = call
       )
     }
   }
@@ -99,7 +106,12 @@ vec_assert <- function(x, ptype = NULL, size = NULL, arg = as_label(substitute(x
 
     x_size <- vec_size(x)
     if (!identical(x_size, size)) {
-      stop_assert_size(x_size, size, arg)
+      stop_assert_size(
+        x_size,
+        size,
+        arg,
+        call = call
+      )
     }
   }
 

--- a/R/assert.R
+++ b/R/assert.R
@@ -107,7 +107,10 @@ vec_assert <- function(x, ptype = NULL, size = NULL, arg = as_label(substitute(x
 }
 
 # Also thrown from C
-stop_assert_size <- function(actual, required, arg) {
+stop_assert_size <- function(actual,
+                             required,
+                             arg,
+                             call = caller_env()) {
   if (!nzchar(arg)) {
     arg <- "Input"
   } else {
@@ -120,12 +123,21 @@ stop_assert_size <- function(actual, required, arg) {
     message,
     class = "vctrs_error_assert_size",
     actual = actual,
-    required = required
+    required = required,
+    call = call
   )
 }
 
-stop_assert <- function(message = NULL, class = NULL, ...) {
-  stop_vctrs(message, class = c(class, "vctrs_error_assert"), ...)
+stop_assert <- function(message = NULL,
+                        class = NULL,
+                        ...,
+                        call = caller_env()) {
+  stop_vctrs(
+    message,
+    class = c(class, "vctrs_error_assert"),
+    ...,
+    call = call
+  )
 }
 
 #' @rdname vec_assert

--- a/R/cast.R
+++ b/R/cast.R
@@ -8,6 +8,7 @@
 #'
 #' @includeRmd man/faq/developer/links-coercion.Rmd
 #'
+#' @inheritParams rlang::args_error_context
 #' @param x Vectors to cast.
 #' @param ... For `vec_cast_common()`, vectors to cast. For
 #'   `vec_cast()`, `vec_cast_default()`, and `vec_restore()`, these
@@ -62,11 +63,16 @@
 #'
 #' # Cast to common type
 #' vec_cast_common(factor("a"), factor(c("a", "b")))
-vec_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast <- function(x,
+                     to,
+                     ...,
+                     x_arg = "",
+                     to_arg = "",
+                     call = caller_env()) {
   if (!missing(...)) {
     check_ptype2_dots_empty(...)
   }
-  return(.Call(vctrs_cast, x, to, x_arg, to_arg))
+  return(.Call(ffi_cast, x, to, x_arg, to_arg, environment()))
   UseMethod("vec_cast", to)
 }
 vec_cast_dispatch <- function(x, to, ..., x_arg = "", to_arg = "") {

--- a/R/cast.R
+++ b/R/cast.R
@@ -82,9 +82,21 @@ vec_cast_dispatch <- function(x, to, ..., x_arg = "", to_arg = "") {
 vec_cast_no_fallback <- function(x, to) {
   vec_cast_common_params(x = x, .to = to, .df_fallback = DF_FALLBACK_none)$x
 }
-vec_cast_dispatch_native <- function(x, to, ..., x_arg = "", to_arg = "") {
-  fallback_opts <- match_fallback_opts(...)
-  .Call(vctrs_cast_dispatch_native, x, to, fallback_opts, x_arg, to_arg)
+vec_cast_dispatch_native <- function(x,
+                                     to,
+                                     ...,
+                                     x_arg = "",
+                                     to_arg = "",
+                                     call = caller_env()) {
+  .Call(
+    ffi_cast_dispatch_native,
+    x,
+    to,
+    match_fallback_opts(...),
+    x_arg,
+    to_arg,
+    environment()
+  )
 }
 
 #' @export

--- a/R/cast.R
+++ b/R/cast.R
@@ -108,16 +108,39 @@ vec_cast_common_fallback <- function(..., .to = NULL) {
 #' @rdname vec_default_ptype2
 #' @inheritParams vec_cast
 #' @export
-vec_default_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_default_cast <- function(x,
+                             to,
+                             ...,
+                             x_arg = "",
+                             to_arg = "",
+                             call = caller_env()) {
   if (is_asis(x)) {
-    return(vec_cast_from_asis(x, to, x_arg = x_arg, to_arg = to_arg))
+    return(vec_cast_from_asis(
+      x,
+      to,
+      x_arg = x_arg,
+      to_arg = to_arg,
+      call = call
+    ))
   }
   if (is_asis(to)) {
-    return(vec_cast_to_asis(x, to, x_arg = x_arg, to_arg = to_arg))
+    return(vec_cast_to_asis(
+      x,
+      to,
+      x_arg = x_arg,
+      to_arg = to_arg,
+      call = call
+    ))
   }
 
   if (inherits(to, "vctrs_vctr") && !inherits(to, c("vctrs_rcrd", "vctrs_list_of"))) {
-    return(vctr_cast(x, to, x_arg = x_arg, to_arg = to_arg))
+    return(vctr_cast(
+      x,
+      to,
+      x_arg = x_arg,
+      to_arg = to_arg,
+      call = call
+    ))
   }
 
   opts <- match_fallback_opts(...)
@@ -158,7 +181,8 @@ vec_default_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
     to,
     x_arg = x_arg,
     to_arg = to_arg,
-    `vctrs:::from_dispatch` = match_from_dispatch(...)
+    `vctrs:::from_dispatch` = match_from_dispatch(...),
+    call = call
   )
 }
 

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -436,10 +436,10 @@ maybe_lossy_cast <- function(result, x, to,
                              loss_type = c("precision", "generality"),
                              x_arg,
                              to_arg,
+                             call = caller_env(),
                              details = NULL,
                              message = NULL,
                              class = NULL,
-                             error_call = caller_env(),
                              .deprecation = FALSE) {
   if (!any(lossy)) {
     return(result)
@@ -465,7 +465,7 @@ maybe_lossy_cast <- function(result, x, to,
       details = details,
       message = message,
       class = class,
-      call = error_call
+      call = call
     )
   )
 }
@@ -825,6 +825,7 @@ ensure_full_stop <- function(x) {
 }
 
 
+# TODO! cli + .internal
 stop_native_implementation <- function(fn) {
   abort(paste_line(
     glue::glue("`{fn}()` is implemented at C level."),

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -5,6 +5,7 @@
 #' These conditions have custom classes and structures to make
 #' testing easier.
 #'
+#' @inheritParams rlang::args_error_context
 #' @param x,y,to Vectors
 #' @param subclass Use if you want to further customize the class.
 #' @param ...,class Only use these fields when creating a subclass.
@@ -56,11 +57,27 @@
 #' @name vctrs-conditions
 NULL
 
-stop_vctrs <- function(message = NULL, class = NULL, ...) {
-  abort(message, class = c(class, "vctrs_error"), ...)
+stop_vctrs <- function(message = NULL,
+                       class = NULL,
+                       ...,
+                       call = caller_env()) {
+  abort(
+    message,
+    class = c(class, "vctrs_error"),
+    ...,
+    call = call
+  )
 }
-warn_vctrs <- function(message = NULL, class = NULL, ...) {
-  warn(message, class = c(class, "vctrs_warning"), ...)
+warn_vctrs <- function(message = NULL,
+                       class = NULL,
+                       ...,
+                       call = caller_env()) {
+  warn(
+    message,
+    class = c(class, "vctrs_warning"),
+    ...,
+    call = call
+  )
 }
 
 stop_incompatible <- function(x,
@@ -68,14 +85,16 @@ stop_incompatible <- function(x,
                               ...,
                               details = NULL,
                               message = NULL,
-                              class = NULL) {
+                              class = NULL,
+                              call = caller_env()) {
   stop_vctrs(
     message,
     class = c(class, "vctrs_error_incompatible"),
     x = x,
     y = y,
     details = details,
-    ...
+    ...,
+    call = call
   )
 }
 
@@ -93,7 +112,8 @@ stop_incompatible_type <- function(x,
                                    action = c("combine", "convert"),
                                    details = NULL,
                                    message = NULL,
-                                   class = NULL) {
+                                   class = NULL,
+                                   call = caller_env()) {
   vec_assert(x, arg = x_arg)
   vec_assert(y, arg = y_arg)
 
@@ -117,7 +137,8 @@ stop_incompatible_type <- function(x,
     details = details,
     ...,
     message = message,
-    class = c(class, "vctrs_error_incompatible_type")
+    class = c(class, "vctrs_error_incompatible_type"),
+    call = call
   )
 }
 
@@ -130,7 +151,8 @@ stop_incompatible_cast <- function(x,
                                    to_arg,
                                    details = NULL,
                                    message = NULL,
-                                   class = NULL) {
+                                   class = NULL,
+                                   call = caller_env()) {
   stop_incompatible_type(
     x = x,
     y = to,
@@ -140,15 +162,30 @@ stop_incompatible_cast <- function(x,
     action = "convert",
     details = details,
     message = message,
-    class = class
+    class = class,
+    call = call
   )
 }
 
-stop_incompatible_shape <- function(x, y, x_size, y_size, axis, x_arg, y_arg) {
+stop_incompatible_shape <- function(x,
+                                    y,
+                                    x_size,
+                                    y_size,
+                                    axis,
+                                    x_arg,
+                                    y_arg,
+                                    call = caller_env()) {
   details <- format_error_bullets(c(
     x = glue::glue("Incompatible sizes {x_size} and {y_size} along axis {axis}.")
   ))
-  stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg, details = details)
+  stop_incompatible_type(
+    x,
+    y,
+    x_arg = x_arg,
+    y_arg = y_arg,
+    details = details,
+    call = call
+  )
 }
 
 type_actions <- c(
@@ -264,7 +301,14 @@ cnd_type_message_df_label <- function(x) {
 
 #' @rdname vctrs-conditions
 #' @export
-stop_incompatible_op <- function(op, x, y, details = NULL, ..., message = NULL, class = NULL) {
+stop_incompatible_op <- function(op,
+                                 x,
+                                 y,
+                                 details = NULL,
+                                 ...,
+                                 message = NULL,
+                                 class = NULL,
+                                 call = caller_env()) {
 
   message <- message %||% glue_lines(
     "<{vec_ptype_full(x)}> {op} <{vec_ptype_full(y)}> is not permitted",
@@ -277,7 +321,8 @@ stop_incompatible_op <- function(op, x, y, details = NULL, ..., message = NULL, 
     details = details,
     ...,
     message = message,
-    class = c(class, "vctrs_error_incompatible_op")
+    class = c(class, "vctrs_error_incompatible_op"),
+    call = call
   )
 }
 
@@ -292,7 +337,8 @@ stop_incompatible_size <- function(x,
                                    y_arg,
                                    details = NULL,
                                    message = NULL,
-                                   class = NULL) {
+                                   class = NULL,
+                                   call = caller_env()) {
   stop_incompatible(
     x,
     y,
@@ -303,7 +349,8 @@ stop_incompatible_size <- function(x,
     y_arg = y_arg,
     details = details,
     message = message,
-    class = c(class, "vctrs_error_incompatible_size")
+    class = c(class, "vctrs_error_incompatible_size"),
+    call = call
   )
 }
 
@@ -362,6 +409,7 @@ cnd_body.vctrs_error_incompatible_size <- function(cnd, ...) {
 #'
 #' @inheritParams stop_incompatible_cast
 #' @inheritParams vec_cast
+#' @inheritParams rlang::args_error_context
 #' @param result The result of a potentially lossy cast.
 #' @param to Type to cast to.
 #' @param lossy A logical vector indicating which elements of `result`
@@ -391,6 +439,7 @@ maybe_lossy_cast <- function(result, x, to,
                              details = NULL,
                              message = NULL,
                              class = NULL,
+                             error_call = caller_env(),
                              .deprecation = FALSE) {
   if (!any(lossy)) {
     return(result)
@@ -415,7 +464,8 @@ maybe_lossy_cast <- function(result, x, to,
       to_arg = to_arg,
       details = details,
       message = message,
-      class = class
+      class = class,
+      call = error_call
     )
   )
 }
@@ -427,7 +477,8 @@ stop_lossy_cast <- function(x, to, result,
                             to_arg,
                             details = NULL,
                             message = NULL,
-                            class = NULL) {
+                            class = NULL,
+                            call = caller_env()) {
   stop_vctrs(
     message,
     x = x,
@@ -440,7 +491,8 @@ stop_lossy_cast <- function(x, to, result,
     x_arg = x_arg,
     to_arg = to_arg,
     details = details,
-    class = c(class, "vctrs_error_cast_lossy")
+    class = c(class, "vctrs_error_cast_lossy"),
+    call = call
   )
 }
 
@@ -559,70 +611,85 @@ maybe_warn_deprecated_lossy_cast <- function(x, to, loss_type, x_arg, to_arg) {
   invisible()
 }
 
-stop_unsupported <- function(x, method) {
+stop_unsupported <- function(x, method, call = caller_env()) {
   msg <- glue::glue("`{method}.{class(x)[[1]]}()` not supported.")
   stop_vctrs(
     "vctrs_error_unsupported",
     message = msg,
     x = x,
-    method = method
+    method = method,
+    call = call
   )
 }
 
-stop_unimplemented <- function(x, method) {
+stop_unimplemented <- function(x, method, call = caller_env()) {
   msg <- glue::glue("`{method}.{class(x)[[1]]}()` not implemented.")
   stop_vctrs(
     "vctrs_error_unimplemented",
     message = msg,
     x = x,
-    method = method
+    method = method,
+    call = call
   )
 }
 
-stop_scalar_type <- function(x, arg = NULL) {
+stop_scalar_type <- function(x, arg = NULL, call = caller_env()) {
   if (is_null(arg) || !nzchar(arg)) {
     arg <- "Input"
   } else {
     arg <- glue::backtick(arg)
   }
   msg <- glue::glue("{arg} must be a vector, not {friendly_type_of(x)}.")
-  stop_vctrs(msg, "vctrs_error_scalar_type", actual = x)
+  stop_vctrs(
+    msg,
+    "vctrs_error_scalar_type",
+    actual = x,
+    call = call
+  )
 }
 
-stop_corrupt_factor_levels <- function(x, arg = "x") {
+stop_corrupt_factor_levels <- function(x,
+                                       arg = "x",
+                                       call = caller_env()) {
   msg <- glue::glue("`{arg}` is a corrupt factor with non-character levels")
-  abort(msg)
+  abort(msg, call = call)
 }
 
-stop_corrupt_ordered_levels <- function(x, arg = "x") {
+stop_corrupt_ordered_levels <- function(x, arg = "x", call = caller_env()) {
   msg <- glue::glue("`{arg}` is a corrupt ordered factor with non-character levels")
-  abort(msg)
+  abort(msg, call = call)
 }
 
-stop_recycle_incompatible_size <- function(x_size, size, x_arg = "x") {
+stop_recycle_incompatible_size <- function(x_size,
+                                           size,
+                                           x_arg = "x",
+                                           call = caller_env()) {
   stop_vctrs(
     x_size = x_size,
     y_size = size,
     x_arg = x_arg,
     # FIXME: tibble is the only package that uses `vctrs_error_recycle_incompatible_size`
-    class = c("vctrs_error_incompatible_size", "vctrs_error_recycle_incompatible_size")
+    class = c("vctrs_error_incompatible_size", "vctrs_error_recycle_incompatible_size"),
+    call = call
   )
 }
 
 
 # Names -------------------------------------------------------------------
 
-stop_names <- function(class = NULL, ...) {
+stop_names <- function(class = NULL, ..., call = caller_env()) {
   stop_vctrs(
     class = c(class, "vctrs_error_names"),
-    ...
+    ...,
+    call = call
   )
 }
 
-stop_names_cannot_be_empty <- function(names) {
+stop_names_cannot_be_empty <- function(names, call = caller_env()) {
   stop_names(
     class = "vctrs_error_names_cannot_be_empty",
-    names = names
+    names = names,
+    call = caller_env()
   )
 }
 
@@ -645,10 +712,11 @@ cnd_body.vctrs_error_names_cannot_be_empty <- function(cnd, ...) {
   format_error_bullets(bullet)
 }
 
-stop_names_cannot_be_dot_dot <- function(names) {
+stop_names_cannot_be_dot_dot <- function(names, call = caller_env()) {
   stop_names(
     class = "vctrs_error_names_cannot_be_dot_dot",
-    names = names
+    names = names,
+    call = call
   )
 }
 
@@ -678,11 +746,14 @@ cnd_body.vctrs_error_names_cannot_be_dot_dot <- function(cnd, ...) {
   message
 }
 
-stop_names_must_be_unique <- function(names, arg = "") {
+stop_names_must_be_unique <- function(names,
+                                      arg = "",
+                                      call = caller_env()) {
   stop_names(
     class = "vctrs_error_names_must_be_unique",
     arg = arg,
-    names = names
+    names = names,
+    call = call
   )
 }
 

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -689,7 +689,7 @@ stop_names_cannot_be_empty <- function(names, call = caller_env()) {
   stop_names(
     class = "vctrs_error_names_cannot_be_empty",
     names = names,
-    call = caller_env()
+    call = call
   )
 }
 

--- a/R/names.R
+++ b/R/names.R
@@ -159,27 +159,31 @@ vec_as_names <- function(names,
   .Call(vctrs_as_names, names, repair, repair_arg, quiet)
 }
 
+# TODO! Error calls
 validate_name_repair_arg <- function(repair) {
   .Call(vctrs_validate_name_repair_arg, repair)
 }
 validate_minimal_names <- function(names, n = NULL) {
   .Call(vctrs_validate_minimal_names, names, n)
 }
-validate_unique <- function(names, arg = "", n = NULL) {
+validate_unique <- function(names,
+                            arg = "",
+                            n = NULL,
+                            call = caller_env()) {
   validate_minimal_names(names, n)
 
   empty_names <- detect_empty_names(names)
   if (has_length(empty_names)) {
-    stop_names_cannot_be_empty(names)
+    stop_names_cannot_be_empty(names, call = call)
   }
 
   dot_dot_name <- detect_dot_dot(names)
   if (has_length(dot_dot_name)) {
-    stop_names_cannot_be_dot_dot(names)
+    stop_names_cannot_be_dot_dot(names, call = call)
   }
 
   if (anyDuplicated(names)) {
-    stop_names_must_be_unique(names, arg)
+    stop_names_must_be_unique(names, arg, call = call)
   }
 
   invisible(names)

--- a/R/names.R
+++ b/R/names.R
@@ -32,6 +32,9 @@
 #' levels are nested.
 #'
 #'
+#' @inheritParams rlang::args_error_context
+#' @inheritParams rlang::args_dots_empty
+#'
 #' @param names A character vector.
 #' @param repair Either a string or a function. If a string, it must
 #'   be one of `"check_unique"`, `"minimal"`, `"unique"`, or `"universal"`.
@@ -57,7 +60,6 @@
 #'   caused by repairing the names. This only concerns unique and
 #'   universal repairing. Set `quiet` to `TRUE` to silence the
 #'   messages.
-#' @inheritParams rlang::args_dots_empty
 #'
 #' @section `minimal` names:
 #'
@@ -154,9 +156,17 @@ vec_as_names <- function(names,
                          ...,
                          repair = c("minimal", "unique", "universal", "check_unique"),
                          repair_arg = "",
-                         quiet = FALSE) {
+                         quiet = FALSE,
+                         call = caller_env()) {
   check_dots_empty0(...)
-  .Call(vctrs_as_names, names, repair, repair_arg, quiet)
+  .Call(
+    ffi_as_names,
+    names,
+    repair,
+    repair_arg,
+    quiet,
+    environment()
+  )
 }
 
 # TODO! Error calls
@@ -258,7 +268,8 @@ vec_names2 <- function(x,
     return(new_names)
   }
 
-  switch(repair,
+  switch(
+    repair,
     minimal = minimal_names(x),
     unique = unique_names(x, quiet = quiet),
     universal = as_universal_names(minimal_names(x), quiet = quiet),

--- a/R/recycle.R
+++ b/R/recycle.R
@@ -22,6 +22,8 @@
 #' We say that two vectors have __compatible size__ if they can be
 #' recycled to be the same length.
 #'
+#' @inheritParams rlang::args_error_context
+#'
 #' @param x A vector to recycle.
 #' @param ...
 #'   * For `vec_recycle_common()`, vectors to recycle.
@@ -49,9 +51,9 @@
 #' vec_recycle_common(data.frame(x = 1), 1:5)
 #' vec_recycle_common(array(1:2, c(1, 2)), 1:5)
 #' vec_recycle_common(array(1:3, c(1, 3, 1)), 1:5)
-vec_recycle <- function(x, size, ..., x_arg = "") {
+vec_recycle <- function(x, size, ..., x_arg = "", call = caller_env()) {
   check_dots_empty0(...)
-  .Call(vctrs_recycle, x, size, x_arg)
+  .Call(ffi_recycle, x, size, x_arg, environment())
 }
 
 #' @export

--- a/R/shape.R
+++ b/R/shape.R
@@ -18,7 +18,12 @@ vec_shape2 <- function(x, y, ..., x_arg = "", y_arg = "") {
 }
 
 # Should take same signature as `vec_cast()`
-shape_broadcast <- function(x, to, ..., x_arg, to_arg) {
+shape_broadcast <- function(x,
+                            to,
+                            ...,
+                            x_arg,
+                            to_arg,
+                            call = caller_env()) {
   if (is.null(x) || is.null(to)) {
     return(x)
   }
@@ -37,7 +42,8 @@ shape_broadcast <- function(x, to, ..., x_arg, to_arg) {
       to,
       details = "Cannot decrease dimensions.",
       x_arg = x_arg,
-      to_arg = to_arg
+      to_arg = to_arg,
+      call = call
     )
   }
 
@@ -50,7 +56,8 @@ shape_broadcast <- function(x, to, ..., x_arg, to_arg) {
       to,
       details = "Non-recyclable dimensions.",
       x_arg = x_arg,
-      to_arg = to_arg
+      to_arg = to_arg,
+      call = call
     )
   }
 

--- a/R/slice.R
+++ b/R/slice.R
@@ -230,7 +230,7 @@ vec_index <- function(x, i, ...) {
 #' vec_init(Sys.Date(), 5)
 #' vec_init(mtcars, 2)
 vec_init <- function(x, n = 1L) {
-  .Call(vctrs_init, x, n)
+  .Call(ffi_init, x, n, environment())
 }
 
 # Exposed for testing (`start` is 0-based)

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -249,11 +249,12 @@ vec_as_location2_result <- function(i,
 }
 
 
-stop_location_negative_missing <- function(i, ...) {
+stop_location_negative_missing <- function(i, ..., call = caller_env()) {
   cnd_signal(new_error_subscript_type(
     i,
     ...,
-    body = cnd_body_vctrs_error_location_negative_missing
+    body = cnd_body_vctrs_error_location_negative_missing,
+    call = call
   ))
 }
 cnd_body_vctrs_error_location_negative_missing <- function(cnd, ...) {
@@ -275,11 +276,12 @@ cnd_body_vctrs_error_location_negative_missing <- function(cnd, ...) {
   ))
 }
 
-stop_location_negative_positive <- function(i, ...) {
+stop_location_negative_positive <- function(i, ..., call = caller_env()) {
   cnd_signal(new_error_subscript_type(
     i,
     ...,
-    body = cnd_body_vctrs_error_location_negative_positive
+    body = cnd_body_vctrs_error_location_negative_positive,
+    call = call
   ))
 }
 cnd_body_vctrs_error_location_negative_positive <- function(cnd, ...) {
@@ -333,11 +335,12 @@ cnd_bullets_location2_need_positive <- function(cnd, ...) {
   ))
 }
 
-stop_location_negative <- function(i, ...) {
+stop_location_negative <- function(i, ..., call = caller_env()) {
   cnd_signal(new_error_subscript_type(
     i,
     body = cnd_bullets_location_need_non_negative,
-    ...
+    ...,
+    call = call
   ))
 }
 cnd_bullets_location_need_non_negative <- function(cnd, ...) {
@@ -347,11 +350,12 @@ cnd_bullets_location_need_non_negative <- function(cnd, ...) {
   ))
 }
 
-stop_location_zero <- function(i, ...) {
+stop_location_zero <- function(i, ..., call = caller_env()) {
   cnd_signal(new_error_subscript_type(
     i,
     body = cnd_bullets_location_need_non_zero,
-    ...
+    ...,
+    call = call
   ))
 }
 cnd_bullets_location_need_non_zero <- function(cnd, ...) {
@@ -373,11 +377,12 @@ cnd_bullets_location_need_non_zero <- function(cnd, ...) {
   ))
 }
 
-stop_subscript_missing <- function(i, ...) {
+stop_subscript_missing <- function(i, ..., call = caller_env()) {
   cnd_signal(new_error_subscript_type(
     i = i,
     body = cnd_bullets_subscript_missing,
-    ...
+    ...,
+    call = call
   ))
 }
 cnd_bullets_subscript_missing <- function(cnd, ...) {
@@ -397,12 +402,13 @@ cnd_bullets_subscript_missing <- function(cnd, ...) {
   ))
 }
 
-stop_indicator_size <- function(i, n, ...) {
+stop_indicator_size <- function(i, n, ..., call = caller_env()) {
   cnd_signal(new_error_subscript_size(
     i,
     n = n,
     ...,
-    body = cnd_body_vctrs_error_indicator_size
+    body = cnd_body_vctrs_error_indicator_size,
+    call = call
   ))
 }
 cnd_body_vctrs_error_indicator_size <- function(cnd, ...) {
@@ -414,12 +420,16 @@ cnd_body_vctrs_error_indicator_size <- function(cnd, ...) {
   )
 }
 
-stop_subscript_oob <- function(i, subscript_type, ...) {
+stop_subscript_oob <- function(i,
+                               subscript_type,
+                               ...,
+                               call = caller_env()) {
   stop_subscript(
     class = "vctrs_error_subscript_oob",
     i = i,
     subscript_type = subscript_type,
-    ...
+    ...,
+    call = call
   )
 }
 
@@ -489,13 +499,17 @@ cnd_body_vctrs_error_subscript_oob_name <- function(cnd, ...) {
   ))
 }
 
-stop_location_oob_non_consecutive <- function(i, size, ...) {
+stop_location_oob_non_consecutive <- function(i,
+                                              size,
+                                              ...,
+                                              call = caller_env()) {
   stop_subscript_oob(
     i = i,
     size = size,
     subscript_type = "numeric",
     subscript_oob_non_consecutive = TRUE,
-    ...
+    ...,
+    call = call
   )
 }
 

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -150,11 +150,15 @@ as_opts_subscript2_type <- function(x, arg = NULL) {
 }
 
 
-stop_subscript <- function(i, ..., class = NULL) {
+stop_subscript <- function(i,
+                           ...,
+                           class = NULL,
+                           call = caller_env()) {
   abort(
     class = c(class, "vctrs_error_subscript"),
     i = i,
-    ...
+    ...,
+    call = call
   )
 }
 new_error_subscript <- function(class = NULL, i, ...) {

--- a/R/type-asis.R
+++ b/R/type-asis.R
@@ -72,14 +72,14 @@ vec_ptype2_asis <- function(x, y, ...) {
 # ------------------------------------------------------------------------------
 # Casting
 
-vec_cast_from_asis <- function(x, to, ...) {
+vec_cast_from_asis <- function(x, to, ..., call = caller_env()) {
   x <- asis_strip(x)
-  vec_cast(x, to, ...)
+  vec_cast(x, to, ..., call = call)
 }
 
-vec_cast_to_asis <- function(x, to, ...) {
+vec_cast_to_asis <- function(x, to, ..., call = caller_env()) {
   to <- asis_strip(to)
-  out <- vec_cast(x, to, ...)
+  out <- vec_cast(x, to, ..., call = call)
   asis_restore(out)
 }
 

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -177,19 +177,57 @@ vec_cast.logical.logical <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.logical integer
-vec_cast.logical.integer <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.logical.integer <- function(x,
+                                     to,
+                                     ...,
+                                     x_arg = "",
+                                     to_arg = "",
+                                     call = caller_env()) {
   out <- vec_coerce_bare(x, "logical")
-  out <- shape_broadcast(out, to, x_arg = x_arg, to_arg = to_arg)
+  out <- shape_broadcast(
+    out,
+    to,
+    x_arg = x_arg,
+    to_arg = to_arg,
+    call = call
+  )
   lossy <- !x %in% c(0L, 1L, NA_integer_)
-  maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
+  maybe_lossy_cast(
+    out,
+    x,
+    to,
+    lossy,
+    x_arg = x_arg,
+    to_arg = to_arg,
+    call = call
+  )
 }
 #' @export
 #' @method vec_cast.logical double
-vec_cast.logical.double <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.logical.double <- function(x,
+                                    to,
+                                    ...,
+                                    x_arg = "",
+                                    to_arg = "",
+                                    call = caller_env()) {
   out <- vec_coerce_bare(x, "logical")
-  out <- shape_broadcast(out, to, x_arg = x_arg, to_arg = to_arg)
+  out <- shape_broadcast(
+    out,
+    to,
+    x_arg = x_arg,
+    to_arg = to_arg,
+    call = call
+  )
   lossy <- !x %in% c(0, 1, NA_real_)
-  maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
+  maybe_lossy_cast(
+    out,
+    x,
+    to,
+    lossy,
+    x_arg = x_arg,
+    to_arg = to_arg,
+    call = call
+  )
 }
 
 #' @export
@@ -212,12 +250,32 @@ vec_cast.integer.integer <- function(x, to, ...) {
 }
 #' @export
 #' @method vec_cast.integer double
-vec_cast.integer.double <- function(x, to, ..., x_arg = "", to_arg = "") {
+vec_cast.integer.double <- function(x,
+                                    to,
+                                    ...,
+                                    x_arg = "",
+                                    to_arg = "",
+                                    call = caller_env()) {
   out <- suppressWarnings(vec_coerce_bare(x, "integer"))
   x_na <- is.na(x)
   lossy <- (out != x & !x_na) | xor(x_na, is.na(out))
-  out <- shape_broadcast(out, to, x_arg = x_arg, to_arg = to_arg)
-  maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
+
+  out <- shape_broadcast(
+    out,
+    to,
+    x_arg = x_arg,
+    to_arg = to_arg,
+    call = call
+  )
+  maybe_lossy_cast(
+    out,
+    x,
+    to,
+    lossy,
+    x_arg = x_arg,
+    to_arg = to_arg,
+    call = call
+  )
 }
 
 #' @export

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -263,6 +263,7 @@ df_ptype2_opts <- function(x, y, ..., opts, x_arg = "", y_arg = "") {
   .Call(vctrs_df_ptype2_opts, x, y, opts = opts, x_arg, y_arg)
 }
 
+# FIXME! Error call
 df_cast_opts <- function(x,
                          to,
                          ...,

--- a/R/type-factor.R
+++ b/R/type-factor.R
@@ -118,12 +118,12 @@ vec_ptype2.character.ordered <- function(x, y, ...) {
   stop_native_implementation("vec_ptype2.character.ordered")
 }
 #' @export
-vec_ptype2.ordered.factor <- function(x, y, ..., x_arg = "", y_arg = "") {
-  stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
+vec_ptype2.ordered.factor <- function(x, y, ...) {
+  vec_incompatible_ptype2(x, y, ...)
 }
 #' @export
-vec_ptype2.factor.ordered <- function(x, y, ..., x_arg = "", y_arg = "") {
-  stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
+vec_ptype2.factor.ordered <- function(x, y, ...) {
+  vec_incompatible_ptype2(x, y, ...)
 }
 
 
@@ -137,11 +137,17 @@ vec_cast.factor <- function(x, to, ...) {
   UseMethod("vec_cast.factor")
 }
 
-fct_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
-  fct_cast_impl(x, to, ..., x_arg = x_arg, to_arg = to_arg, ordered = FALSE)
+fct_cast <- function(x, to, ..., call = caller_env()) {
+  fct_cast_impl(x, to, ..., ordered = FALSE, call = call)
 }
 
-fct_cast_impl <- function(x, to, ..., x_arg = "", to_arg = "", ordered = FALSE) {
+fct_cast_impl <- function(x,
+                          to,
+                          ...,
+                          x_arg = "",
+                          to_arg = "",
+                          ordered = FALSE,
+                          call = caller_env()) {
   if (length(levels(to)) == 0L) {
     levels <- levels(x)
     if (is.null(levels)) {
@@ -150,10 +156,20 @@ fct_cast_impl <- function(x, to, ..., x_arg = "", to_arg = "", ordered = FALSE) 
     } else {
       exclude <- NULL
     }
-    factor(as.character(x), levels = levels, ordered = ordered, exclude = exclude)
+    factor(
+      as.character(x),
+      levels = levels,
+      ordered = ordered,
+      exclude = exclude
+    )
   } else {
     lossy <- !(x %in% levels(to) | is.na(x))
-    out <- factor(x, levels = levels(to), ordered = ordered, exclude = NULL)
+    out <- factor(
+      x,
+      levels = levels(to),
+      ordered = ordered,
+      exclude = NULL
+    )
     maybe_lossy_cast(
       out,
       x,
@@ -161,7 +177,8 @@ fct_cast_impl <- function(x, to, ..., x_arg = "", to_arg = "", ordered = FALSE) 
       lossy,
       loss_type = "generality",
       x_arg = x_arg,
-      to_arg = to_arg
+      to_arg = to_arg,
+      call = call
     )
   }
 }
@@ -187,8 +204,8 @@ vec_cast.ordered <- function(x, to, ...) {
   UseMethod("vec_cast.ordered")
 }
 
-ord_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
-  fct_cast_impl(x, to, ..., x_arg = x_arg, to_arg = to_arg, ordered = TRUE)
+ord_cast <- function(x, to, ..., call = caller_env()) {
+  fct_cast_impl(x, to, ..., ordered = TRUE, call = call)
 }
 
 #' @export

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -414,7 +414,7 @@ na.fail.vctrs_vctr <- function(object, ...) {
 
   if (any(missing)) {
     # Return the same error as `na.fail.default()`
-    stop("missing values in object")
+    abort("missing values in object")
   }
 
   object

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -138,14 +138,25 @@ vec_cast.vctrs_vctr <- function(x, to, ...) {
   UseMethod("vec_cast.vctrs_vctr")
 }
 
-vctr_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
+vctr_cast <- function(x,
+                      to,
+                      ...,
+                      x_arg = "",
+                      to_arg = "",
+                      call = caller_env()) {
   # These are not strictly necessary, but make bootstrapping a new class
   # a bit simpler
   if (is.object(x)) {
     if (is_same_type(x, to)) {
       x
     } else {
-      stop_incompatible_cast(x, to, x_arg = x_arg, to_arg = to_arg)
+      stop_incompatible_cast(
+        x,
+        to,
+        x_arg = x_arg,
+        to_arg = to_arg,
+        call = call
+      )
     }
   } else {
     # FIXME: `vec_restore()` should only be called on proxies

--- a/R/type2.R
+++ b/R/type2.R
@@ -37,11 +37,15 @@ vec_ptype2 <- function(x,
   if (!missing(...)) {
     check_ptype2_dots_empty(...)
   }
-  # FIXME! Error call
-  return(.Call(vctrs_ptype2, x, y, x_arg, y_arg))
+  return(.Call(ffi_ptype2, x, y, x_arg, y_arg, environment()))
   UseMethod("vec_ptype2")
 }
-vec_ptype2_dispatch_s3 <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_ptype2_dispatch_s3 <- function(x,
+                                   y,
+                                   ...,
+                                   x_arg = "",
+                                   y_arg = "",
+                                   call = caller_env()) {
   UseMethod("vec_ptype2")
 }
 

--- a/R/type2.R
+++ b/R/type2.R
@@ -148,6 +148,24 @@ vec_default_ptype2 <- function(x,
   )
 }
 
+# This wrapper for `stop_incompatible_type()` matches error context
+# arguments. It is useful to pass ptype2 arguments through dots
+# without risking unknown arguments getting stored as condition fields.
+vec_incompatible_ptype2 <- function(x,
+                                    y,
+                                    ...,
+                                    x_arg = "",
+                                    y_arg = "",
+                                    call = caller_env()) {
+  stop_incompatible_type(
+    x,
+    y,
+    x_arg = x_arg,
+    y_arg = y_arg,
+    call = call
+  )
+}
+
 # We can't check for a proxy or ptype2 method to determine whether a
 # class is foreign, because we implement these generics for many base
 # classes and we still need to allow base fallbacks with subclasses.

--- a/R/type2.R
+++ b/R/type2.R
@@ -15,6 +15,7 @@
 #' @includeRmd man/faq/developer/links-coercion.Rmd
 #'
 #' @inheritParams rlang::args_dots_empty
+#' @inheritParams rlang::args_error_context
 #' @param x,y Vector types.
 #' @param x_arg,y_arg Argument names for `x` and `y`. These are used
 #'   in error messages to inform the user about the locations of
@@ -27,10 +28,16 @@
 #' - [vec_ptype()] is applied to `x` and `y`
 #'
 #' @export
-vec_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_ptype2 <- function(x,
+                       y,
+                       ...,
+                       x_arg = "",
+                       y_arg = "",
+                       call = caller_env()) {
   if (!missing(...)) {
     check_ptype2_dots_empty(...)
   }
+  # FIXME! Error call
   return(.Call(vctrs_ptype2, x, y, x_arg, y_arg))
   UseMethod("vec_ptype2")
 }
@@ -68,12 +75,29 @@ vec_ptype2_dispatch_native <- function(x, y, ..., x_arg = "", y_arg = "") {
 #'
 #' @keywords internal
 #' @export
-vec_default_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
+vec_default_ptype2 <- function(x,
+                               y,
+                               ...,
+                               x_arg = "",
+                               y_arg = "",
+                               call = caller_env()) {
   if (is_asis(x)) {
-    return(vec_ptype2_asis_left(x, y, x_arg = x_arg, y_arg = y_arg))
+    return(vec_ptype2_asis_left(
+      x,
+      y,
+      x_arg = x_arg,
+      y_arg = y_arg,
+      call = call
+    ))
   }
   if (is_asis(y)) {
-    return(vec_ptype2_asis_right(x, y, x_arg = x_arg, y_arg = y_arg))
+    return(vec_ptype2_asis_right(
+      x,
+      y,
+      x_arg = x_arg,
+      y_arg = y_arg,
+      call = call
+    ))
   }
 
   opts <- match_fallback_opts(...)
@@ -115,7 +139,8 @@ vec_default_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
     y,
     x_arg = x_arg,
     y_arg = y_arg,
-    `vctrs:::from_dispatch` = match_from_dispatch(...)
+    `vctrs:::from_dispatch` = match_from_dispatch(...),
+    call = call
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -284,3 +284,18 @@ named <- function(x) {
   }
   x
 }
+
+browser <- function(...,
+                    skipCalls = 0,
+                    frame = parent.frame()) {
+  if (!identical(stdout(), getConnection(1))) {
+    sink(getConnection(1))
+    withr::defer(sink(), envir = frame)
+  }
+
+  # Calling `browser()` on exit avoids RStudio displaying the
+  # `browser2()` location. We still need one `n` to get to the
+  # expected place. Ideally `skipCalls` would not skip but exit the
+  # contexts.
+  on.exit(base::browser(..., skipCalls = skipCalls + 1))
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,7 +12,7 @@ ones <- function(...) {
 }
 
 vec_coerce_bare <- function(x, type) {
-  # Unexported wrapper around Rf_coerceVector()
+  # FIXME! Unexported wrapper around Rf_coerceVector()
   coerce <- env_get(ns_env("rlang"), "vec_coerce")
   coerce(x, type)
 }

--- a/man/faq-compatibility-types.Rd
+++ b/man/faq-compatibility-types.Rd
@@ -58,7 +58,7 @@ When vctrs can’t convert a vector because the target type is not as rich
 as the source type, it throws a lossy cast error. Assigning a fractional
 number to an integer vector is a typical example of a lossy cast error:\if{html}{\out{<div class="sourceCode r">}}\preformatted{int_vector <- 1:3
 vec_assign(int_vector, 2, 0.001)
-#> Error in `stop_vctrs()`:
+#> Error in `vec_cast.integer.double()`:
 #> ! Can't convert from <double> to <integer> due to loss of precision.
 #> * Locations: 1
 }\if{html}{\out{</div>}}

--- a/man/faq-compatibility-types.Rd
+++ b/man/faq-compatibility-types.Rd
@@ -58,7 +58,7 @@ When vctrs can’t convert a vector because the target type is not as rich
 as the source type, it throws a lossy cast error. Assigning a fractional
 number to an integer vector is a typical example of a lossy cast error:\if{html}{\out{<div class="sourceCode r">}}\preformatted{int_vector <- 1:3
 vec_assign(int_vector, 2, 0.001)
-#> Error in `vec_cast.integer.double()`:
+#> Error:
 #> ! Can't convert from <double> to <integer> due to loss of precision.
 #> * Locations: 1
 }\if{html}{\out{</div>}}

--- a/man/faq-error-scalar-type.Rd
+++ b/man/faq-error-scalar-type.Rd
@@ -50,7 +50,7 @@ fit[1:3]
 
 # But not in vctrs
 vctrs::vec_slice(fit, 1:3)
-#> Error in `stop_vctrs()`:
+#> Error:
 #> ! Input must be a vector, not a <lm> object.
 }\if{html}{\out{</div>}}
 
@@ -73,7 +73,7 @@ lapply(call, function(x) x)
 
 # But not with vctrs:
 vctrs::vec_slice(call, 1:2)
-#> Error in `stop_vctrs()`:
+#> Error:
 #> ! Input must be a vector, not a call.
 }\if{html}{\out{</div>}}
 }

--- a/man/howto-faq-coercion-data-frame.Rd
+++ b/man/howto-faq-coercion-data-frame.Rd
@@ -324,7 +324,7 @@ vec_rbind(green, green)
 #> 2 TRUE
 
 vec_rbind(green, red)
-#> Error in `stop_vctrs()`:
+#> Error in `my_tib_ptype2()`:
 #> ! Can't combine `..1` <my_tibble> and `..2` <my_tibble>.
 #> Can't combine colours.
 }\if{html}{\out{</div>}}

--- a/man/howto-faq-coercion.Rd
+++ b/man/howto-faq-coercion.Rd
@@ -228,10 +228,10 @@ vector:\if{html}{\out{<div class="sourceCode r">}}\preformatted{vec_c(TRUE, new_
 Because we haven’t implemented conversions \emph{from} natural, it still
 doesn’t know how to combine natural with the richer integer and double
 types:\if{html}{\out{<div class="sourceCode r">}}\preformatted{vec_c(new_natural(1), 10L)
-#> Error in `vec_default_cast()`:
+#> Error:
 #> ! Can't convert <my_natural> to <integer>.
 vec_c(1.5, new_natural(1))
-#> Error in `vec_default_cast()`:
+#> Error:
 #> ! Can't convert <my_natural> to <double>.
 }\if{html}{\out{</div>}}
 

--- a/man/howto-faq-coercion.Rd
+++ b/man/howto-faq-coercion.Rd
@@ -98,11 +98,11 @@ makes your class a bit more efficient.
 Our natural number class is conceptually a parent of \verb{<logical>} and a
 child of \verb{<integer>}, but the class is not compatible with logical,
 integer, or double vectors yet:\if{html}{\out{<div class="sourceCode r">}}\preformatted{vec_ptype2(TRUE, new_natural(2:3))
-#> Error in `stop_vctrs()`:
+#> Error in `vec_default_ptype2()`:
 #> ! Can't combine <logical> and <my_natural>.
 
 vec_ptype2(new_natural(1), 2:3)
-#> Error in `stop_vctrs()`:
+#> Error in `vec_default_ptype2()`:
 #> ! Can't combine <my_natural> and <integer>.
 }\if{html}{\out{</div>}}
 
@@ -228,10 +228,10 @@ vector:\if{html}{\out{<div class="sourceCode r">}}\preformatted{vec_c(TRUE, new_
 Because we haven’t implemented conversions \emph{from} natural, it still
 doesn’t know how to combine natural with the richer integer and double
 types:\if{html}{\out{<div class="sourceCode r">}}\preformatted{vec_c(new_natural(1), 10L)
-#> Error in `stop_vctrs()`:
+#> Error in `vec_default_cast()`:
 #> ! Can't convert <my_natural> to <integer>.
 vec_c(1.5, new_natural(1))
-#> Error in `stop_vctrs()`:
+#> Error in `vec_default_cast()`:
 #> ! Can't convert <my_natural> to <double>.
 }\if{html}{\out{</div>}}
 

--- a/man/howto-faq-coercion.Rd
+++ b/man/howto-faq-coercion.Rd
@@ -98,11 +98,11 @@ makes your class a bit more efficient.
 Our natural number class is conceptually a parent of \verb{<logical>} and a
 child of \verb{<integer>}, but the class is not compatible with logical,
 integer, or double vectors yet:\if{html}{\out{<div class="sourceCode r">}}\preformatted{vec_ptype2(TRUE, new_natural(2:3))
-#> Error in `vec_default_ptype2()`:
+#> Error:
 #> ! Can't combine <logical> and <my_natural>.
 
 vec_ptype2(new_natural(1), 2:3)
-#> Error in `vec_default_ptype2()`:
+#> Error:
 #> ! Can't combine <my_natural> and <integer>.
 }\if{html}{\out{</div>}}
 

--- a/man/howto-faq-fix-scalar-type-error.Rd
+++ b/man/howto-faq-fix-scalar-type-error.Rd
@@ -53,7 +53,7 @@ class} is not \code{"data.frame"}:\if{html}{\out{<div class="sourceCode r">}}\pr
 class(my_df) <- c("data.frame", "my_class")
 
 vctrs::vec_assert(my_df)
-#> Error in `vctrs::vec_assert()`:
+#> Error:
 #> ! `my_df` must be a vector, not a <data.frame/my_class> object.
 }\if{html}{\out{</div>}}
 

--- a/man/howto-faq-fix-scalar-type-error.Rd
+++ b/man/howto-faq-fix-scalar-type-error.Rd
@@ -53,12 +53,12 @@ class} is not \code{"data.frame"}:\if{html}{\out{<div class="sourceCode r">}}\pr
 class(my_df) <- c("data.frame", "my_class")
 
 vctrs::vec_assert(my_df)
-#> Error in `stop_vctrs()`:
+#> Error in `vctrs::vec_assert()`:
 #> ! `my_df` must be a vector, not a <data.frame/my_class> object.
 }\if{html}{\out{</div>}}
 
 This is problematic as many tidyverse functions won’t work properly:\if{html}{\out{<div class="sourceCode r">}}\preformatted{dplyr::slice(my_df, 1)
-#> Error in `stop_vctrs()`:
+#> Error:
 #> ! Input must be a vector, not a <data.frame/my_class> object.
 }\if{html}{\out{</div>}}
 

--- a/man/maybe_lossy_cast.Rd
+++ b/man/maybe_lossy_cast.Rd
@@ -14,10 +14,10 @@ maybe_lossy_cast(
   loss_type = c("precision", "generality"),
   x_arg,
   to_arg,
+  call = caller_env(),
   details = NULL,
   message = NULL,
   class = NULL,
-  error_call = caller_env(),
   .deprecation = FALSE
 )
 }
@@ -52,17 +52,17 @@ types.}
 error messages to inform the user about the locations of incompatible
 types.}
 
+\item{call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
+
 \item{details}{Any additional human readable details.}
 
 \item{message}{An overriding message for the error. \code{details} and
 \code{message} are mutually exclusive, supplying both is an error.}
 
 \item{class}{Only use these fields when creating a subclass.}
-
-\item{error_call}{The execution environment of a currently
-running function, e.g. \code{caller_env()}. The function will be
-mentioned in error messages as the source of the error. See the
-\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 
 \item{.deprecation}{If \code{TRUE}, the error is downgraded to a
 deprecation warning. This is useful for transitioning your class

--- a/man/maybe_lossy_cast.Rd
+++ b/man/maybe_lossy_cast.Rd
@@ -17,6 +17,7 @@ maybe_lossy_cast(
   details = NULL,
   message = NULL,
   class = NULL,
+  error_call = caller_env(),
   .deprecation = FALSE
 )
 }
@@ -57,6 +58,11 @@ types.}
 \code{message} are mutually exclusive, supplying both is an error.}
 
 \item{class}{Only use these fields when creating a subclass.}
+
+\item{error_call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 
 \item{.deprecation}{If \code{TRUE}, the error is downgraded to a
 deprecation warning. This is useful for transitioning your class

--- a/man/theory-faq-coercion.Rd
+++ b/man/theory-faq-coercion.Rd
@@ -24,7 +24,7 @@ functions that use the split-apply-combine strategy. For example:\if{html}{\out{
 #> [1] 1 1
 
 vec_c("a", 1)
-#> Error in `vec_default_ptype2()`:
+#> Error:
 #> ! Can't combine `..1` <character> and `..2` <double>.
 
 vec_rbind(
@@ -39,7 +39,7 @@ vec_rbind(
   data.frame(x = "a"),
   data.frame(x = 1, y = 2)
 )
-#> Error in `vec_default_ptype2()`:
+#> Error:
 #> ! Can't combine `..1$x` <character> and `..2$x` <double>.
 }\if{html}{\out{</div>}}
 
@@ -97,7 +97,7 @@ vec_ptype2(factor("a"), "b")
 
 # But they are incompatible with integers
 vec_ptype2(factor("a"), 1L)
-#> Error in `vec_default_ptype2()`:
+#> Error:
 #> ! Can't combine <factor<4d52a>> and <integer>.
 }\if{html}{\out{</div>}}
 }

--- a/man/theory-faq-coercion.Rd
+++ b/man/theory-faq-coercion.Rd
@@ -24,7 +24,7 @@ functions that use the split-apply-combine strategy. For example:\if{html}{\out{
 #> [1] 1 1
 
 vec_c("a", 1)
-#> Error in `stop_vctrs()`:
+#> Error in `vec_default_ptype2()`:
 #> ! Can't combine `..1` <character> and `..2` <double>.
 
 vec_rbind(
@@ -39,7 +39,7 @@ vec_rbind(
   data.frame(x = "a"),
   data.frame(x = 1, y = 2)
 )
-#> Error in `stop_vctrs()`:
+#> Error in `vec_default_ptype2()`:
 #> ! Can't combine `..1$x` <character> and `..2$x` <double>.
 }\if{html}{\out{</div>}}
 
@@ -97,7 +97,7 @@ vec_ptype2(factor("a"), "b")
 
 # But they are incompatible with integers
 vec_ptype2(factor("a"), 1L)
-#> Error in `stop_vctrs()`:
+#> Error in `vec_default_ptype2()`:
 #> ! Can't combine <factor<4d52a>> and <integer>.
 }\if{html}{\out{</div>}}
 }

--- a/man/vctrs-conditions.Rd
+++ b/man/vctrs-conditions.Rd
@@ -18,7 +18,8 @@ stop_incompatible_type(
   action = c("combine", "convert"),
   details = NULL,
   message = NULL,
-  class = NULL
+  class = NULL,
+  call = caller_env()
 )
 
 stop_incompatible_cast(
@@ -29,7 +30,8 @@ stop_incompatible_cast(
   to_arg,
   details = NULL,
   message = NULL,
-  class = NULL
+  class = NULL,
+  call = caller_env()
 )
 
 stop_incompatible_op(
@@ -39,7 +41,8 @@ stop_incompatible_op(
   details = NULL,
   ...,
   message = NULL,
-  class = NULL
+  class = NULL,
+  call = caller_env()
 )
 
 stop_incompatible_size(
@@ -52,7 +55,8 @@ stop_incompatible_size(
   y_arg,
   details = NULL,
   message = NULL,
-  class = NULL
+  class = NULL,
+  call = caller_env()
 )
 
 allow_lossy_cast(expr, x_ptype = NULL, to_ptype = NULL)
@@ -74,6 +78,11 @@ those thrown from \code{\link[=vec_cast]{vec_cast()}} use \code{"convert"}.}
 
 \item{message}{An overriding message for the error. \code{details} and
 \code{message} are mutually exclusive, supplying both is an error.}
+
+\item{call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 
 \item{x_ptype, to_ptype}{Suppress only the casting errors where \code{x}
 or \code{to} match these \link[=vec_ptype]{prototypes}.}

--- a/man/vec_as_names.Rd
+++ b/man/vec_as_names.Rd
@@ -9,7 +9,8 @@ vec_as_names(
   ...,
   repair = c("minimal", "unique", "universal", "check_unique"),
   repair_arg = "",
-  quiet = FALSE
+  quiet = FALSE,
+  call = caller_env()
 )
 }
 \arguments{
@@ -42,6 +43,11 @@ will include a hint to set the \code{repair_arg}.}
 caused by repairing the names. This only concerns unique and
 universal repairing. Set \code{quiet} to \code{TRUE} to silence the
 messages.}
+
+\item{call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 }
 \description{
 \code{vec_as_names()} takes a character vector of names and repairs it

--- a/man/vec_assert.Rd
+++ b/man/vec_assert.Rd
@@ -5,7 +5,13 @@
 \alias{vec_is}
 \title{Assert an argument has known prototype and/or size}
 \usage{
-vec_assert(x, ptype = NULL, size = NULL, arg = as_label(substitute(x)))
+vec_assert(
+  x,
+  ptype = NULL,
+  size = NULL,
+  arg = caller_arg(x),
+  call = caller_env()
+)
 
 vec_is(x, ptype = NULL, size = NULL)
 }
@@ -22,6 +28,11 @@ class, its \code{\link[=vec_ptype]{vec_ptype()}} is compared to that of \code{x}
 \item{arg}{Name of argument being checked. This is used in error
 messages. The label of the expression passed as \code{x} is taken as
 default.}
+
+\item{call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 }
 \value{
 \code{vec_is()} returns \code{TRUE} or \code{FALSE}. \code{vec_assert()} either

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -12,7 +12,7 @@
 \alias{vec_cast.list}
 \title{Cast a vector to a specified type}
 \usage{
-vec_cast(x, to, ..., x_arg = "", to_arg = "")
+vec_cast(x, to, ..., x_arg = "", to_arg = "", call = caller_env())
 
 vec_cast_common(..., .to = NULL)
 
@@ -42,6 +42,11 @@ dots are only for future extensions and should be empty.}
 \item{x_arg, to_arg}{Argument names for \code{x} and \code{to}. These are used
 in error messages to inform the user about the locations of
 incompatible types (see \code{\link[=stop_incompatible_type]{stop_incompatible_type()}}).}
+
+\item{call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 }
 \value{
 A vector the same length as \code{x} with the same type as \code{to},

--- a/man/vec_default_ptype2.Rd
+++ b/man/vec_default_ptype2.Rd
@@ -25,6 +25,11 @@ incompatible types (see \code{\link[=stop_incompatible_type]{stop_incompatible_t
 \item{to_arg}{Argument names for \code{x} and \code{to}. These are used
 in error messages to inform the user about the locations of
 incompatible types (see \code{\link[=stop_incompatible_type]{stop_incompatible_type()}}).}
+
+\item{call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 }
 \description{
 These functions are automatically called when no \code{\link[=vec_ptype2]{vec_ptype2()}} or

--- a/man/vec_default_ptype2.Rd
+++ b/man/vec_default_ptype2.Rd
@@ -5,9 +5,9 @@
 \alias{vec_default_ptype2}
 \title{Default cast and ptype2 methods}
 \usage{
-vec_default_cast(x, to, ..., x_arg = "", to_arg = "")
+vec_default_cast(x, to, ..., x_arg = "", to_arg = "", call = caller_env())
 
-vec_default_ptype2(x, y, ..., x_arg = "", y_arg = "")
+vec_default_ptype2(x, y, ..., x_arg = "", y_arg = "", call = caller_env())
 }
 \arguments{
 \item{x}{Vectors to cast.}

--- a/man/vec_ptype2.Rd
+++ b/man/vec_ptype2.Rd
@@ -25,7 +25,7 @@
 
 \method{vec_ptype2}{list}(x, y, ..., x_arg = "", y_arg = "")
 
-vec_ptype2(x, y, ..., x_arg = "", y_arg = "")
+vec_ptype2(x, y, ..., x_arg = "", y_arg = "", call = caller_env())
 }
 \arguments{
 \item{x, y}{Vector types.}
@@ -35,6 +35,11 @@ vec_ptype2(x, y, ..., x_arg = "", y_arg = "")
 \item{x_arg, y_arg}{Argument names for \code{x} and \code{y}. These are used
 in error messages to inform the user about the locations of
 incompatible types (see \code{\link[=stop_incompatible_type]{stop_incompatible_type()}}).}
+
+\item{call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 }
 \description{
 \code{vec_ptype2()} defines the coercion hierarchy for a set of related

--- a/man/vec_recycle.Rd
+++ b/man/vec_recycle.Rd
@@ -5,7 +5,7 @@
 \alias{vec_recycle_common}
 \title{Vector recycling}
 \usage{
-vec_recycle(x, size, ..., x_arg = "")
+vec_recycle(x, size, ..., x_arg = "", call = caller_env())
 
 vec_recycle_common(..., .size = NULL)
 }
@@ -24,6 +24,11 @@ vec_recycle_common(..., .size = NULL)
 \item{x_arg}{Argument name for \code{x}. These are used in error
 messages to inform the user about which argument has an
 incompatible size.}
+
+\item{call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 
 \item{.size}{Desired output size. If omitted,
 will use the common size from \code{\link[=vec_size_common]{vec_size_common()}}.}

--- a/src/bind.c
+++ b/src/bind.c
@@ -38,7 +38,7 @@ SEXP vctrs_rbind(SEXP call, SEXP op, SEXP args, SEXP env) {
   }
 
   struct name_repair_opts name_repair_opts = validate_bind_name_repair(name_repair, false);
-  PROTECT_NAME_REPAIR_OPTS(&name_repair_opts);
+  KEEP(name_repair_opts.shelter);
 
   SEXP out = vec_rbind(xs, ptype, names_to, &name_repair_opts, name_spec);
 
@@ -349,7 +349,7 @@ SEXP vctrs_cbind(SEXP call, SEXP op, SEXP args, SEXP env) {
   SEXP name_repair = PROTECT(Rf_eval(CAR(args), env));
 
   struct name_repair_opts name_repair_opts = validate_bind_name_repair(name_repair, true);
-  PROTECT_NAME_REPAIR_OPTS(&name_repair_opts);
+  KEEP(name_repair_opts.shelter);
 
   SEXP out = vec_cbind(xs, ptype, size, &name_repair_opts);
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -578,7 +578,10 @@ static SEXP vec_as_df_col(SEXP x, SEXP outer) {
 }
 
 struct name_repair_opts validate_bind_name_repair(SEXP name_repair, bool allow_minimal) {
-  struct name_repair_opts opts = new_name_repair_opts(name_repair, args_empty, false);
+  struct name_repair_opts opts = new_name_repair_opts(name_repair,
+                                                      args_empty,
+                                                      false,
+                                                      r_lazy_null);
 
   switch (opts.type) {
   case name_repair_custom:

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -19,7 +19,10 @@ static SEXP vec_unchop(SEXP x,
 
 // [[ register() ]]
 SEXP vctrs_unchop(SEXP x, SEXP indices, SEXP ptype, SEXP name_spec, SEXP name_repair) {
-  struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair, args_empty, false);
+  struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair,
+                                                                  args_empty,
+                                                                  false,
+                                                                  r_lazy_null);
   KEEP(name_repair_opts.shelter);
 
   SEXP out = vec_unchop(x, indices, ptype, name_spec, &name_repair_opts);

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -20,11 +20,11 @@ static SEXP vec_unchop(SEXP x,
 // [[ register() ]]
 SEXP vctrs_unchop(SEXP x, SEXP indices, SEXP ptype, SEXP name_spec, SEXP name_repair) {
   struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair, args_empty, false);
-  PROTECT_NAME_REPAIR_OPTS(&name_repair_opts);
+  KEEP(name_repair_opts.shelter);
 
   SEXP out = vec_unchop(x, indices, ptype, name_spec, &name_repair_opts);
 
-  UNPROTECT(1);
+  FREE(1);
   return out;
 }
 

--- a/src/c.c
+++ b/src/c.c
@@ -17,7 +17,7 @@ SEXP vctrs_c(SEXP call, SEXP op, SEXP args, SEXP env) {
   SEXP name_repair = PROTECT(Rf_eval(CAR(args), env));
 
   struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair, args_empty, false);
-  PROTECT_NAME_REPAIR_OPTS(&name_repair_opts);
+  KEEP(name_repair_opts.shelter);
 
   SEXP out = vec_c(xs, ptype, name_spec, &name_repair_opts);
 

--- a/src/c.c
+++ b/src/c.c
@@ -16,7 +16,10 @@ SEXP vctrs_c(SEXP call, SEXP op, SEXP args, SEXP env) {
   SEXP name_spec = PROTECT(Rf_eval(CAR(args), env)); args = CDR(args);
   SEXP name_repair = PROTECT(Rf_eval(CAR(args), env));
 
-  struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair, args_empty, false);
+  struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair,
+                                                                  args_empty,
+                                                                  false,
+                                                                  r_lazy_null);
   KEEP(name_repair_opts.shelter);
 
   SEXP out = vec_c(xs, ptype, name_spec, &name_repair_opts);

--- a/src/callables.c
+++ b/src/callables.c
@@ -17,7 +17,7 @@ SEXP short_vec_recycle(SEXP x, R_len_t size) {
 // Experimental
 
 SEXP exp_vec_cast(SEXP x, SEXP to) {
-  return vec_cast(x, to, args_empty, args_empty);
+  return vec_cast(x, to, args_empty, args_empty, r_lazy_null);
 }
 
 SEXP exp_vec_chop(SEXP x, SEXP indices) {

--- a/src/cast.h
+++ b/src/cast.h
@@ -4,10 +4,11 @@
 #include "ptype2.h"
 
 struct cast_opts {
-  SEXP x;
-  SEXP to;
+  r_obj* x;
+  r_obj* to;
   struct vctrs_arg* x_arg;
   struct vctrs_arg* to_arg;
+  struct r_lazy call;
   struct fallback_opts fallback;
 };
 

--- a/src/cast.h
+++ b/src/cast.h
@@ -56,11 +56,12 @@ SEXP vec_cast_common_params(SEXP xs,
                             enum df_fallback df_fallback,
                             enum s3_fallback s3_fallback);
 
-struct cast_opts new_cast_opts(SEXP x,
-                               SEXP y,
+struct cast_opts new_cast_opts(r_obj* x,
+                               r_obj* y,
                                struct vctrs_arg* x_arg,
                                struct vctrs_arg* y_arg,
-                               SEXP opts);
+                               struct r_lazy call,
+                               r_obj* opts);
 
 SEXP vec_cast_dispatch_native(const struct cast_opts* opts,
                               enum vctrs_type x_type,
@@ -70,11 +71,12 @@ SEXP vec_cast_dispatch_native(const struct cast_opts* opts,
 SEXP vec_cast_e(const struct cast_opts* opts,
                 ERR* err);
 
-SEXP vec_cast_default(SEXP x,
-                      SEXP y,
-                      SEXP x_arg,
-                      SEXP to_arg,
-                      const struct fallback_opts* opts);
+r_obj* vec_cast_default(r_obj* x,
+                        r_obj* y,
+                        r_obj* x_arg,
+                        r_obj* to_arg,
+                        struct r_lazy call,
+                        const struct fallback_opts* opts);
 
 // Defined in cast-bare.c
 SEXP int_as_double(SEXP x, bool* lossy);

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -93,23 +93,27 @@ void stop_incompatible_size(SEXP x, SEXP y,
   never_reached("stop_incompatible_size");
 }
 
-void stop_recycle_incompatible_size(R_len_t x_size, R_len_t size,
-                                    struct vctrs_arg* x_arg) {
-  SEXP syms[4] = {
+void stop_recycle_incompatible_size(r_ssize x_size,
+                                    r_ssize size,
+                                    struct vctrs_arg* x_arg,
+                                    struct r_lazy call) {
+  r_obj* syms[5] = {
     r_sym("x_size"),
     r_sym("size"),
     r_sym("x_arg"),
+    syms_call,
     NULL
   };
-  SEXP args[4] = {
-    PROTECT(r_int(x_size)),
-    PROTECT(r_int(size)),
-    PROTECT(vctrs_arg(x_arg)),
+  r_obj* args[5] = {
+    KEEP(r_int(x_size)),
+    KEEP(r_int(size)),
+    KEEP(vctrs_arg(x_arg)),
+    KEEP(r_lazy_eval(call)),
     NULL
   };
 
-  SEXP call = PROTECT(r_call_n(r_sym("stop_recycle_incompatible_size"), syms, args));
-  Rf_eval(call, vctrs_ns_env);
+  r_obj* stop_call = KEEP(r_call_n(r_sym("stop_recycle_incompatible_size"), syms, args));
+  r_eval(stop_call, vctrs_ns_env);
 
   never_reached("stop_recycle_incompatible_size");
 }

--- a/src/decl/names-decl.h
+++ b/src/decl/names-decl.h
@@ -1,0 +1,3 @@
+static
+r_obj* check_unique_names(r_obj* names,
+                          const struct name_repair_opts* opts);

--- a/src/fill.c
+++ b/src/fill.c
@@ -246,12 +246,16 @@ void stop_bad_direction() {
 }
 
 static
-int parse_max_fill(SEXP x) {
+int parse_max_fill(r_obj* x) {
   if (x == R_NilValue) {
     return INFINITE_FILL;
   }
 
-  x = PROTECT(vec_cast(x, vctrs_shared_empty_int, args_max_fill, args_empty));
+  x = KEEP(vec_cast(x,
+                    vctrs_shared_empty_int,
+                    args_max_fill,
+                    args_empty,
+                    r_lazy_null));
 
   if (!r_is_positive_number(x)) {
     r_abort("`max_fill` must be `NULL` or a single positive integer.");
@@ -259,6 +263,6 @@ int parse_max_fill(SEXP x) {
 
   int out = r_int_get(x, 0);
 
-  UNPROTECT(1);
+  FREE(1);
   return out;
 }

--- a/src/init.c
+++ b/src/init.c
@@ -41,13 +41,13 @@ extern SEXP vctrs_dim_n(SEXP);
 extern SEXP vctrs_is_unspecified(SEXP);
 extern SEXP vctrs_typeof(SEXP, SEXP);
 extern SEXP vctrs_is_vector(SEXP);
-extern SEXP vctrs_ptype2(SEXP, SEXP, SEXP, SEXP);
+extern r_obj* ffi_ptype2(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_typeof2(SEXP, SEXP);
 extern SEXP vctrs_typeof2_s3(SEXP, SEXP);
-extern SEXP vctrs_cast(SEXP, SEXP, SEXP, SEXP);
+extern r_obj* ffi_cast(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_as_location(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vec_slice(SEXP, SEXP);
-extern SEXP vctrs_init(SEXP, SEXP);
+extern SEXP ffi_init(SEXP, SEXP);
 extern SEXP vctrs_chop(SEXP, SEXP);
 extern SEXP vctrs_unchop(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_chop_seq(SEXP, SEXP, SEXP, SEXP);
@@ -197,13 +197,13 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_typeof",                     (DL_FUNC) &vctrs_typeof, 2},
   {"vctrs_init_library",               (DL_FUNC) &vctrs_init_library, 1},
   {"vctrs_is_vector",                  (DL_FUNC) &vctrs_is_vector, 1},
-  {"vctrs_ptype2",                     (DL_FUNC) &vctrs_ptype2, 4},
+  {"ffi_ptype2",                       (DL_FUNC) &ffi_ptype2, 5},
   {"vctrs_typeof2",                    (DL_FUNC) &vctrs_typeof2, 2},
   {"vctrs_typeof2_s3",                 (DL_FUNC) &vctrs_typeof2_s3, 2},
-  {"vctrs_cast",                       (DL_FUNC) &vctrs_cast, 4},
+  {"ffi_cast",                         (DL_FUNC) &ffi_cast, 5},
   {"vctrs_as_location",                (DL_FUNC) &vctrs_as_location, 8},
   {"vctrs_slice",                      (DL_FUNC) &vec_slice, 2},
-  {"vctrs_init",                       (DL_FUNC) &vctrs_init, 2},
+  {"ffi_init",                         (DL_FUNC) &ffi_init, 3},
   {"vctrs_chop",                       (DL_FUNC) &vctrs_chop, 2},
   {"vctrs_unchop",                     (DL_FUNC) &vctrs_unchop, 5},
   {"vctrs_chop_seq",                   (DL_FUNC) &vctrs_chop_seq, 4},

--- a/src/init.c
+++ b/src/init.c
@@ -76,7 +76,7 @@ extern SEXP vctrs_type_info(SEXP);
 extern SEXP vctrs_proxy_info(SEXP);
 extern SEXP vctrs_class_type(SEXP);
 extern SEXP vctrs_bare_df_restore(SEXP, SEXP, SEXP);
-extern SEXP vctrs_recycle(SEXP, SEXP, SEXP);
+extern r_obj* ffi_recycle(r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_assign(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_assign_seq(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_set_attributes(SEXP, SEXP);
@@ -232,7 +232,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_proxy_info",                 (DL_FUNC) &vctrs_proxy_info, 1},
   {"vctrs_class_type",                 (DL_FUNC) &vctrs_class_type, 1},
   {"vctrs_bare_df_restore",            (DL_FUNC) &vctrs_bare_df_restore, 3},
-  {"vctrs_recycle",                    (DL_FUNC) &vctrs_recycle, 3},
+  {"ffi_recycle",                      (DL_FUNC) &ffi_recycle, 4},
   {"vctrs_assign",                     (DL_FUNC) &vctrs_assign, 5},
   {"vctrs_assign_seq",                 (DL_FUNC) &vctrs_assign_seq, 5},
   {"vctrs_set_attributes",             (DL_FUNC) &vctrs_set_attributes, 2},

--- a/src/init.c
+++ b/src/init.c
@@ -88,7 +88,7 @@ extern SEXP vctrs_apply_name_spec(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_unset_s4(SEXP);
 extern SEXP vctrs_validate_name_repair_arg(SEXP);
 extern SEXP vctrs_validate_minimal_names(SEXP, SEXP);
-extern SEXP vctrs_as_names(SEXP, SEXP, SEXP, SEXP);
+extern r_obj* ffi_as_names(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_is_partial(SEXP);
 extern SEXP vctrs_is_list(SEXP);
 extern SEXP vctrs_try_catch_callback(SEXP, SEXP);
@@ -246,7 +246,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_altrep_rle_is_materialized", (DL_FUNC) &altrep_rle_is_materialized, 1},
   {"vctrs_validate_name_repair_arg",   (DL_FUNC) &vctrs_validate_name_repair_arg, 1},
   {"vctrs_validate_minimal_names",     (DL_FUNC) &vctrs_validate_minimal_names, 2},
-  {"vctrs_as_names",                   (DL_FUNC) &vctrs_as_names, 4},
+  {"ffi_as_names",                     (DL_FUNC) &ffi_as_names, 5},
   {"vctrs_is_partial",                 (DL_FUNC) &vctrs_is_partial, 1},
   {"vctrs_is_list",                    (DL_FUNC) &vctrs_is_list, 1},
   {"vctrs_try_catch_callback",         (DL_FUNC) &vctrs_try_catch_callback, 2},

--- a/src/init.c
+++ b/src/init.c
@@ -116,7 +116,7 @@ extern SEXP vctrs_ptype2_opts(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_s3_find_method(SEXP, SEXP, SEXP);
 extern SEXP vctrs_implements_ptype2(SEXP);
 extern SEXP vctrs_ptype2_dispatch_native(SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP vctrs_cast_dispatch_native(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern r_obj* ffi_cast_dispatch_native(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_fast_c(SEXP, SEXP);
 extern SEXP vctrs_data_frame(SEXP, SEXP, SEXP);
 extern SEXP vctrs_df_list(SEXP, SEXP, SEXP);
@@ -274,7 +274,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_s3_find_method",             (DL_FUNC) &vctrs_s3_find_method, 3},
   {"vctrs_implements_ptype2",          (DL_FUNC) &vctrs_implements_ptype2, 1},
   {"vctrs_ptype2_dispatch_native",     (DL_FUNC) &vctrs_ptype2_dispatch_native, 5},
-  {"vctrs_cast_dispatch_native",       (DL_FUNC) &vctrs_cast_dispatch_native, 5},
+  {"ffi_cast_dispatch_native",         (DL_FUNC) &ffi_cast_dispatch_native, 6},
   {"vctrs_fast_c",                     (DL_FUNC) &vctrs_fast_c, 2},
   {"vctrs_data_frame",                 (DL_FUNC) &vctrs_data_frame, 3},
   {"vctrs_df_list",                    (DL_FUNC) &vctrs_df_list, 3},

--- a/src/names.h
+++ b/src/names.h
@@ -1,6 +1,8 @@
 #ifndef VCTRS_NAMES_H
 #define VCTRS_NAMES_H
 
+#include "utils.h"
+
 enum name_repair_type {
   name_repair_none = 0,
   name_repair_minimal,
@@ -16,6 +18,7 @@ struct name_repair_opts {
   struct vctrs_arg* name_repair_arg;
   r_obj* fn;
   bool quiet;
+  struct r_lazy call;
 };
 
 extern struct name_repair_opts unique_repair_default_opts;
@@ -27,7 +30,10 @@ static struct name_repair_opts const * const p_unique_repair_silent_opts = &uniq
 static struct name_repair_opts const * const p_no_repair_opts = &no_repair_opts;
 
 SEXP vec_as_names(SEXP names, const struct name_repair_opts* opts);
-struct name_repair_opts new_name_repair_opts(SEXP name_repair, struct vctrs_arg* arg, bool quiet);
+struct name_repair_opts new_name_repair_opts(r_obj* name_repair,
+                                             struct vctrs_arg* name_repair_arg,
+                                             bool quiet,
+                                             struct r_lazy call);
 const char* name_repair_arg_as_c_string(enum name_repair_type type);
 bool is_unique_names(SEXP names);
 SEXP vec_as_unique_names(SEXP names, bool quiet);

--- a/src/names.h
+++ b/src/names.h
@@ -11,9 +11,10 @@ enum name_repair_type {
 };
 
 struct name_repair_opts {
+  r_obj* shelter;
   enum name_repair_type type;
-  struct vctrs_arg* arg;
-  SEXP fn;
+  struct vctrs_arg* name_repair_arg;
+  r_obj* fn;
   bool quiet;
 };
 
@@ -24,8 +25,6 @@ extern struct name_repair_opts no_repair_opts;
 static struct name_repair_opts const * const p_unique_repair_default_opts = &unique_repair_default_opts;
 static struct name_repair_opts const * const p_unique_repair_silent_opts = &unique_repair_silent_opts;
 static struct name_repair_opts const * const p_no_repair_opts = &no_repair_opts;
-
-#define PROTECT_NAME_REPAIR_OPTS(opts) PROTECT((opts)->fn)
 
 SEXP vec_as_names(SEXP names, const struct name_repair_opts* opts);
 struct name_repair_opts new_name_repair_opts(SEXP name_repair, struct vctrs_arg* arg, bool quiet);

--- a/src/ptype2-dispatch.c
+++ b/src/ptype2-dispatch.c
@@ -51,22 +51,25 @@ SEXP vec_ptype2_dispatch_native(const struct ptype2_opts* opts,
 static SEXP syms_vec_ptype2_default = NULL;
 
 static inline
-SEXP vec_ptype2_default(SEXP x,
-                        SEXP y,
-                        SEXP x_arg,
-                        SEXP y_arg,
-                        const struct fallback_opts* opts) {
-  SEXP df_fallback_obj = PROTECT(r_int(opts->df));
-  SEXP s3_fallback_obj = PROTECT(r_int(opts->s3));
-  SEXP out = vctrs_eval_mask7(syms_vec_ptype2_default,
-                              syms_x, x,
-                              syms_y, y,
-                              syms_x_arg, x_arg,
-                              syms_y_arg, y_arg,
-                              syms_from_dispatch, vctrs_shared_true,
-                              syms_df_fallback, df_fallback_obj,
-                              syms_s3_fallback, s3_fallback_obj);
-  UNPROTECT(2);
+r_obj* vec_ptype2_default(r_obj* x,
+                          r_obj* y,
+                          r_obj* x_arg,
+                          r_obj* y_arg,
+                          struct r_lazy call,
+                          const struct fallback_opts* opts) {
+  r_obj* df_fallback_obj = KEEP(r_int(opts->df));
+  r_obj* s3_fallback_obj = KEEP(r_int(opts->s3));
+  r_obj* ffi_call = KEEP(r_lazy_eval(call));
+  r_obj* out = vctrs_eval_mask8(syms_vec_ptype2_default,
+                                syms_x, x,
+                                syms_y, y,
+                                syms_x_arg, x_arg,
+                                syms_y_arg, y_arg,
+                                syms_call, ffi_call,
+                                syms_from_dispatch, vctrs_shared_true,
+                                syms_df_fallback, df_fallback_obj,
+                                syms_s3_fallback, s3_fallback_obj);
+  FREE(3);
   return out;
 }
 
@@ -128,7 +131,12 @@ SEXP vec_ptype2_dispatch_s3(const struct ptype2_opts* opts) {
   PROTECT(method);
 
   if (method == R_NilValue) {
-    SEXP out = vec_ptype2_default(x, y, r_x_arg, r_y_arg, &(opts->fallback));
+    SEXP out = vec_ptype2_default(x,
+                                  y,
+                                  r_x_arg,
+                                  r_y_arg,
+                                  opts->call,
+                                  &(opts->fallback));
     UNPROTECT(5);
     return out;
   }
@@ -197,7 +205,12 @@ SEXP vctrs_ptype2_dispatch_native(SEXP x,
   SEXP out = vec_ptype2_dispatch_native(&c_opts, vec_typeof(x), vec_typeof(y), &_left);
 
   if (out == R_NilValue) {
-    return vec_ptype2_default(x, y, x_arg, y_arg, &c_opts.fallback);
+    return vec_ptype2_default(x,
+                              y,
+                              x_arg,
+                              y_arg,
+                              c_opts.call,
+                              &c_opts.fallback);
   } else {
     return out;
   }

--- a/src/ptype2-dispatch.c
+++ b/src/ptype2-dispatch.c
@@ -138,38 +138,46 @@ SEXP vec_ptype2_dispatch_s3(const struct ptype2_opts* opts) {
                                       syms_y, y,
                                       syms_x_arg, r_x_arg,
                                       syms_y_arg, r_y_arg,
+                                      opts->call,
                                       &(opts->fallback));
 
   UNPROTECT(5);
   return out;
 }
 
-SEXP vec_invoke_coerce_method(SEXP method_sym, SEXP method,
-                              SEXP x_sym, SEXP x,
-                              SEXP y_sym, SEXP y,
-                              SEXP x_arg_sym, SEXP x_arg,
-                              SEXP y_arg_sym, SEXP y_arg,
-                              const struct fallback_opts* opts) {
+r_obj* vec_invoke_coerce_method(r_obj* method_sym, r_obj* method,
+                                r_obj* x_sym, r_obj* x,
+                                r_obj* y_sym, r_obj* y,
+                                r_obj* x_arg_sym, r_obj* x_arg,
+                                r_obj* y_arg_sym, r_obj* y_arg,
+                                struct r_lazy lazy_call,
+                                const struct fallback_opts* opts) {
+  r_obj* call = KEEP(r_lazy_eval(lazy_call));
+
   if (opts->df != DF_FALLBACK_DEFAULT ||
       opts->s3 != S3_FALLBACK_DEFAULT) {
-    SEXP df_fallback_obj = PROTECT(r_int(opts->df));
-    SEXP s3_fallback_obj = PROTECT(r_int(opts->s3));
+    r_obj* df_fallback_obj = KEEP(r_int(opts->df));
+    r_obj* s3_fallback_obj = KEEP(r_int(opts->s3));
 
-    SEXP out = vctrs_dispatch6(method_sym, method,
-                               x_sym, x,
-                               y_sym, y,
-                               x_arg_sym, x_arg,
-                               y_arg_sym, y_arg,
-                               syms_df_fallback, df_fallback_obj,
-                               syms_s3_fallback, s3_fallback_obj);
-    UNPROTECT(2);
+    r_obj* out = vctrs_dispatch7(method_sym, method,
+                                 x_sym, x,
+                                 y_sym, y,
+                                 x_arg_sym, x_arg,
+                                 y_arg_sym, y_arg,
+                                 syms_call, call,
+                                 syms_df_fallback, df_fallback_obj,
+                                 syms_s3_fallback, s3_fallback_obj);
+    FREE(3);
     return out;
   } else {
-    return vctrs_dispatch4(method_sym, method,
-                           x_sym, x,
-                           y_sym, y,
-                           x_arg_sym, x_arg,
-                           y_arg_sym, y_arg);
+    r_obj* out = vctrs_dispatch5(method_sym, method,
+                                 x_sym, x,
+                                 y_sym, y,
+                                 x_arg_sym, x_arg,
+                                 y_arg_sym, y_arg,
+                                 syms_call, call);
+    FREE(1);
+    return out;
   }
 }
 

--- a/src/ptype2.h
+++ b/src/ptype2.h
@@ -27,10 +27,11 @@ struct fallback_opts {
 };
 
 struct ptype2_opts {
-  SEXP x;
-  SEXP y;
+  r_obj* x;
+  r_obj* y;
   struct vctrs_arg* x_arg;
   struct vctrs_arg* y_arg;
+  struct r_lazy call;
   struct fallback_opts fallback;
 };
 
@@ -62,11 +63,12 @@ SEXP vec_ptype2_params(SEXP x,
 }
 
 static inline
-SEXP vec_ptype2(SEXP x,
-                SEXP y,
-                struct vctrs_arg* x_arg,
-                struct vctrs_arg* y_arg,
-                int* left) {
+r_obj* vec_ptype2(r_obj* x,
+                  r_obj* y,
+                  struct vctrs_arg* x_arg,
+                  struct vctrs_arg* y_arg,
+                  int* left,
+                  struct r_lazy call) {
   const struct ptype2_opts opts = {
     .x = x,
     .y = y,
@@ -89,12 +91,13 @@ struct ptype2_opts new_ptype2_opts(SEXP x,
 SEXP new_fallback_r_opts(const struct ptype2_opts* opts);
 struct fallback_opts new_fallback_opts(SEXP opts);
 
-SEXP vec_invoke_coerce_method(SEXP method_sym, SEXP method,
-                              SEXP x_sym, SEXP x,
-                              SEXP y_sym, SEXP y,
-                              SEXP x_arg_sym, SEXP x_arg,
-                              SEXP y_arg_sym, SEXP y_arg,
-                              const struct fallback_opts* opts);
+r_obj* vec_invoke_coerce_method(r_obj* method_sym, r_obj* method,
+                                r_obj* x_sym, r_obj* x,
+                                r_obj* y_sym, r_obj* y,
+                                r_obj* x_arg_sym, r_obj* x_arg,
+                                r_obj* y_arg_sym, r_obj* y_arg,
+                                struct r_lazy call,
+                                const struct fallback_opts* opts);
 
 SEXP vec_ptype2_from_unspecified(const struct ptype2_opts* opts,
                                  enum vctrs_type other_type,

--- a/src/ptype2.h
+++ b/src/ptype2.h
@@ -73,7 +73,8 @@ r_obj* vec_ptype2(r_obj* x,
     .x = x,
     .y = y,
     .x_arg = x_arg,
-    .y_arg = y_arg
+    .y_arg = y_arg,
+    .call = call
   };
   return vec_ptype2_opts(&opts, left);
 }

--- a/src/rep.c
+++ b/src/rep.c
@@ -22,7 +22,11 @@ static SEXP vec_rep(SEXP x, int times);
 
 // [[ register() ]]
 SEXP vctrs_rep(SEXP x, SEXP times) {
-  times = PROTECT(vec_cast(times, vctrs_shared_empty_int, args_times, args_empty));
+  times = PROTECT(vec_cast(times,
+                           vctrs_shared_empty_int,
+                           args_times,
+                           args_empty,
+                           r_lazy_null));
 
   if (vec_size(times) != 1) {
     stop_rep_times_size();
@@ -86,7 +90,11 @@ static SEXP vec_rep_each_uniform(SEXP x, int times);
 static SEXP vec_rep_each_impl(SEXP x, SEXP times, const R_len_t times_size);
 
 static SEXP vec_rep_each(SEXP x, SEXP times) {
-  times = PROTECT(vec_cast(times, vctrs_shared_empty_int, args_times, args_empty));
+  times = PROTECT(vec_cast(times,
+                           vctrs_shared_empty_int,
+                           args_times,
+                           args_empty,
+                           r_lazy_null));
 
   const R_len_t times_size = vec_size(times);
 

--- a/src/rep.c
+++ b/src/rep.c
@@ -151,7 +151,10 @@ static SEXP vec_rep_each_impl(SEXP x, SEXP times, const R_len_t times_size) {
   const R_len_t x_size = vec_size(x);
 
   if (x_size != times_size) {
-    stop_recycle_incompatible_size(times_size, x_size, args_times);
+    stop_recycle_incompatible_size(times_size,
+                                   x_size,
+                                   args_times,
+                                   r_lazy_null);
   }
 
   const int* p_times = INTEGER_RO(times);

--- a/src/size.c
+++ b/src/size.c
@@ -165,7 +165,11 @@ SEXP vctrs_recycle(SEXP x, SEXP size_obj, SEXP x_arg) {
     return R_NilValue;
   }
 
-  size_obj = PROTECT(vec_cast(size_obj, vctrs_shared_empty_int, args_empty, args_empty));
+  size_obj = PROTECT(vec_cast(size_obj,
+                              vctrs_shared_empty_int,
+                              args_empty,
+                              args_empty,
+                              r_lazy_null));
   R_len_t size = r_int_get(size_obj, 0);
   UNPROTECT(1);
 
@@ -202,7 +206,11 @@ SEXP vec_recycle_fallback(SEXP x, R_len_t size, struct vctrs_arg* x_arg) {
 
 // [[ include("utils.h") ]]
 R_len_t size_validate(SEXP size, const char* arg) {
-  size = vec_cast(size, vctrs_shared_empty_int, args_empty, args_empty);
+  size = vec_cast(size,
+                  vctrs_shared_empty_int,
+                  args_empty,
+                  args_empty,
+                  r_lazy_null);
 
   if (Rf_length(size) != 1) {
     Rf_errorcall(R_NilValue, "`%s` must be a single integer.", arg);

--- a/src/size.c
+++ b/src/size.c
@@ -137,45 +137,54 @@ SEXP vctrs_df_size(SEXP x) {
 
 
 // [[ include("vctrs.h") ]]
-SEXP vec_recycle(SEXP x, R_len_t size, struct vctrs_arg* x_arg) {
-  if (x == R_NilValue) {
-    return R_NilValue;
+r_obj* vec_recycle2(r_obj* x,
+                    r_ssize size,
+                    struct vctrs_arg* x_arg,
+                    struct r_lazy call) {
+  if (x == r_null) {
+    return r_null;
   }
 
-  R_len_t n_x = vec_size(x);
+  r_ssize n_x = vec_size(x);
 
   if (n_x == size) {
     return x;
   }
 
   if (n_x == 1L) {
-    SEXP i = PROTECT(compact_rep(1, size));
-    SEXP out = vec_slice_impl(x, i);
+    r_obj* i = KEEP(compact_rep(1, size));
+    r_obj* out = vec_slice_impl(x, i);
 
-    UNPROTECT(1);
+    FREE(1);
     return out;
   }
 
-  stop_recycle_incompatible_size(n_x, size, x_arg);
+  stop_recycle_incompatible_size(n_x, size, x_arg, call);
 }
 
 // [[ register() ]]
-SEXP vctrs_recycle(SEXP x, SEXP size_obj, SEXP x_arg) {
-  if (x == R_NilValue || size_obj == R_NilValue) {
-    return R_NilValue;
+r_obj* ffi_recycle(r_obj* x,
+                   r_obj* size_obj,
+                   r_obj* ffi_x_arg,
+                   r_obj* frame) {
+  if (x == r_null || size_obj == r_null) {
+    return r_null;
   }
 
-  size_obj = PROTECT(vec_cast(size_obj,
-                              vctrs_shared_empty_int,
-                              args_empty,
-                              args_empty,
-                              r_lazy_null));
+  struct r_lazy recycle_call = { .x = frame, .env = r_null };
+
+  size_obj = KEEP(vec_cast(size_obj,
+                           vctrs_shared_empty_int,
+                           args_empty,
+                           args_empty,
+                           recycle_call));
   R_len_t size = r_int_get(size_obj, 0);
-  UNPROTECT(1);
+  FREE(1);
 
-  struct vctrs_arg x_arg_ = vec_as_arg(x_arg);
+  struct vctrs_arg x_arg = vec_as_arg(ffi_x_arg);
+  struct r_lazy call = { .x = syms_call, .env = frame };
 
-  return vec_recycle(x, size, &x_arg_);
+  return vec_recycle2(x, size, &x_arg, call);
 }
 
 // [[ include("vctrs.h") ]]
@@ -200,7 +209,7 @@ SEXP vec_recycle_fallback(SEXP x, R_len_t size, struct vctrs_arg* x_arg) {
     return out;
   }
 
-  stop_recycle_incompatible_size(x_size, size, x_arg);
+  stop_recycle_incompatible_size(x_size, size, x_arg, r_lazy_null);
 }
 
 

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -43,7 +43,7 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
                                        location_default_assign_opts));
 
   // Cast and recycle `value`
-  value = PROTECT(vec_cast(value, x, opts->value_arg, opts->x_arg));
+  value = PROTECT(vec_cast(value, x, opts->value_arg, opts->x_arg, r_lazy_null));
   value = PROTECT(vec_recycle(value, vec_size(index), opts->value_arg));
 
   SEXP proxy = PROTECT(vec_proxy(x));
@@ -424,7 +424,7 @@ SEXP vctrs_assign_seq(SEXP x, SEXP value, SEXP start, SEXP size, SEXP increasing
   const struct vec_assign_opts* opts = &vec_assign_default_opts;
 
   // Cast and recycle `value`
-  value = PROTECT(vec_cast(value, x, opts->value_arg, opts->x_arg));
+  value = PROTECT(vec_cast(value, x, opts->value_arg, opts->x_arg, r_lazy_null));
   value = PROTECT(vec_recycle(value, vec_subscript_size(index), opts->value_arg));
 
   SEXP proxy = PROTECT(vec_proxy(x));

--- a/src/slice.c
+++ b/src/slice.c
@@ -483,14 +483,22 @@ SEXP vec_init(SEXP x, R_len_t n) {
 }
 
 // [[ register() ]]
-SEXP vctrs_init(SEXP x, SEXP n) {
-  n = PROTECT(vec_cast(n, vctrs_shared_empty_int, args_n, args_empty));
-  vec_assert_size(n, 1, args_n);
-  R_len_t n_ = r_int_get(n, 0);
+r_obj* ffi_init(r_obj* x, r_obj* ffi_n, r_obj* ffi_frame) {
+  struct r_lazy frame = { .x = ffi_frame, .env = r_null };
 
-  SEXP out = vec_init(x, n_);
+  ffi_n = KEEP(vec_cast(ffi_n,
+                        vctrs_shared_empty_int,
+                        args_n,
+                        args_empty,
+                        frame));
+  // TODO! Pass `frame`
+  vec_assert_size(ffi_n, 1, args_n);
 
-  UNPROTECT(1);
+  // TODO! Pass `frame`
+  r_ssize n = r_int_get(ffi_n, 0);
+  r_obj* out = vec_init(x, n);
+
+  FREE(1);
   return out;
 }
 

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -207,12 +207,18 @@ static void int_check_consecutive(SEXP subscript, R_len_t n, R_len_t n_extend,
   UNPROTECT(1);
 }
 
-static SEXP dbl_as_location(SEXP subscript, R_len_t n,
-                            const struct location_opts* opts) {
-  subscript = PROTECT(vec_cast(subscript, vctrs_shared_empty_int, args_empty, args_empty));
+static
+r_obj* dbl_as_location(r_obj* subscript,
+                       R_len_t n,
+                       const struct location_opts* opts) {
+  subscript = KEEP(vec_cast(subscript,
+                            vctrs_shared_empty_int,
+                            args_empty,
+                            args_empty,
+                            r_lazy_null));
   subscript = int_as_location(subscript, n, opts);
 
-  UNPROTECT(1);
+  FREE(1);
   return subscript;
 }
 
@@ -413,7 +419,11 @@ SEXP vctrs_as_location(SEXP subscript, SEXP n_, SEXP names,
     n = Rf_length(subscript);
   } else {
     if (OBJECT(n_) || TYPEOF(n_) != INTSXP) {
-      n_ = vec_cast(n_, vctrs_shared_empty_int, args_empty, args_empty);
+      n_ = vec_cast(n_,
+                    vctrs_shared_empty_int,
+                    args_empty,
+                    args_empty,
+                    r_lazy_null);
     }
     PROTECT(n_);
 

--- a/src/subscript.c
+++ b/src/subscript.c
@@ -73,9 +73,17 @@ SEXP vec_as_subscript_opts(SEXP subscript,
   if (opts->logical == SUBSCRIPT_TYPE_ACTION_ERROR && vec_is_unspecified(subscript)) {
     struct vctrs_arg* arg = opts->subscript_arg;
     if (opts->numeric == SUBSCRIPT_TYPE_ACTION_CAST) {
-      subscript = vec_cast(subscript, vctrs_shared_empty_int, arg, NULL);
+      subscript = vec_cast(subscript,
+                           vctrs_shared_empty_int,
+                           arg,
+                           NULL,
+                           r_lazy_null);
     } else {
-      subscript = vec_cast(subscript, vctrs_shared_empty_chr, arg, NULL);
+      subscript = vec_cast(subscript,
+                           vctrs_shared_empty_chr,
+                           arg,
+                           NULL,
+                           r_lazy_null);
     }
   }
   REPROTECT(subscript, subscript_pi);

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -651,7 +651,13 @@ SEXP vctrs_df_cast_opts(SEXP x, SEXP to, SEXP opts, SEXP x_arg, SEXP to_arg) {
   struct vctrs_arg c_x_arg = vec_as_arg(x_arg);
   struct vctrs_arg c_to_arg = vec_as_arg(to_arg);
 
-  const struct cast_opts c_opts = new_cast_opts(x, to, &c_x_arg, &c_to_arg, opts);
+  // FIXME! Error call
+  struct cast_opts c_opts = new_cast_opts(x,
+                                          to,
+                                          &c_x_arg,
+                                          &c_to_arg,
+                                          r_lazy_null,
+                                          opts);
 
   return df_cast_opts(&c_opts);
 }

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -180,7 +180,10 @@ SEXP data_frame(SEXP x, r_ssize size, const struct name_repair_opts* p_name_repa
 
 // [[ register() ]]
 SEXP vctrs_data_frame(SEXP x, SEXP size, SEXP name_repair) {
-  struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair, args_empty, false);
+  struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair,
+                                                                  args_empty,
+                                                                  false,
+                                                                  r_lazy_null);
   KEEP(name_repair_opts.shelter);
 
   r_ssize c_size = 0;
@@ -208,7 +211,10 @@ SEXP data_frame(SEXP x, r_ssize size, const struct name_repair_opts* p_name_repa
 
 // [[ register() ]]
 SEXP vctrs_df_list(SEXP x, SEXP size, SEXP name_repair) {
-  struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair, args_empty, false);
+  struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair,
+                                                                  args_empty,
+                                                                  false,
+                                                                  r_lazy_null);
   KEEP(name_repair_opts.shelter);
 
   r_ssize c_size = 0;

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -181,7 +181,7 @@ SEXP data_frame(SEXP x, r_ssize size, const struct name_repair_opts* p_name_repa
 // [[ register() ]]
 SEXP vctrs_data_frame(SEXP x, SEXP size, SEXP name_repair) {
   struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair, args_empty, false);
-  PROTECT_NAME_REPAIR_OPTS(&name_repair_opts);
+  KEEP(name_repair_opts.shelter);
 
   r_ssize c_size = 0;
   if (size == R_NilValue) {
@@ -192,7 +192,7 @@ SEXP vctrs_data_frame(SEXP x, SEXP size, SEXP name_repair) {
 
   SEXP out = data_frame(x, c_size, &name_repair_opts);
 
-  UNPROTECT(1);
+  FREE(1);
   return out;
 }
 
@@ -209,7 +209,7 @@ SEXP data_frame(SEXP x, r_ssize size, const struct name_repair_opts* p_name_repa
 // [[ register() ]]
 SEXP vctrs_df_list(SEXP x, SEXP size, SEXP name_repair) {
   struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair, args_empty, false);
-  PROTECT_NAME_REPAIR_OPTS(&name_repair_opts);
+  KEEP(name_repair_opts.shelter);
 
   r_ssize c_size = 0;
   if (size == R_NilValue) {
@@ -220,7 +220,7 @@ SEXP vctrs_df_list(SEXP x, SEXP size, SEXP name_repair) {
 
   SEXP out = df_list(x, c_size, &name_repair_opts);
 
-  UNPROTECT(1);
+  FREE(1);
   return out;
 }
 

--- a/src/type2.c
+++ b/src/type2.c
@@ -227,12 +227,18 @@ SEXP vctrs_is_coercible(SEXP x,
 
 
 // [[ register() ]]
-SEXP vctrs_ptype2(SEXP x, SEXP y, SEXP x_arg, SEXP y_arg) {
-  struct vctrs_arg x_arg_ = vec_as_arg(x_arg);
-  struct vctrs_arg y_arg_ = vec_as_arg(y_arg);
+r_obj* ffi_ptype2(r_obj* x,
+                  r_obj* y,
+                  r_obj* ffi_x_arg,
+                  r_obj* ffi_y_arg,
+                  r_obj* frame) {
+  struct vctrs_arg x_arg = vec_as_arg(ffi_x_arg);
+  struct vctrs_arg y_arg = vec_as_arg(ffi_y_arg);
+
+  struct r_lazy call = { .x = syms_call, .env = frame };
 
   int _left;
-  return vec_ptype2(x, y, &x_arg_, &y_arg_, &_left);
+  return vec_ptype2(x, y, &x_arg, &y_arg, &_left, call);
 }
 
 // [[ include("ptype2.h") ]]

--- a/src/unspecified.c
+++ b/src/unspecified.c
@@ -26,7 +26,11 @@ SEXP vctrs_unspecified(SEXP n) {
     Rf_errorcall(R_NilValue, "`n` must be a single number");
   }
   if (TYPEOF(n) != INTSXP) {
-    n = vec_cast(n, vctrs_shared_empty_int, args_empty, args_empty);
+    n = vec_cast(n,
+                 vctrs_shared_empty_int,
+                 args_empty,
+                 args_empty,
+                 r_lazy_null);
   }
   int len = INTEGER(n)[0];
   return vec_unspecified(len);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1637,7 +1637,7 @@ void c_print_backtrace() {
 #endif
 }
 
-struct r_lazy r_lazy_null = (struct r_lazy) { 0 };
+struct r_lazy r_lazy_null;
 
 void vctrs_init_utils(SEXP ns) {
   vctrs_ns_env = ns;
@@ -1918,6 +1918,8 @@ void vctrs_init_utils(SEXP ns) {
     MARK_NOT_MUTABLE(result_attrib);
     UNPROTECT(4);
   }
+
+  r_lazy_null = (struct r_lazy) { 0 };
 
   // We assume the following in `union vctrs_dbl_indicator`
   VCTRS_ASSERT(sizeof(double) == sizeof(int64_t));

--- a/src/utils.c
+++ b/src/utils.c
@@ -1593,6 +1593,7 @@ SEXP syms_message = NULL;
 SEXP syms_chr_proxy_collate = NULL;
 SEXP syms_actual = NULL;
 SEXP syms_required = NULL;
+SEXP syms_call = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -1635,6 +1636,8 @@ void c_print_backtrace() {
   Rprintf("vctrs must be compliled with -DRLIB_DEBUG.");
 #endif
 }
+
+struct r_lazy r_lazy_null = (struct r_lazy) { 0 };
 
 void vctrs_init_utils(SEXP ns) {
   vctrs_ns_env = ns;
@@ -1860,6 +1863,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_chr_proxy_collate = Rf_install("chr_proxy_collate");
   syms_actual = Rf_install("actual");
   syms_required = Rf_install("required");
+  syms_call = Rf_install("call");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.c
+++ b/src/utils.c
@@ -135,6 +135,19 @@ SEXP vctrs_eval_mask7(SEXP fn,
   SEXP args[8] = { x1, x2, x3, x4, x5, x6, x7, NULL };
   return vctrs_eval_mask_n(fn, syms, args);
 }
+r_obj* vctrs_eval_mask8(r_obj* fn,
+                        r_obj* x1_sym, r_obj* x1,
+                        r_obj* x2_sym, r_obj* x2,
+                        r_obj* x3_sym, r_obj* x3,
+                        r_obj* x4_sym, r_obj* x4,
+                        r_obj* x5_sym, r_obj* x5,
+                        r_obj* x6_sym, r_obj* x6,
+                        r_obj* x7_sym, r_obj* x7,
+                        r_obj* x8_sym, r_obj* x8) {
+  r_obj* syms[9] = { x1_sym, x2_sym, x3_sym, x4_sym, x5_sym, x6_sym, x7_sym, x8_sym, NULL };
+  r_obj* args[9] = { x1, x2, x3, x4, x5, x6, x7, x8, NULL };
+  return vctrs_eval_mask_n(fn, syms, args);
+}
 
 /**
  * Dispatch in the current environment

--- a/src/utils.h
+++ b/src/utils.h
@@ -84,6 +84,17 @@ SEXP vctrs_dispatch4(SEXP fn_sym, SEXP fn,
                      SEXP x_sym, SEXP x,
                      SEXP y_sym, SEXP y,
                      SEXP z_sym, SEXP z);
+static inline
+r_obj* vctrs_dispatch5(r_obj* fn_sym, r_obj* fn,
+                     r_obj* x1_sym, r_obj* x1,
+                     r_obj* x2_sym, r_obj* x2,
+                     r_obj* x3_sym, r_obj* x3,
+                     r_obj* x4_sym, r_obj* x4,
+                     r_obj* x5_sym, r_obj* x5) {
+  r_obj* syms[6] = { x1_sym, x2_sym, x3_sym, x4_sym, x5_sym, NULL };
+  r_obj* args[6] = { x1, x2, x3, x4, x5, NULL };
+  return vctrs_dispatch_n(fn_sym, fn, syms, args);
+}
 SEXP vctrs_dispatch6(SEXP fn_sym, SEXP fn,
                      SEXP x1_sym, SEXP x1,
                      SEXP x2_sym, SEXP x2,
@@ -91,6 +102,19 @@ SEXP vctrs_dispatch6(SEXP fn_sym, SEXP fn,
                      SEXP x4_sym, SEXP x4,
                      SEXP x5_sym, SEXP x5,
                      SEXP x6_sym, SEXP x6);
+static inline
+r_obj* vctrs_dispatch7(r_obj* fn_sym, r_obj* fn,
+                       r_obj* x1_sym, r_obj* x1,
+                       r_obj* x2_sym, r_obj* x2,
+                       r_obj* x3_sym, r_obj* x3,
+                       r_obj* x4_sym, r_obj* x4,
+                       r_obj* x5_sym, r_obj* x5,
+                       r_obj* x6_sym, r_obj* x6,
+                       r_obj* x7_sym, r_obj* x7) {
+  r_obj* syms[8] = { x1_sym, x2_sym, x3_sym, x4_sym, x5_sym, x6_sym, x7_sym, NULL };
+  r_obj* args[8] = { x1, x2, x3, x4, x5, x6, x7, NULL };
+  return vctrs_dispatch_n(fn_sym, fn, syms, args);
+}
 
 __attribute__((noreturn)) void stop_unimplemented_vctrs_type(const char* fn, enum vctrs_type);
 
@@ -512,6 +536,7 @@ extern SEXP syms_message;
 extern SEXP syms_chr_proxy_collate;
 extern SEXP syms_actual;
 extern SEXP syms_required;
+extern SEXP syms_call;
 
 static const char * const c_strs_vctrs_common_class_fallback = "vctrs:::common_class_fallback";
 
@@ -531,6 +556,28 @@ extern SEXP s4_c_method_table;
 SEXP R_inspect(SEXP x);
 SEXP R_inspect3(SEXP x, int deep, int pvec);
 #endif
+
+
+struct r_lazy {
+  r_obj* x;
+  r_obj* env;
+};
+
+static inline
+r_obj* r_lazy_eval(struct r_lazy lazy) {
+  if (!lazy.env) {
+    // Unitialised lazy variable
+    return r_null;
+  } else if (lazy.env == r_null) {
+    // Forced lazy variable
+    return lazy.x;
+  } else {
+    return r_eval(lazy.x, lazy.env);
+  }
+}
+
+extern
+struct r_lazy r_lazy_null;
 
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -67,6 +67,15 @@ SEXP vctrs_eval_mask7(SEXP fn,
                       SEXP x5_sym, SEXP x5,
                       SEXP x6_sym, SEXP x6,
                       SEXP x7_sym, SEXP x7);
+r_obj* vctrs_eval_mask8(r_obj* fn,
+                        r_obj* x1_sym, r_obj* x1,
+                        r_obj* x2_sym, r_obj* x2,
+                        r_obj* x3_sym, r_obj* x3,
+                        r_obj* x4_sym, r_obj* x4,
+                        r_obj* x5_sym, r_obj* x5,
+                        r_obj* x6_sym, r_obj* x6,
+                        r_obj* x7_sym, r_obj* x7,
+                        r_obj* x8_sym, r_obj* x8);
 
 SEXP vctrs_dispatch_n(SEXP fn_sym, SEXP fn,
                       SEXP* syms, SEXP* args);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -374,7 +374,7 @@ SEXP vec_init(SEXP x, R_len_t n);
 SEXP vec_ptype(SEXP x, struct vctrs_arg* x_arg);
 SEXP vec_ptype_finalise(SEXP x);
 bool vec_is_unspecified(SEXP x);
-SEXP vec_recycle(SEXP x, R_len_t size, struct vctrs_arg* x_arg);
+r_obj* vec_recycle2(r_obj* x, r_ssize size, struct vctrs_arg* x_arg, struct r_lazy call);
 SEXP vec_recycle_fallback(SEXP x, R_len_t size, struct vctrs_arg* x_arg);
 SEXP vec_recycle_common(SEXP xs, R_len_t size);
 SEXP vec_names(SEXP x);
@@ -383,6 +383,14 @@ SEXP vec_group_loc(SEXP x);
 SEXP vec_identify_runs(SEXP x);
 SEXP vec_match_params(SEXP needles, SEXP haystack, bool na_equal,
                       struct vctrs_arg* needles_arg, struct vctrs_arg* haystack_arg);
+
+// FIXME: Pass error call everywhere
+static inline
+r_obj* vec_recycle(r_obj* x,
+                   r_ssize size,
+                   struct vctrs_arg* x_arg) {
+  return vec_recycle2(x, size, x_arg, r_lazy_null);
+}
 
 #include "cast.h"
 static inline r_obj* vec_cast(r_obj* x,
@@ -619,8 +627,10 @@ void stop_incompatible_type(SEXP x,
                             struct vctrs_arg* y_arg,
                             bool cast);
 __attribute__((noreturn))
-void stop_recycle_incompatible_size(R_len_t x_size, R_len_t size,
-                                    struct vctrs_arg* x_arg);
+void stop_recycle_incompatible_size(r_ssize x_size,
+                                    r_ssize size,
+                                    struct vctrs_arg* x_arg,
+                                    struct r_lazy call);
 __attribute__((noreturn))
 void stop_incompatible_shape(SEXP x, SEXP y,
                              R_len_t x_size, R_len_t y_size, int axis,

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -385,12 +385,17 @@ SEXP vec_match_params(SEXP needles, SEXP haystack, bool na_equal,
                       struct vctrs_arg* needles_arg, struct vctrs_arg* haystack_arg);
 
 #include "cast.h"
-static inline SEXP vec_cast(SEXP x, SEXP to, struct vctrs_arg* x_arg, struct vctrs_arg* to_arg) {
+static inline r_obj* vec_cast(r_obj* x,
+                              r_obj* to,
+                              struct vctrs_arg* x_arg,
+                              struct vctrs_arg* to_arg,
+                              struct r_lazy call) {
   struct cast_opts opts = {
     .x = x,
     .to = to,
     .x_arg = x_arg,
-    .to_arg = to_arg
+    .to_arg = to_arg,
+    .call = call
   };
   return vec_cast_opts(&opts);
 }

--- a/tests/testthat/_snaps/assert.md
+++ b/tests/testthat/_snaps/assert.md
@@ -185,6 +185,6 @@
       (expect_error(vec_assert(1, size = "x")))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert `size` <character> to <integer>.
 

--- a/tests/testthat/_snaps/assert.md
+++ b/tests/testthat/_snaps/assert.md
@@ -185,6 +185,6 @@
       (expect_error(vec_assert(1, size = "x")))
     Output
       <error/vctrs_error_incompatible_type>
-      Error:
+      Error in `vec_assert()`:
       ! Can't convert `size` <character> to <integer>.
 

--- a/tests/testthat/_snaps/assert.md
+++ b/tests/testthat/_snaps/assert.md
@@ -178,7 +178,7 @@
       (expect_error(vec_assert(1, size = 1.5)))
     Output
       <error/vctrs_error_cast_lossy>
-      Error in `vec_cast.integer.double()`:
+      Error in `vec_assert()`:
       ! Can't convert from `size` <double> to <integer> due to loss of precision.
       * Locations: 1
     Code

--- a/tests/testthat/_snaps/assert.md
+++ b/tests/testthat/_snaps/assert.md
@@ -178,13 +178,13 @@
       (expect_error(vec_assert(1, size = 1.5)))
     Output
       <error/vctrs_error_cast_lossy>
-      Error in `stop_vctrs()`:
+      Error in `vec_cast.integer.double()`:
       ! Can't convert from `size` <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
       (expect_error(vec_assert(1, size = "x")))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert `size` <character> to <integer>.
 

--- a/tests/testthat/_snaps/assert.md
+++ b/tests/testthat/_snaps/assert.md
@@ -3,7 +3,7 @@
     Code
       vec_assert(lgl(), chr())
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `lgl()` must be a vector with type <character>.
       Instead, it has type <logical>.
 
@@ -12,7 +12,7 @@
     Code
       vec_assert(lgl(), factor())
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `lgl()` must be a vector with type <factor<>>.
       Instead, it has type <logical>.
 
@@ -21,7 +21,7 @@
     Code
       vec_assert(lgl(), factor(levels = "foo"))
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `lgl()` must be a vector with type <factor<c1562>>.
       Instead, it has type <logical>.
 
@@ -30,7 +30,7 @@
     Code
       vec_assert(factor(levels = "bar"), factor(levels = "foo"))
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `factor(levels = "bar")` must be a vector with type <factor<c1562>>.
       Instead, it has type <factor<9f154>>.
 
@@ -39,7 +39,7 @@
     Code
       vec_assert(factor(), chr())
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `factor()` must be a vector with type <character>.
       Instead, it has type <factor<>>.
 
@@ -48,7 +48,7 @@
     Code
       vec_assert(lgl(), data.frame())
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `lgl()` must be a vector with type <data.frame<>>.
       Instead, it has type <logical>.
 
@@ -57,7 +57,7 @@
     Code
       vec_assert(lgl(), data.frame(x = 1))
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `lgl()` must be a vector with type <data.frame<x:double>>.
       Instead, it has type <logical>.
 
@@ -66,7 +66,7 @@
     Code
       vec_assert(lgl(), data.frame(x = 1, y = 2))
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `lgl()` must be a vector with type:
       
         <data.frame<
@@ -81,7 +81,7 @@
     Code
       vec_assert(data.frame(), chr())
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `data.frame()` must be a vector with type <character>.
       Instead, it has type <data.frame<>>.
 
@@ -90,7 +90,7 @@
     Code
       vec_assert(data.frame(x = 1), chr())
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `data.frame(x = 1)` must be a vector with type <character>.
       Instead, it has type <data.frame<x:double>>.
 
@@ -99,7 +99,7 @@
     Code
       vec_assert(data.frame(x = 1), data.frame(x = "foo"))
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `data.frame(x = 1)` must be a vector with type <data.frame<x:character>>.
       Instead, it has type <data.frame<x:double>>.
 
@@ -108,7 +108,7 @@
     Code
       vec_assert(data.frame(x = 1), data.frame(x = "foo", y = 2))
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `data.frame(x = 1)` must be a vector with type:
       
         <data.frame<
@@ -123,7 +123,7 @@
     Code
       vec_assert(data.frame(x = 1, y = 2), chr())
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `data.frame(x = 1, y = 2)` must be a vector with type <character>.
       Instead, it has type:
       
@@ -137,7 +137,7 @@
     Code
       vec_assert(data.frame(x = 1, y = 2), data.frame(x = "foo"))
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `data.frame(x = 1, y = 2)` must be a vector with type <data.frame<x:character>>.
       Instead, it has type:
       
@@ -151,7 +151,7 @@
     Code
       vec_assert(data.frame(x = 1, y = 2), data.frame(x = "foo", y = 2))
     Condition
-      Error in `vec_assert()`:
+      Error:
       ! `data.frame(x = 1, y = 2)` must be a vector with type:
       
         <data.frame<

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -187,7 +187,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -202,7 +202,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1` <vctrs_Counts> and `..2` <vctrs:::common_class_fallback>.
 
 # row-binding performs expected allocations

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -187,7 +187,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -202,7 +202,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1` <vctrs_Counts> and `..2` <vctrs:::common_class_fallback>.
 
 # row-binding performs expected allocations

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -3,7 +3,7 @@
     Code
       vec_c(df1, df2)
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1$x$y$z` <double> and `..2$x$y$z` <character>.
 
 ---
@@ -11,7 +11,7 @@
     Code
       vec_c(df1, df1, df2)
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1$x$y$z` <double> and `..3$x$y$z` <character>.
 
 ---
@@ -19,7 +19,7 @@
     Code
       vec_c(foo = df1, bar = df2)
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `foo$x$y$z` <double> and `bar$x$y$z` <character>.
 
 # vec_c() fails with complex foreign S3 classes
@@ -30,7 +30,7 @@
       (expect_error(vec_c(x, y), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -44,7 +44,7 @@
       (expect_error(vec_c(joe, jane), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1` <vctrs_Counts> and `..2` <vctrs_Counts>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -74,7 +74,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `a` <character> and `b` <double>.
 
 # concatenation performs expected allocations

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -3,7 +3,7 @@
     Code
       vec_c(df1, df2)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1$x$y$z` <double> and `..2$x$y$z` <character>.
 
 ---
@@ -11,7 +11,7 @@
     Code
       vec_c(df1, df1, df2)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1$x$y$z` <double> and `..3$x$y$z` <character>.
 
 ---
@@ -19,7 +19,7 @@
     Code
       vec_c(foo = df1, bar = df2)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `foo$x$y$z` <double> and `bar$x$y$z` <character>.
 
 # vec_c() fails with complex foreign S3 classes
@@ -30,7 +30,7 @@
       (expect_error(vec_c(x, y), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -44,7 +44,7 @@
       (expect_error(vec_c(joe, jane), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1` <vctrs_Counts> and `..2` <vctrs_Counts>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -64,7 +64,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert <vctrs_foobar> to <character>.
 
 # can ignore names in `vec_c()` by providing a `zap()` name-spec (#232)
@@ -74,7 +74,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `a` <character> and `b` <double>.
 
 # concatenation performs expected allocations

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -64,7 +64,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert <vctrs_foobar> to <character>.
 
 # can ignore names in `vec_c()` by providing a `zap()` name-spec (#232)

--- a/tests/testthat/_snaps/cast.md
+++ b/tests/testthat/_snaps/cast.md
@@ -3,7 +3,7 @@
     Code
       vec_cast(1, "", x_arg = "foo", to_arg = "bar")
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert `foo` <double> to match type of `bar` <character>.
 
 ---
@@ -11,7 +11,7 @@
     Code
       vec_cast(1, "", x_arg = "foo")
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert `foo` <double> to <character>.
 
 # cast errors create helpful messages (#57, #225)
@@ -19,7 +19,7 @@
     Code
       vec_cast(1.5, 10L)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_cast.integer.double()`:
       ! Can't convert from <double> to <integer> due to loss of precision.
       * Locations: 1
 
@@ -28,7 +28,7 @@
     Code
       vec_cast(factor("foo"), 10)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert <factor<c1562>> to <double>.
 
 ---
@@ -38,7 +38,7 @@
       y <- tibble(a = tibble(b = 10L))
       vec_cast(x, y)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_cast.integer.double()`:
       ! Can't convert from `a$b` <double> to `a$b` <integer> due to loss of precision.
       * Locations: 1
 
@@ -49,7 +49,7 @@
       y <- tibble(a = tibble(b = 10))
       vec_cast(x, y)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert `a$b` <factor<c1562>> to match type of `a$b` <double>.
 
 ---
@@ -59,6 +59,6 @@
       y <- tibble(a = tibble(b = 10))
       vec_cast_common(x, y)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1$a$b` <factor<c1562>> and `..2$a$b` <double>.
 

--- a/tests/testthat/_snaps/cast.md
+++ b/tests/testthat/_snaps/cast.md
@@ -3,7 +3,7 @@
     Code
       vec_cast(1, "", x_arg = "foo", to_arg = "bar")
     Condition
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert `foo` <double> to match type of `bar` <character>.
 
 ---
@@ -11,7 +11,7 @@
     Code
       vec_cast(1, "", x_arg = "foo")
     Condition
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert `foo` <double> to <character>.
 
 # cast errors create helpful messages (#57, #225)
@@ -28,7 +28,7 @@
     Code
       vec_cast(factor("foo"), 10)
     Condition
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert <factor<c1562>> to <double>.
 
 ---
@@ -49,7 +49,7 @@
       y <- tibble(a = tibble(b = 10))
       vec_cast(x, y)
     Condition
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert `a$b` <factor<c1562>> to match type of `a$b` <double>.
 
 ---

--- a/tests/testthat/_snaps/cast.md
+++ b/tests/testthat/_snaps/cast.md
@@ -19,7 +19,7 @@
     Code
       vec_cast(1.5, 10L)
     Condition
-      Error in `vec_cast.integer.double()`:
+      Error:
       ! Can't convert from <double> to <integer> due to loss of precision.
       * Locations: 1
 
@@ -38,7 +38,7 @@
       y <- tibble(a = tibble(b = 10L))
       vec_cast(x, y)
     Condition
-      Error in `vec_cast.integer.double()`:
+      Error:
       ! Can't convert from `a$b` <double> to `a$b` <integer> due to loss of precision.
       * Locations: 1
 

--- a/tests/testthat/_snaps/cast.md
+++ b/tests/testthat/_snaps/cast.md
@@ -59,6 +59,6 @@
       y <- tibble(a = tibble(b = 10))
       vec_cast_common(x, y)
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1$a$b` <factor<c1562>> and `..2$a$b` <double>.
 

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -21,7 +21,7 @@
       class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Element `foo` doesn't exist.
     Code
@@ -29,7 +29,7 @@
         foo)), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Element `foo` doesn't exist.
     Code
@@ -37,7 +37,7 @@
         foo(bar))), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Element `foo` doesn't exist.
 
@@ -47,14 +47,14 @@
       (expect_error(vec_slice(foobar(list(1)), 1), class = "vctrs_error_scalar_type"))
     Output
       <error/vctrs_error_scalar_type>
-      Error in `stop_vctrs()`:
+      Error:
       ! Input must be a vector, not a <vctrs_foobar> object.
     Code
       (expect_error(stop_scalar_type(foobar(list(1)), arg = "foo"), class = "vctrs_error_scalar_type")
       )
     Output
       <error/vctrs_error_scalar_type>
-      Error in `stop_vctrs()`:
+      Error:
       ! `foo` must be a vector, not a <vctrs_foobar> object.
 
 # empty names errors are informative
@@ -64,7 +64,7 @@
       )
     Output
       <error/vctrs_error_names_cannot_be_empty>
-      Error in `stop_vctrs()`:
+      Error in `validate_unique()`:
       ! Names can't be empty.
       x Empty name found at location 2.
     Code
@@ -72,7 +72,7 @@
       class = "vctrs_error_names_cannot_be_empty"))
     Output
       <error/vctrs_error_names_cannot_be_empty>
-      Error in `stop_vctrs()`:
+      Error in `validate_unique()`:
       ! Names can't be empty.
       x Empty names found at locations 2 and 4.
     Code
@@ -80,7 +80,7 @@
       )
     Output
       <error/vctrs_error_names_cannot_be_empty>
-      Error in `stop_vctrs()`:
+      Error in `validate_unique()`:
       ! Names can't be empty.
       x Empty names found at locations 1, 2, 3, 4, 5, etc.
 
@@ -91,7 +91,7 @@
       class = "vctrs_error_names_cannot_be_dot_dot"))
     Output
       <error/vctrs_error_names_cannot_be_dot_dot>
-      Error in `stop_vctrs()`:
+      Error:
       ! Names can't be of the form `...` or `..j`.
       x These names are invalid:
         * "..1" at locations 1, 2, and 3.
@@ -102,7 +102,7 @@
       )
     Output
       <error/vctrs_error_names_cannot_be_dot_dot>
-      Error in `stop_vctrs()`:
+      Error:
       ! Names can't be of the form `...` or `..j`.
       x These names are invalid:
         * "..1" at locations 1, 2, 3, 4, 5, etc.
@@ -119,7 +119,7 @@
       class = "vctrs_error_names_must_be_unique"))
     Output
       <error/vctrs_error_names_must_be_unique>
-      Error in `stop_vctrs()`:
+      Error:
       ! Names must be unique.
       x These names are duplicated:
         * "x" at locations 1, 2, and 3.
@@ -129,7 +129,7 @@
       repair = "check_unique"), class = "vctrs_error_names_must_be_unique"))
     Output
       <error/vctrs_error_names_must_be_unique>
-      Error in `stop_vctrs()`:
+      Error:
       ! Names must be unique.
       x These names are duplicated:
         * "x" at locations 1, 2, 3, 4, 5, etc.
@@ -145,7 +145,7 @@
       (expect_error(vec_cast("a", factor("b")), class = "vctrs_error_cast_lossy"))
     Output
       <error/vctrs_error_cast_lossy>
-      Error in `stop_vctrs()`:
+      Error in `fct_cast_impl()`:
       ! Can't convert from <character> to <factor<9b7e3>> due to loss of generality.
       * Locations: 1
 
@@ -156,7 +156,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't convert <ordered<bf275>> to <ordered<fd1ad>>.
 
 # incompatible size errors
@@ -165,27 +165,27 @@
       (expect_error(stop_incompatible_size(1:2, 3:5, 2L, 3L, x_arg = "", y_arg = "")))
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't recycle input of size 2 to size 3.
     Code
       (expect_error(stop_incompatible_size(1:2, 3:5, 2L, 3L, x_arg = quote(foo),
       y_arg = "")))
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't recycle `foo` (size 2) to size 3.
     Code
       (expect_error(stop_incompatible_size(1:2, 3:5, 2L, 3L, x_arg = "", y_arg = "bar"))
       )
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't recycle input of size 2 to match `bar` (size 3).
     Code
       (expect_error(stop_incompatible_size(1:2, 3:5, 2L, 3L, x_arg = quote(foo),
       y_arg = quote(bar))))
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't recycle `foo` (size 2) to match `bar` (size 3).
 

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -64,7 +64,7 @@
       )
     Output
       <error/vctrs_error_names_cannot_be_empty>
-      Error in `validate_unique()`:
+      Error:
       ! Names can't be empty.
       x Empty name found at location 2.
     Code
@@ -72,7 +72,7 @@
       class = "vctrs_error_names_cannot_be_empty"))
     Output
       <error/vctrs_error_names_cannot_be_empty>
-      Error in `validate_unique()`:
+      Error:
       ! Names can't be empty.
       x Empty names found at locations 2 and 4.
     Code
@@ -80,7 +80,7 @@
       )
     Output
       <error/vctrs_error_names_cannot_be_empty>
-      Error in `validate_unique()`:
+      Error:
       ! Names can't be empty.
       x Empty names found at locations 1, 2, 3, 4, 5, etc.
 

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -145,7 +145,7 @@
       (expect_error(vec_cast("a", factor("b")), class = "vctrs_error_cast_lossy"))
     Output
       <error/vctrs_error_cast_lossy>
-      Error in `fct_cast_impl()`:
+      Error:
       ! Can't convert from <character> to <factor<9b7e3>> due to loss of generality.
       * Locations: 1
 

--- a/tests/testthat/_snaps/dictionary.md
+++ b/tests/testthat/_snaps/dictionary.md
@@ -6,26 +6,26 @@
       (expect_error(vec_match(df1, df2), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `x$foo` <double> and `x$foo` <character>.
     Code
       (expect_error(vec_match(df1, df2, needles_arg = "n", haystack_arg = "h"),
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `n$x$foo` <double> and `h$x$foo` <character>.
     Code
       (expect_error(vec_in(df1, df2), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `x$foo` <double> and `x$foo` <character>.
     Code
       (expect_error(vec_in(df1, df2, needles_arg = "n", haystack_arg = "h"), class = "vctrs_error_incompatible_type")
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `n$x$foo` <double> and `h$x$foo` <character>.
 

--- a/tests/testthat/_snaps/dictionary.md
+++ b/tests/testthat/_snaps/dictionary.md
@@ -6,26 +6,26 @@
       (expect_error(vec_match(df1, df2), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `x$foo` <double> and `x$foo` <character>.
     Code
       (expect_error(vec_match(df1, df2, needles_arg = "n", haystack_arg = "h"),
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `n$x$foo` <double> and `h$x$foo` <character>.
     Code
       (expect_error(vec_in(df1, df2), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `x$foo` <double> and `x$foo` <character>.
     Code
       (expect_error(vec_in(df1, df2, needles_arg = "n", haystack_arg = "h"), class = "vctrs_error_incompatible_type")
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `n$x$foo` <double> and `h$x$foo` <character>.
 

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -32,7 +32,7 @@
       (expect_error(my_function()))
     Output
       <error/vctrs_error_incompatible_size>
-      Error:
+      Error in `my_function()`:
       ! Can't recycle input of size 2 to size 10.
 
 ---

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -1,0 +1,73 @@
+# failing common type reports correct error call
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `vec_default_ptype2()`:
+      ! Can't combine <double> and <character>.
+
+# failing cast reports correct error call
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `vec_default_cast()`:
+      ! Can't convert <double> to <character>.
+
+# lossy cast reports correct error call
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_cast_lossy>
+      Error in `vec_cast.logical.double()`:
+      ! Can't convert from <double> to <logical> due to loss of precision.
+      * Locations: 1
+
+# failing common size reports correct error call
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_incompatible_size>
+      Error:
+      ! Can't recycle input of size 2 to size 10.
+
+---
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_incompatible_size>
+      Error:
+      ! Can't recycle `..1` (size 2) to match `..2` (size 10).
+
+# unsupported error reports correct error call
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_unsupported>
+      Error in `dim<-`:
+      ! `dim<-.vctrs_vctr()` not supported.
+
+---
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_unimplemented>
+      Error in `median()`:
+      ! `median.vctrs_vctr()` not implemented.
+
+# scalar error reports correct error call
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_scalar_type>
+      Error in `vec_assert()`:
+      ! `foobar()` must be a vector, not a <vctrs_foobar> object.
+

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -4,7 +4,7 @@
       (expect_error(my_function()))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine <double> and <character>.
 
 # failing cast reports correct error call

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -13,7 +13,7 @@
       (expect_error(my_function()))
     Output
       <error/vctrs_error_incompatible_type>
-      Error:
+      Error in `my_function()`:
       ! Can't convert <double> to <character>.
 
 # lossy cast reports correct error call

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -22,7 +22,7 @@
       (expect_error(my_function()))
     Output
       <error/vctrs_error_cast_lossy>
-      Error in `vec_cast.logical.double()`:
+      Error in `my_function()`:
       ! Can't convert from <double> to <logical> due to loss of precision.
       * Locations: 1
 
@@ -89,4 +89,44 @@
       <error/vctrs_error_assert_size>
       Error in `my_function()`:
       ! `1:2` must have size 1, not size 2.
+
+# bare casts report correct error call
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_cast_lossy>
+      Error in `my_function()`:
+      ! Can't convert from <double> to <integer> due to loss of precision.
+      * Locations: 1
+
+---
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_cast_lossy>
+      Error in `my_function()`:
+      ! Can't convert from <double> to <logical> due to loss of precision.
+      * Locations: 1
+
+---
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_cast_lossy>
+      Error in `my_function()`:
+      ! Can't convert from <integer> to <logical> due to loss of precision.
+      * Locations: 1
+
+---
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `my_function()`:
+      ! Can't convert <double[,1]> to <double>.
+      Cannot decrease dimensions.
 

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -130,3 +130,36 @@
       ! Can't convert <double[,1]> to <double>.
       Cannot decrease dimensions.
 
+# names validation reports correct error call
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_names_cannot_be_empty>
+      Error in `my_function()`:
+      ! Names can't be empty.
+      x Empty name found at location 2.
+
+---
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_names_must_be_unique>
+      Error in `my_function()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "x" at locations 1 and 2.
+      i Use argument `repair` to specify repair strategy.
+
+---
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_names_cannot_be_dot_dot>
+      Error in `my_function()`:
+      ! Names can't be of the form `...` or `..j`.
+      x These names are invalid:
+        * "..." at location 1.
+

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -4,7 +4,7 @@
       (expect_error(my_function()))
     Output
       <error/vctrs_error_incompatible_type>
-      Error:
+      Error in `my_function()`:
       ! Can't combine <double> and <character>.
 
 # failing cast reports correct error call

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -68,6 +68,25 @@
       (expect_error(my_function()))
     Output
       <error/vctrs_error_scalar_type>
-      Error in `vec_assert()`:
+      Error in `my_function()`:
       ! `foobar()` must be a vector, not a <vctrs_foobar> object.
+
+---
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_assert_ptype>
+      Error in `my_function()`:
+      ! `1:2` must be a vector with type <double>.
+      Instead, it has type <integer>.
+
+---
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_assert_size>
+      Error in `my_function()`:
+      ! `1:2` must have size 1, not size 2.
 

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -13,7 +13,7 @@
       (expect_error(my_function()))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert <double> to <character>.
 
 # lossy cast reports correct error call

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -130,6 +130,16 @@
       ! Can't convert <double[,1]> to <double>.
       Cannot decrease dimensions.
 
+# base S3 casts report correct error call
+
+    Code
+      (expect_error(my_function()))
+    Output
+      <error/vctrs_error_cast_lossy>
+      Error in `my_function()`:
+      ! Can't convert from <character> to <factor<9b7e3>> due to loss of generality.
+      * Locations: 1
+
 # names validation reports correct error call
 
     Code

--- a/tests/testthat/_snaps/names.md
+++ b/tests/testthat/_snaps/names.md
@@ -17,7 +17,7 @@
       )
     Output
       <error/vctrs_error_names_must_be_unique>
-      Error in `stop_vctrs()`:
+      Error:
       ! Names must be unique.
       x These names are duplicated:
         * "x" at locations 1 and 2.

--- a/tests/testthat/_snaps/recycle.md
+++ b/tests/testthat/_snaps/recycle.md
@@ -5,7 +5,7 @@
       )
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't recycle input of size 2 to size 1.
 
 # incompatible recycling size has informative error
@@ -13,7 +13,7 @@
     Code
       vec_recycle(1:2, 4)
     Condition
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't recycle input of size 2 to size 4.
 
 ---
@@ -21,6 +21,6 @@
     Code
       vec_recycle(1:2, 4, x_arg = "foo")
     Condition
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't recycle `foo` (size 2) to size 4.
 

--- a/tests/testthat/_snaps/rep.md
+++ b/tests/testthat/_snaps/rep.md
@@ -3,7 +3,7 @@
     Code
       vec_rep(1, "x")
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert `times` <character> to <integer>.
 
 ---
@@ -35,7 +35,7 @@
     Code
       vec_rep_each(1, "x")
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert `times` <character> to <integer>.
 
 ---
@@ -75,6 +75,6 @@
     Code
       vec_rep_each(1:2, 1:3)
     Condition
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't recycle `times` (size 3) to size 2.
 

--- a/tests/testthat/_snaps/rep.md
+++ b/tests/testthat/_snaps/rep.md
@@ -3,7 +3,7 @@
     Code
       vec_rep(1, "x")
     Condition
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert `times` <character> to <integer>.
 
 ---
@@ -35,7 +35,7 @@
     Code
       vec_rep_each(1, "x")
     Condition
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert `times` <character> to <integer>.
 
 ---

--- a/tests/testthat/_snaps/shape.md
+++ b/tests/testthat/_snaps/shape.md
@@ -5,7 +5,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't combine <integer[,0,5]> and <integer[,5,1]>.
       x Incompatible sizes 0 and 5 along axis 2.
     Code
@@ -13,7 +13,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't combine <integer[,5,0]> and <integer[,1,5]>.
       x Incompatible sizes 0 and 5 along axis 3.
 
@@ -24,7 +24,7 @@
       y_arg = "bar"), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't combine `foo` <integer[,0,5]> and `bar` <integer[,5,1]>.
       x Incompatible sizes 0 and 5 along axis 2.
 

--- a/tests/testthat/_snaps/size.md
+++ b/tests/testthat/_snaps/size.md
@@ -3,7 +3,7 @@
     Code
       vec_size_common(1:2, 1, 1:4)
     Condition
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't recycle `..1` (size 2) to match `..3` (size 4).
 
 ---
@@ -11,6 +11,6 @@
     Code
       vec_size_common(foo = 1:2, 1, bar = 1:4)
     Condition
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't recycle `foo` (size 2) to match `bar` (size 4).
 

--- a/tests/testthat/_snaps/slice-assign.md
+++ b/tests/testthat/_snaps/slice-assign.md
@@ -5,7 +5,7 @@
       )
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't recycle input of size 2 to size 3.
 
 # logical subscripts must match size of indexed vector
@@ -38,7 +38,7 @@
       (expect_error(vec_assign(1:3, 5, 10), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't assign to elements that don't exist.
       x Location 5 doesn't exist.
       i There are only 3 elements.
@@ -51,7 +51,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't negate elements that don't exist.
       x Location 100 doesn't exist.
       i There are only 26 elements.
@@ -60,7 +60,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't assign to elements that don't exist.
       x Element `foo` doesn't exist.
 
@@ -92,13 +92,13 @@
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert `bar` <character> to match type of `foo` <integer>.
     Code
       (expect_error(vec_assign(1:2, 1L, 1:2, value_arg = "bar"), class = "vctrs_error_recycle_incompatible_size")
       )
     Output
       <error/vctrs_error_incompatible_size>
-      Error in `stop_vctrs()`:
+      Error:
       ! Can't recycle `bar` (size 2) to size 1.
 

--- a/tests/testthat/_snaps/slice-assign.md
+++ b/tests/testthat/_snaps/slice-assign.md
@@ -92,7 +92,7 @@
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert `bar` <character> to match type of `foo` <integer>.
     Code
       (expect_error(vec_assign(1:2, 1L, 1:2, value_arg = "bar"), class = "vctrs_error_recycle_incompatible_size")

--- a/tests/testthat/_snaps/slice-chop.md
+++ b/tests/testthat/_snaps/slice-chop.md
@@ -26,7 +26,7 @@
       (expect_error(vec_unchop(list(x, y)), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -41,7 +41,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1` <vctrs_Counts> and `..2` <vctrs_Counts>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -54,7 +54,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1` <vctrs_Counts> and `..2` <double>.
 
 # vec_unchop() fallback doesn't support `name_spec` or `ptype`
@@ -104,13 +104,13 @@
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `a` <character> and `b` <integer>.
     Code
       (expect_error(vec_unchop(list(a = c(foo = 1:2), b = c(bar = "")), indices = list(
         2:1, 3), name_spec = zap()), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `a` <integer> and `b` <character>.
 

--- a/tests/testthat/_snaps/slice-chop.md
+++ b/tests/testthat/_snaps/slice-chop.md
@@ -26,7 +26,7 @@
       (expect_error(vec_unchop(list(x, y)), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1` <vctrs_foobar> and `..2` <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -41,7 +41,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1` <vctrs_Counts> and `..2` <vctrs_Counts>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -54,7 +54,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1` <vctrs_Counts> and `..2` <double>.
 
 # vec_unchop() fallback doesn't support `name_spec` or `ptype`
@@ -73,7 +73,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert <vctrs_foobar> to <character>.
 
 # vec_unchop() does not support non-numeric S3 indices
@@ -104,13 +104,13 @@
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `a` <character> and `b` <integer>.
     Code
       (expect_error(vec_unchop(list(a = c(foo = 1:2), b = c(bar = "")), indices = list(
         2:1, 3), name_spec = zap()), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `a` <integer> and `b` <character>.
 

--- a/tests/testthat/_snaps/slice-chop.md
+++ b/tests/testthat/_snaps/slice-chop.md
@@ -73,7 +73,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert <vctrs_foobar> to <character>.
 
 # vec_unchop() does not support non-numeric S3 indices

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -23,7 +23,7 @@
       (expect_error(vec_slice(1:2, 3L), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Location 3 doesn't exist.
       i There are only 2 elements.
@@ -31,7 +31,7 @@
       (expect_error(vec_slice(1:2, -3L), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't negate elements that don't exist.
       x Location 3 doesn't exist.
       i There are only 2 elements.
@@ -69,7 +69,7 @@
     Code
       vec_slice(c(bar = 1), "foo")
     Condition
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Element `foo` doesn't exist.
 
@@ -78,7 +78,7 @@
     Code
       vec_slice(letters, c(100, 1000))
     Condition
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Locations 100 and 1000 don't exist.
       i There are only 26 elements.
@@ -88,7 +88,7 @@
     Code
       vec_slice(letters, c(1, 100:103, 2, 104:110))
     Condition
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Locations 100, 101, 102, 103, 104, etc. don't exist.
       i There are only 26 elements.
@@ -98,7 +98,7 @@
     Code
       vec_slice(set_names(letters), c("foo", "bar"))
     Condition
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Elements `foo` and `bar` don't exist.
 
@@ -107,7 +107,7 @@
     Code
       vec_slice(set_names(letters), toupper(letters))
     Condition
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Elements `A`, `B`, `C`, `D`, `E`, etc. don't exist.
 

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -86,7 +86,7 @@
       Caused by error:
       ! Must extract element with a single valid subscript.
       x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `stop_vctrs()`:
+      Caused by error in `vec_cast.integer.double()`:
       ! Can't convert from <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
@@ -99,7 +99,7 @@
       Caused by error:
       ! Must extract element with a single valid subscript.
       x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `stop_vctrs()`:
+      Caused by error in `vec_cast.integer.double()`:
       ! Can't convert from <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
@@ -113,7 +113,7 @@
       Caused by error:
       ! Must extract element with a single valid subscript.
       x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `stop_vctrs()`:
+      Caused by error in `vec_cast.integer.double()`:
       ! Can't convert from <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
@@ -141,7 +141,7 @@
       Caused by error:
       ! Must extract element with a single valid subscript.
       x Can't convert from `foo` <double> to <integer> due to loss of precision.
-      Caused by error in `stop_vctrs()`:
+      Caused by error in `vec_cast.integer.double()`:
       ! Can't convert from `foo` <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
@@ -206,7 +206,7 @@
       Error:
       ! Must subset elements with a valid subscript vector.
       x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `stop_vctrs()`:
+      Caused by error in `vec_cast.integer.double()`:
       ! Can't convert from <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
@@ -263,7 +263,7 @@
       Error:
       ! Must subset elements with a valid subscript vector.
       x Can't convert from `foo` <double> to <integer> due to loss of precision.
-      Caused by error in `stop_vctrs()`:
+      Caused by error in `vec_cast.integer.double()`:
       ! Can't convert from `foo` <double> to <integer> due to loss of precision.
       * Locations: 1
 
@@ -274,7 +274,7 @@
       (expect_error(vec_as_location(10L, 2L), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Location 10 doesn't exist.
       i There are only 2 elements.
@@ -282,7 +282,7 @@
       (expect_error(vec_as_location(-10L, 2L), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't negate elements that don't exist.
       x Location 10 doesn't exist.
       i There are only 2 elements.
@@ -290,7 +290,7 @@
       (expect_error(vec_as_location2(10L, 2L), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Location 10 doesn't exist.
       i There are only 2 elements.
@@ -300,7 +300,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Element `foo` doesn't exist.
     Code
@@ -308,7 +308,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Element `foo` doesn't exist.
 
@@ -538,7 +538,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements beyond the end with non-consecutive locations.
       i Input has size 1.
       x Subscript contains non-consecutive location 3.
@@ -547,7 +547,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements beyond the end with non-consecutive locations.
       i Input has size 1.
       x Subscript contains non-consecutive location 3.
@@ -556,7 +556,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements beyond the end with non-consecutive locations.
       i Input has size 3.
       x Subscript contains non-consecutive locations 4 and 7.
@@ -565,7 +565,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements beyond the end with non-consecutive locations.
       i Input has size 3.
       x Subscript contains non-consecutive locations 4 and 7.
@@ -574,7 +574,7 @@
       10), 3, oob = "extend")))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements beyond the end with non-consecutive locations.
       i Input has size 3.
       x Subscript contains non-consecutive locations 4, 7, and 10.
@@ -586,7 +586,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Locations 2 and 3 don't exist.
       i There are only 1 element.
@@ -595,7 +595,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements beyond the end with non-consecutive locations.
       i Input has size 1.
       x Subscript contains non-consecutive location 3.
@@ -705,7 +705,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements beyond the end with non-consecutive locations.
       i Input has size 2.
       x Subscript `foo` contains non-consecutive location 4.
@@ -791,7 +791,7 @@
       class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't rename columns beyond the end with non-consecutive locations.
       i Input has size 2.
       x Subscript `foo(bar)` contains non-consecutive location 4.
@@ -812,7 +812,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Element `foo` doesn't exist.
     Code
@@ -821,7 +821,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Location 30 doesn't exist.
       i There are only 26 elements.
@@ -830,7 +830,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't subset elements that don't exist.
       x Element `foo` doesn't exist.
     Code
@@ -839,7 +839,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't rename columns that don't exist.
       x Column `foo` doesn't exist.
     Code
@@ -847,7 +847,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't rename columns that don't exist.
       x Location 30 doesn't exist.
       i There are only 26 columns.
@@ -856,7 +856,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't rename columns that don't exist.
       x Location 30 doesn't exist.
       i There are only 26 columns.
@@ -866,7 +866,7 @@
       class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't remove rows that don't exist.
       x Rows `foo` and `bar` don't exist.
     Code
@@ -874,7 +874,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't remove rows that don't exist.
       x Locations 27, 28, 29, and 30 don't exist.
       i There are only 26 rows.
@@ -883,7 +883,7 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `stop_subscript()`:
+      Error:
       ! Can't remove rows that don't exist.
       x Locations 27, 28, 29, and 30 don't exist.
       i There are only 26 rows.

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -86,7 +86,7 @@
       Caused by error:
       ! Must extract element with a single valid subscript.
       x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `vec_cast.integer.double()`:
+      Caused by error:
       ! Can't convert from <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
@@ -99,7 +99,7 @@
       Caused by error:
       ! Must extract element with a single valid subscript.
       x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `vec_cast.integer.double()`:
+      Caused by error:
       ! Can't convert from <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
@@ -113,7 +113,7 @@
       Caused by error:
       ! Must extract element with a single valid subscript.
       x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `vec_cast.integer.double()`:
+      Caused by error:
       ! Can't convert from <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
@@ -141,7 +141,7 @@
       Caused by error:
       ! Must extract element with a single valid subscript.
       x Can't convert from `foo` <double> to <integer> due to loss of precision.
-      Caused by error in `vec_cast.integer.double()`:
+      Caused by error:
       ! Can't convert from `foo` <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
@@ -206,7 +206,7 @@
       Error:
       ! Must subset elements with a valid subscript vector.
       x Can't convert from <double> to <integer> due to loss of precision.
-      Caused by error in `vec_cast.integer.double()`:
+      Caused by error:
       ! Can't convert from <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
@@ -263,7 +263,7 @@
       Error:
       ! Must subset elements with a valid subscript vector.
       x Can't convert from `foo` <double> to <integer> due to loss of precision.
-      Caused by error in `vec_cast.integer.double()`:
+      Caused by error:
       ! Can't convert from `foo` <double> to <integer> due to loss of precision.
       * Locations: 1
 

--- a/tests/testthat/_snaps/type-asis.md
+++ b/tests/testthat/_snaps/type-asis.md
@@ -5,7 +5,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine <double> and <character>.
 
 # AsIs objects throw cast errors with their underlying types
@@ -15,6 +15,6 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert <double> to <factor<bf275>>.
 

--- a/tests/testthat/_snaps/type-asis.md
+++ b/tests/testthat/_snaps/type-asis.md
@@ -5,7 +5,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine <double> and <character>.
 
 # AsIs objects throw cast errors with their underlying types

--- a/tests/testthat/_snaps/type-asis.md
+++ b/tests/testthat/_snaps/type-asis.md
@@ -15,6 +15,6 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert <double> to <factor<bf275>>.
 

--- a/tests/testthat/_snaps/type-rcrd.md
+++ b/tests/testthat/_snaps/type-rcrd.md
@@ -3,7 +3,7 @@
     Code
       na.fail(x)
     Condition
-      Error in `na.fail.vctrs_vctr()`:
+      Error in `na.fail()`:
       ! missing values in object
 
 # print and str use format

--- a/tests/testthat/_snaps/type-vctr.md
+++ b/tests/testthat/_snaps/type-vctr.md
@@ -3,7 +3,7 @@
     Code
       na.fail(x)
     Condition
-      Error in `na.fail.vctrs_vctr()`:
+      Error in `na.fail()`:
       ! missing values in object
 
 # default print and str methods are useful

--- a/tests/testthat/_snaps/type.md
+++ b/tests/testthat/_snaps/type.md
@@ -36,7 +36,7 @@
     Code
       vec_ptype_common(df1, df2)
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1$x$y$z` <double> and `..2$x$y$z` <character>.
 
 ---
@@ -44,7 +44,7 @@
     Code
       vec_ptype_common(df1, df1, df2)
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1$x$y$z` <double> and `..3$x$y$z` <character>.
 
 ---
@@ -52,7 +52,7 @@
     Code
       vec_ptype_common(large_df1, large_df2)
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1$foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar$y$z` <double> and `..2$foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar$y$z` <character>.
 
 ---
@@ -60,7 +60,7 @@
     Code
       vec_ptype_common(foo = TRUE, bar = "foo")
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `foo` <logical> and `bar` <character>.
 
 ---
@@ -68,7 +68,7 @@
     Code
       vec_ptype_common(foo = TRUE, baz = FALSE, bar = "foo")
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `foo` <logical> and `bar` <character>.
 
 ---
@@ -76,7 +76,7 @@
     Code
       vec_ptype_common(foo = df1, bar = df2)
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `foo$x$y$z` <double> and `bar$x$y$z` <character>.
 
 ---
@@ -84,7 +84,7 @@
     Code
       vec_ptype_common(df1, df1, bar = df2)
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1$x$y$z` <double> and `bar$x$y$z` <character>.
 
 ---
@@ -92,7 +92,7 @@
     Code
       vec_ptype_common(TRUE, !!!list(1, "foo"))
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..2` <double> and `..3` <character>.
 
 ---
@@ -100,7 +100,7 @@
     Code
       vec_ptype_common(TRUE, !!!list(1, 2), "foo")
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..2` <double> and `..5` <character>.
 
 ---
@@ -108,7 +108,7 @@
     Code
       vec_ptype_common(1, !!!list(TRUE, FALSE), "foo")
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `..1` <double> and `..5` <character>.
 
 ---
@@ -116,7 +116,7 @@
     Code
       vec_ptype_common(foo = TRUE, !!!list(FALSE, FALSE), bar = "foo")
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `foo` <logical> and `bar` <character>.
 
 ---
@@ -124,7 +124,7 @@
     Code
       vec_ptype_common(foo = TRUE, !!!list(bar = 1, "foo"))
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `bar` <double> and `..3` <character>.
 
 ---
@@ -132,7 +132,7 @@
     Code
       vec_ptype_common(foo = TRUE, !!!list(bar = "foo"))
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `foo` <logical> and `bar` <character>.
 
 ---
@@ -140,7 +140,7 @@
     Code
       vec_ptype_common(foo = TRUE, !!!list(bar = FALSE), baz = "chr")
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `foo` <logical> and `baz` <character>.
 
 ---
@@ -148,6 +148,6 @@
     Code
       vec_ptype_common(foo = TRUE, !!!list(bar = FALSE), !!!list(baz = "chr"))
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `foo` <logical> and `baz` <character>.
 

--- a/tests/testthat/_snaps/type.md
+++ b/tests/testthat/_snaps/type.md
@@ -36,7 +36,7 @@
     Code
       vec_ptype_common(df1, df2)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1$x$y$z` <double> and `..2$x$y$z` <character>.
 
 ---
@@ -44,7 +44,7 @@
     Code
       vec_ptype_common(df1, df1, df2)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1$x$y$z` <double> and `..3$x$y$z` <character>.
 
 ---
@@ -52,7 +52,7 @@
     Code
       vec_ptype_common(large_df1, large_df2)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1$foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar$y$z` <double> and `..2$foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar$y$z` <character>.
 
 ---
@@ -60,7 +60,7 @@
     Code
       vec_ptype_common(foo = TRUE, bar = "foo")
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `foo` <logical> and `bar` <character>.
 
 ---
@@ -68,7 +68,7 @@
     Code
       vec_ptype_common(foo = TRUE, baz = FALSE, bar = "foo")
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `foo` <logical> and `bar` <character>.
 
 ---
@@ -76,7 +76,7 @@
     Code
       vec_ptype_common(foo = df1, bar = df2)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `foo$x$y$z` <double> and `bar$x$y$z` <character>.
 
 ---
@@ -84,7 +84,7 @@
     Code
       vec_ptype_common(df1, df1, bar = df2)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1$x$y$z` <double> and `bar$x$y$z` <character>.
 
 ---
@@ -92,7 +92,7 @@
     Code
       vec_ptype_common(TRUE, !!!list(1, "foo"))
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..2` <double> and `..3` <character>.
 
 ---
@@ -100,7 +100,7 @@
     Code
       vec_ptype_common(TRUE, !!!list(1, 2), "foo")
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..2` <double> and `..5` <character>.
 
 ---
@@ -108,7 +108,7 @@
     Code
       vec_ptype_common(1, !!!list(TRUE, FALSE), "foo")
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `..1` <double> and `..5` <character>.
 
 ---
@@ -116,7 +116,7 @@
     Code
       vec_ptype_common(foo = TRUE, !!!list(FALSE, FALSE), bar = "foo")
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `foo` <logical> and `bar` <character>.
 
 ---
@@ -124,7 +124,7 @@
     Code
       vec_ptype_common(foo = TRUE, !!!list(bar = 1, "foo"))
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `bar` <double> and `..3` <character>.
 
 ---
@@ -132,7 +132,7 @@
     Code
       vec_ptype_common(foo = TRUE, !!!list(bar = "foo"))
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `foo` <logical> and `bar` <character>.
 
 ---
@@ -140,7 +140,7 @@
     Code
       vec_ptype_common(foo = TRUE, !!!list(bar = FALSE), baz = "chr")
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `foo` <logical> and `baz` <character>.
 
 ---
@@ -148,6 +148,6 @@
     Code
       vec_ptype_common(foo = TRUE, !!!list(bar = FALSE), !!!list(baz = "chr"))
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `foo` <logical> and `baz` <character>.
 

--- a/tests/testthat/_snaps/type2.md
+++ b/tests/testthat/_snaps/type2.md
@@ -103,14 +103,14 @@
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_cast.vctrs_foobar.vctrs_foobar()`:
+      Error:
       ! Can't convert <vctrs_foobar> to <vctrs_foobar>.
     Code
       (expect_error(with_foobar_ptype2(vec_ptype2(foobar(1, bar = TRUE), foobar(2,
         baz = TRUE))), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_ptype2.vctrs_foobar.vctrs_foobar()`:
+      Error:
       ! Can't combine <vctrs_foobar> and <vctrs_foobar>.
 
 # common type errors don't mention columns if they are compatible

--- a/tests/testthat/_snaps/type2.md
+++ b/tests/testthat/_snaps/type2.md
@@ -70,7 +70,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert <vctrs_foobar> to <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -103,7 +103,7 @@
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_cast()`:
+      Error in `vec_cast.vctrs_foobar.vctrs_foobar()`:
       ! Can't convert <vctrs_foobar> to <vctrs_foobar>.
     Code
       (expect_error(with_foobar_ptype2(vec_ptype2(foobar(1, bar = TRUE), foobar(2,
@@ -123,7 +123,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_cast()`:
+      Error:
       ! Can't convert <vctrs_foo> to <vctrs_bar>.
 
 # common type warnings for data frames take attributes into account

--- a/tests/testthat/_snaps/type2.md
+++ b/tests/testthat/_snaps/type2.md
@@ -16,7 +16,7 @@
     Code
       vec_ptype2("foo", 10)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine <character> and <double>.
 
 ---
@@ -26,7 +26,7 @@
       df2 <- tibble(x = tibble(y = tibble(z = "a")))
       vec_ptype2(df1, df2)
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine `x$y$z` <double> and `x$y$z` <character>.
 
 # can override scalar vector error message for base scalar types
@@ -36,14 +36,14 @@
       )
     Output
       <error/vctrs_error_scalar_type>
-      Error in `stop_vctrs()`:
+      Error:
       ! `foo` must be a vector, not a symbol.
     Code
       (expect_error(vec_ptype2(quote(x), NULL, x_arg = "foo"), class = "vctrs_error_scalar_type")
       )
     Output
       <error/vctrs_error_scalar_type>
-      Error in `stop_vctrs()`:
+      Error:
       ! `foo` must be a vector, not a symbol.
 
 # can override scalar vector error message for S3 types
@@ -53,14 +53,14 @@
       )
     Output
       <error/vctrs_error_scalar_type>
-      Error in `stop_vctrs()`:
+      Error:
       ! `foo` must be a vector, not a <vctrs_foobar> object.
     Code
       (expect_error(vec_ptype2(foobar(), NULL, x_arg = "foo"), class = "vctrs_error_scalar_type")
       )
     Output
       <error/vctrs_error_scalar_type>
-      Error in `stop_vctrs()`:
+      Error:
       ! `foo` must be a vector, not a <vctrs_foobar> object.
 
 # ptype2 and cast errors when same class fallback is impossible are informative
@@ -70,7 +70,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert <vctrs_foobar> to <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -80,7 +80,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine <vctrs_foobar> and <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -103,14 +103,14 @@
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert <vctrs_foobar> to <vctrs_foobar>.
     Code
       (expect_error(with_foobar_ptype2(vec_ptype2(foobar(1, bar = TRUE), foobar(2,
         baz = TRUE))), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine <vctrs_foobar> and <vctrs_foobar>.
 
 # common type errors don't mention columns if they are compatible
@@ -123,7 +123,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_cast()`:
       ! Can't convert <vctrs_foo> to <vctrs_bar>.
 
 # common type warnings for data frames take attributes into account
@@ -154,7 +154,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine <vctrs_foobar> and <vctrs_foobaz>.
 
 # For reference, warning for incompatible classes
@@ -173,6 +173,6 @@
     Code
       vec_ptype2_no_fallback(foobar(mtcars), foobaz(mtcars))
     Condition
-      Error in `stop_vctrs()`:
+      Error in `vec_default_ptype2()`:
       ! Can't combine <vctrs_foobar> and <vctrs_foobaz>.
 

--- a/tests/testthat/_snaps/type2.md
+++ b/tests/testthat/_snaps/type2.md
@@ -16,7 +16,7 @@
     Code
       vec_ptype2("foo", 10)
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine <character> and <double>.
 
 ---
@@ -26,7 +26,7 @@
       df2 <- tibble(x = tibble(y = tibble(z = "a")))
       vec_ptype2(df1, df2)
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine `x$y$z` <double> and `x$y$z` <character>.
 
 # can override scalar vector error message for base scalar types
@@ -80,7 +80,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine <vctrs_foobar> and <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
@@ -110,7 +110,7 @@
         baz = TRUE))), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error in `vec_ptype2.vctrs_foobar.vctrs_foobar()`:
       ! Can't combine <vctrs_foobar> and <vctrs_foobar>.
 
 # common type errors don't mention columns if they are compatible
@@ -154,7 +154,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine <vctrs_foobar> and <vctrs_foobaz>.
 
 # For reference, warning for incompatible classes
@@ -173,6 +173,6 @@
     Code
       vec_ptype2_no_fallback(foobar(mtcars), foobaz(mtcars))
     Condition
-      Error in `vec_default_ptype2()`:
+      Error:
       ! Can't combine <vctrs_foobar> and <vctrs_foobaz>.
 

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -34,4 +34,10 @@ test_that("unsupported error reports correct error call", {
 test_that("scalar error reports correct error call", {
   my_function <- function() vec_assert(foobar())
   expect_snapshot((expect_error(my_function())))
+
+  my_function <- function() vec_assert(1:2, dbl())
+  expect_snapshot((expect_error(my_function())))
+
+  my_function <- function() vec_assert(1:2, size = 1)
+  expect_snapshot((expect_error(my_function())))
 })

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -56,3 +56,14 @@ test_that("bare casts report correct error call", {
   my_function <- function() vec_cast(matrix(TRUE), dbl())
   expect_snapshot((expect_error(my_function())))
 })
+
+test_that("names validation reports correct error call", {
+  my_function <- function() vec_as_names(c("x", "", "y"), repair = "check_unique")
+  expect_snapshot((expect_error(my_function())))
+
+  my_function <- function() vec_as_names(c("x", "x"), repair = "check_unique", repair_arg = "repair")
+  expect_snapshot((expect_error(my_function())))
+
+  my_function <- function() vec_as_names("...", repair = "check_unique", repair_arg = "repair")
+  expect_snapshot((expect_error(my_function())))
+})

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -17,6 +17,7 @@ test_that("failing common size reports correct error call", {
   my_function <- function() vec_recycle(1:2, 10)
   expect_snapshot((expect_error(my_function())))
 
+  # FIXME
   my_function <- function() vec_size_common(1:2, 1:10)
   expect_snapshot((expect_error(my_function())))
 })

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -57,6 +57,11 @@ test_that("bare casts report correct error call", {
   expect_snapshot((expect_error(my_function())))
 })
 
+test_that("base S3 casts report correct error call", {
+  my_function <- function() vec_cast("a", factor("b"))
+  expect_snapshot((expect_error(my_function())))
+})
+
 test_that("names validation reports correct error call", {
   my_function <- function() vec_as_names(c("x", "", "y"), repair = "check_unique")
   expect_snapshot((expect_error(my_function())))

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -1,0 +1,37 @@
+test_that("failing common type reports correct error call", {
+  my_function <- function() vec_ptype2(2, chr())
+  expect_snapshot((expect_error(my_function())))
+})
+
+test_that("failing cast reports correct error call", {
+  my_function <- function() vec_cast(2, chr())
+  expect_snapshot((expect_error(my_function())))
+})
+
+test_that("lossy cast reports correct error call", {
+  my_function <- function() vec_cast(2, lgl())
+  expect_snapshot((expect_error(my_function())))
+})
+
+test_that("failing common size reports correct error call", {
+  my_function <- function() vec_recycle(1:2, 10)
+  expect_snapshot((expect_error(my_function())))
+
+  my_function <- function() vec_size_common(1:2, 1:10)
+  expect_snapshot((expect_error(my_function())))
+})
+
+test_that("unsupported error reports correct error call", {
+  x <- new_vctr(1:2)
+
+  my_function <- function() dim(x) <- 1:2
+  expect_snapshot((expect_error(my_function())))
+
+  my_function <- function() median(x)
+  expect_snapshot((expect_error(my_function())))
+})
+
+test_that("scalar error reports correct error call", {
+  my_function <- function() vec_assert(foobar())
+  expect_snapshot((expect_error(my_function())))
+})

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -41,3 +41,18 @@ test_that("scalar error reports correct error call", {
   my_function <- function() vec_assert(1:2, size = 1)
   expect_snapshot((expect_error(my_function())))
 })
+
+test_that("bare casts report correct error call", {
+  my_function <- function() vec_cast(1.5, int())
+  expect_snapshot((expect_error(my_function())))
+
+  my_function <- function() vec_cast(1.5, lgl())
+  expect_snapshot((expect_error(my_function())))
+
+  my_function <- function() vec_cast(2L, lgl())
+  expect_snapshot((expect_error(my_function())))
+
+  # Passing call to `shape_broadcast()`
+  my_function <- function() vec_cast(matrix(TRUE), dbl())
+  expect_snapshot((expect_error(my_function())))
+})


### PR DESCRIPTION
This adds `call` argument to:

- `vec_cast()` and `vec_ptype2()`
- `vec_default_cast()` and `vec_default_ptype2()`
- `vec_assert()`
- `vec_as_names()`
- `stop_` constructors like `stop_incompatible_type()`

Default ptype2 and cast methods should automatically pass the error call to the stop function if they pass `...` to `vec_default_ptype2()` and `vec_default_cast()`, as they should.

I've decided not to use the `local_error_call()` pattern in the end. My current feeling is that it's too easy to get it wrong, with internal errors reported as caller errors.

At the C level, we pass `call` through a new `struct r_lazy`. This way we don't evaluate `call` arguments unless needed. This struct is flexible. It sometimes carry a `call` symbol and a frame environment, and other times it carries a forced `call` value.

There's still a lot of places where the error call is not forwarded, but I think this should be tackled progressively as we encounter the cases. For this release I plan to do some more work on subscript errors for tidyselect and look into what tidyr needs for call reporting (e.g. the bind operations).