### PR TITLE
Evaluate args lazily

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -72,7 +72,7 @@ vec_cast <- function(x,
   if (!missing(...)) {
     check_ptype2_dots_empty(...)
   }
-  return(.Call(ffi_cast, x, to, x_arg, to_arg, environment()))
+  return(.Call(ffi_cast, x, to, environment()))
   UseMethod("vec_cast", to)
 }
 vec_cast_dispatch <- function(x, to, ..., x_arg = "", to_arg = "") {

--- a/R/names.R
+++ b/R/names.R
@@ -163,7 +163,6 @@ vec_as_names <- function(names,
     ffi_as_names,
     names,
     repair,
-    repair_arg,
     quiet,
     environment()
   )

--- a/R/recycle.R
+++ b/R/recycle.R
@@ -53,7 +53,7 @@
 #' vec_recycle_common(array(1:3, c(1, 3, 1)), 1:5)
 vec_recycle <- function(x, size, ..., x_arg = "", call = caller_env()) {
   check_dots_empty0(...)
-  .Call(ffi_recycle, x, size, x_arg, environment())
+  .Call(ffi_recycle, x, size, environment())
 }
 
 #' @export

--- a/R/slice.R
+++ b/R/slice.R
@@ -170,13 +170,13 @@ vec_slice_dispatch_integer64 <- function(x, i) {
 #' @rdname vec_slice
 #' @export
 `vec_slice<-` <- function(x, i, value) {
-  .Call(vctrs_assign, x, i, value, "", "")
+  .Call(vctrs_assign, x, i, value, environment())
 }
 #' @rdname vec_slice
 #' @export
 vec_assign <- function(x, i, value, ..., x_arg = "", value_arg = "") {
   check_dots_empty0(...)
-  .Call(vctrs_assign, x, i, value, x_arg, value_arg)
+  .Call(vctrs_assign, x, i, value, environment())
 }
 vec_assign_fallback <- function(x, i, value) {
   # Work around bug in base `[<-`

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -40,7 +40,6 @@ vec_as_subscript <- function(i,
     logical = logical,
     numeric = numeric,
     character = character,
-    arg = arg,
     frame = environment()
   )
 }
@@ -56,7 +55,6 @@ vec_as_subscript_result <- function(i,
     logical = logical,
     numeric = numeric,
     character = character,
-    arg = arg,
     frame = environment()
   )
 }

--- a/R/type2.R
+++ b/R/type2.R
@@ -37,7 +37,7 @@ vec_ptype2 <- function(x,
   if (!missing(...)) {
     check_ptype2_dots_empty(...)
   }
-  return(.Call(ffi_ptype2, x, y, x_arg, y_arg, environment()))
+  return(.Call(ffi_ptype2, x, y, environment()))
   UseMethod("vec_ptype2")
 }
 vec_ptype2_dispatch_s3 <- function(x,

--- a/src/cast.c
+++ b/src/cast.c
@@ -19,11 +19,11 @@ static SEXP vec_cast_dispatch_s3(const struct cast_opts* opts);
 // [[ register() ]]
 r_obj* ffi_cast(r_obj* x,
                 r_obj* to,
-                r_obj* ffi_x_arg,
-                r_obj* ffi_to_arg,
                 r_obj* frame) {
-  struct vctrs_arg x_arg = vec_as_arg(ffi_x_arg);
-  struct vctrs_arg to_arg = vec_as_arg(ffi_to_arg);
+  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
+  struct arg_data_lazy to_arg_ = new_lazy_arg_data(frame, "to_arg");
+  struct vctrs_arg to_arg = new_lazy_arg(&to_arg_);
 
   struct r_lazy call = { .x = syms_call, .env = frame };
 

--- a/src/init.c
+++ b/src/init.c
@@ -77,7 +77,7 @@ extern SEXP vctrs_proxy_info(SEXP);
 extern SEXP vctrs_class_type(SEXP);
 extern SEXP vctrs_bare_df_restore(SEXP, SEXP, SEXP);
 extern r_obj* ffi_recycle(r_obj*, r_obj*, r_obj*);
-extern SEXP vctrs_assign(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_assign(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_assign_seq(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_set_attributes(SEXP, SEXP);
 extern SEXP vctrs_as_df_row(SEXP, SEXP);
@@ -233,7 +233,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_class_type",                 (DL_FUNC) &vctrs_class_type, 1},
   {"vctrs_bare_df_restore",            (DL_FUNC) &vctrs_bare_df_restore, 3},
   {"ffi_recycle",                      (DL_FUNC) &ffi_recycle, 3},
-  {"vctrs_assign",                     (DL_FUNC) &vctrs_assign, 5},
+  {"vctrs_assign",                     (DL_FUNC) &vctrs_assign, 4},
   {"vctrs_assign_seq",                 (DL_FUNC) &vctrs_assign_seq, 5},
   {"vctrs_set_attributes",             (DL_FUNC) &vctrs_set_attributes, 2},
   {"vctrs_as_df_row",                  (DL_FUNC) &vctrs_as_df_row, 2},

--- a/src/init.c
+++ b/src/init.c
@@ -88,7 +88,7 @@ extern SEXP vctrs_apply_name_spec(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_unset_s4(SEXP);
 extern SEXP vctrs_validate_name_repair_arg(SEXP);
 extern SEXP vctrs_validate_minimal_names(SEXP, SEXP);
-extern r_obj* ffi_as_names(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_as_names(r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_is_partial(SEXP);
 extern SEXP vctrs_is_list(SEXP);
 extern SEXP vctrs_try_catch_callback(SEXP, SEXP);
@@ -246,7 +246,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_altrep_rle_is_materialized", (DL_FUNC) &altrep_rle_is_materialized, 1},
   {"vctrs_validate_name_repair_arg",   (DL_FUNC) &vctrs_validate_name_repair_arg, 1},
   {"vctrs_validate_minimal_names",     (DL_FUNC) &vctrs_validate_minimal_names, 2},
-  {"ffi_as_names",                     (DL_FUNC) &ffi_as_names, 5},
+  {"ffi_as_names",                     (DL_FUNC) &ffi_as_names, 4},
   {"vctrs_is_partial",                 (DL_FUNC) &vctrs_is_partial, 1},
   {"vctrs_is_list",                    (DL_FUNC) &vctrs_is_list, 1},
   {"vctrs_try_catch_callback",         (DL_FUNC) &vctrs_try_catch_callback, 2},

--- a/src/init.c
+++ b/src/init.c
@@ -41,7 +41,7 @@ extern SEXP vctrs_dim_n(SEXP);
 extern SEXP vctrs_is_unspecified(SEXP);
 extern SEXP vctrs_typeof(SEXP, SEXP);
 extern SEXP vctrs_is_vector(SEXP);
-extern r_obj* ffi_ptype2(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_ptype2(r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_typeof2(SEXP, SEXP);
 extern SEXP vctrs_typeof2_s3(SEXP, SEXP);
 extern r_obj* ffi_cast(r_obj*, r_obj*, r_obj*);
@@ -197,7 +197,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_typeof",                     (DL_FUNC) &vctrs_typeof, 2},
   {"vctrs_init_library",               (DL_FUNC) &vctrs_init_library, 1},
   {"vctrs_is_vector",                  (DL_FUNC) &vctrs_is_vector, 1},
-  {"ffi_ptype2",                       (DL_FUNC) &ffi_ptype2, 5},
+  {"ffi_ptype2",                       (DL_FUNC) &ffi_ptype2, 3},
   {"vctrs_typeof2",                    (DL_FUNC) &vctrs_typeof2, 2},
   {"vctrs_typeof2_s3",                 (DL_FUNC) &vctrs_typeof2_s3, 2},
   {"ffi_cast",                         (DL_FUNC) &ffi_cast, 3},

--- a/src/init.c
+++ b/src/init.c
@@ -93,8 +93,8 @@ extern SEXP vctrs_is_partial(SEXP);
 extern SEXP vctrs_is_list(SEXP);
 extern SEXP vctrs_try_catch_callback(SEXP, SEXP);
 extern SEXP vctrs_is_coercible(SEXP, SEXP, SEXP, SEXP, SEXP);
-extern r_obj* ffi_as_subscript(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
-extern r_obj* ffi_as_subscript_result(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_as_subscript(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_as_subscript_result(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_df_flatten_info(SEXP);
 extern SEXP df_flatten(SEXP);
 extern SEXP vctrs_linked_version();
@@ -251,8 +251,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_is_list",                    (DL_FUNC) &vctrs_is_list, 1},
   {"vctrs_try_catch_callback",         (DL_FUNC) &vctrs_try_catch_callback, 2},
   {"vctrs_is_coercible",               (DL_FUNC) &vctrs_is_coercible, 5},
-  {"ffi_as_subscript",                 (DL_FUNC) &ffi_as_subscript, 6},
-  {"ffi_as_subscript_result",          (DL_FUNC) &ffi_as_subscript_result, 6},
+  {"ffi_as_subscript",                 (DL_FUNC) &ffi_as_subscript, 5},
+  {"ffi_as_subscript_result",          (DL_FUNC) &ffi_as_subscript_result, 5},
   {"vctrs_df_flatten_info",            (DL_FUNC) &vctrs_df_flatten_info, 1},
   {"vctrs_df_flatten",                 (DL_FUNC) &df_flatten, 1},
   {"vctrs_linked_version",             (DL_FUNC) &vctrs_linked_version, 0},

--- a/src/init.c
+++ b/src/init.c
@@ -76,7 +76,7 @@ extern SEXP vctrs_type_info(SEXP);
 extern SEXP vctrs_proxy_info(SEXP);
 extern SEXP vctrs_class_type(SEXP);
 extern SEXP vctrs_bare_df_restore(SEXP, SEXP, SEXP);
-extern r_obj* ffi_recycle(r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_recycle(r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_assign(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_assign_seq(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_set_attributes(SEXP, SEXP);
@@ -232,7 +232,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_proxy_info",                 (DL_FUNC) &vctrs_proxy_info, 1},
   {"vctrs_class_type",                 (DL_FUNC) &vctrs_class_type, 1},
   {"vctrs_bare_df_restore",            (DL_FUNC) &vctrs_bare_df_restore, 3},
-  {"ffi_recycle",                      (DL_FUNC) &ffi_recycle, 4},
+  {"ffi_recycle",                      (DL_FUNC) &ffi_recycle, 3},
   {"vctrs_assign",                     (DL_FUNC) &vctrs_assign, 5},
   {"vctrs_assign_seq",                 (DL_FUNC) &vctrs_assign_seq, 5},
   {"vctrs_set_attributes",             (DL_FUNC) &vctrs_set_attributes, 2},

--- a/src/init.c
+++ b/src/init.c
@@ -44,7 +44,7 @@ extern SEXP vctrs_is_vector(SEXP);
 extern r_obj* ffi_ptype2(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_typeof2(SEXP, SEXP);
 extern SEXP vctrs_typeof2_s3(SEXP, SEXP);
-extern r_obj* ffi_cast(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_cast(r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_as_location(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vec_slice(SEXP, SEXP);
 extern SEXP ffi_init(SEXP, SEXP);
@@ -200,7 +200,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"ffi_ptype2",                       (DL_FUNC) &ffi_ptype2, 5},
   {"vctrs_typeof2",                    (DL_FUNC) &vctrs_typeof2, 2},
   {"vctrs_typeof2_s3",                 (DL_FUNC) &vctrs_typeof2_s3, 2},
-  {"ffi_cast",                         (DL_FUNC) &ffi_cast, 5},
+  {"ffi_cast",                         (DL_FUNC) &ffi_cast, 3},
   {"ffi_as_location",                  (DL_FUNC) &ffi_as_location, 8},
   {"vctrs_slice",                      (DL_FUNC) &vec_slice, 2},
   {"ffi_init",                         (DL_FUNC) &ffi_init, 3},

--- a/src/names.c
+++ b/src/names.c
@@ -43,7 +43,6 @@ SEXP vec_as_names(SEXP names, const struct name_repair_opts* opts) {
 // [[ register() ]]
 r_obj* ffi_as_names(r_obj* names,
                     r_obj* repair,
-                    r_obj* ffi_repair_arg,
                     r_obj* ffi_quiet,
                     r_obj* frame) {
   if (!r_is_bool(ffi_quiet)) {
@@ -53,7 +52,8 @@ r_obj* ffi_as_names(r_obj* names,
 
   struct r_lazy call = (struct r_lazy) { .x = syms_call, .env = frame };
 
-  struct vctrs_arg repair_arg = vec_as_arg(ffi_repair_arg);
+  struct arg_data_lazy repair_arg_ = new_lazy_arg_data(frame, "repair_arg");
+  struct vctrs_arg repair_arg = new_lazy_arg(&repair_arg_);
   struct name_repair_opts repair_opts = new_name_repair_opts(repair,
                                                              &repair_arg,
                                                              quiet,

--- a/src/size.c
+++ b/src/size.c
@@ -165,7 +165,6 @@ r_obj* vec_recycle2(r_obj* x,
 // [[ register() ]]
 r_obj* ffi_recycle(r_obj* x,
                    r_obj* size_obj,
-                   r_obj* ffi_x_arg,
                    r_obj* frame) {
   if (x == r_null || size_obj == r_null) {
     return r_null;
@@ -181,7 +180,8 @@ r_obj* ffi_recycle(r_obj* x,
   R_len_t size = r_int_get(size_obj, 0);
   FREE(1);
 
-  struct vctrs_arg x_arg = vec_as_arg(ffi_x_arg);
+  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
   struct r_lazy call = { .x = syms_call, .env = frame };
 
   return vec_recycle2(x, size, &x_arg, call);

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -57,9 +57,11 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
 }
 
 // [[ register() ]]
-SEXP vctrs_assign(SEXP x, SEXP index, SEXP value, SEXP x_arg_, SEXP value_arg_) {
-  struct vctrs_arg x_arg = vec_as_arg(x_arg_);
-  struct vctrs_arg value_arg = vec_as_arg(value_arg_);
+SEXP vctrs_assign(SEXP x, SEXP index, SEXP value, SEXP frame) {
+  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
+  struct arg_data_lazy value_arg_ = new_lazy_arg_data(frame, "value_arg");
+  struct vctrs_arg value_arg = new_lazy_arg(&value_arg_);
 
   const struct vec_assign_opts opts = {
     .assign_names = false,

--- a/src/subscript.c
+++ b/src/subscript.c
@@ -211,9 +211,9 @@ r_obj* ffi_as_subscript(r_obj* subscript,
                         r_obj* logical,
                         r_obj* numeric,
                         r_obj* character,
-                        r_obj* ffi_arg,
                         r_obj* frame) {
-  struct vctrs_arg arg = vec_as_arg(ffi_arg);
+  struct arg_data_lazy arg_ = new_lazy_arg_data(frame, "arg");
+  struct vctrs_arg arg = new_lazy_arg(&arg_);
   struct r_lazy call = { .x = r_syms.call, .env = frame };
 
   struct subscript_opts opts = {
@@ -239,9 +239,9 @@ r_obj* ffi_as_subscript_result(r_obj* subscript,
                                r_obj* logical,
                                r_obj* numeric,
                                r_obj* character,
-                               r_obj* ffi_arg,
                                r_obj* frame) {
-  struct vctrs_arg arg = vec_as_arg(ffi_arg);
+  struct arg_data_lazy arg_ = new_lazy_arg_data(frame, "arg");
+  struct vctrs_arg arg = new_lazy_arg(&arg_);
   struct r_lazy call = { .x = r_syms.call, .env = frame };
 
   struct subscript_opts opts = {

--- a/src/type2.c
+++ b/src/type2.c
@@ -229,11 +229,11 @@ SEXP vctrs_is_coercible(SEXP x,
 // [[ register() ]]
 r_obj* ffi_ptype2(r_obj* x,
                   r_obj* y,
-                  r_obj* ffi_x_arg,
-                  r_obj* ffi_y_arg,
                   r_obj* frame) {
-  struct vctrs_arg x_arg = vec_as_arg(ffi_x_arg);
-  struct vctrs_arg y_arg = vec_as_arg(ffi_y_arg);
+  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
+  struct arg_data_lazy y_arg_ = new_lazy_arg_data(frame, "y_arg");
+  struct vctrs_arg y_arg = new_lazy_arg(&y_arg_);
 
   struct r_lazy call = { .x = syms_call, .env = frame };
 

--- a/tests/testthat/test-cast.R
+++ b/tests/testthat/test-cast.R
@@ -4,7 +4,7 @@ test_that("Casting to named argument mentions 'match type <foo>'", {
   expect_snapshot(error = TRUE, vec_cast(1, "", x_arg = "foo"))
 })
 
-# vec_cast ---------------------------------------------------------------
+# vec_cast() ---------------------------------------------------------------
 
 test_that("new classes are uncoercible by default", {
   x <- structure(1:10, class = "vctrs_nonexistant")
@@ -98,6 +98,11 @@ test_that("vec_cast() only falls back when casting to base type", {
     vec_cast(mtcars, foobar(mtcars)),
     class = "vctrs_error_incompatible_type"
   )
+})
+
+test_that("vec_cast() evaluates x_arg and to_arg lazily", {
+  expect_silent(vec_cast(TRUE, logical(), x_arg = print("oof")))
+  expect_silent(vec_cast(TRUE, logical(), to_arg = print("oof")))
 })
 
 

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -162,6 +162,10 @@ test_that("vec_as_names() is quiet when function is supplied (#1018)", {
   )
 })
 
+test_that("vec_as_names() evaluates repair_arg lazily", {
+  expect_silent(vec_as_names(letters, repair_arg = print("oof")))
+})
+
 
 # vec_repair_names() -------------------------------------------------------
 

--- a/tests/testthat/test-recycle.R
+++ b/tests/testthat/test-recycle.R
@@ -1,5 +1,5 @@
 
-# vec_recycle -------------------------------------------------------------
+# vec_recycle() -------------------------------------------------------------
 
 test_that("vec_recycle recycles size 1 to any other size", {
   x <- 1
@@ -37,6 +37,10 @@ test_that("can recycle arrays", {
   expect_equal(vec_recycle(x, 1), x)
   expect_equal(vec_recycle(x, 0), x0)
   expect_equal(vec_recycle(x, 2), x2)
+})
+
+test_that("vec_recycle() evaluates x_arg lazily", {
+  expect_silent(vec_recycle(1L, 1L, x_arg = print("oof")))
 })
 
 # Empty -------------------------------------------------------------------

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -410,16 +410,9 @@ test_that("can slice-assign unspecified vectors with default type2 method", {
   expect_identical(x, rational(c(NA, 2L), c(NA, 3L)))
 })
 
-test_that("`vec_assign()` validates `x_arg`", {
-  expect_error(vec_assign(1, 1, 1, x_arg = 1), "must be a string")
-  expect_error(vec_assign(1, 1, 1, x_arg = c("x", "y")), "must be a string")
-  expect_error(vec_assign(1, 1, 1, x_arg = NA_character_), "must be a string")
-})
-
-test_that("`vec_assign()` validates `value_arg`", {
-  expect_error(vec_assign(1, 1, 1, value_arg = 1), "must be a string")
-  expect_error(vec_assign(1, 1, 1, value_arg = c("x", "y")), "must be a string")
-  expect_error(vec_assign(1, 1, 1, value_arg = NA_character_), "must be a string")
+test_that("`vec_assign()` evaluates arg lazily", {
+  expect_silent(vec_assign(1L, 1L, 1L, x_arg = print("oof")))
+  expect_silent(vec_assign(1L, 1L, 1L, value_arg = print("oof")))
 })
 
 test_that("`vec_assign()` requires recyclable value", {

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -492,3 +492,12 @@ test_that("num_as_location() UI", {
 test_that("vec_as_location2() UI", {
   expect_snapshot(error = TRUE, vec_as_location2(1, 1L, missing = "bogus"))
 })
+
+test_that("vec_as_location() evaluates arg lazily", {
+  expect_silent(vec_as_location(1L, 1L, arg = print("oof")))
+})
+
+test_that("vec_as_location2() evaluates arg lazily", {
+  expect_silent(vec_as_location2(1L, 1L, arg = print("oof")))
+  expect_silent(vec_as_location2_result(1L, 1L, names = NULL, arg = print("oof"), missing = "error", negative = "error", call = NULL))
+})

--- a/tests/testthat/test-subscript.R
+++ b/tests/testthat/test-subscript.R
@@ -85,3 +85,13 @@ test_that("vec_as_subscript2() forbids subscript types", {
   expect_snapshot(error = TRUE, vec_as_subscript2("foo", character = "error", logical = "error"))
   expect_snapshot(error = TRUE, vec_as_subscript2(TRUE, logical = "error"))
 })
+
+test_that("vec_as_subscript() evaluates arg lazily", {
+  expect_silent(vec_as_subscript(1L, arg = print("oof")))
+  expect_silent(vec_as_subscript_result(1L, arg = print("oof"), NULL, logical = "error", numeric = "cast", character = "error"))
+})
+
+test_that("vec_as_subscript2() evaluates arg lazily", {
+  expect_silent(vec_as_subscript2(1L, arg = print("oof")))
+  expect_silent(vec_as_subscript2_result(1L, arg = print("oof"), NULL, logical = "error", numeric = "cast", character = "error"))
+})

--- a/tests/testthat/test-type2.R
+++ b/tests/testthat/test-type2.R
@@ -337,3 +337,8 @@ test_that("For reference, warning for incompatible classes", {
 test_that("For reference, error when fallback is disabled", {
   expect_snapshot(error = TRUE, vec_ptype2_no_fallback(foobar(mtcars), foobaz(mtcars)))
 })
+
+test_that("vec_ptype2() evaluates x_arg and y_arg lazily", {
+  expect_silent(vec_ptype2(1L, 1L, x_arg = print("oof")))
+  expect_silent(vec_ptype2(1L, 1L, y_arg = print("oof")))
+})


### PR DESCRIPTION
This removes calls to `vec_as_arg()` when the `frame` argument is already available. More complicated cases follow in separate PRs. 

Part of #1150.