### PR TITLE
Implement unexported interval merge helpers

### DIFF
--- a/R/interval.R
+++ b/R/interval.R
@@ -1,0 +1,111 @@
+#' Merge intervals
+#'
+#' @description
+#' These functions are used to merge overlaps present within a set of vector
+#' intervals. They take a parallel set of `start` and `end` vectors of any type
+#' that define the bounds of the intervals.
+#'
+#' - `vec_locate_interval_merge_bounds()` returns locations to slice `start`
+#' and `end` with to generate the set of intervals that remain after all
+#' overlaps are merged.
+#'
+#' - `vec_locate_interval_merge_groups()` returns a two column data frame
+#' with a `key` column containing the result of
+#' `vec_locate_interval_merge_bounds()` and a `loc` list-column containing
+#' integer vectors that map each original interval to one of the resulting
+#' merge bounds.
+#'
+#' These functions require that `start < end`. Additionally, intervals are
+#' treated as if they are right-open, i.e. `[start, end)`.
+#'
+#' @param start,end
+#'   A pair of vectors representing the starts and ends of the intervals.
+#'
+#'   It is required that `start < end`.
+#'
+#'   `start` and `end` will be cast to their common type, and must have the same
+#'   size.
+#'
+#' @param abutting
+#'   A single logical controlling whether or not abutting intervals should be
+#'   merged together. If `TRUE`, `[a, b)` and `[b, c)` will be merged.
+#'
+#' @param incomplete
+#'   Merging of missing and [incomplete][vec_detect_complete] intervals. An
+#'   interval is considered incomplete if either `start` or `end` contain any
+#'   missing values.
+#'
+#'   - `"merge"`: Merge all incomplete intervals together. The bound location
+#'   returned for an incomplete interval is `NA`.
+#'
+#'   - `"drop"`: Drop incomplete intervals from the result.
+#'
+#'   - `"error"`: Error if any incomplete intervals are detected.
+#'
+#' @return
+#' - `vec_locate_interval_merge_bounds()` returns a data frame with two columns,
+#' `start` and `end`, both of which are integer vectors.
+#'
+#' - `vec_locate_interval_merge_groups()` returns a data frame with two columns,
+#' `key` and `loc`. `key` contains the result of
+#' `vec_locate_interval_merge_bounds()` and `loc` is a list of integer vectors.
+#'
+#' @name interval-merge
+#'
+#' @examples
+#' bounds <- data_frame(
+#'   start = c(1, 2, NA, 5, 6, 9, 12),
+#'   end = c(5, 3, 2, 6, NA, 12, 14)
+#' )
+#' bounds
+#'
+#' # Locate the bounds that will generate the merged intervals
+#' loc <- vec_locate_interval_merge_bounds(bounds$start, bounds$end)
+#' loc
+#'
+#' # Notice that the incomplete intervals are standardized in the merged result
+#' data_frame(
+#'   start = vec_slice(bounds$start, loc$start),
+#'   end = vec_slice(bounds$end, loc$end)
+#' )
+#'
+#' # You can choose not to merge abutting intervals if you want to retain
+#' # those boundaries
+#' loc <- vec_locate_interval_merge_bounds(
+#'   bounds$start,
+#'   bounds$end,
+#'   abutting = FALSE
+#' )
+#'
+#' data_frame(
+#'   start = vec_slice(bounds$start, loc$start),
+#'   end = vec_slice(bounds$end, loc$end)
+#' )
+#'
+#' # You can also locate the merge groups, which allow you to map each original
+#' # interval to its corresponding merged interval
+#' vec_locate_interval_merge_groups(bounds$start, bounds$end)
+#'
+#' @noRd
+NULL
+
+# ------------------------------------------------------------------------------
+
+vec_locate_interval_merge_bounds <- function(start,
+                                             end,
+                                             ...,
+                                             abutting = TRUE,
+                                             incomplete = "merge") {
+  check_dots_empty0(...)
+  .Call(ffi_locate_interval_merge_bounds, start, end, abutting, incomplete)
+}
+
+vec_locate_interval_merge_groups <- function(start,
+                                             end,
+                                             ...,
+                                             abutting = TRUE,
+                                             incomplete = "merge") {
+  check_dots_empty0(...)
+  .Call(ffi_locate_interval_merge_groups, start, end, abutting, incomplete)
+}
+

--- a/R/interval.R
+++ b/R/interval.R
@@ -51,6 +51,13 @@
 #'   A single logical controlling whether or not abutting intervals should be
 #'   merged together. If `TRUE`, `[a, b)` and `[b, c)` will be merged.
 #'
+#' @param missing
+#'   Handling of missing intervals.
+#'
+#'   - `"merge"`: Merge all missing intervals together.
+#'
+#'   - `"drop"`: Drop all missing intervals from the result.
+#'
 #' @return
 #' - `vec_locate_interval_merge_bounds()` returns a data frame with two columns,
 #' `start` and `end`, both of which are integer vectors.
@@ -90,6 +97,19 @@
 #'   end = vec_slice(bounds$end, loc$end)
 #' )
 #'
+#' # You can also choose to drop all missing intervals if you don't consider
+#' # them part of the merged result
+#' loc <- vec_locate_interval_merge_bounds(
+#'   bounds$start,
+#'   bounds$end,
+#'   missing = "drop"
+#' )
+#'
+#' data_frame(
+#'   start = vec_slice(bounds$start, loc$start),
+#'   end = vec_slice(bounds$end, loc$end)
+#' )
+#'
 #' # You can also locate the merge groups, which allow you to map each original
 #' # interval to its corresponding merged interval
 #' vec_locate_interval_merge_groups(bounds$start, bounds$end)
@@ -102,17 +122,19 @@ NULL
 vec_locate_interval_merge_bounds <- function(start,
                                              end,
                                              ...,
-                                             abutting = TRUE) {
+                                             abutting = TRUE,
+                                             missing = "merge") {
   check_dots_empty0(...)
-  .Call(ffi_locate_interval_merge_bounds, start, end, abutting)
+  .Call(ffi_locate_interval_merge_bounds, start, end, abutting, missing)
 }
 
 vec_locate_interval_merge_groups <- function(start,
                                              end,
                                              ...,
-                                             abutting = TRUE) {
+                                             abutting = TRUE,
+                                             missing = "merge") {
   check_dots_empty0(...)
-  .Call(ffi_locate_interval_merge_groups, start, end, abutting)
+  .Call(ffi_locate_interval_merge_groups, start, end, abutting, missing)
 }
 
 # ------------------------------------------------------------------------------
@@ -131,23 +153,27 @@ vec_locate_interval_merge_groups <- function(start,
 exp_vec_locate_interval_merge_bounds <- function(start,
                                                  end,
                                                  ...,
-                                                 abutting = TRUE) {
+                                                 abutting = TRUE,
+                                                 missing = "merge") {
   vec_locate_interval_merge_bounds(
     start = start,
     end = end,
     ...,
-    abutting = abutting
+    abutting = abutting,
+    missing = missing
   )
 }
 
 exp_vec_locate_interval_merge_groups <- function(start,
                                                  end,
                                                  ...,
-                                                 abutting = TRUE) {
+                                                 abutting = TRUE,
+                                                 missing = "merge") {
   vec_locate_interval_merge_groups(
     start = start,
     end = end,
     ...,
-    abutting = abutting
+    abutting = abutting,
+    missing = missing
   )
 }

--- a/R/interval.R
+++ b/R/interval.R
@@ -109,3 +109,43 @@ vec_locate_interval_merge_groups <- function(start,
   .Call(ffi_locate_interval_merge_groups, start, end, abutting, incomplete)
 }
 
+# ------------------------------------------------------------------------------
+
+# Experimental shims of interval functions used by other packages (mainly, iv).
+#
+# This gives us the freedom to experiment with the signature of these functions
+# while being backwards compatible with iv in the meantime.
+#
+# We can remove these after:
+# - The interval functions are exported
+# - iv updates to use them directly
+# - A short deprecation period goes by that allows users time to update their
+#   version of iv
+
+exp_vec_locate_interval_merge_bounds <- function(start,
+                                                 end,
+                                                 ...,
+                                                 abutting = TRUE,
+                                                 incomplete = "merge") {
+  vec_locate_interval_merge_bounds(
+    start = start,
+    end = end,
+    ...,
+    abutting = abutting,
+    incomplete = incomplete
+  )
+}
+
+exp_vec_locate_interval_merge_groups <- function(start,
+                                                 end,
+                                                 ...,
+                                                 abutting = TRUE,
+                                                 incomplete = "merge") {
+  vec_locate_interval_merge_groups(
+    start = start,
+    end = end,
+    ...,
+    abutting = abutting,
+    incomplete = incomplete
+  )
+}

--- a/src/compare.c
+++ b/src/compare.c
@@ -29,10 +29,8 @@ do {                                                    \
 }                                                       \
 while (0)
 
-// [[ register() ]]
-SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal_) {
-  bool na_equal = r_bool_as_int(na_equal_);
-
+// [[ include("compare.h") ]]
+SEXP vec_compare(SEXP x, SEXP y, bool na_equal) {
   R_len_t size = vec_size(x);
 
   enum vctrs_type type = vec_proxy_typeof(x);
@@ -55,9 +53,9 @@ SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal_) {
     case vctrs_type_integer:   COMPARE(int, INTEGER_RO, int_compare_na_equal);
     case vctrs_type_double:    COMPARE(double, REAL_RO, dbl_compare_na_equal);
     case vctrs_type_character: COMPARE(SEXP, STRING_PTR_RO, chr_compare_na_equal);
-    case vctrs_type_scalar:    r_abort("Can't compare scalars with `vctrs_compare()`");
-    case vctrs_type_list:      r_abort("Can't compare lists with `vctrs_compare()`");
-    default:                   stop_unimplemented_vctrs_type("vctrs_compare", type);
+    case vctrs_type_scalar:    r_abort("Can't compare scalars with `vec_compare()`");
+    case vctrs_type_list:      r_abort("Can't compare lists with `vec_compare()`");
+    default:                   stop_unimplemented_vctrs_type("vec_compare", type);
     }
   } else {
     switch (type) {
@@ -65,14 +63,20 @@ SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal_) {
     case vctrs_type_integer:   COMPARE(int, INTEGER_RO, int_compare_na_propagate);
     case vctrs_type_double:    COMPARE(double, REAL_RO, dbl_compare_na_propagate);
     case vctrs_type_character: COMPARE(SEXP, STRING_PTR_RO, chr_compare_na_propagate);
-    case vctrs_type_scalar:    r_abort("Can't compare scalars with `vctrs_compare()`");
-    case vctrs_type_list:      r_abort("Can't compare lists with `vctrs_compare()`");
-    default:                   stop_unimplemented_vctrs_type("vctrs_compare", type);
+    case vctrs_type_scalar:    r_abort("Can't compare scalars with `vec_compare()`");
+    case vctrs_type_list:      r_abort("Can't compare lists with `vec_compare()`");
+    default:                   stop_unimplemented_vctrs_type("vec_compare", type);
     }
   }
 }
 
 #undef COMPARE
