### PR TITLE
Take error call in `vec_ptype_common()` and `vec_cast_common()`

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -101,26 +101,42 @@ vec_cast_dispatch_native <- function(x,
 
 #' @export
 #' @rdname vec_cast
-vec_cast_common <- function(..., .to = NULL) {
+vec_cast_common <- function(...,
+                            .to = NULL,
+                            .call = caller_env()) {
   .External2(ffi_cast_common, .to)
 }
 vec_cast_common_opts <- function(...,
                                  .to = NULL,
-                                 .opts = fallback_opts()) {
+                                 .opts = fallback_opts(),
+                                 .call = caller_env()) {
   .External2(ffi_cast_common_opts, .to, .opts)
 }
 vec_cast_common_params <- function(...,
                                    .to = NULL,
                                    .df_fallback = NULL,
-                                   .s3_fallback = NULL) {
+                                   .s3_fallback = NULL,
+                                   .call = caller_env()) {
   opts <- fallback_opts(
     df_fallback = .df_fallback,
     s3_fallback = .s3_fallback
   )
-  vec_cast_common_opts(..., .to = .to, .opts = opts)
+  vec_cast_common_opts(
+    ...,
+    .to = .to,
+    .opts = opts,
+    .call = .call
+  )
 }
-vec_cast_common_fallback <- function(..., .to = NULL) {
-  vec_cast_common_opts(..., .to = .to, .opts = full_fallback_opts())
+vec_cast_common_fallback <- function(...,
+                                     .to = NULL,
+                                     .call = caller_env()) {
+  vec_cast_common_opts(
+    ...,
+    .to = .to,
+    .opts = full_fallback_opts(),
+    .call = .call
+  )
 }
 
 #' @rdname vec_default_ptype2

--- a/R/type.R
+++ b/R/type.R
@@ -108,26 +108,42 @@ vec_ptype <- function(x, ..., x_arg = "", call = caller_env()) {
 
 #' @export
 #' @rdname vec_ptype
-vec_ptype_common <- function(..., .ptype = NULL) {
+vec_ptype_common <- function(...,
+                             .ptype = NULL,
+                             .call = caller_env()) {
   .External2(ffi_ptype_common, .ptype)
 }
 vec_ptype_common_opts <- function(...,
                                   .ptype = NULL,
-                                  .opts = fallback_opts()) {
+                                  .opts = fallback_opts(),
+                                  .call = caller_env()) {
   .External2(ffi_ptype_common_opts, .ptype, .opts)
 }
 vec_ptype_common_params <- function(...,
                                     .ptype = NULL,
                                     .df_fallback = NULL,
-                                    .s3_fallback = NULL) {
+                                    .s3_fallback = NULL,
+                                    .call = caller_env()) {
   opts <- fallback_opts(
     df_fallback = .df_fallback,
     s3_fallback = .s3_fallback
   )
-  vec_ptype_common_opts(..., .ptype = .ptype, .opts = opts)
+  vec_ptype_common_opts(
+    ...,
+    .ptype = .ptype,
+    .opts = opts,
+    .call = .call
+  )
 }
-vec_ptype_common_fallback <- function(..., .ptype = NULL) {
-  vec_ptype_common_opts(..., .ptype = .ptype, .opts = full_fallback_opts())
+vec_ptype_common_fallback <- function(...,
+                                      .ptype = NULL,
+                                      .call = caller_env()) {
+  vec_ptype_common_opts(
+    ...,
+    .ptype = .ptype,
+    .opts = full_fallback_opts(),
+    .call = .call
+  )
 }
 
 #' @export

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -14,7 +14,7 @@
 \usage{
 vec_cast(x, to, ..., x_arg = "", to_arg = "", call = caller_env())
 
-vec_cast_common(..., .to = NULL)
+vec_cast_common(..., .to = NULL, .call = caller_env())
 
 \method{vec_cast}{logical}(x, to, ...)
 
@@ -44,6 +44,11 @@ in error messages to inform the user about the locations of
 incompatible types (see \code{\link[=stop_incompatible_type]{stop_incompatible_type()}}).}
 
 \item{call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
+
+\item{.call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be
 mentioned in error messages as the source of the error. See the
 \code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}

--- a/man/vec_ptype.Rd
+++ b/man/vec_ptype.Rd
@@ -8,7 +8,7 @@
 \usage{
 vec_ptype(x, ..., x_arg = "", call = caller_env())
 
-vec_ptype_common(..., .ptype = NULL)
+vec_ptype_common(..., .ptype = NULL, .call = caller_env())
 
 vec_ptype_show(...)
 }
@@ -34,6 +34,11 @@ computing the common type across all elements of \code{...}.
 Alternatively, you can supply \code{.ptype} to give the output known type.
 If \code{getOption("vctrs.no_guessing")} is \code{TRUE} you must supply this value:
 this is a convenient way to make production code demand fixed types.}
+
+\item{.call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 }
 \value{
 \code{vec_ptype()} and \code{vec_ptype_common()} return a prototype

--- a/src/arg.h
+++ b/src/arg.h
@@ -49,25 +49,14 @@ struct arg_data_counter new_counter_arg_data(r_ssize* i,
                                              r_ssize* names_i);
 
 
-// Wrapper around a string that should be prefixed with `$`, unless
-// that's the first argument of the chain
-
-struct arg_data_index {
-  const char* arg;
-  struct vctrs_arg* parent;
-};
-
-struct vctrs_arg new_index_arg(struct vctrs_arg* parent,
-                               struct arg_data_index* data);
-
-struct arg_data_index new_index_arg_data(const char* arg,
-                                         struct vctrs_arg* parent);
-
+struct vctrs_arg* new_subscript_arg_vec(struct vctrs_arg* parent,
+                                        r_obj* x,
+                                        r_ssize* p_i);
 
 struct vctrs_arg* new_subscript_arg(struct vctrs_arg* parent,
-                                    r_obj* x,
+                                    r_obj* names,
+                                    r_ssize n,
                                     r_ssize* p_i);
-
 
 // Materialise an argument tag as a CHARSXP.
 r_obj* vctrs_arg(struct vctrs_arg* arg);

--- a/src/assert.c
+++ b/src/assert.c
@@ -67,7 +67,7 @@ r_obj* ffi_list_check_all_vectors(r_obj* x, r_obj* frame) {
   struct vctrs_arg arg_caller = new_lazy_arg(&arg_caller_data);
 
   r_ssize i = 0;
-  struct vctrs_arg* arg = new_subscript_arg(&arg_caller, x, &i);
+  struct vctrs_arg* arg = new_subscript_arg_vec(&arg_caller, x, &i);
   KEEP(arg->shelter);
 
   r_ssize n = r_length(x);

--- a/src/bind.c
+++ b/src/bind.c
@@ -98,7 +98,11 @@ static SEXP vec_rbind(SEXP xs,
   }
 
   // Must happen after the `names_to` column has been added to `ptype`
-  xs = vec_cast_common_params(xs, ptype, DF_FALLBACK_DEFAULT, S3_FALLBACK_true);
+  xs = vec_cast_common_params(xs,
+                              ptype,
+                              DF_FALLBACK_DEFAULT,
+                              S3_FALLBACK_true,
+                              r_lazy_null);
   PROTECT_N(xs, &n_prot);
 
   // Find individual input sizes and total size of output

--- a/src/bind.c
+++ b/src/bind.c
@@ -60,7 +60,11 @@ static SEXP vec_rbind(SEXP xs,
   // The common type holds information about common column names,
   // types, etc. Each element of `xs` needs to be cast to that type
   // before assignment.
-  ptype = vec_ptype_common_params(xs, ptype, DF_FALLBACK_DEFAULT, S3_FALLBACK_true);
+  ptype = vec_ptype_common_params(xs,
+                                  ptype,
+                                  DF_FALLBACK_DEFAULT,
+                                  S3_FALLBACK_true,
+                                  r_lazy_null);
   PROTECT_N(ptype, &n_prot);
 
   R_len_t n_cols = Rf_length(ptype);
@@ -371,7 +375,8 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
   SEXP type = PROTECT(vec_ptype_common_params(containers,
                                               ptype,
                                               DF_FALLBACK_DEFAULT,
-                                              S3_FALLBACK_false));
+                                              S3_FALLBACK_false,
+                                              r_lazy_null));
   if (type == R_NilValue) {
     type = new_data_frame(vctrs_shared_empty_list, 0);
   } else if (!is_data_frame(type)) {

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -66,7 +66,11 @@ static SEXP vec_unchop(SEXP xs,
     Rf_errorcall(R_NilValue, "`indices` must be a list of integers, or `NULL`");
   }
 
-  ptype = PROTECT(vec_ptype_common_params(xs, ptype, DF_FALLBACK_DEFAULT, S3_FALLBACK_true));
+  ptype = PROTECT(vec_ptype_common_params(xs,
+                                          ptype,
+                                          DF_FALLBACK_DEFAULT,
+                                          S3_FALLBACK_true,
+                                          r_lazy_null));
 
   if (needs_vec_c_fallback(ptype)) {
     SEXP out = vec_unchop_fallback(ptype, xs, indices, name_spec, name_repair, FALLBACK_HOMOGENEOUS_false);

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -85,7 +85,7 @@ static SEXP vec_unchop(SEXP xs,
     return R_NilValue;
   }
 
-  xs = PROTECT(vec_cast_common(xs, ptype));
+  xs = PROTECT(vec_cast_common(xs, ptype, r_lazy_null));
 
   bool assign_names = !Rf_inherits(name_spec, "rlang_zap");
   SEXP xs_names = PROTECT(r_names(xs));

--- a/src/c.c
+++ b/src/c.c
@@ -45,8 +45,12 @@ SEXP vec_c_opts(SEXP xs,
                 SEXP name_spec,
                 const struct name_repair_opts* name_repair,
                 const struct fallback_opts* fallback_opts) {
+  struct ptype_common_opts ptype_opts = {
+    .fallback = *fallback_opts
+  };
+
   SEXP orig_ptype = ptype;
-  ptype = PROTECT(vec_ptype_common_opts(xs, orig_ptype, fallback_opts));
+  ptype = PROTECT(vec_ptype_common_opts(xs, orig_ptype, &ptype_opts));
 
   if (ptype == R_NilValue) {
     UNPROTECT(1);
@@ -76,11 +80,10 @@ SEXP vec_c_opts(SEXP xs,
   // fallback disabled as well.
   if ((is_data_frame(ptype) && fallback_opts->s3 == S3_FALLBACK_true) ||
       vec_is_common_class_fallback(ptype)) {
-    struct fallback_opts d_fallback_opts = *fallback_opts;
-    d_fallback_opts.s3 = S3_FALLBACK_false;
-    ptype = PROTECT(vec_ptype_common_opts(xs, orig_ptype, &d_fallback_opts));
+    ptype_opts.fallback.s3 = S3_FALLBACK_false;
+    ptype = PROTECT(vec_ptype_common_opts(xs, orig_ptype, &ptype_opts));
   } else {
-    ptype = PROTECT(vec_ptype_common_opts(xs, ptype, fallback_opts));
+    ptype = PROTECT(vec_ptype_common_opts(xs, ptype, &ptype_opts));
   }
 
   // Find individual input sizes and total size of output
@@ -278,19 +281,21 @@ SEXP vec_c_fallback(SEXP ptype,
   if (implements_c) {
     return vec_c_fallback_invoke(xs, name_spec);
   } else {
-    struct fallback_opts fallback_opts = {
-      .df = DF_FALLBACK_none,
-      .s3 = S3_FALLBACK_false
+    struct ptype_common_opts ptype_opts = {
+      .fallback = {
+        .df = DF_FALLBACK_none,
+        .s3 = S3_FALLBACK_false
+      }
     };
 
     // Should cause a common type error, unless another fallback
     // kicks in (for instance, homogeneous class with homogeneous
     // attributes)
-    vec_ptype_common_opts(xs, R_NilValue, &fallback_opts);
+    vec_ptype_common_opts(xs, R_NilValue, &ptype_opts);
 
     // Suboptimal: Call `vec_c()` again to combine vector with
     // homogeneous class fallback
-    return vec_c_opts(xs, R_NilValue, name_spec, name_repair, &fallback_opts);
+    return vec_c_opts(xs, R_NilValue, name_spec, name_repair, &ptype_opts.fallback);
   }
 }
 

--- a/src/cast-bare.c
+++ b/src/cast-bare.c
@@ -1,6 +1,5 @@
 #include "vctrs.h"
 #include "type-data-frame.h"
-#include "utils.h"
 
 r_obj* int_as_logical(r_obj* x, bool* lossy) {
   int* data = r_int_begin(x);

--- a/src/cast-dispatch.c
+++ b/src/cast-dispatch.c
@@ -1,7 +1,6 @@
 #include "vctrs.h"
 #include "type-factor.h"
 #include "type-tibble.h"
-#include "utils.h"
 
 r_obj* vec_cast_dispatch_native(const struct cast_opts* opts,
                                 enum vctrs_type x_type,

--- a/src/cast.c
+++ b/src/cast.c
@@ -231,7 +231,11 @@ r_obj* vec_cast_e(const struct cast_opts* opts,
 r_obj* vec_cast_common_opts(r_obj* xs,
                             r_obj* to,
                             const struct cast_common_opts* opts) {
-  r_obj* type = KEEP(vec_ptype_common_opts(xs, to, &opts->fallback));
+  struct ptype_common_opts ptype_opts = {
+    .call = opts->call,
+    .fallback = opts->fallback
+  };
+  r_obj* type = KEEP(vec_ptype_common_opts(xs, to, &ptype_opts));
 
   r_ssize n = r_length(xs);
   r_obj* out = KEEP(r_alloc_list(n));

--- a/src/cast.c
+++ b/src/cast.c
@@ -240,11 +240,15 @@ r_obj* vec_cast_common_opts(r_obj* xs,
   r_ssize n = r_length(xs);
   r_obj* out = KEEP(r_alloc_list(n));
 
-  for (r_ssize i = 0; i < n; ++i) {
+  r_ssize i = 0;
+  struct vctrs_arg* p_x_arg = new_subscript_arg(NULL, r_names(xs), n, &i);
+
+  for (; i < n; ++i) {
     r_obj* elt = r_list_get(xs, i);
     struct cast_opts cast_opts = {
       .x = elt,
       .to = type,
+      .x_arg = p_x_arg,
       .call = opts->call,
       .fallback = opts->fallback
     };

--- a/src/cast.h
+++ b/src/cast.h
@@ -13,6 +13,11 @@ struct cast_opts {
   struct fallback_opts fallback;
 };
 
+struct cast_common_opts {
+  struct r_lazy call;
+  struct fallback_opts fallback;
+};
+
 // Defined in type-data-frame.c
 r_obj* df_cast_opts(const struct cast_opts* opts);
 
@@ -52,15 +57,19 @@ r_obj* vec_cast_params(r_obj* x,
   return vec_cast_opts(&opts);
 }
 
-r_obj* vec_cast_common(r_obj* xs, r_obj* to);
+r_obj* vec_cast_common(r_obj* xs,
+                       r_obj* to,
+                       struct r_lazy call);
 
 r_obj* vec_cast_common_opts(r_obj* xs,
                             r_obj* to,
-                            const struct fallback_opts* fallback_opts);
+                            const struct cast_common_opts* opts);
+
 r_obj* vec_cast_common_params(r_obj* xs,
                               r_obj* to,
                               enum df_fallback df_fallback,
-                              enum s3_fallback s3_fallback);
+                              enum s3_fallback s3_fallback,
+                              struct r_lazy call);
 
 struct cast_opts new_cast_opts(r_obj* x,
                                r_obj* y,

--- a/src/decl/arg-decl.h
+++ b/src/decl/arg-decl.h
@@ -14,9 +14,6 @@ static
 r_ssize lazy_arg_fill(void* data, char* buf, r_ssize remaining);
 
 static
-r_ssize index_arg_fill(void* data, char* buf, r_ssize remaining);
-
-static
 r_ssize subscript_arg_fill(void* p_data, char* buf, r_ssize remaining);
 
 static

--- a/src/globals.c
+++ b/src/globals.c
@@ -5,6 +5,7 @@ struct syms syms;
 
 void vctrs_init_globals(r_obj* ns) {
   syms.arg = r_sym("arg");
+  syms.dot_call = r_sym(".call");
   syms.haystack_arg = r_sym("haystack_arg");
   syms.needles_arg = r_sym("needles_arg");
   syms.repair_arg = r_sym("repair_arg");

--- a/src/globals.h
+++ b/src/globals.h
@@ -5,6 +5,7 @@
 
 struct syms {
   r_obj* arg;
+  r_obj* dot_call;
   r_obj* haystack_arg;
   r_obj* needles_arg;
   r_obj* repair_arg;

--- a/src/ptype-common.h
+++ b/src/ptype-common.h
@@ -2,8 +2,11 @@
 #define VCTRS_PTYPE_COMMON_H
 
 #include "vctrs-core.h"
-#include "ptype2.h"
-#include "utils.h"
+
+struct ptype_common_opts {
+  struct r_lazy call;
+  struct fallback_opts fallback;
+};
 
 static inline
 bool vec_is_common_class_fallback(r_obj* ptype) {
@@ -13,10 +16,11 @@ bool vec_is_common_class_fallback(r_obj* ptype) {
 r_obj* vec_ptype_common_params(r_obj* dots,
                                r_obj* ptype,
                                enum df_fallback df_fallback,
-                               enum s3_fallback s3_fallback);
+                               enum s3_fallback s3_fallback,
+                               struct r_lazy call);
 
 r_obj* vec_ptype_common_opts(r_obj* dots,
                              r_obj* ptype,
-                             const struct fallback_opts* opts);
+                             const struct ptype_common_opts* opts);
 
 #endif

--- a/src/size.c
+++ b/src/size.c
@@ -92,7 +92,7 @@ r_obj* list_sizes(r_obj* x, const struct vec_error_info* opts) {
   r_attrib_poke_names(out, names);
 
   r_ssize i = 0;
-  struct vctrs_arg* arg = new_subscript_arg(opts->arg, x, &i);
+  struct vctrs_arg* arg = new_subscript_arg_vec(opts->arg, x, &i);
   KEEP(arg->shelter);
 
   struct vec_error_info local_opts = *opts;

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -356,7 +356,7 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error in `my_function()`:
-      ! Can't convert from <double> to <integer> due to loss of precision.
+      ! Can't convert from `my_arg` <double> to <integer> due to loss of precision.
       * Locations: 1
 
 ---

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -359,3 +359,12 @@
       ! Can't convert from <double> to <integer> due to loss of precision.
       * Locations: 1
 
+# vec_ptype_common() reports error context
+
+    Code
+      (expect_error(my_function(this_arg = 1, that_arg = "foo")))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `my_function()`:
+      ! Can't combine `this_arg` <double> and `that_arg` <character>.
+

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -349,3 +349,13 @@
       Error in `vec_size()`:
       ! `x` must be a vector, not an environment.
 
+# vec_cast_common() reports error context
+
+    Code
+      (expect_error(my_function(my_arg = 1.5, .to = int())))
+    Output
+      <error/vctrs_error_cast_lossy>
+      Error in `my_function()`:
+      ! Can't convert from <double> to <integer> due to loss of precision.
+      * Locations: 1
+

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -359,6 +359,15 @@
       ! Can't convert from <double> to <integer> due to loss of precision.
       * Locations: 1
 
+---
+
+    Code
+      (expect_error(my_function(this_arg = x, that_arg = y)))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `my_function()`:
+      ! Can't combine `this_arg$x` <character> and `that_arg$x` <double>.
+
 # vec_ptype_common() reports error context
 
     Code

--- a/tests/testthat/_snaps/type2.md
+++ b/tests/testthat/_snaps/type2.md
@@ -123,7 +123,7 @@
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error:
+      Error in `vec_cast_no_fallback()`:
       ! Can't convert <vctrs_foo> to <vctrs_bar>.
 
 # common type warnings for data frames take attributes into account

--- a/tests/testthat/_snaps/type2.md
+++ b/tests/testthat/_snaps/type2.md
@@ -124,7 +124,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error in `vec_cast_no_fallback()`:
-      ! Can't convert <vctrs_foo> to <vctrs_bar>.
+      ! Can't convert `x` <vctrs_foo> to <vctrs_bar>.
 
 # common type warnings for data frames take attributes into account
 

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -153,3 +153,8 @@ test_that("vec_cast_common() reports error context", {
   my_function <- function(...) vec_cast_common(...)
   expect_snapshot((expect_error(my_function(my_arg = 1.5, .to = int()))))
 })
+
+test_that("vec_ptype_common() reports error context", {
+  my_function <- function(...) vec_ptype_common(...)
+  expect_snapshot((expect_error(my_function(this_arg = 1, that_arg = "foo"))))
+})

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -152,6 +152,10 @@ test_that("vec_size() reports error context", {
 test_that("vec_cast_common() reports error context", {
   my_function <- function(...) vec_cast_common(...)
   expect_snapshot((expect_error(my_function(my_arg = 1.5, .to = int()))))
+
+  x <- data.frame(x = "a")
+  y <- data.frame(x = 1, y = 2)
+  expect_snapshot((expect_error(my_function(this_arg = x, that_arg = y))))
 })
 
 test_that("vec_ptype_common() reports error context", {

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -148,3 +148,8 @@ test_that("vec_size() reports error context", {
     (expect_error(vec_size(env())))
   })
 })
+
+test_that("vec_cast_common() reports error context", {
+  my_function <- function(...) vec_cast_common(...)
+  expect_snapshot((expect_error(my_function(my_arg = 1.5, .to = int()))))
+})


### PR DESCRIPTION
- Add `.call` arguments to `vec_ptype_common()` and `vec_cast_common()`.

- Replace `index_arg` by the new `subscript_arg` (updated to handle the parentless case).

- Pass `x` arg in `vec_cast_common()`. The `to` doesn't have any easily determined arg since it comes from `vec_ptype_common()` most of the time.