### PR TITLE
Error call ownership

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -65,7 +65,7 @@ stop_vctrs <- function(message = NULL,
     message,
     class = c(class, "vctrs_error"),
     ...,
-    call = call
+    call = vctrs_error_call(call)
   )
 }
 warn_vctrs <- function(message = NULL,
@@ -870,4 +870,28 @@ append_arg <- function(x, arg) {
   } else {
     x
   }
+}
+
+vctrs_local_error_call <- function(call = frame, frame = caller_env()) {
+  # This doesn't implement the semantics of a `local_` function
+  # perfectly in order to be as fast as possible
+  frame$.__vctrs_error_call__. <- call
+  invisible(NULL)
+}
+
+vctrs_error_call <- function(call) {
+  if (is_environment(call)) {
+    caller_call <- env_get(
+      call,
+      ".__vctrs_error_call__.",
+      inherit = TRUE,
+      last = topenv(call),
+      default = NULL
+    )
+    if (!is_null(caller_call)) {
+      return(caller_call)
+    }
+  }
+
+  call
 }

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -881,17 +881,31 @@ vctrs_local_error_call <- function(call = frame, frame = caller_env()) {
 
 vctrs_error_call <- function(call) {
   if (is_environment(call)) {
-    caller_call <- env_get(
-      call,
-      ".__vctrs_error_call__.",
-      inherit = TRUE,
-      last = topenv(call),
-      default = NULL
-    )
+    caller_call <- get_vctrs_error_call(call)
     if (!is_null(caller_call)) {
       return(caller_call)
     }
   }
 
   call
+}
+
+vctrs_error_borrowed_call <- function() {
+  borrower <- get_vctrs_error_call(caller_env(2))
+
+  if (is_null(borrower)) {
+    caller_env()
+  } else {
+    borrower
+  }
+}
+
+get_vctrs_error_call <- function(call) {
+  env_get(
+    call,
+    ".__vctrs_error_call__.",
+    inherit = TRUE,
+    last = topenv(call),
+    default = NULL
+  )
 }

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -890,13 +890,14 @@ vctrs_error_call <- function(call) {
   call
 }
 
-vctrs_error_borrowed_call <- function() {
-  borrower <- get_vctrs_error_call(caller_env(2))
+vctrs_error_borrowed_call <- function(call = caller_env(),
+                                      borrower = caller_env(2)) {
+  borrower_call <- get_vctrs_error_call(borrower)
 
-  if (is_null(borrower)) {
-    caller_env()
+  if (is_null(borrower_call)) {
+    call
   } else {
-    borrower
+    borrower_call
   }
 }
 

--- a/R/slice.R
+++ b/R/slice.R
@@ -105,7 +105,8 @@
 #' x <- 1:3
 #' try(vec_slice(x, 2) <- 1.5)
 vec_slice <- function(x, i) {
-  .Call(vctrs_slice, x, i)
+  delayedAssign("call", vctrs_error_borrowed_call())
+  .Call(ffi_slice, x, i, environment())
 }
 
 # Called when `x` has dimensions

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -147,7 +147,7 @@ num_as_location2 <- function(i,
   check_dots_empty0(...)
 
   if (!is_integer(i) && !is_double(i)) {
-    abort("`i` must be a numeric vector.", call = call)
+    abort("`i` must be a numeric vector.", call = vctrs_error_call(call))
   }
   result_get(vec_as_location2_result(
     i,

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -183,6 +183,7 @@ new_error_subscript_type <- function(i,
                                      numeric = "cast",
                                      character = "cast",
                                      ...,
+                                     call = NULL,
                                      class = NULL) {
   new_error_subscript(
     class = c(class, "vctrs_error_subscript_type"),
@@ -190,7 +191,8 @@ new_error_subscript_type <- function(i,
     logical = logical,
     numeric = numeric,
     character = character,
-    ...
+    ...,
+    call = vctrs_error_call(call)
   )
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -139,6 +139,7 @@ extern r_obj* vctrs_integer64_restore(r_obj*);
 extern r_obj* vctrs_list_drop_empty(r_obj*);
 extern r_obj* vctrs_is_altrep(r_obj* x);
 extern r_obj* ffi_interleave_indices(r_obj*, r_obj*);
+extern r_obj* ffi_slice(r_obj*, r_obj*, r_obj*);
 
 
 // Maturing
@@ -203,7 +204,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_typeof2_s3",                 (DL_FUNC) &vctrs_typeof2_s3, 2},
   {"ffi_cast",                         (DL_FUNC) &ffi_cast, 3},
   {"ffi_as_location",                  (DL_FUNC) &ffi_as_location, 8},
-  {"vctrs_slice",                      (DL_FUNC) &vec_slice, 2},
+  {"ffi_slice",                        (DL_FUNC) &ffi_slice, 3},
   {"ffi_init",                         (DL_FUNC) &ffi_init, 3},
   {"vctrs_chop",                       (DL_FUNC) &vctrs_chop, 2},
   {"vctrs_unchop",                     (DL_FUNC) &vctrs_unchop, 5},

--- a/src/slice.c
+++ b/src/slice.c
@@ -411,16 +411,29 @@ bool vec_is_restored(SEXP x, SEXP to) {
   return false;
 }
 
+r_obj* vec_slice_ctxt(r_obj* x,
+                      r_obj* i,
+                      struct r_lazy call) {
+  vec_assert_vector(x, args_empty, call);
 
-// [[ include("vctrs.h"); register() ]]
-SEXP vec_slice(SEXP x, SEXP subscript) {
-  vec_assert_vector(x, args_empty, r_lazy_null);
+  // TODO! Propagate `call` through `vec_slice_impl()`
+  i = KEEP(vec_as_location(i, vec_size(x), KEEP(vec_names(x))));
+  r_obj* out = vec_slice_impl(x, i);
 
-  subscript = PROTECT(vec_as_location(subscript, vec_size(x), PROTECT(vec_names(x))));
-  SEXP out = vec_slice_impl(x, subscript);
-
-  UNPROTECT(2);
+  FREE(2);
   return out;
+}
+
+// [[ include("vctrs.h") ]]
+r_obj* vec_slice(r_obj* x, r_obj* i) {
+  return vec_slice_ctxt(x, i, r_lazy_null);
+}
+
+r_obj* ffi_slice(r_obj* x,
+                 r_obj* i,
+                 r_obj* frame) {
+  struct r_lazy call = { .x = r_syms.call, .env = frame };
+  return vec_slice_ctxt(x, i, call);
 }
 
 // [[ include("vctrs.h") ]]

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -47,7 +47,7 @@
       (expect_error(vec_slice(foobar(list(1)), 1), class = "vctrs_error_scalar_type"))
     Output
       <error/vctrs_error_scalar_type>
-      Error:
+      Error in `vec_slice()`:
       ! Input must be a vector, not a <vctrs_foobar> object.
     Code
       (expect_error(stop_scalar_type(foobar(list(1)), arg = "foo"), class = "vctrs_error_scalar_type")

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -260,3 +260,24 @@
       Error in `my_function()`:
       ! Input must be a vector, not a <vctrs_foobar> object.
 
+# can take ownership of vctrs errors
+
+    Code
+      (expect_error(vec_assert(foobar(list()))))
+    Output
+      <error/vctrs_error_scalar_type>
+      Error in `foo()`:
+      ! `foobar(list())` must be a vector, not a <vctrs_foobar> object.
+    Code
+      (expect_error(local(vec_assert(foobar(list())))))
+    Output
+      <error/vctrs_error_scalar_type>
+      Error in `foo()`:
+      ! `foobar(list())` must be a vector, not a <vctrs_foobar> object.
+    Code
+      (expect_error(vec_cast(1, list())))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `foo()`:
+      ! Can't convert <double> to <list>.
+

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -280,4 +280,19 @@
       <error/vctrs_error_incompatible_type>
       Error in `foo()`:
       ! Can't convert <double> to <list>.
+    Code
+      (expect_error(vec_slice(env(), list())))
+    Output
+      <error/vctrs_error_scalar_type>
+      Error in `foo()`:
+      ! Input must be a vector, not an environment.
+    Code
+      local({
+        vctrs_local_error_call(NULL)
+        (expect_error(vec_slice(env(), list())))
+      })
+    Output
+      <error/vctrs_error_scalar_type>
+      Error in `vec_slice()`:
+      ! Input must be a vector, not an environment.
 

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -113,5 +113,13 @@ test_that("can take ownership of vctrs errors", {
     (expect_error(local(vec_assert(foobar(list())))))
 
     (expect_error(vec_cast(1, list())))
+
+    (expect_error(vec_slice(env(), list())))
+
+    # This should show `vec_slice()` if no local call
+    local({
+      vctrs_local_error_call(NULL)
+      (expect_error(vec_slice(env(), list())))
+    })
   })
 })

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -104,3 +104,14 @@ test_that("`vec_ptype()` reports correct error call", {
     (expect_error(my_function(foobar(list()))))
   })
 })
+
+test_that("can take ownership of vctrs errors", {
+  vctrs_local_error_call(call("foo"))
+
+  expect_snapshot({
+    (expect_error(vec_assert(foobar(list()))))
+    (expect_error(local(vec_assert(foobar(list())))))
+
+    (expect_error(vec_cast(1, list())))
+  })
+})


### PR DESCRIPTION
This is a POC for borrowing vctrs errors within a function (e.g. a dplyr, tidyr, or funs verb). This mechanism is similar to the one implemented in https://github.com/tidyverse/dplyr/pull/6123 to take ownership of dplyr errors.

The verb calls `vctrs_local_error_call()` to set an error call binding within its execution env.

```r
manip <- function(x, check = FALSE, slice = FALSE) {
  # Borrow all vctrs errors
  vctrs_local_error_call()

  if (check) {
    vec_assert(x)
  }
  if (slice) {
    vec_slice(x, 1)
  }
}
```

The vctrs operations taking `call = caller_env()` pick up on this automatically, so that it is not necessary to pass on `call`:

```r
manip(env(), check = TRUE)
#> Error in `manip()`:
#> ! `x` must be a vector, not an environment.
```

Other operations that don't take calls also look for a flag.

```r
manip(env(), slice = TRUE)
#> Error in `manip()`:
#> ! Input must be a vector, not an environment.
```

If not found, the vctrs op call is used instead (not the caller call as in `vec_assert()` and friends):

```r
vec_slice(env(), 1)
#> Error in `vec_slice()`:
#> ! Input must be a vector, not an environment.
```

Ideally, operations like `vec_slice()` would also provide information about the argument, but I'm not sure how to tackle this problem yet. It might be that all operations should take `call` and `arg` arguments. Nevertheless, `vctrs_local_error_call()` seems like a nice way of passing a call to all vctrs operations without boilerplate.