### PR TITLE
Follow-up to lazy arg

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -170,6 +170,9 @@ vec_slice_dispatch_integer64 <- function(x, i) {
 #' @rdname vec_slice
 #' @export
 `vec_slice<-` <- function(x, i, value) {
+  x_arg <- "" # Substitution is `*tmp*`
+  delayedAssign("value_arg", as_label(substitute(value)))
+
   .Call(vctrs_assign, x, i, value, environment())
 }
 #' @rdname vec_slice

--- a/src/arg.c
+++ b/src/arg.c
@@ -113,30 +113,19 @@ r_ssize wrapper_arg_fill(void* data, char* buf, r_ssize remaining) {
 
 // Wrapper that accesses a symbol in an environment, for lazy evaluation
 
-struct vctrs_arg new_lazy_arg(struct arg_data_lazy* data) {
+struct vctrs_arg new_lazy_arg(struct r_lazy* arg) {
   return (struct vctrs_arg) {
     .parent = NULL,
     .fill = &lazy_arg_fill,
-    .data = data
-  };
-}
-
-struct arg_data_lazy new_lazy_arg_data(SEXP environment, const char* arg_name) {
-  if (environment == R_NilValue) {
-    r_stop_internal("new_lazy_arg_data", "`env` can't be NULL.");
-  }
-
-  return (struct arg_data_lazy) {
-    .environment = environment,
-    .arg_name = arg_name
+    .data = arg
   };
 }
 
 static
 r_ssize lazy_arg_fill(void* data_, char* buf, r_ssize remaining) {
-  struct arg_data_lazy* data = (struct arg_data_lazy*) data_;
+  struct r_lazy* data = (struct r_lazy*) data_;
 
-  r_obj* arg = KEEP(r_eval(r_sym(data->arg_name), data->environment));
+  r_obj* arg = KEEP(r_lazy_eval(*data));
 
   const char* arg_str = "";
   if (r_is_string(arg)) {

--- a/src/arg.c
+++ b/src/arg.c
@@ -78,12 +78,24 @@ static int fill_arg_buffer(struct vctrs_arg* arg,
   }
 }
 
+static
+r_ssize str_arg_fill(const char* data, char* buf, r_ssize remaining) {
+  size_t len = strlen(data);
+
+  if (len >= remaining) {
+    return -1;
+  }
+
+  memcpy(buf, data, len);
+  buf[len] = '\0';
+
+  return len;
+}
+
 
 // Objects -------------------------------------------------------------
 
 // Simple wrapper around a `const char*` argument tag
-
-static r_ssize wrapper_arg_fill(void* data, char* buf, r_ssize remaining);
 
 struct vctrs_arg new_wrapper_arg(struct vctrs_arg* parent, const char* arg) {
   return (struct vctrs_arg) {
@@ -93,24 +105,13 @@ struct vctrs_arg new_wrapper_arg(struct vctrs_arg* parent, const char* arg) {
   };
 }
 
-static r_ssize wrapper_arg_fill(void* data, char* buf, r_ssize remaining) {
-  const char* src = (const char*) data;
-
-  size_t len = strlen(src);
-
-  if (len >= remaining) {
-    return -1;
-  }
-
-  memcpy(buf, src, len);
-  buf[len] = '\0';
-
-  return len;
+static
+r_ssize wrapper_arg_fill(void* data, char* buf, r_ssize remaining) {
+  return str_arg_fill((const char*) data, buf, remaining);
 }
 
 
 // Wrapper that accesses a symbol in an environment, for lazy evaluation
-static r_ssize lazy_arg_fill(void* data, char* buf, r_ssize remaining);
 
 struct vctrs_arg new_lazy_arg(struct arg_data_lazy* data) {
   return (struct vctrs_arg) {
@@ -131,34 +132,23 @@ struct arg_data_lazy new_lazy_arg_data(SEXP environment, const char* arg_name) {
   };
 }
 
-static r_ssize lazy_arg_fill(void* data_, char* buf, r_ssize remaining) {
+static
+r_ssize lazy_arg_fill(void* data_, char* buf, r_ssize remaining) {
   struct arg_data_lazy* data = (struct arg_data_lazy*) data_;
 
-  SEXP arg_name = r_sym(data->arg_name);
-  SEXP value = PROTECT(r_env_get(data->environment, arg_name));
-  const char* c_value;
+  r_obj* arg = KEEP(r_eval(r_sym(data->arg_name), data->environment));
 
-  // NULL values are mapped to an empty string. We also silently ignore
-  // non-character values or zero-length vectors and take the first element of a
-  // character vector. We could do better with a warning or a combined error.
-  if (!r_is_string(value) || r_length(value) < 1) {
-    c_value = "";
-  } else {
-    c_value = r_chr_get_c_string(value, 0);
+  const char* arg_str = "";
+  if (r_is_string(arg)) {
+    arg_str = r_chr_get_c_string(arg, 0);
+  } else if (arg != r_null) {
+    r_abort("`arg` must be a string.");
   }
 
-  size_t len = strlen(c_value);
+  r_ssize out = str_arg_fill(arg_str, buf, remaining);
 
-  if (len >= remaining) {
-    UNPROTECT(1);
-    return -1;
-  }
-
-  memcpy(buf, c_value, len);
-  buf[len] = '\0';
-
-  UNPROTECT(1);
-  return len;
+  FREE(1);
+  return out;
 }
 
 

--- a/src/arg.h
+++ b/src/arg.h
@@ -1,6 +1,8 @@
 #ifndef VCTRS_ARG_H
 #define VCTRS_ARG_H
 
+#include "rlang-dev.h"
+
 
 /**
  * Structure for argument tags
@@ -27,15 +29,7 @@ struct vctrs_arg new_wrapper_arg(struct vctrs_arg* parent,
                                  const char* arg);
 
 
-// Wrapper that accesses a symbol in an environment, for lazy evaluation
-struct arg_data_lazy {
-  SEXP environment;
-  const char* arg_name;
-};
-
-struct vctrs_arg new_lazy_arg(struct arg_data_lazy* data);
-
-struct arg_data_lazy new_lazy_arg_data(SEXP environment, const char* arg_name);
+struct vctrs_arg new_lazy_arg(struct r_lazy* data);
 
 
 // Wrapper around a counter representing the current position of the

--- a/src/cast.c
+++ b/src/cast.c
@@ -20,9 +20,10 @@ static SEXP vec_cast_dispatch_s3(const struct cast_opts* opts);
 r_obj* ffi_cast(r_obj* x,
                 r_obj* to,
                 r_obj* frame) {
-  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct r_lazy x_arg_ = { .x = syms.x_arg, .env = frame};
   struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
-  struct arg_data_lazy to_arg_ = new_lazy_arg_data(frame, "to_arg");
+
+  struct r_lazy to_arg_ = { .x = syms.to_arg, .env = frame};
   struct vctrs_arg to_arg = new_lazy_arg(&to_arg_);
 
   struct r_lazy call = { .x = syms_call, .env = frame };

--- a/src/decl/arg-decl.h
+++ b/src/decl/arg-decl.h
@@ -1,1 +1,8 @@
-static r_ssize counter_arg_fill(void* data, char* buf, r_ssize remaining);
+static
+r_ssize counter_arg_fill(void* data, char* buf, r_ssize remaining);
+
+static
+r_ssize wrapper_arg_fill(void* data, char* buf, r_ssize remaining);
+
+static
+r_ssize lazy_arg_fill(void* data, char* buf, r_ssize remaining);

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -337,9 +337,10 @@ SEXP vctrs_id(SEXP x) {
 // [[ register() ]]
 SEXP vctrs_match(SEXP needles, SEXP haystack, SEXP na_equal,
                  SEXP frame) {
-  struct arg_data_lazy needles_arg_ = new_lazy_arg_data(frame, "needles_arg");
+  struct r_lazy needles_arg_ = { .x = syms.needles_arg, .env = frame};
   struct vctrs_arg needles_arg = new_lazy_arg(&needles_arg_);
-  struct arg_data_lazy haystack_arg_ = new_lazy_arg_data(frame, "haystack_arg");
+
+  struct r_lazy haystack_arg_ = { .x = syms.haystack_arg, .env = frame};
   struct vctrs_arg haystack_arg = new_lazy_arg(&haystack_arg_);
 
   return vec_match_params(needles,
@@ -463,9 +464,11 @@ SEXP vctrs_in(SEXP needles, SEXP haystack, SEXP na_equal_, SEXP frame) {
   bool na_equal = r_bool_as_int(na_equal_);
 
   int _;
-  struct arg_data_lazy needles_arg_ = new_lazy_arg_data(frame, "needles_arg");
+
+  struct r_lazy needles_arg_ = { .x = syms.needles_arg, .env = frame};
   struct vctrs_arg needles_arg = new_lazy_arg(&needles_arg_);
-  struct arg_data_lazy haystack_arg_ = new_lazy_arg_data(frame, "haystack_arg");
+
+  struct r_lazy haystack_arg_ = { .x = syms.haystack_arg, .env = frame};
   struct vctrs_arg haystack_arg = new_lazy_arg(&haystack_arg_);
 
   SEXP type = vec_ptype2_params(needles, haystack,

--- a/src/globals.c
+++ b/src/globals.c
@@ -1,0 +1,15 @@
+#include <rlang.h>
+#include "globals.h"
+
+struct syms syms;
+
+void vctrs_init_globals(r_obj* ns) {
+  syms.arg = r_sym("arg");
+  syms.haystack_arg = r_sym("haystack_arg");
+  syms.needles_arg = r_sym("needles_arg");
+  syms.repair_arg = r_sym("repair_arg");
+  syms.to_arg = r_sym("to_arg");
+  syms.value_arg = r_sym("value_arg");
+  syms.x_arg = r_sym("x_arg");
+  syms.y_arg = r_sym("y_arg");
+}

--- a/src/globals.h
+++ b/src/globals.h
@@ -1,0 +1,18 @@
+#ifndef VCTRS_GLOBALS_H
+#define VCTRS_GLOBALS_H
+
+struct syms {
+  r_obj* arg;
+  r_obj* haystack_arg;
+  r_obj* needles_arg;
+  r_obj* repair_arg;
+  r_obj* to_arg;
+  r_obj* value_arg;
+  r_obj* x_arg;
+  r_obj* y_arg;
+};
+
+extern struct syms syms;
+
+
+#endif

--- a/src/init.c
+++ b/src/init.c
@@ -369,8 +369,9 @@ void vctrs_init_type_date_time(SEXP ns);
 void vctrs_init_type_info(SEXP ns);
 void vctrs_init_unspecified(SEXP ns);
 void vctrs_init_utils(SEXP ns);
+void vctrs_init_globals(r_obj* ns);
 
-SEXP vctrs_init_library(SEXP ns) {
+r_obj* vctrs_init_library(r_obj* ns) {
   r_init_library(ns);
 
   vctrs_init_bind(ns);
@@ -392,5 +393,7 @@ SEXP vctrs_init_library(SEXP ns) {
   vctrs_init_type_info(ns);
   vctrs_init_unspecified(ns);
   vctrs_init_utils(ns);
-  return R_NilValue;
+  vctrs_init_globals(ns);
+
+  return r_null;
 }

--- a/src/names.c
+++ b/src/names.c
@@ -52,8 +52,9 @@ r_obj* ffi_as_names(r_obj* names,
 
   struct r_lazy call = (struct r_lazy) { .x = syms_call, .env = frame };
 
-  struct arg_data_lazy repair_arg_ = new_lazy_arg_data(frame, "repair_arg");
+  struct r_lazy repair_arg_ = { .x = syms.repair_arg, .env = frame };
   struct vctrs_arg repair_arg = new_lazy_arg(&repair_arg_);
+
   struct name_repair_opts repair_opts = new_name_repair_opts(repair,
                                                              &repair_arg,
                                                              quiet,

--- a/src/rlang-dev.h
+++ b/src/rlang-dev.h
@@ -1,0 +1,36 @@
+#ifndef VCTRS_RLANG_DEV_H
+#define VCTRS_RLANG_DEV_H
+
+
+struct r_lazy {
+  r_obj* x;
+  r_obj* env;
+};
+
+static inline
+r_obj* r_lazy_eval(struct r_lazy lazy) {
+  if (!lazy.env) {
+    // Unitialised lazy variable
+    return r_null;
+  } else if (lazy.env == r_null) {
+    // Forced lazy variable
+    return lazy.x;
+  } else {
+    return r_eval(lazy.x, lazy.env);
+  }
+}
+
+extern
+struct r_lazy r_lazy_null;
+
+static inline
+r_obj* r_lazy_eval_protect(struct r_lazy lazy) {
+  r_obj* out = KEEP(r_lazy_eval(lazy));
+  out = r_expr_protect(out);
+
+  FREE(1);
+  return out;
+}
+
+
+#endif

--- a/src/shape.c
+++ b/src/shape.c
@@ -4,9 +4,10 @@
 
 // [[ register() ]]
 SEXP vctrs_shaped_ptype(SEXP ptype, SEXP x, SEXP y, SEXP frame) {
-  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct r_lazy x_arg_ = { .x = syms.x_arg, .env = frame};
   struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
-  struct arg_data_lazy y_arg_ = new_lazy_arg_data(frame, "y_arg");
+
+  struct r_lazy y_arg_ = { .x = syms.y_arg, .env = frame};
   struct vctrs_arg y_arg = new_lazy_arg(&y_arg_);
 
   return vec_shaped_ptype(ptype, x, y, &x_arg, &y_arg);
@@ -40,9 +41,10 @@ SEXP vec_shaped_ptype(SEXP ptype,
 
 // [[ register() ]]
 SEXP vctrs_shape2(SEXP x, SEXP y, SEXP frame) {
-  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct r_lazy x_arg_ = { .x = syms.x_arg, .env = frame};
   struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
-  struct arg_data_lazy y_arg_ = new_lazy_arg_data(frame, "y_arg");
+
+  struct r_lazy y_arg_ = { .x = syms.y_arg, .env = frame};
   struct vctrs_arg y_arg = new_lazy_arg(&y_arg_);
 
   return vec_shape2(x, y, &x_arg, &y_arg);

--- a/src/size.c
+++ b/src/size.c
@@ -181,8 +181,9 @@ r_obj* ffi_recycle(r_obj* x,
   R_len_t size = r_int_get(size_obj, 0);
   FREE(1);
 
-  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct r_lazy x_arg_ = { .x = syms.x_arg, .env = frame};
   struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
+
   struct r_lazy call = { .x = syms_call, .env = frame };
 
   return vec_recycle2(x, size, &x_arg, call);

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -59,9 +59,10 @@ SEXP vec_assign_opts(SEXP x, SEXP index, SEXP value,
 
 // [[ register() ]]
 SEXP vctrs_assign(SEXP x, SEXP index, SEXP value, SEXP frame) {
-  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct r_lazy x_arg_ = { .x = syms.x_arg, .env = frame};
   struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
-  struct arg_data_lazy value_arg_ = new_lazy_arg_data(frame, "value_arg");
+
+  struct r_lazy value_arg_ = { .x = syms.value_arg, .env = frame};
   struct vctrs_arg value_arg = new_lazy_arg(&value_arg_);
 
   const struct vec_assign_opts opts = {

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -376,7 +376,7 @@ r_obj* ffi_as_location(r_obj* subscript,
     FREE(1);
   }
 
-  struct arg_data_lazy arg_ = new_lazy_arg_data(frame, "arg");
+  struct r_lazy arg_ = { .x = syms.arg, .env = frame};
   struct vctrs_arg arg = new_lazy_arg(&arg_);
 
   struct r_lazy call = (struct r_lazy) { .x = syms_call, .env = frame };

--- a/src/subscript.c
+++ b/src/subscript.c
@@ -212,8 +212,9 @@ r_obj* ffi_as_subscript(r_obj* subscript,
                         r_obj* numeric,
                         r_obj* character,
                         r_obj* frame) {
-  struct arg_data_lazy arg_ = new_lazy_arg_data(frame, "arg");
+  struct r_lazy arg_ = { .x = syms.arg, .env = frame};
   struct vctrs_arg arg = new_lazy_arg(&arg_);
+
   struct r_lazy call = { .x = r_syms.call, .env = frame };
 
   struct subscript_opts opts = {
@@ -240,8 +241,9 @@ r_obj* ffi_as_subscript_result(r_obj* subscript,
                                r_obj* numeric,
                                r_obj* character,
                                r_obj* frame) {
-  struct arg_data_lazy arg_ = new_lazy_arg_data(frame, "arg");
+  struct r_lazy arg_ = { .x = syms.arg, .env = frame};
   struct vctrs_arg arg = new_lazy_arg(&arg_);
+
   struct r_lazy call = { .x = r_syms.call, .env = frame };
 
   struct subscript_opts opts = {

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -474,9 +474,10 @@ static SEXP new_compact_rownames(R_len_t n) {
 
 // [[ register() ]]
 SEXP vctrs_df_ptype2_opts(SEXP x, SEXP y, SEXP opts, SEXP frame) {
-  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct r_lazy x_arg_ = { .x = syms.x_arg, .env = frame};
   struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
-  struct arg_data_lazy y_arg_ = new_lazy_arg_data(frame, "y_arg");
+
+  struct r_lazy y_arg_ = { .x = syms.y_arg, .env = frame};
   struct vctrs_arg y_arg = new_lazy_arg(&y_arg_);
 
   const struct ptype2_opts c_opts = new_ptype2_opts(x, y, &x_arg, &y_arg, opts);
@@ -650,9 +651,10 @@ SEXP df_ptype2_loop(const struct ptype2_opts* opts,
 
 // [[ register() ]]
 SEXP vctrs_df_cast_opts(SEXP x, SEXP to, SEXP opts, SEXP frame) {
-  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct r_lazy x_arg_ = { .x = syms.x_arg, .env = frame};
   struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
-  struct arg_data_lazy to_arg_ = new_lazy_arg_data(frame, "to_arg");
+
+  struct r_lazy to_arg_ = { .x = syms.to_arg, .env = frame};
   struct vctrs_arg to_arg = new_lazy_arg(&to_arg_);
 
   // FIXME! Error call

--- a/src/type2.c
+++ b/src/type2.c
@@ -230,9 +230,10 @@ SEXP vctrs_is_coercible(SEXP x,
 r_obj* ffi_ptype2(r_obj* x,
                   r_obj* y,
                   r_obj* frame) {
-  struct arg_data_lazy x_arg_ = new_lazy_arg_data(frame, "x_arg");
+  struct r_lazy x_arg_ = { .x = syms.x_arg, .env = frame};
   struct vctrs_arg x_arg = new_lazy_arg(&x_arg_);
-  struct arg_data_lazy y_arg_ = new_lazy_arg_data(frame, "y_arg");
+
+  struct r_lazy y_arg_ = { .x = syms.y_arg, .env = frame};
   struct vctrs_arg y_arg = new_lazy_arg(&y_arg_);
 
   struct r_lazy call = { .x = syms_call, .env = frame };

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,6 +3,7 @@
 
 #include <rlang.h>
 #include "arg-counter.h"
+#include "rlang-dev.h"
 
 
 #define SWAP(T, x, y) do {                      \
@@ -552,37 +553,6 @@ extern SEXP s4_c_method_table;
 SEXP R_inspect(SEXP x);
 SEXP R_inspect3(SEXP x, int deep, int pvec);
 #endif
-
-
-struct r_lazy {
-  r_obj* x;
-  r_obj* env;
-};
-
-static inline
-r_obj* r_lazy_eval(struct r_lazy lazy) {
-  if (!lazy.env) {
-    // Unitialised lazy variable
-    return r_null;
-  } else if (lazy.env == r_null) {
-    // Forced lazy variable
-    return lazy.x;
-  } else {
-    return r_eval(lazy.x, lazy.env);
-  }
-}
-
-extern
-struct r_lazy r_lazy_null;
-
-static inline
-r_obj* r_lazy_eval_protect(struct r_lazy lazy) {
-  r_obj* out = KEEP(r_lazy_eval(lazy));
-  out = r_expr_protect(out);
-
-  FREE(1);
-  return out;
-}
 
 
 #endif

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -10,6 +10,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "globals.h"
+
 
 extern bool vctrs_debug_verbose;
 


### PR DESCRIPTION
Follow-up to #1484.

- Use common buffer filling implementation in wrapper args and lazy args.
- Use new `struct r_lazy` in lazy args

cc @krlmlr 