### PR TITLE
More lazy evaluation of args

### DIFF
--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -260,7 +260,7 @@ vec_match <- function(needles,
                       needles_arg = "",
                       haystack_arg = "") {
   check_dots_empty0(...)
-  .Call(vctrs_match, needles, haystack, na_equal, needles_arg, haystack_arg)
+  .Call(vctrs_match, needles, haystack, na_equal, environment())
 }
 
 #' @export

--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -272,5 +272,5 @@ vec_in <- function(needles,
                    needles_arg = "",
                    haystack_arg = "") {
   check_dots_empty0(...)
-  .Call(vctrs_in, needles, haystack, na_equal, needles_arg, haystack_arg)
+  .Call(vctrs_in, needles, haystack, na_equal, environment())
 }

--- a/R/shape.R
+++ b/R/shape.R
@@ -9,7 +9,7 @@ new_shape <- function(type, shape = integer()) {
 
 vec_shaped_ptype  <- function(ptype, x, y, ..., x_arg = "", y_arg = "") {
   check_dots_empty0(...)
-  .Call(vctrs_shaped_ptype, ptype, x, y, x_arg, y_arg)
+  .Call(vctrs_shaped_ptype, ptype, x, y, environment())
 }
 
 vec_shape2 <- function(x, y, ..., x_arg = "", y_arg = "") {

--- a/R/shape.R
+++ b/R/shape.R
@@ -14,7 +14,7 @@ vec_shaped_ptype  <- function(ptype, x, y, ..., x_arg = "", y_arg = "") {
 
 vec_shape2 <- function(x, y, ..., x_arg = "", y_arg = "") {
   check_dots_empty0(...)
-  .Call(vctrs_shape2, x, y, x_arg, y_arg)
+  .Call(vctrs_shape2, x, y, environment())
 }
 
 # Should take same signature as `vec_cast()`

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -251,7 +251,7 @@ df_is_coercible <- function(x, y, opts) {
 #'
 #' @export
 df_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
-  .Call(vctrs_df_ptype2_opts, x, y, opts = match_fallback_opts(...), x_arg, y_arg)
+  .Call(vctrs_df_ptype2_opts, x, y, opts = match_fallback_opts(...), environment())
 }
 #' @rdname df_ptype2
 #' @export
@@ -260,7 +260,7 @@ df_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
 }
 
 df_ptype2_opts <- function(x, y, ..., opts, x_arg = "", y_arg = "") {
-  .Call(vctrs_df_ptype2_opts, x, y, opts = opts, x_arg, y_arg)
+  .Call(vctrs_df_ptype2_opts, x, y, opts = opts, environment())
 }
 
 # FIXME! Error call

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -256,7 +256,7 @@ df_ptype2 <- function(x, y, ..., x_arg = "", y_arg = "") {
 #' @rdname df_ptype2
 #' @export
 df_cast <- function(x, to, ..., x_arg = "", to_arg = "") {
-  .Call(vctrs_df_cast_opts, x, to, opts = match_fallback_opts(...), x_arg, to_arg)
+  .Call(vctrs_df_cast_opts, x, to, opts = match_fallback_opts(...), environment())
 }
 
 df_ptype2_opts <- function(x, y, ..., opts, x_arg = "", y_arg = "") {
@@ -270,7 +270,7 @@ df_cast_opts <- function(x,
                          opts = fallback_opts(),
                          x_arg = "",
                          to_arg = "") {
-  .Call(vctrs_df_cast_opts, x, to, opts, x_arg, to_arg)
+  .Call(vctrs_df_cast_opts, x, to, opts, environment())
 }
 df_cast_params <- function(x,
                            to,

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -336,9 +336,11 @@ SEXP vctrs_id(SEXP x) {
 
 // [[ register() ]]
 SEXP vctrs_match(SEXP needles, SEXP haystack, SEXP na_equal,
-                 SEXP needles_arg_, SEXP haystack_arg_) {
-  struct vctrs_arg needles_arg = vec_as_arg(needles_arg_);
-  struct vctrs_arg haystack_arg = vec_as_arg(haystack_arg_);
+                 SEXP frame) {
+  struct arg_data_lazy needles_arg_ = new_lazy_arg_data(frame, "needles_arg");
+  struct vctrs_arg needles_arg = new_lazy_arg(&needles_arg_);
+  struct arg_data_lazy haystack_arg_ = new_lazy_arg_data(frame, "haystack_arg");
+  struct vctrs_arg haystack_arg = new_lazy_arg(&haystack_arg_);
 
   return vec_match_params(needles,
                           haystack,

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -458,14 +458,15 @@ static inline void vec_match_loop_propagate(int* p_out,
 }
 
 // [[ register() ]]
-SEXP vctrs_in(SEXP needles, SEXP haystack, SEXP na_equal_,
-              SEXP needles_arg_, SEXP haystack_arg_) {
+SEXP vctrs_in(SEXP needles, SEXP haystack, SEXP na_equal_, SEXP frame) {
   int nprot = 0;
   bool na_equal = r_bool_as_int(na_equal_);
 
   int _;
-  struct vctrs_arg needles_arg = vec_as_arg(needles_arg_);
-  struct vctrs_arg haystack_arg = vec_as_arg(haystack_arg_);
+  struct arg_data_lazy needles_arg_ = new_lazy_arg_data(frame, "needles_arg");
+  struct vctrs_arg needles_arg = new_lazy_arg(&needles_arg_);
+  struct arg_data_lazy haystack_arg_ = new_lazy_arg_data(frame, "haystack_arg");
+  struct vctrs_arg haystack_arg = new_lazy_arg(&haystack_arg_);
 
   SEXP type = vec_ptype2_params(needles, haystack,
                                 &needles_arg, &haystack_arg,

--- a/src/init.c
+++ b/src/init.c
@@ -31,7 +31,7 @@ extern SEXP vec_group_loc(SEXP);
 extern SEXP vctrs_equal(SEXP, SEXP, SEXP);
 extern SEXP vctrs_equal_na(SEXP);
 extern SEXP vctrs_compare(SEXP, SEXP, SEXP);
-extern SEXP vctrs_match(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_match(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_in(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_duplicated_any(SEXP);
 extern SEXP vctrs_size(SEXP);
@@ -192,7 +192,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_equal",                      (DL_FUNC) &vctrs_equal, 3},
   {"vctrs_equal_na",                   (DL_FUNC) &vctrs_equal_na, 1},
   {"vctrs_compare",                    (DL_FUNC) &vctrs_compare, 3},
-  {"vctrs_match",                      (DL_FUNC) &vctrs_match, 5},
+  {"vctrs_match",                      (DL_FUNC) &vctrs_match, 4},
   {"vctrs_in",                         (DL_FUNC) &vctrs_in, 5},
   {"vctrs_typeof",                     (DL_FUNC) &vctrs_typeof, 2},
   {"vctrs_init_library",               (DL_FUNC) &vctrs_init_library, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -71,7 +71,7 @@ extern SEXP vctrs_is_unique_names(SEXP);
 extern SEXP vctrs_as_unique_names(SEXP, SEXP);
 extern SEXP vec_set_names(SEXP, SEXP);
 extern SEXP vctrs_df_cast_opts(SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP vctrs_df_ptype2_opts(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_df_ptype2_opts(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_type_info(SEXP);
 extern SEXP vctrs_proxy_info(SEXP);
 extern SEXP vctrs_class_type(SEXP);
@@ -227,7 +227,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_as_unique_names",            (DL_FUNC) &vctrs_as_unique_names, 2},
   {"vctrs_set_names",                  (DL_FUNC) &vec_set_names, 2},
   {"vctrs_df_cast_opts",               (DL_FUNC) &vctrs_df_cast_opts, 5},
-  {"vctrs_df_ptype2_opts",             (DL_FUNC) &vctrs_df_ptype2_opts, 5},
+  {"vctrs_df_ptype2_opts",             (DL_FUNC) &vctrs_df_ptype2_opts, 4},
   {"vctrs_type_info",                  (DL_FUNC) &vctrs_type_info, 1},
   {"vctrs_proxy_info",                 (DL_FUNC) &vctrs_proxy_info, 1},
   {"vctrs_class_type",                 (DL_FUNC) &vctrs_class_type, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -70,7 +70,7 @@ extern SEXP vec_names(SEXP);
 extern SEXP vctrs_is_unique_names(SEXP);
 extern SEXP vctrs_as_unique_names(SEXP, SEXP);
 extern SEXP vec_set_names(SEXP, SEXP);
-extern SEXP vctrs_df_cast_opts(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_df_cast_opts(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_df_ptype2_opts(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_type_info(SEXP);
 extern SEXP vctrs_proxy_info(SEXP);
@@ -226,7 +226,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_is_unique_names",            (DL_FUNC) &vctrs_is_unique_names, 1},
   {"vctrs_as_unique_names",            (DL_FUNC) &vctrs_as_unique_names, 2},
   {"vctrs_set_names",                  (DL_FUNC) &vec_set_names, 2},
-  {"vctrs_df_cast_opts",               (DL_FUNC) &vctrs_df_cast_opts, 5},
+  {"vctrs_df_cast_opts",               (DL_FUNC) &vctrs_df_cast_opts, 4},
   {"vctrs_df_ptype2_opts",             (DL_FUNC) &vctrs_df_ptype2_opts, 4},
   {"vctrs_type_info",                  (DL_FUNC) &vctrs_type_info, 1},
   {"vctrs_proxy_info",                 (DL_FUNC) &vctrs_proxy_info, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -107,7 +107,7 @@ extern SEXP vctrs_rep_each(SEXP, SEXP);
 extern SEXP vctrs_maybe_shared_col(SEXP, SEXP);
 extern SEXP vctrs_new_df_unshared_col();
 extern SEXP vctrs_shaped_ptype(SEXP, SEXP, SEXP, SEXP);
-extern SEXP vctrs_shape2(SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_shape2(SEXP, SEXP, SEXP);
 extern SEXP vctrs_new_date(SEXP);
 extern SEXP vctrs_date_validate(SEXP);
 extern SEXP vctrs_new_datetime(SEXP, SEXP);
@@ -265,7 +265,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_maybe_shared_col",           (DL_FUNC) &vctrs_maybe_shared_col, 2},
   {"vctrs_new_df_unshared_col",        (DL_FUNC) &vctrs_new_df_unshared_col, 0},
   {"vctrs_shaped_ptype",               (DL_FUNC) &vctrs_shaped_ptype, 4},
-  {"vctrs_shape2",                     (DL_FUNC) &vctrs_shape2, 4},
+  {"vctrs_shape2",                     (DL_FUNC) &vctrs_shape2, 3},
   {"vctrs_new_date",                   (DL_FUNC) &vctrs_new_date, 1},
   {"vctrs_date_validate",              (DL_FUNC) &vctrs_date_validate, 1},
   {"vctrs_new_datetime",               (DL_FUNC) &vctrs_new_datetime, 2},

--- a/src/init.c
+++ b/src/init.c
@@ -193,7 +193,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_equal_na",                   (DL_FUNC) &vctrs_equal_na, 1},
   {"vctrs_compare",                    (DL_FUNC) &vctrs_compare, 3},
   {"vctrs_match",                      (DL_FUNC) &vctrs_match, 4},
-  {"vctrs_in",                         (DL_FUNC) &vctrs_in, 5},
+  {"vctrs_in",                         (DL_FUNC) &vctrs_in, 4},
   {"vctrs_typeof",                     (DL_FUNC) &vctrs_typeof, 2},
   {"vctrs_init_library",               (DL_FUNC) &vctrs_init_library, 1},
   {"vctrs_is_vector",                  (DL_FUNC) &vctrs_is_vector, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -106,7 +106,7 @@ extern SEXP vctrs_rep(SEXP, SEXP);
 extern SEXP vctrs_rep_each(SEXP, SEXP);
 extern SEXP vctrs_maybe_shared_col(SEXP, SEXP);
 extern SEXP vctrs_new_df_unshared_col();
-extern SEXP vctrs_shaped_ptype(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_shaped_ptype(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_shape2(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_new_date(SEXP);
 extern SEXP vctrs_date_validate(SEXP);
@@ -264,7 +264,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_rep_each",                   (DL_FUNC) &vctrs_rep_each, 2},
   {"vctrs_maybe_shared_col",           (DL_FUNC) &vctrs_maybe_shared_col, 2},
   {"vctrs_new_df_unshared_col",        (DL_FUNC) &vctrs_new_df_unshared_col, 0},
-  {"vctrs_shaped_ptype",               (DL_FUNC) &vctrs_shaped_ptype, 5},
+  {"vctrs_shaped_ptype",               (DL_FUNC) &vctrs_shaped_ptype, 4},
   {"vctrs_shape2",                     (DL_FUNC) &vctrs_shape2, 4},
   {"vctrs_new_date",                   (DL_FUNC) &vctrs_new_date, 1},
   {"vctrs_date_validate",              (DL_FUNC) &vctrs_date_validate, 1},

--- a/src/shape.c
+++ b/src/shape.c
@@ -39,11 +39,13 @@ SEXP vec_shaped_ptype(SEXP ptype,
 // -----------------------------------------------------------------------------
 
 // [[ register() ]]
-SEXP vctrs_shape2(SEXP x, SEXP y, SEXP x_arg, SEXP y_arg) {
-  struct vctrs_arg x_arg_ = vec_as_arg(x_arg);
-  struct vctrs_arg y_arg_ = vec_as_arg(y_arg);
+SEXP vctrs_shape2(SEXP x, SEXP y, SEXP frame) {
+  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
+  struct arg_data_lazy y_arg_ = new_lazy_arg_data(frame, "y_arg");
+  struct vctrs_arg y_arg = new_lazy_arg(&y_arg_);
 
-  return vec_shape2(x, y, &x_arg_, &y_arg_);
+  return vec_shape2(x, y, &x_arg, &y_arg);
 }
 
 static SEXP vec_shape2_impl(SEXP x_dimensions, SEXP y_dimensions,

--- a/src/shape.c
+++ b/src/shape.c
@@ -3,11 +3,13 @@
 #include "dim.h"
 
 // [[ register() ]]
-SEXP vctrs_shaped_ptype(SEXP ptype, SEXP x, SEXP y, SEXP x_arg, SEXP y_arg) {
-  struct vctrs_arg x_arg_ = vec_as_arg(x_arg);
-  struct vctrs_arg y_arg_ = vec_as_arg(y_arg);
+SEXP vctrs_shaped_ptype(SEXP ptype, SEXP x, SEXP y, SEXP frame) {
+  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
+  struct arg_data_lazy y_arg_ = new_lazy_arg_data(frame, "y_arg");
+  struct vctrs_arg y_arg = new_lazy_arg(&y_arg_);
 
-  return vec_shaped_ptype(ptype, x, y, &x_arg_, &y_arg_);
+  return vec_shaped_ptype(ptype, x, y, &x_arg, &y_arg);
 }
 
 static SEXP vec_shape2(SEXP x, SEXP y, struct vctrs_arg* p_x_arg, struct vctrs_arg* p_y_arg);

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -473,11 +473,13 @@ static SEXP new_compact_rownames(R_len_t n) {
 // vctrs type methods ------------------------------------------------
 
 // [[ register() ]]
-SEXP vctrs_df_ptype2_opts(SEXP x, SEXP y, SEXP opts, SEXP x_arg, SEXP y_arg) {
-  struct vctrs_arg c_x_arg = vec_as_arg(x_arg);
-  struct vctrs_arg c_y_arg = vec_as_arg(y_arg);
+SEXP vctrs_df_ptype2_opts(SEXP x, SEXP y, SEXP opts, SEXP frame) {
+  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
+  struct arg_data_lazy y_arg_ = new_lazy_arg_data(frame, "y_arg");
+  struct vctrs_arg y_arg = new_lazy_arg(&y_arg_);
 
-  const struct ptype2_opts c_opts = new_ptype2_opts(x, y, &c_x_arg, &c_y_arg, opts);
+  const struct ptype2_opts c_opts = new_ptype2_opts(x, y, &x_arg, &y_arg, opts);
 
   return df_ptype2(&c_opts);
 }

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -649,15 +649,17 @@ SEXP df_ptype2_loop(const struct ptype2_opts* opts,
 }
 
 // [[ register() ]]
-SEXP vctrs_df_cast_opts(SEXP x, SEXP to, SEXP opts, SEXP x_arg, SEXP to_arg) {
-  struct vctrs_arg c_x_arg = vec_as_arg(x_arg);
-  struct vctrs_arg c_to_arg = vec_as_arg(to_arg);
+SEXP vctrs_df_cast_opts(SEXP x, SEXP to, SEXP opts, SEXP frame) {
+  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
+  struct arg_data_lazy to_arg_ = new_lazy_arg_data(frame, "to_arg");
+  struct vctrs_arg to_arg = new_lazy_arg(&to_arg_);
 
   // FIXME! Error call
   struct cast_opts c_opts = new_cast_opts(x,
                                           to,
-                                          &c_x_arg,
-                                          &c_to_arg,
+                                          &x_arg,
+                                          &to_arg,
                                           r_lazy_null,
                                           opts);
 

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -336,3 +336,8 @@ test_that("vec_match() and vec_in() silently fall back to base data frame", {
     rep(TRUE, 32)
   ))
 })
+
+test_that("vec_match() evaluates arg lazily", {
+  expect_silent(vec_match(1L, 1L, needles_arg = print("oof")))
+  expect_silent(vec_match(1L, 1L, haystack_arg = print("oof")))
+})

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -337,6 +337,11 @@ test_that("vec_match() and vec_in() silently fall back to base data frame", {
   ))
 })
 
+test_that("vec_in() evaluates arg lazily", {
+  expect_silent(vec_in(1L, 1L, needles_arg = print("oof")))
+  expect_silent(vec_in(1L, 1L, haystack_arg = print("oof")))
+})
+
 test_that("vec_match() evaluates arg lazily", {
   expect_silent(vec_match(1L, 1L, needles_arg = print("oof")))
   expect_silent(vec_match(1L, 1L, haystack_arg = print("oof")))

--- a/tests/testthat/test-shape.R
+++ b/tests/testthat/test-shape.R
@@ -30,6 +30,11 @@ test_that("can override error args", {
   })
 })
 
+test_that("vec_shape2() evaluates arg lazily", {
+  expect_silent(vec_shape2(shaped_int(1, 5, 5), shaped_int(1), x_arg = print("oof")))
+  expect_silent(vec_shape2(shaped_int(1, 5, 5), shaped_int(1), y_arg = print("oof")))
+})
+
 # broadcasting -------------------------------------------------------------
 
 test_that("can broadcast to higher dimension, but not lower", {

--- a/tests/testthat/test-type-bare.R
+++ b/tests/testthat/test-type-bare.R
@@ -43,6 +43,11 @@ test_that("vec_shaped_ptype()", {
   expect_identical(vec_shaped_ptype(integer(), int(5, 1, 2), int(10, 1, 2)), new_shape(integer(), 1:2))
 })
 
+test_that("vec_shaped_ptype() evaluates arg lazily", {
+  expect_silent(vec_shaped_ptype(integer(), int(5), int(10), x_arg = print("oof")))
+  expect_silent(vec_shaped_ptype(integer(), int(5), int(10), y_arg = print("oof")))
+})
+
 # vec_cast() --------------------------------------------------------------
 
 # NULL

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -230,6 +230,11 @@ test_that("casting to and from data frame preserves row names", {
   expect_identical(row.names(out), row.names(mtcars))
 })
 
+test_that("df_cast() evaluates arg lazily", {
+  expect_silent(df_cast(data_frame(), data_frame(), x_arg = print("oof")))
+  expect_silent(df_cast(data_frame(), data_frame(), to_arg = print("oof")))
+})
+
 # df_ptype2 ---------------------------------------------------------------
 
 test_that("df_ptype2() evaluates arg lazily", {

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -230,6 +230,13 @@ test_that("casting to and from data frame preserves row names", {
   expect_identical(row.names(out), row.names(mtcars))
 })
 
+# df_ptype2 ---------------------------------------------------------------
+
+test_that("df_ptype2() evaluates arg lazily", {
+  expect_silent(df_ptype2(data_frame(), data_frame(), x_arg = print("oof")))
+  expect_silent(df_ptype2(data_frame(), data_frame(), y_arg = print("oof")))
+})
+
 
 # new_data_frame ----------------------------------------------------------
 


### PR DESCRIPTION
The remaining instances of `vec_as_arg()` seem very tricky and not worth it.

Closes #1150.