+
+// [[ register() ]]
+SEXP vctrs_compare(SEXP x, SEXP y, SEXP na_equal) {
+  const bool c_na_equal = r_bool_as_int(na_equal);
+  return vec_compare(x, y, c_na_equal);
+}
 
 // -----------------------------------------------------------------------------
 

--- a/src/compare.h
+++ b/src/compare.h
@@ -7,6 +7,10 @@
 
 // -----------------------------------------------------------------------------
 
+SEXP vec_compare(SEXP x, SEXP y, bool na_equal);
+
+// -----------------------------------------------------------------------------
+
 // https://stackoverflow.com/questions/10996418
 static inline
 int int_compare_scalar(int x, int y) {

--- a/src/decl/interval-decl.h
+++ b/src/decl/interval-decl.h
@@ -8,10 +8,6 @@ static struct vctrs_arg* const args_end = &args_end_;
 static r_obj* vec_locate_interval_merge_info(r_obj* start,
                                              r_obj* end,
                                              bool abutting,
-                                             enum vctrs_interval_incomplete incomplete,
                                              bool groups);
 
-static inline r_obj* interval_order(r_obj* complete, r_obj* start, r_obj* end);
-static inline r_obj* interval_detect_complete(r_obj* start, r_obj* end);
-
-static inline enum vctrs_interval_incomplete parse_incomplete(r_obj* incomplete);
+static inline r_obj* interval_order(r_obj* start, r_obj* end, r_ssize size);

--- a/src/decl/interval-decl.h
+++ b/src/decl/interval-decl.h
@@ -8,6 +8,11 @@ static struct vctrs_arg* const args_end = &args_end_;
 static r_obj* vec_locate_interval_merge_info(r_obj* start,
                                              r_obj* end,
                                              bool abutting,
+                                             enum vctrs_interval_missing missing,
                                              bool groups);
 
-static inline r_obj* interval_order(r_obj* start, r_obj* end, r_ssize size);
+static inline
+r_obj* interval_order(r_obj* start, r_obj* end, r_ssize size);
+
+static inline
+enum vctrs_interval_missing parse_missing(r_obj* missing);

--- a/src/decl/interval-decl.h
+++ b/src/decl/interval-decl.h
@@ -1,0 +1,17 @@
+// Initialized at load time
+struct vctrs_arg args_start_;
+static struct vctrs_arg* const args_start = &args_start_;
+
+struct vctrs_arg args_end_;
+static struct vctrs_arg* const args_end = &args_end_;
+
+static r_obj* vec_locate_interval_merge_info(r_obj* start,
+                                             r_obj* end,
+                                             bool abutting,
+                                             enum vctrs_interval_incomplete incomplete,
+                                             bool groups);
+
+static inline r_obj* interval_order(r_obj* complete, r_obj* start, r_obj* end);
+static inline r_obj* interval_detect_complete(r_obj* start, r_obj* end);
+
+static inline enum vctrs_interval_incomplete parse_incomplete(r_obj* incomplete);

--- a/src/init.c
+++ b/src/init.c
@@ -140,8 +140,8 @@ extern r_obj* vctrs_is_altrep(r_obj* x);
 extern r_obj* ffi_interleave_indices(r_obj*, r_obj*);
 extern r_obj* ffi_compute_nesting_container_info(r_obj*, r_obj*);
 extern r_obj* ffi_locate_matches(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
-extern r_obj* ffi_locate_interval_merge_bounds(r_obj*, r_obj*, r_obj*, r_obj*);
-extern r_obj* ffi_locate_interval_merge_groups(r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_locate_interval_merge_bounds(r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_locate_interval_merge_groups(r_obj*, r_obj*, r_obj*);
 
 
 // Maturing
@@ -303,8 +303,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"ffi_interleave_indices",                (DL_FUNC) &ffi_interleave_indices, 2},
   {"ffi_compute_nesting_container_info",    (DL_FUNC) &ffi_compute_nesting_container_info, 2},
   {"ffi_locate_matches",                    (DL_FUNC) &ffi_locate_matches, 12},
-  {"ffi_locate_interval_merge_bounds",      (DL_FUNC) &ffi_locate_interval_merge_bounds, 4},
-  {"ffi_locate_interval_merge_groups",      (DL_FUNC) &ffi_locate_interval_merge_groups, 4},
+  {"ffi_locate_interval_merge_bounds",      (DL_FUNC) &ffi_locate_interval_merge_bounds, 3},
+  {"ffi_locate_interval_merge_groups",      (DL_FUNC) &ffi_locate_interval_merge_groups, 3},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -140,8 +140,8 @@ extern r_obj* vctrs_is_altrep(r_obj* x);
 extern r_obj* ffi_interleave_indices(r_obj*, r_obj*);
 extern r_obj* ffi_compute_nesting_container_info(r_obj*, r_obj*);
 extern r_obj* ffi_locate_matches(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
-extern r_obj* ffi_locate_interval_merge_bounds(r_obj*, r_obj*, r_obj*);
-extern r_obj* ffi_locate_interval_merge_groups(r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_locate_interval_merge_bounds(r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_locate_interval_merge_groups(r_obj*, r_obj*, r_obj*, r_obj*);
 
 
 // Maturing
@@ -303,8 +303,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"ffi_interleave_indices",                (DL_FUNC) &ffi_interleave_indices, 2},
   {"ffi_compute_nesting_container_info",    (DL_FUNC) &ffi_compute_nesting_container_info, 2},
   {"ffi_locate_matches",                    (DL_FUNC) &ffi_locate_matches, 12},
-  {"ffi_locate_interval_merge_bounds",      (DL_FUNC) &ffi_locate_interval_merge_bounds, 3},
-  {"ffi_locate_interval_merge_groups",      (DL_FUNC) &ffi_locate_interval_merge_groups, 3},
+  {"ffi_locate_interval_merge_bounds",      (DL_FUNC) &ffi_locate_interval_merge_bounds, 4},
+  {"ffi_locate_interval_merge_groups",      (DL_FUNC) &ffi_locate_interval_merge_groups, 4},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -140,6 +140,8 @@ extern r_obj* vctrs_is_altrep(r_obj* x);
 extern r_obj* ffi_interleave_indices(r_obj*, r_obj*);
 extern r_obj* ffi_compute_nesting_container_info(r_obj*, r_obj*);
 extern r_obj* ffi_locate_matches(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_locate_interval_merge_bounds(r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_locate_interval_merge_groups(r_obj*, r_obj*, r_obj*, r_obj*);
 
 
 // Maturing
@@ -301,6 +303,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"ffi_interleave_indices",                (DL_FUNC) &ffi_interleave_indices, 2},
   {"ffi_compute_nesting_container_info",    (DL_FUNC) &ffi_compute_nesting_container_info, 2},
   {"ffi_locate_matches",                    (DL_FUNC) &ffi_locate_matches, 12},
+  {"ffi_locate_interval_merge_bounds",      (DL_FUNC) &ffi_locate_interval_merge_bounds, 4},
+  {"ffi_locate_interval_merge_groups",      (DL_FUNC) &ffi_locate_interval_merge_groups, 4},
   {NULL, NULL, 0}
 };
 
@@ -359,6 +363,7 @@ void vctrs_init_bind(SEXP ns);
 void vctrs_init_cast(SEXP ns);
 void vctrs_init_data(SEXP ns);
 void vctrs_init_dictionary(SEXP ns);
+void vctrs_init_interval(r_obj* ns);
 void vctrs_init_match(r_obj* ns);
 void vctrs_init_names(SEXP ns);
 void vctrs_init_proxy_restore(SEXP ns);
@@ -384,6 +389,7 @@ r_obj* vctrs_init_library(r_obj* ns) {
   vctrs_init_cast(ns);
   vctrs_init_data(ns);
   vctrs_init_dictionary(ns);
+  vctrs_init_interval(ns);
   vctrs_init_match(ns);
   vctrs_init_names(ns);
   vctrs_init_proxy_restore(ns);

--- a/src/interval.c
+++ b/src/interval.c
@@ -1,15 +1,7 @@
 #include "vctrs.h"
 #include "order.h"
-#include "compare.h"
-#include "complete.h"
 #include "translate.h"
 #include "poly-op.h"
-
-enum vctrs_interval_incomplete {
-  VCTRS_INTERVAL_INCOMPLETE_merge = 0,
-  VCTRS_INTERVAL_INCOMPLETE_drop = 1,
-  VCTRS_INTERVAL_INCOMPLETE_error = 2
-};
 
 #include "decl/interval-decl.h"
 
@@ -18,30 +10,25 @@ enum vctrs_interval_incomplete {
 // [[ register() ]]
 r_obj* ffi_locate_interval_merge_bounds(r_obj* start,
                                         r_obj* end,
-                                        r_obj* ffi_abutting,
-                                        r_obj* ffi_incomplete) {
+                                        r_obj* ffi_abutting) {
   const bool abutting = r_arg_as_bool(ffi_abutting, "abutting");
-  const enum vctrs_interval_incomplete incomplete = parse_incomplete(ffi_incomplete);
   const bool groups = false;
-  return vec_locate_interval_merge_info(start, end, abutting, incomplete, groups);
+  return vec_locate_interval_merge_info(start, end, abutting, groups);
 }
 
 // [[ register() ]]
 r_obj* ffi_locate_interval_merge_groups(r_obj* start,
                                         r_obj* end,
-                                        r_obj* ffi_abutting,
-                                        r_obj* ffi_incomplete) {
+                                        r_obj* ffi_abutting) {
   const bool abutting = r_arg_as_bool(ffi_abutting, "abutting");
-  const enum vctrs_interval_incomplete incomplete = parse_incomplete(ffi_incomplete);
   const bool groups = true;
-  return vec_locate_interval_merge_info(start, end, abutting, incomplete, groups);
+  return vec_locate_interval_merge_info(start, end, abutting, groups);
 }
 
 static
 r_obj* vec_locate_interval_merge_info(r_obj* start,
                                       r_obj* end,
                                       bool abutting,
-                                      enum vctrs_interval_incomplete incomplete,
                                       bool groups) {
   int n_prot = 0;
 
@@ -93,6 +80,7 @@ r_obj* vec_locate_interval_merge_info(r_obj* start,
   const void* p_end = p_poly_end->p_vec;
 
   const poly_binary_int_fn_ptr fn_compare = new_poly_p_compare_na_equal(type_proxy);
+  const poly_unary_bool_fn_ptr fn_is_missing = new_poly_p_is_missing(type_proxy);
 
   const r_ssize size = vec_size(start_proxy);
 
@@ -100,46 +88,11 @@ r_obj* vec_locate_interval_merge_info(r_obj* start,
     r_abort("`start` and `end` must have the same size.");
   }
 
-  /*
-   * NA == (either incomplete), possibly allowed, but we don't check that here
-   * -1 == (start < end), typical case
-   * 0  == (start == end), not allowed (empty interval)
-   * 1  == (start > end), not allowed
-   *
-   * Comparison loop relies on `NA` being the smallest integer value, so it
-   * isn't flagged as being `>= 0`.
-   */
-  r_obj* compare = KEEP_N(vec_compare(start_proxy, end_proxy, false), &n_prot);
-  const int* v_compare = r_int_cbegin(compare);
-
-  for (r_ssize i = 0; i < size; ++i) {
-    if (v_compare[i] >= 0) {
-      r_abort("`start` must be less than `end`.");
-    }
-  }
-
-  /*
-   * Joint completeness is used to determine how incomplete intervals should
-   * be handled.
-   *
-   * We can't rely on the `NA`s produced by `vec_compare(na_equal = false)`,
-   * because that only propagates an `NA` if the comparison hits a missing
-   * value before it can be finalized.
-   * i.e. this can be finalized early, but we want to treat it as incomplete:
-   * vec_compare(data_frame(x = 1, y = NA), data_frame(x = 2, y = NA))
-   */
-  r_obj* complete = KEEP_N(interval_detect_complete(start, end), &n_prot);
-  const int* v_complete = r_lgl_cbegin(complete);
-
-  r_obj* order = KEEP_N(interval_order(complete, start, end), &n_prot);
+  // Order is computed as ascending order, placing missing intervals up front
+  // as the "smallest" values. We document that we assume that if `start` is
+  // missing, then `end` is missing too.
+  r_obj* order = KEEP_N(interval_order(start_proxy, end_proxy, size), &n_prot);
   const int* v_order = r_int_cbegin(order);
-
-  if (incomplete == VCTRS_INTERVAL_INCOMPLETE_error &&
-      size > 0 &&
-      !v_complete[v_order[0] - 1]) {
-      // Incomplete intervals will be at the front of `order`
-      r_abort("`start` and `end` can't contain missing values.");
-  }
 
   // Assume the intervals can be merged into half their original size.
   // Apply a minimum size to avoid a size of zero.
@@ -159,19 +112,21 @@ r_obj* vec_locate_interval_merge_info(r_obj* start,
 
   r_ssize i = 0;
 
-  r_ssize loc_order_incomplete_start = 0;
-  r_ssize loc_order_incomplete_end = -1;
+  r_ssize loc_order_missing_start = 0;
+  r_ssize loc_order_missing_end = -1;
 
-  // Move `i` past any incomplete intervals (they are at the front),
-  // recording last incomplete interval location for later
+  // Move `i` past any missing intervals (they are at the front),
+  // recording last missing interval location for later. Only need to check
+  // missingness of `start`, because we document that we assume that `end`
+  // is missing if `start` is missing.
   for (; i < size; ++i) {
     const r_ssize loc = v_order[i] - 1;
 
-    if (v_complete[loc]) {
+    if (!fn_is_missing(p_start, loc)) {
       break;
     }
 
-    loc_order_incomplete_end = i;
+    loc_order_missing_end = i;
   }
 
   r_ssize loc_order_start = 0;
@@ -239,22 +194,22 @@ r_obj* vec_locate_interval_merge_info(r_obj* start,
     }
   }
 
-  if (incomplete == VCTRS_INTERVAL_INCOMPLETE_merge &&
-      loc_order_incomplete_end >= loc_order_incomplete_start) {
-    // Log incomplete interval at the end.
-    // Log with `NA_integer_` as the location so slicing the original
-    // inputs consistently gives missing values.
-    r_dyn_int_push_back(p_loc_start, r_globals.na_int);
-    r_dyn_int_push_back(p_loc_end, r_globals.na_int);
+  if (loc_order_missing_end >= loc_order_missing_start) {
+    // Log missing interval at the end
+    const r_ssize loc_group_missing_start = v_order[loc_order_missing_start] - 1;
+    const r_ssize loc_group_missing_end = v_order[loc_order_missing_end] - 1;
+
+    r_dyn_int_push_back(p_loc_start, loc_group_missing_start + 1);
+    r_dyn_int_push_back(p_loc_end, loc_group_missing_end + 1);
 
     if (groups) {
-      const r_ssize loc_size = loc_order_incomplete_end - loc_order_incomplete_start + 1;
+      const r_ssize loc_size = loc_order_missing_end - loc_order_missing_start + 1;
 
       r_obj* loc = r_new_integer(loc_size);
       r_dyn_list_push_back(p_loc, loc);
       int* v_loc = r_int_begin(loc);
 
-      const int* v_order_start = v_order + loc_order_incomplete_start;
+      const int* v_order_start = v_order + loc_order_missing_start;
       memcpy(v_loc, v_order_start, loc_size * sizeof(*v_loc));
     }
   }
@@ -299,28 +254,25 @@ r_obj* vec_locate_interval_merge_info(r_obj* start,
 
 /*
  * `interval_order()` orders the `start` and `end` values of a vector of
- * intervals, but also groups them by their `complete` value. We sort in
- * ascending order, so we end up with:
- *
- * - Incomplete intervals first (`complete == FALSE`)
- * - Then sorted typical intervals (`complete == TRUE`)
- * - Empty and invalid intervals have already been handled
+ * intervals in ascending order. It places missing intervals at the front.
+ * We document that we make the assumption that if `start` is missing, then
+ * `end` is also missing. We also document the assumption that partially missing
+ * (i.e. incomplete but not missing) observations are not allowed in either
+ * bound.
  */
 static inline
-r_obj* interval_order(r_obj* complete, r_obj* start, r_obj* end) {
+r_obj* interval_order(r_obj* start, r_obj* end, r_ssize size) {
   // Put them in a data frame to compute joint ordering
-  r_obj* df = KEEP(r_new_list(3));
-  r_list_poke(df, 0, complete);
-  r_list_poke(df, 1, start);
-  r_list_poke(df, 2, end);
+  r_obj* df = KEEP(r_new_list(2));
+  r_list_poke(df, 0, start);
+  r_list_poke(df, 1, end);
 
-  r_obj* df_names = r_new_character(3);
+  r_obj* df_names = r_new_character(2);
   r_attrib_poke_names(df, df_names);
-  r_chr_poke(df_names, 0, r_str("complete"));
-  r_chr_poke(df_names, 1, r_str("start"));
-  r_chr_poke(df_names, 2, r_str("end"));
+  r_chr_poke(df_names, 0, r_str("start"));
+  r_chr_poke(df_names, 1, r_str("end"));
 
-  r_init_data_frame(df, r_length(complete));
+  r_init_data_frame(df, size);
 
   const bool nan_distinct = false;
   r_obj* chr_proxy_collate = r_null;
@@ -335,43 +287,6 @@ r_obj* interval_order(r_obj* complete, r_obj* start, r_obj* end) {
 
   FREE(1);
   return out;
-}
-
-static inline
-r_obj* interval_detect_complete(r_obj* start, r_obj* end) {
-  // Put them in a data frame to compute joint completeness
-  r_obj* df = KEEP(r_new_list(2));
-  r_list_poke(df, 0, start);
-  r_list_poke(df, 1, end);
-
-  r_obj* df_names = r_new_character(2);
-  r_attrib_poke_names(df, df_names);
-  r_chr_poke(df_names, 0, r_str("start"));
-  r_chr_poke(df_names, 1, r_str("end"));
-
-  r_init_data_frame(df, vec_size(start));
-
-  r_obj* out = vec_detect_complete(df);
-
-  FREE(1);
-  return out;
-}
-
-// -----------------------------------------------------------------------------
-
-static inline
-enum vctrs_interval_incomplete parse_incomplete(r_obj* incomplete) {
-  if (!r_is_string(incomplete)) {
-    r_abort("`incomplete` must be a string.");
-  }
-
-  const char* c_incomplete = r_chr_get_c_string(incomplete, 0);
-
-  if (!strcmp(c_incomplete, "merge")) return VCTRS_INTERVAL_INCOMPLETE_merge;
-  if (!strcmp(c_incomplete, "drop")) return VCTRS_INTERVAL_INCOMPLETE_drop;
-  if (!strcmp(c_incomplete, "error")) return VCTRS_INTERVAL_INCOMPLETE_error;
-
-  r_abort("`incomplete` must be one of: \"merge\", \"drop\", or \"error\".");
 }
 
 // -----------------------------------------------------------------------------

--- a/src/interval.c
+++ b/src/interval.c
@@ -1,0 +1,382 @@
+#include "vctrs.h"
+#include "order.h"
+#include "compare.h"
+#include "complete.h"
+#include "translate.h"
+#include "poly-op.h"
+
+enum vctrs_interval_incomplete {
+  VCTRS_INTERVAL_INCOMPLETE_merge = 0,
+  VCTRS_INTERVAL_INCOMPLETE_drop = 1,
+  VCTRS_INTERVAL_INCOMPLETE_error = 2
+};
+
+#include "decl/interval-decl.h"
+
+// -----------------------------------------------------------------------------
+
+// [[ register() ]]
+r_obj* ffi_locate_interval_merge_bounds(r_obj* start,
+                                        r_obj* end,
+                                        r_obj* ffi_abutting,
+                                        r_obj* ffi_incomplete) {
+  const bool abutting = r_arg_as_bool(ffi_abutting, "abutting");
+  const enum vctrs_interval_incomplete incomplete = parse_incomplete(ffi_incomplete);
+  const bool groups = false;
+  return vec_locate_interval_merge_info(start, end, abutting, incomplete, groups);
+}
+
+// [[ register() ]]
+r_obj* ffi_locate_interval_merge_groups(r_obj* start,
+                                        r_obj* end,
+                                        r_obj* ffi_abutting,
+                                        r_obj* ffi_incomplete) {
+  const bool abutting = r_arg_as_bool(ffi_abutting, "abutting");
+  const enum vctrs_interval_incomplete incomplete = parse_incomplete(ffi_incomplete);
+  const bool groups = true;
+  return vec_locate_interval_merge_info(start, end, abutting, incomplete, groups);
+}
+
+static
+r_obj* vec_locate_interval_merge_info(r_obj* start,
+                                      r_obj* end,
+                                      bool abutting,
+                                      enum vctrs_interval_incomplete incomplete,
+                                      bool groups) {
+  int n_prot = 0;
+
+  int _;
+  r_obj* ptype = vec_ptype2_params(
+    start,
+    end,
+    args_start,
+    args_end,
+    DF_FALLBACK_quiet,
+    &_
+  );
+  KEEP_N(ptype, &n_prot);
+
+  start = vec_cast_params(
+    start,
+    ptype,
+    args_start,
+    args_empty,
+    DF_FALLBACK_quiet,
+    S3_FALLBACK_false
+  );
+  KEEP_N(start, &n_prot);
+
+  end = vec_cast_params(
+    end,
+    ptype,
+    args_end,
+    args_empty,
+    DF_FALLBACK_quiet,
+    S3_FALLBACK_false
+  );
+  KEEP_N(end, &n_prot);
+
+  r_obj* start_proxy = KEEP_N(vec_proxy_compare(start), &n_prot);
+  start_proxy = KEEP_N(vec_normalize_encoding(start_proxy), &n_prot);
+
+  r_obj* end_proxy = KEEP_N(vec_proxy_compare(end), &n_prot);
+  end_proxy = KEEP_N(vec_normalize_encoding(end_proxy), &n_prot);
+
+  const enum vctrs_type type_proxy = vec_proxy_typeof(start_proxy);
+
+  struct poly_vec* p_poly_start = new_poly_vec(start_proxy, type_proxy);
+  PROTECT_POLY_VEC(p_poly_start, &n_prot);
+  const void* p_start = p_poly_start->p_vec;
+
+  struct poly_vec* p_poly_end = new_poly_vec(end_proxy, type_proxy);
+  PROTECT_POLY_VEC(p_poly_end, &n_prot);
+  const void* p_end = p_poly_end->p_vec;
+
+  const poly_binary_int_fn_ptr fn_compare = new_poly_p_compare_na_equal(type_proxy);
+
+  const r_ssize size = vec_size(start_proxy);
+
+  if (size != vec_size(end_proxy)) {
+    r_abort("`start` and `end` must have the same size.");
+  }
+
+  /*
+   * NA == (either incomplete), possibly allowed, but we don't check that here
+   * -1 == (start < end), typical case
+   * 0  == (start == end), not allowed (empty interval)
+   * 1  == (start > end), not allowed
+   *
+   * Comparison loop relies on `NA` being the smallest integer value, so it
+   * isn't flagged as being `>= 0`.
+   */
+  r_obj* compare = KEEP_N(vec_compare(start_proxy, end_proxy, false), &n_prot);
+  const int* v_compare = r_int_cbegin(compare);
+
+  for (r_ssize i = 0; i < size; ++i) {
+    if (v_compare[i] >= 0) {
+      r_abort("`start` must be less than `end`.");
+    }
+  }
+
+  /*
+   * Joint completeness is used to determine how incomplete intervals should
+   * be handled.
+   *
+   * We can't rely on the `NA`s produced by `vec_compare(na_equal = false)`,
+   * because that only propagates an `NA` if the comparison hits a missing
+   * value before it can be finalized.
+   * i.e. this can be finalized early, but we want to treat it as incomplete:
+   * vec_compare(data_frame(x = 1, y = NA), data_frame(x = 2, y = NA))
+   */
+  r_obj* complete = KEEP_N(interval_detect_complete(start, end), &n_prot);
+  const int* v_complete = r_lgl_cbegin(complete);
+
+  r_obj* order = KEEP_N(interval_order(complete, start, end), &n_prot);
+  const int* v_order = r_int_cbegin(order);
+
+  if (incomplete == VCTRS_INTERVAL_INCOMPLETE_error &&
+      size > 0 &&
+      !v_complete[v_order[0] - 1]) {
+      // Incomplete intervals will be at the front of `order`
+      r_abort("`start` and `end` can't contain missing values.");
+  }
+
+  // Assume the intervals can be merged into half their original size.
+  // Apply a minimum size to avoid a size of zero.
+  const r_ssize initial_size = r_ssize_max(size / 2, 1);
+
+  struct r_dyn_array* p_loc_start = r_new_dyn_vector(R_TYPE_integer, initial_size);
+  KEEP_N(p_loc_start->shelter, &n_prot);
+
+  struct r_dyn_array* p_loc_end = r_new_dyn_vector(R_TYPE_integer, initial_size);
+  KEEP_N(p_loc_end->shelter, &n_prot);
+
+  struct r_dyn_array* p_loc = NULL;
+  if (groups) {
+    p_loc = r_new_dyn_vector(R_TYPE_list, initial_size);
+    KEEP_N(p_loc->shelter, &n_prot);
+  }
+
+  r_ssize i = 0;
+
+  r_ssize loc_order_incomplete_start = 0;
+  r_ssize loc_order_incomplete_end = -1;
+
+  // Move `i` past any incomplete intervals (they are at the front),
+  // recording last incomplete interval location for later
+  for (; i < size; ++i) {
+    const r_ssize loc = v_order[i] - 1;
+
+    if (v_complete[loc]) {
+      break;
+    }
+
+    loc_order_incomplete_end = i;
+  }
+
+  r_ssize loc_order_start = 0;
+  r_ssize loc_order_end = -1;
+
+  r_ssize loc_group_start = 0;
+  r_ssize loc_group_end = -1;
+
+  if (i < size) {
+    // Set information about first usable interval
+    const r_ssize loc = v_order[i] - 1;
+    loc_order_start = i;
+    loc_order_end = i;
+    loc_group_start = loc;
+    loc_group_end = loc;
+    ++i;
+  }
+
+  const int merge_limit = abutting ? -1 : 0;
+
+  for (; i < size; ++i) {
+    const r_ssize loc = v_order[i] - 1;
+
+    // If `abutting`, this says: if group end < new start, finish out the group
+    // If `!abutting`, this says: if group end <= new start, finish out the group
+    if (fn_compare(p_end, loc_group_end, p_start, loc) <= merge_limit) {
+      r_dyn_int_push_back(p_loc_start, loc_group_start + 1);
+      r_dyn_int_push_back(p_loc_end, loc_group_end + 1);
+
+      if (groups) {
+        const r_ssize loc_size = loc_order_end - loc_order_start + 1;
+
+        r_obj* loc = r_new_integer(loc_size);
+        r_dyn_list_push_back(p_loc, loc);
+        int* v_loc = r_int_begin(loc);
+
+        const int* v_order_start = v_order + loc_order_start;
+        memcpy(v_loc, v_order_start, loc_size * sizeof(*v_loc));
+      }
+
+      loc_order_start = loc_order_end + 1;
+      loc_group_start = loc;
+      loc_group_end = loc;
+    } else if (fn_compare(p_end, loc_group_end, p_end, loc) == -1) {
+      loc_group_end = loc;
+    }
+
+    loc_order_end = i;
+  }
+
+  if (loc_order_end >= loc_order_start) {
+    // Log last interval
+    r_dyn_int_push_back(p_loc_start, loc_group_start + 1);
+    r_dyn_int_push_back(p_loc_end, loc_group_end + 1);
+
+    if (groups) {
+      const r_ssize loc_size = loc_order_end - loc_order_start + 1;
+
+      r_obj* loc = r_new_integer(loc_size);
+      r_dyn_list_push_back(p_loc, loc);
+      int* v_loc = r_int_begin(loc);
+
+      const int* v_order_start = v_order + loc_order_start;
+      memcpy(v_loc, v_order_start, loc_size * sizeof(*v_loc));
+    }
+  }
+
+  if (incomplete == VCTRS_INTERVAL_INCOMPLETE_merge &&
+      loc_order_incomplete_end >= loc_order_incomplete_start) {
+    // Log incomplete interval at the end.
+    // Log with `NA_integer_` as the location so slicing the original
+    // inputs consistently gives missing values.
+    r_dyn_int_push_back(p_loc_start, r_globals.na_int);
+    r_dyn_int_push_back(p_loc_end, r_globals.na_int);
+
+    if (groups) {
+      const r_ssize loc_size = loc_order_incomplete_end - loc_order_incomplete_start + 1;
+
+      r_obj* loc = r_new_integer(loc_size);
+      r_dyn_list_push_back(p_loc, loc);
+      int* v_loc = r_int_begin(loc);
+
+      const int* v_order_start = v_order + loc_order_incomplete_start;
+      memcpy(v_loc, v_order_start, loc_size * sizeof(*v_loc));
+    }
+  }
+
+  r_obj* key = KEEP_N(r_new_list(2), &n_prot);
+  r_list_poke(key, 0, r_dyn_unwrap(p_loc_start));
+  r_list_poke(key, 1, r_dyn_unwrap(p_loc_end));
+
+  r_obj* key_names = r_new_character(2);
+  r_attrib_poke_names(key, key_names);
+  r_chr_poke(key_names, 0, r_str("start"));
+  r_chr_poke(key_names, 1, r_str("end"));
+
+  r_init_data_frame(key, p_loc_start->count);
+
+  r_obj* out = r_null;
+  r_keep_loc out_shelter;
+  KEEP_HERE(out, &out_shelter);
+  ++n_prot;
+
+  if (groups) {
+    out = r_new_list(2);
+    KEEP_AT(out, out_shelter);
+    r_list_poke(out, 0, key);
+    r_list_poke(out, 1, r_dyn_unwrap(p_loc));
+
+    r_obj* out_names = r_new_character(2);
+    r_attrib_poke_names(out, out_names);
+    r_chr_poke(out_names, 0, r_str("key"));
+    r_chr_poke(out_names, 1, r_str("loc"));
+
+    r_init_data_frame(out, p_loc_start->count);
+  } else {
+    out = key;
+  }
+
+  FREE(n_prot);
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+
+/*
+ * `interval_order()` orders the `start` and `end` values of a vector of
+ * intervals, but also groups them by their `complete` value. We sort in
+ * ascending order, so we end up with:
+ *
+ * - Incomplete intervals first (`complete == FALSE`)
+ * - Then sorted typical intervals (`complete == TRUE`)
+ * - Empty and invalid intervals have already been handled
+ */
+static inline
+r_obj* interval_order(r_obj* complete, r_obj* start, r_obj* end) {
+  // Put them in a data frame to compute joint ordering
+  r_obj* df = KEEP(r_new_list(3));
+  r_list_poke(df, 0, complete);
+  r_list_poke(df, 1, start);
+  r_list_poke(df, 2, end);
+
+  r_obj* df_names = r_new_character(3);
+  r_attrib_poke_names(df, df_names);
+  r_chr_poke(df_names, 0, r_str("complete"));
+  r_chr_poke(df_names, 1, r_str("start"));
+  r_chr_poke(df_names, 2, r_str("end"));
+
+  r_init_data_frame(df, r_length(complete));
+
+  const bool nan_distinct = false;
+  r_obj* chr_proxy_collate = r_null;
+
+  r_obj* out = vec_order(
+    df,
+    chrs_asc,
+    chrs_smallest,
+    nan_distinct,
+    chr_proxy_collate
+  );
+
+  FREE(1);
+  return out;
+}
+
+static inline
+r_obj* interval_detect_complete(r_obj* start, r_obj* end) {
+  // Put them in a data frame to compute joint completeness
+  r_obj* df = KEEP(r_new_list(2));
+  r_list_poke(df, 0, start);
+  r_list_poke(df, 1, end);
+
+  r_obj* df_names = r_new_character(2);
+  r_attrib_poke_names(df, df_names);
+  r_chr_poke(df_names, 0, r_str("start"));
+  r_chr_poke(df_names, 1, r_str("end"));
+
+  r_init_data_frame(df, vec_size(start));
+
+  r_obj* out = vec_detect_complete(df);
+
+  FREE(1);
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+
+static inline
+enum vctrs_interval_incomplete parse_incomplete(r_obj* incomplete) {
+  if (!r_is_string(incomplete)) {
+    r_abort("`incomplete` must be a string.");
+  }
+
+  const char* c_incomplete = r_chr_get_c_string(incomplete, 0);
+
+  if (!strcmp(c_incomplete, "merge")) return VCTRS_INTERVAL_INCOMPLETE_merge;
+  if (!strcmp(c_incomplete, "drop")) return VCTRS_INTERVAL_INCOMPLETE_drop;
+  if (!strcmp(c_incomplete, "error")) return VCTRS_INTERVAL_INCOMPLETE_error;
+
+  r_abort("`incomplete` must be one of: \"merge\", \"drop\", or \"error\".");
+}
+
+// -----------------------------------------------------------------------------
+
+void vctrs_init_interval(r_obj* ns) {
+  args_start_ = new_wrapper_arg(NULL, "start");
+  args_end_ = new_wrapper_arg(NULL, "end");
+}

--- a/src/poly-op.c
+++ b/src/poly-op.c
@@ -100,6 +100,44 @@ int p_df_compare_na_equal(const void* x, r_ssize i, const void* y, r_ssize j) {
 
 // -----------------------------------------------------------------------------
 
+static bool p_df_is_missing(const void* x, r_ssize i);
+
+// [[ include("poly-op.h") ]]
+poly_unary_bool_fn_ptr new_poly_p_is_missing(enum vctrs_type type) {
+  switch (type) {
+  case vctrs_type_null: return p_nil_is_missing;
+  case vctrs_type_logical: return p_lgl_is_missing;
+  case vctrs_type_integer: return p_int_is_missing;
+  case vctrs_type_double: return p_dbl_is_missing;
+  case vctrs_type_complex: return p_cpl_is_missing;
+  case vctrs_type_character: return p_chr_is_missing;
+  case vctrs_type_raw: return p_raw_is_missing;
+  case vctrs_type_list: return p_list_is_missing;
+  case vctrs_type_dataframe: return p_df_is_missing;
+  default: stop_unimplemented_vctrs_type("new_poly_p_is_missing", type);
+  }
+}
+
+static
+bool p_df_is_missing(const void* x, r_ssize i) {
+  struct poly_df_data* x_data = (struct poly_df_data*) x;
+
+  enum vctrs_type* v_col_type = x_data->v_col_type;
+  const void** v_col_ptr = x_data->v_col_ptr;
+  r_ssize n_col = x_data->n_col;
+
+  // df-cols should already be flattened
+  for (r_ssize col = 0; col < n_col; ++col) {
+    if (!p_is_missing(v_col_ptr[col], i, v_col_type[col])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+
 static bool p_df_is_incomplete(const void* x, r_ssize i);
 
 // [[ include("poly-op.h") ]]

--- a/src/poly-op.h
+++ b/src/poly-op.h
@@ -8,6 +8,7 @@ poly_binary_int_fn_ptr new_poly_p_equal_na_equal(enum vctrs_type type);
 poly_binary_int_fn_ptr new_poly_p_compare_na_equal(enum vctrs_type type);
 
 typedef bool (*poly_unary_bool_fn_ptr)(const void* x, r_ssize i);
+poly_unary_bool_fn_ptr new_poly_p_is_missing(enum vctrs_type type);
 poly_unary_bool_fn_ptr new_poly_p_is_incomplete(enum vctrs_type type);
 
 struct poly_df_data {

--- a/src/poly-op.h
+++ b/src/poly-op.h
@@ -5,6 +5,7 @@
 
 typedef int (*poly_binary_int_fn_ptr)(const void* x, r_ssize i, const void* y, r_ssize j);
 poly_binary_int_fn_ptr new_poly_p_equal_na_equal(enum vctrs_type type);
+poly_binary_int_fn_ptr new_poly_p_compare_na_equal(enum vctrs_type type);
 
 typedef bool (*poly_unary_bool_fn_ptr)(const void* x, r_ssize i);
 poly_unary_bool_fn_ptr new_poly_p_is_incomplete(enum vctrs_type type);

--- a/tests/testthat/_snaps/interval.md
+++ b/tests/testthat/_snaps/interval.md
@@ -1,3 +1,22 @@
+# `missing` is validated
+
+    Code
+      (expect_error(vec_locate_interval_merge_groups(1, 2, missing = "s")))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_interval_merge_groups()`:
+      ! `missing` must be either "merge" or "drop".
+
+---
+
+    Code
+      (expect_error(vec_locate_interval_merge_groups(1, 2, missing = c("merge",
+        "drop"))))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_interval_merge_groups()`:
+      ! `missing` must be a string.
+
 # common type is taken
 
     Code

--- a/tests/testthat/_snaps/interval.md
+++ b/tests/testthat/_snaps/interval.md
@@ -1,39 +1,3 @@
-# incomplete intervals can cause an error
-
-    Code
-      (expect_error(vec_locate_interval_merge_groups(NA, NA, incomplete = "error")))
-    Output
-      <error/rlang_error>
-      Error in `vec_locate_interval_merge_groups()`:
-      ! `start` and `end` can't contain missing values.
-    Code
-      (expect_error(vec_locate_interval_merge_groups(1, NA, incomplete = "error")))
-    Output
-      <error/rlang_error>
-      Error in `vec_locate_interval_merge_groups()`:
-      ! `start` and `end` can't contain missing values.
-    Code
-      (expect_error(vec_locate_interval_merge_groups(NA, 1, incomplete = "error")))
-    Output
-      <error/rlang_error>
-      Error in `vec_locate_interval_merge_groups()`:
-      ! `start` and `end` can't contain missing values.
-
-# empty and invalid intervals cause an error
-
-    Code
-      (expect_error(vec_locate_interval_merge_groups(1, 1)))
-    Output
-      <error/rlang_error>
-      Error in `vec_locate_interval_merge_groups()`:
-      ! `start` must be less than `end`.
-    Code
-      (expect_error(vec_locate_interval_merge_groups(1, 0)))
-    Output
-      <error/rlang_error>
-      Error in `vec_locate_interval_merge_groups()`:
-      ! `start` must be less than `end`.
-
 # common type is taken
 
     Code

--- a/tests/testthat/_snaps/interval.md
+++ b/tests/testthat/_snaps/interval.md
@@ -1,0 +1,45 @@
+# incomplete intervals can cause an error
+
+    Code
+      (expect_error(vec_locate_interval_merge_groups(NA, NA, incomplete = "error")))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_interval_merge_groups()`:
+      ! `start` and `end` can't contain missing values.
+    Code
+      (expect_error(vec_locate_interval_merge_groups(1, NA, incomplete = "error")))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_interval_merge_groups()`:
+      ! `start` and `end` can't contain missing values.
+    Code
+      (expect_error(vec_locate_interval_merge_groups(NA, 1, incomplete = "error")))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_interval_merge_groups()`:
+      ! `start` and `end` can't contain missing values.
+
+# empty and invalid intervals cause an error
+
+    Code
+      (expect_error(vec_locate_interval_merge_groups(1, 1)))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_interval_merge_groups()`:
+      ! `start` must be less than `end`.
+    Code
+      (expect_error(vec_locate_interval_merge_groups(1, 0)))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_interval_merge_groups()`:
+      ! `start` must be less than `end`.
+
+# common type is taken
+
+    Code
+      (expect_error(vec_locate_interval_merge_groups(1, "x")))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error:
+      ! Can't combine `start` <double> and `end` <character>.
+

--- a/tests/testthat/test-interval.R
+++ b/tests/testthat/test-interval.R
@@ -31,25 +31,26 @@ test_that("can locate bounds with size zero input", {
   )
 })
 
-test_that("incomplete intervals are retained by default, but can be dropped", {
+test_that("incomplete intervals are retained", {
   x <- data_frame(start = NA, end = NA)
 
   expect_identical(
     vec_locate_interval_merge_bounds(x$start, x$end),
-    data_frame(start = NA_integer_, end = NA_integer_)
+    data_frame(start = 1L, end = 1L)
   )
+
+  x <- data_frame(start = c(NA, NA), end = c(NA, NA))
 
   expect_identical(
-    vec_locate_interval_merge_bounds(x$start, x$end, incomplete = "drop"),
-    data_frame(start = integer(), end = integer())
+    vec_locate_interval_merge_bounds(x$start, x$end),
+    data_frame(start = 1L, end = 2L)
   )
-})
 
-test_that("incomplete intervals don't affect the result if dropped", {
   x <- data_frame(start = c(3, NA, 2, NA), end = c(5, NA, 3, NA))
+
   expect_identical(
-    vec_locate_interval_merge_bounds(x$start, x$end, incomplete = "drop"),
-    data_frame(start = 3L, end = 1L)
+    vec_locate_interval_merge_bounds(x$start, x$end),
+    data_frame(start = c(3L, 2L), end = c(1L, 4L))
   )
 })
 
@@ -123,112 +124,74 @@ test_that("locations are ordered by both `start` and `end`", {
   )
 })
 
-test_that("incomplete intervals are retained by default", {
+test_that("incomplete intervals are retained", {
   x <- data_frame(start = NA, end = NA)
 
   out <- vec_locate_interval_merge_groups(x$start, x$end)
 
   expect_identical(
     out$key,
-    data_frame(start = NA_integer_, end = NA_integer_)
+    data_frame(start = 1L, end = 1L)
   )
   expect_identical(
     out$loc,
     list(1L)
   )
-})
 
-test_that("incomplete intervals can be dropped", {
-  x <- data_frame(start = NA, end = NA)
-
-  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "drop")
-
-  expect_identical(
-    out$key,
-    data_frame(start = integer(), end = integer())
-  )
-  expect_identical(
-    out$loc,
-    list()
-  )
-})
-
-test_that("incomplete intervals can cause an error", {
-  expect_snapshot({
-    (expect_error(vec_locate_interval_merge_groups(NA, NA, incomplete = "error")))
-    (expect_error(vec_locate_interval_merge_groups(1, NA, incomplete = "error")))
-    (expect_error(vec_locate_interval_merge_groups(NA, 1, incomplete = "error")))
-  })
-})
-
-test_that("incomplete intervals don't affect the result if dropped", {
   x <- data_frame(start = c(3, NA, 2, NA), end = c(5, NA, 3, NA))
-
-  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "drop")
-
-  expect_identical(
-    out$key,
-    data_frame(start = 3L, end = 1L)
-  )
-  expect_identical(
-    out$loc,
-    list(c(3L, 1L))
-  )
-})
-
-test_that("can have missings in either input", {
-  x <- data_frame(start = c(1L, NA, 1L), end = c(NA, 1L, 2L))
 
   out <- vec_locate_interval_merge_groups(x$start, x$end)
 
-  expect_identical(out$key, data_frame(start = c(3L, NA), end = c(3L, NA)))
-  expect_identical(out$loc, list(3L, c(2L, 1L)))
-
-  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "drop")
-
-  expect_identical(out$key, data_frame(start = 3L, end = 3L))
-  expect_identical(out$loc, list(3L))
+  expect_identical(
+    out$key,
+    data_frame(start = c(3L, 2L), end = c(1L, 4L))
+  )
+  expect_identical(
+    out$loc,
+    list(c(3L, 1L), c(2L, 4L)),
+  )
 })
 
-test_that("`incomplete = 'merge'` works without any missings", {
-  x <- data_frame(start = c(1, 3), end = c(3, 5))
+test_that("treats NA and NaN as equivalent with doubles", {
+  x <- data_frame(start = c(NA, NaN, NA, NaN), end = c(NA, NA, NaN, NaN))
 
-  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "merge")
+  out <- vec_locate_interval_merge_groups(x, x)
 
-  expect_identical(out$key, data_frame(start = 1L, end = 2L))
-  expect_identical(out$loc, list(c(1L, 2L)))
+  expect_identical(
+    out$key,
+    data_frame(start = 1L, end = 4L)
+  )
+  expect_identical(
+    out$loc,
+    list(1:4),
+  )
 })
 
-test_that("`incomplete = 'merge'` recognizes incomplete rows in data frames", {
-  start <- data_frame(year = c(2019, NA, 2019, 2019, 2019), month = c(12, 11, NA, 12, 12))
-  end <- data_frame(year = c(2020, 2020, 2020, NA, 2020), month = c(2, 11, 11, 11, NA))
+test_that("recognizes missing rows in data frames", {
+  start <- data_frame(year = c(2019, NA, NA, 2019, 2019), month = c(12, NA, NA, 12, 12))
+  end <- data_frame(year = c(2020, NA, NA, 2020, 2020), month = c(2, NA, NA, 11, 12))
   x <- data_frame(start = start, end = end)
 
   out <- vec_locate_interval_merge_groups(x$start, x$end)
 
-  expect_identical(out$key, data_frame(start = c(1L, NA), end = c(1L, NA)))
-  expect_identical(out$loc, list(1L, 2:5))
-
-  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "drop")
-
-  expect_identical(out$key, data_frame(start = 1L, end = 1L))
-  expect_identical(out$loc, list(1L))
+  expect_identical(out$key, data_frame(start = c(1L, 2L), end = c(5L, 3L)))
+  expect_identical(out$loc, list(c(1L, 4L, 5L), c(2L, 3L)))
 })
 
 test_that("works on various types", {
-  x <- data_frame(start = c(1.5, 2, 3.1, 1.2), end = c(1.7, 3.2, 4.5, NA))
+  x <- data_frame(start = c(1.5, 2, 3.1, NA), end = c(1.7, 3.2, 4.5, NA))
 
-  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "drop")
+  out <- vec_locate_interval_merge_groups(x$start, x$end)
 
-  expect_identical(out$key, data_frame(start = c(1L, 2L), end = c(1L, 3L)))
-  expect_identical(out$loc, list(1L, 2:3))
+  expect_identical(out$key, data_frame(start = c(1L, 2L, 4L), end = c(1L, 3L, 4L)))
+  expect_identical(out$loc, list(1L, 2:3, 4L))
 
-  x <- data_frame(start = c("a", "c", "f", NA), end = c("b", "g", "h", "l"))
+  x <- data_frame(start = c("a", "c", "f", NA), end = c("b", "g", "h", NA))
 
-  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "drop")
+  out <- vec_locate_interval_merge_groups(x$start, x$end)
 
-  expect_identical(out$key, data_frame(start = c(1L, 2L), end = c(1L, 3L)))
-  expect_identical(out$loc, list(1L, 2:3))
+  expect_identical(out$key, data_frame(start = c(1L, 2L, 4L), end = c(1L, 3L, 4L)))
+  expect_identical(out$loc, list(1L, 2:3, 4L))
 })
 
 test_that("can keep abutting intervals separate", {
@@ -256,14 +219,6 @@ test_that("can keep abutting intervals separate", {
   expect_identical(out$key, data_frame(start = c(2L, 1L, 3L), end = c(2L, 1L, 3L)))
   expect_identical(out$loc, list(2L, 1L, 3L))
 })
-
-test_that("empty and invalid intervals cause an error", {
-  expect_snapshot({
-    (expect_error(vec_locate_interval_merge_groups(1, 1)))
-    (expect_error(vec_locate_interval_merge_groups(1, 0)))
-  })
-})
-
 
 test_that("common type is taken", {
   expect_snapshot((expect_error(vec_locate_interval_merge_groups(1, "x"))))

--- a/tests/testthat/test-interval.R
+++ b/tests/testthat/test-interval.R
@@ -1,0 +1,270 @@
+# ------------------------------------------------------------------------------
+# vec_locate_interval_merge_bounds()
+
+test_that("can compute merge bounds", {
+  x <- data_frame(
+    start = c(1L, 9L,  2L, 2L, 10L),
+    end = c(5L, 11L, 6L, 8L, 12L)
+  )
+
+  expect_identical(
+    vec_locate_interval_merge_bounds(x$start, x$end),
+    data_frame(start = c(1L, 2L), end = c(4L, 5L))
+  )
+})
+
+test_that("can locate bounds with size one input", {
+  x <- data_frame(start = 1L, end = 2L)
+
+  expect_identical(
+    vec_locate_interval_merge_bounds(x$start, x$end),
+    data_frame(start = 1L, end = 1L)
+  )
+})
+
+test_that("can locate bounds with size zero input", {
+  x <- data_frame(start = integer(), end = integer())
+
+  expect_identical(
+    vec_locate_interval_merge_bounds(x$start, x$end),
+    data_frame(start = integer(), end = integer())
+  )
+})
+
+test_that("incomplete intervals are retained by default, but can be dropped", {
+  x <- data_frame(start = NA, end = NA)
+
+  expect_identical(
+    vec_locate_interval_merge_bounds(x$start, x$end),
+    data_frame(start = NA_integer_, end = NA_integer_)
+  )
+
+  expect_identical(
+    vec_locate_interval_merge_bounds(x$start, x$end, incomplete = "drop"),
+    data_frame(start = integer(), end = integer())
+  )
+})
+
+test_that("incomplete intervals don't affect the result if dropped", {
+  x <- data_frame(start = c(3, NA, 2, NA), end = c(5, NA, 3, NA))
+  expect_identical(
+    vec_locate_interval_merge_bounds(x$start, x$end, incomplete = "drop"),
+    data_frame(start = 3L, end = 1L)
+  )
+})
+
+test_that("max endpoint is retained even if it isn't the last in the group", {
+  # 10 is max end of first group, but 5 is last value in that group
+  x <- data_frame(start = c(1L, 2L, 12L), end = c(10L, 5L, 15L))
+
+  expect_identical(
+    vec_locate_interval_merge_bounds(x$start, x$end),
+    data_frame(start = c(1L, 3L), end = c(1L, 3L))
+  )
+})
+
+# ------------------------------------------------------------------------------
+# vec_locate_interval_merge_groups()
+
+test_that("can locate merge bounds and groups", {
+  x <- data_frame(
+    start = c(1L, 9L,  2L, 2L, 10L),
+    end = c(5L, 11L, 6L, 8L, 12L)
+  )
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end)
+
+  expect_identical(
+    out$key,
+    data_frame(start = c(1L, 2L), end = c(4L, 5L))
+  )
+
+  expect_identical(
+    out$loc,
+    list(c(1L, 3L, 4L), c(2L, 5L))
+  )
+})
+
+test_that("can locate groups with size one input", {
+  expect_identical(
+    vec_locate_interval_merge_groups(1L, 2L),
+    data_frame(
+      key = data_frame(start = 1L, end = 1L),
+      loc = list(1L)
+    )
+  )
+})
+
+test_that("can locate groups with size zero input", {
+  expect_identical(
+    vec_locate_interval_merge_groups(integer(), integer()),
+    data_frame(
+      key = data_frame(start = integer(), end = integer()),
+      loc = list()
+    )
+  )
+})
+
+test_that("locations are ordered by both `start` and `end`", {
+  x <- data_frame(start = c(4L, 4L, 1L), end = c(6L, 5L, 2L))
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end)
+
+  # Ties of `start = 4` are broken by `end` values and reordered
+  expect_identical(
+    out$loc,
+    list(3L, c(2L, 1L))
+  )
+
+  # So this orders `x`
+  expect_identical(
+    vec_slice(x, unlist(out$loc)),
+    vec_sort(x)
+  )
+})
+
+test_that("incomplete intervals are retained by default", {
+  x <- data_frame(start = NA, end = NA)
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end)
+
+  expect_identical(
+    out$key,
+    data_frame(start = NA_integer_, end = NA_integer_)
+  )
+  expect_identical(
+    out$loc,
+    list(1L)
+  )
+})
+
+test_that("incomplete intervals can be dropped", {
+  x <- data_frame(start = NA, end = NA)
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "drop")
+
+  expect_identical(
+    out$key,
+    data_frame(start = integer(), end = integer())
+  )
+  expect_identical(
+    out$loc,
+    list()
+  )
+})
+
+test_that("incomplete intervals can cause an error", {
+  expect_snapshot({
+    (expect_error(vec_locate_interval_merge_groups(NA, NA, incomplete = "error")))
+    (expect_error(vec_locate_interval_merge_groups(1, NA, incomplete = "error")))
+    (expect_error(vec_locate_interval_merge_groups(NA, 1, incomplete = "error")))
+  })
+})
+
+test_that("incomplete intervals don't affect the result if dropped", {
+  x <- data_frame(start = c(3, NA, 2, NA), end = c(5, NA, 3, NA))
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "drop")
+
+  expect_identical(
+    out$key,
+    data_frame(start = 3L, end = 1L)
+  )
+  expect_identical(
+    out$loc,
+    list(c(3L, 1L))
+  )
+})
+
+test_that("can have missings in either input", {
+  x <- data_frame(start = c(1L, NA, 1L), end = c(NA, 1L, 2L))
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end)
+
+  expect_identical(out$key, data_frame(start = c(3L, NA), end = c(3L, NA)))
+  expect_identical(out$loc, list(3L, c(2L, 1L)))
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "drop")
+
+  expect_identical(out$key, data_frame(start = 3L, end = 3L))
+  expect_identical(out$loc, list(3L))
+})
+
+test_that("`incomplete = 'merge'` works without any missings", {
+  x <- data_frame(start = c(1, 3), end = c(3, 5))
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "merge")
+
+  expect_identical(out$key, data_frame(start = 1L, end = 2L))
+  expect_identical(out$loc, list(c(1L, 2L)))
+})
+
+test_that("`incomplete = 'merge'` recognizes incomplete rows in data frames", {
+  start <- data_frame(year = c(2019, NA, 2019, 2019, 2019), month = c(12, 11, NA, 12, 12))
+  end <- data_frame(year = c(2020, 2020, 2020, NA, 2020), month = c(2, 11, 11, 11, NA))
+  x <- data_frame(start = start, end = end)
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end)
+
+  expect_identical(out$key, data_frame(start = c(1L, NA), end = c(1L, NA)))
+  expect_identical(out$loc, list(1L, 2:5))
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "drop")
+
+  expect_identical(out$key, data_frame(start = 1L, end = 1L))
+  expect_identical(out$loc, list(1L))
+})
+
+test_that("works on various types", {
+  x <- data_frame(start = c(1.5, 2, 3.1, 1.2), end = c(1.7, 3.2, 4.5, NA))
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "drop")
+
+  expect_identical(out$key, data_frame(start = c(1L, 2L), end = c(1L, 3L)))
+  expect_identical(out$loc, list(1L, 2:3))
+
+  x <- data_frame(start = c("a", "c", "f", NA), end = c("b", "g", "h", "l"))
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end, incomplete = "drop")
+
+  expect_identical(out$key, data_frame(start = c(1L, 2L), end = c(1L, 3L)))
+  expect_identical(out$loc, list(1L, 2:3))
+})
+
+test_that("can keep abutting intervals separate", {
+  # after
+  x <- data_frame(start = c(1L, 2L, 0L), end = c(2L, 3L, 2L))
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end, abutting = FALSE)
+
+  expect_identical(out$key, data_frame(start = c(3L, 2L), end = c(3L, 2L)))
+  expect_identical(out$loc, list(c(3L, 1L), 2L))
+
+  # before
+  x <- data_frame(start = c(1L, 0L), end = c(2L, 1L))
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end, abutting = FALSE)
+
+  expect_identical(out$key, data_frame(start = c(2L, 1L), end = c(2L, 1L)))
+  expect_identical(out$loc, list(2L, 1L))
+
+  # both
+  x <- data_frame(start = c(1L, 0L, 2L), end = c(2L, 1L, 3L))
+
+  out <- vec_locate_interval_merge_groups(x$start, x$end, abutting = FALSE)
+
+  expect_identical(out$key, data_frame(start = c(2L, 1L, 3L), end = c(2L, 1L, 3L)))
+  expect_identical(out$loc, list(2L, 1L, 3L))
+})
+
+test_that("empty and invalid intervals cause an error", {
+  expect_snapshot({
+    (expect_error(vec_locate_interval_merge_groups(1, 1)))
+    (expect_error(vec_locate_interval_merge_groups(1, 0)))
+  })
+})
+
+
+test_that("common type is taken", {
+  expect_snapshot((expect_error(vec_locate_interval_merge_groups(1, "x"))))
+})


### PR DESCRIPTION
- Exposed `vec_compare()` in `compare.h`
- New poly helper for comparisons
- New poly helper for missingness
- Two helpers related to merging overlapping intervals

---

One helper is used for locating the _bounds_ of the remaining intervals after merging all the overlaps. This is used by `iv_merge()` (which is then used by all the iv set-ops).

The other helper is used for locating the bounds and the "groups" that map each original interval to the interval that remains after the overlaps have been removed. This is used by `iv_replace_merged()`.

``` r
library(vctrs)

bounds <- data_frame(
  start = c(1, 2, NA, 5, NA, 9, 12),
  end = c(5, 3, NA, 6, NA, 12, 14)
)
bounds
#>   start end
#> 1     1   5
#> 2     2   3
#> 3    NA  NA
#> 4     5   6
#> 5    NA  NA
#> 6     9  12
#> 7    12  14

# Locate the bounds that will generate the merged intervals
loc <- vctrs:::vec_locate_interval_merge_bounds(bounds$start, bounds$end)
loc
#>   start end
#> 1     1   4
#> 2     6   7
#> 3     3   5

data_frame(
  start = vec_slice(bounds$start, loc$start),
  end = vec_slice(bounds$end, loc$end)
)
#>   start end
#> 1     1   6
#> 2     9  14
#> 3    NA  NA

# You can also locate the merge groups, which allow you to map each original
# interval to its corresponding merged interval
vctrs:::vec_locate_interval_merge_groups(bounds$start, bounds$end)
#>   key.start key.end     loc
#> 1         1       4 1, 2, 4
#> 2         6       7    6, 7
#> 3         3       5    3, 5
```

---

We make a number of assumptions about `start` and `end` that are not validated by the C code for performance and simplicity. The idea is that if these functions lived in iv, then we wouldn't have to validate these assumptions because the `iv()` helper / constructor always asserts them for us. It is also worth noting that we are fairly close to being able to move these into iv itself, we really just need the generic poly-op helpers here.

- `start < end` must be true, with an exception for missing intervals.

- If the i-th observation of `start` is missing, then the i-th observation of `end` must also be missing.

- Each observation of `start` and `end` must be either complete or missing. Partially complete values such as `start = data_frame(x = 1, y = NA)` are not allowed.

Making these assumptions avoids a variety of edge cases with "partially complete" but not fully missing intervals.

It also allows us to return an actual location when locating the merge bounds for missing intervals (i.e. the `3` and `5` locations above that correspond to the missing intervals). Imagine we had this example with partially complete intervals. If we called both of these "missing" intervals and merged them together, then we'd end up generating locations to slice the original intervals with that actually generate a non-missing interval, which we don't want.

``` r
library(vctrs)

bounds <- data_frame(
  start = c(3, NA),
  end = c(NA, 6)
)
bounds
#>   start end
#> 1     3  NA
#> 2    NA   6

loc <- data_frame(start = 1L, end = 2L)

# woops, not a missing interval
data_frame(
  start = vec_slice(bounds$start, loc$start),
  end = vec_slice(bounds$end, loc$end)
)
#>   start end
#> 1     3   6
```