### PR TITLE
Treat zero column data frames as equal in `vec_compare()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `vec_compare()` can now compare zero column data frames (#1500).
+
 * `new_data_frame()` now errors on negative and missing `n` values (#1477).
 
 * `vec_order()` now correctly orders zero column data frames (#1499).

--- a/src/compare.c
+++ b/src/compare.c
@@ -98,8 +98,8 @@ static SEXP df_compare(SEXP x, SEXP y, bool na_equal, R_len_t size) {
   SEXP out = PROTECT_N(Rf_allocVector(INTSXP, size), &nprot);
   int* p_out = INTEGER(out);
 
-  // Initialize to "equality" value
-  // and only change if we learn that it differs
+  // Initialize to "equality" value and only change if we learn that it differs.
+  // This also determines the zero column result.
   memset(p_out, 0, size * sizeof(int));
 
   struct df_short_circuit_info info = new_df_short_circuit_info(size, false);
@@ -118,10 +118,6 @@ static void df_compare_impl(int* p_out,
                             SEXP y,
                             bool na_equal) {
   int n_col = Rf_length(x);
-
-  if (n_col == 0) {
-    stop_not_comparable(x, y, "data frame with zero columns");
-  }
 
   if (n_col != Rf_length(y)) {
     stop_not_comparable(x, y, "must have the same number of columns");

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -81,6 +81,11 @@ test_that("can compare data frames with data frame columns", {
   expect_equal(vec_compare(df1, df2), -1)
 })
 
+test_that("can compare data frames with 0 columns", {
+  x <- new_data_frame(n = 2L)
+  expect_identical(vec_compare(x, x), c(0L, 0L))
+})
+
 test_that("C code doesn't crash with bad inputs", {
   df <- data.frame(x = c(1, 1, 1), y = c(-1, 0, 1))
 
@@ -193,11 +198,6 @@ test_that("vec_proxy_order() works on deeply nested lists", {
 
   df2 <- data_frame(x = df_col, y = 1:3)
   expect_identical(vec_proxy_order(df2), data_frame(x = c(1L, 2L, 1L), y = 1:3))
-})
-
-test_that("error is thrown with data frames with 0 columns", {
-  x <- new_data_frame(n = 1L)
-  expect_error(vec_compare(x, x), "data frame with zero columns")
 })
 
 test_that("error is thrown when comparing lists", {


### PR DESCRIPTION
Closes #1500 