### PR TITLE
Rename poly function from missing to incomplete

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -80,7 +80,7 @@ static struct dictionary* new_dictionary_opts(SEXP x, struct dictionary_opts* op
   d->p_poly_vec = p_poly_vec;
 
   d->p_equal_na_equal = new_poly_p_equal_na_equal(type);
-  d->p_is_missing = new_poly_p_is_missing(type);
+  d->p_is_incomplete = new_poly_p_is_incomplete(type);
 
   d->used = 0;
 
@@ -157,9 +157,9 @@ uint32_t dict_hash_scalar(struct dictionary* d, R_len_t i) {
   return dict_hash_with(d, d, i);
 }
 
-bool dict_is_missing(struct dictionary* d, R_len_t i) {
+bool dict_is_incomplete(struct dictionary* d, R_len_t i) {
   return d->hash[i] == HASH_MISSING &&
-    d->p_is_missing(d->p_poly_vec->p_vec, i);
+    d->p_is_incomplete(d->p_poly_vec->p_vec, i);
 }
 
 
@@ -441,7 +441,7 @@ static inline void vec_match_loop_propagate(int* p_out,
                                             struct dictionary* d_needles,
                                             R_len_t n_needle) {
   for (R_len_t i = 0; i < n_needle; ++i) {
-    if (dict_is_missing(d_needles, i)) {
+    if (dict_is_incomplete(d_needles, i)) {
       p_out[i] = NA_INTEGER;
       continue;
     }
@@ -519,7 +519,7 @@ SEXP vctrs_in(SEXP needles, SEXP haystack, SEXP na_equal_, SEXP frame) {
   bool propagate = !na_equal;
 
   for (int i = 0; i < n_needle; ++i) {
-    if (propagate && dict_is_missing(d_needles, i)) {
+    if (propagate && dict_is_incomplete(d_needles, i)) {
       p_out[i] = NA_LOGICAL;
     } else {
       uint32_t hash = dict_hash_with(d, d_needles, i);

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -13,7 +13,7 @@ struct dictionary {
   SEXP protect;
 
   poly_binary_int_fn_ptr p_equal_na_equal;
-  poly_unary_bool_fn_ptr p_is_missing;
+  poly_unary_bool_fn_ptr p_is_incomplete;
   struct poly_vec* p_poly_vec;
 
   uint32_t* hash;
@@ -60,6 +60,6 @@ struct dictionary* new_dictionary_partial(SEXP x);
 uint32_t dict_hash_scalar(struct dictionary* d, R_len_t i);
 uint32_t dict_hash_with(struct dictionary* d, struct dictionary* x, R_len_t i);
 
-bool dict_is_missing(struct dictionary* d, R_len_t i);
+bool dict_is_incomplete(struct dictionary* d, R_len_t i);
 
 void dict_put(struct dictionary* d, uint32_t k, R_len_t i);

--- a/src/poly-op.c
+++ b/src/poly-op.c
@@ -49,10 +49,10 @@ int p_df_equal_na_equal(const void* x, r_ssize i, const void* y, r_ssize j) {
 
 // -----------------------------------------------------------------------------
 
-static bool p_df_is_missing(const void* x, r_ssize i);
+static bool p_df_is_incomplete(const void* x, r_ssize i);
 
 // [[ include("poly-op.h") ]]
-poly_unary_bool_fn_ptr new_poly_p_is_missing(enum vctrs_type type) {
+poly_unary_bool_fn_ptr new_poly_p_is_incomplete(enum vctrs_type type) {
   switch (type) {
   case vctrs_type_null: return p_nil_is_missing;
   case vctrs_type_logical: return p_lgl_is_missing;
@@ -62,13 +62,13 @@ poly_unary_bool_fn_ptr new_poly_p_is_missing(enum vctrs_type type) {
   case vctrs_type_character: return p_chr_is_missing;
   case vctrs_type_raw: return p_raw_is_missing;
   case vctrs_type_list: return p_list_is_missing;
-  case vctrs_type_dataframe: return p_df_is_missing;
-  default: stop_unimplemented_vctrs_type("new_poly_p_is_missing", type);
+  case vctrs_type_dataframe: return p_df_is_incomplete;
+  default: stop_unimplemented_vctrs_type("new_poly_p_is_incomplete", type);
   }
 }
 
 static
-bool p_df_is_missing(const void* x, r_ssize i) {
+bool p_df_is_incomplete(const void* x, r_ssize i) {
   struct poly_df_data* x_data = (struct poly_df_data*) x;
 
   enum vctrs_type* v_col_type = x_data->v_col_type;

--- a/src/poly-op.c
+++ b/src/poly-op.c
@@ -75,6 +75,8 @@ bool p_df_is_incomplete(const void* x, r_ssize i) {
   const void** v_col_ptr = x_data->v_col_ptr;
   r_ssize n_col = x_data->n_col;
 
+  // df-cols should already be flattened,
+  // so we only need missingness of each column, not completeness
   for (r_ssize col = 0; col < n_col; ++col) {
     if (p_is_missing(v_col_ptr[col], i, v_col_type[col])) {
       return true;

--- a/src/poly-op.h
+++ b/src/poly-op.h
@@ -7,7 +7,7 @@ typedef int (*poly_binary_int_fn_ptr)(const void* x, r_ssize i, const void* y, r
 poly_binary_int_fn_ptr new_poly_p_equal_na_equal(enum vctrs_type type);
 
 typedef bool (*poly_unary_bool_fn_ptr)(const void* x, r_ssize i);
-poly_unary_bool_fn_ptr new_poly_p_is_missing(enum vctrs_type type);
+poly_unary_bool_fn_ptr new_poly_p_is_incomplete(enum vctrs_type type);
 
 struct poly_df_data {
   enum vctrs_type* v_col_type;


### PR DESCRIPTION
The data frame handling here aligns with the idea of completeness, not missingness. I wanted to add a poly function for true missingness, but this was in the way.

I think this also makes it clearer that `vec_match()` and `vec_in()` work off completeness to decide whether or not to propagate an `NA` into the result