### PR TITLE
Add `.arg` argument to `vec_ptype_common()` and `vec_cast_common()`

### DIFF
--- a/R/cast.R
+++ b/R/cast.R
@@ -103,12 +103,14 @@ vec_cast_dispatch_native <- function(x,
 #' @rdname vec_cast
 vec_cast_common <- function(...,
                             .to = NULL,
+                            .arg = "",
                             .call = caller_env()) {
   .External2(ffi_cast_common, .to)
 }
 vec_cast_common_opts <- function(...,
                                  .to = NULL,
                                  .opts = fallback_opts(),
+                                 .arg = "",
                                  .call = caller_env()) {
   .External2(ffi_cast_common_opts, .to, .opts)
 }
@@ -116,6 +118,7 @@ vec_cast_common_params <- function(...,
                                    .to = NULL,
                                    .df_fallback = NULL,
                                    .s3_fallback = NULL,
+                                   .arg = "",
                                    .call = caller_env()) {
   opts <- fallback_opts(
     df_fallback = .df_fallback,
@@ -125,16 +128,19 @@ vec_cast_common_params <- function(...,
     ...,
     .to = .to,
     .opts = opts,
+    .arg = .arg,
     .call = .call
   )
 }
 vec_cast_common_fallback <- function(...,
                                      .to = NULL,
+                                     .arg = "",
                                      .call = caller_env()) {
   vec_cast_common_opts(
     ...,
     .to = .to,
     .opts = full_fallback_opts(),
+    .arg = .arg,
     .call = .call
   )
 }

--- a/R/type.R
+++ b/R/type.R
@@ -110,6 +110,7 @@ vec_ptype <- function(x, ..., x_arg = "", call = caller_env()) {
 #' @rdname vec_ptype
 vec_ptype_common <- function(...,
                              .ptype = NULL,
+                             .arg = "",
                              .call = caller_env()) {
   .External2(ffi_ptype_common, .ptype)
 }

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -14,7 +14,7 @@
 \usage{
 vec_cast(x, to, ..., x_arg = "", to_arg = "", call = caller_env())
 
-vec_cast_common(..., .to = NULL, .call = caller_env())
+vec_cast_common(..., .to = NULL, .arg = "", .call = caller_env())
 
 \method{vec_cast}{logical}(x, to, ...)
 
@@ -47,6 +47,10 @@ incompatible types (see \code{\link[=stop_incompatible_type]{stop_incompatible_t
 running function, e.g. \code{caller_env()}. The function will be
 mentioned in error messages as the source of the error. See the
 \code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
+
+\item{.arg}{An argument name as a string. This argument
+will be mentioned in error messages as the input that is at the
+origin of a problem.}
 
 \item{.call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be

--- a/man/vec_ptype.Rd
+++ b/man/vec_ptype.Rd
@@ -8,7 +8,7 @@
 \usage{
 vec_ptype(x, ..., x_arg = "", call = caller_env())
 
-vec_ptype_common(..., .ptype = NULL, .call = caller_env())
+vec_ptype_common(..., .ptype = NULL, .arg = "", .call = caller_env())
 
 vec_ptype_show(...)
 }
@@ -34,6 +34,10 @@ computing the common type across all elements of \code{...}.
 Alternatively, you can supply \code{.ptype} to give the output known type.
 If \code{getOption("vctrs.no_guessing")} is \code{TRUE} you must supply this value:
 this is a convenient way to make production code demand fixed types.}
+
+\item{.arg}{An argument name as a string. This argument
+will be mentioned in error messages as the input that is at the
+origin of a problem.}
 
 \item{.call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be

--- a/src/arg-counter.h
+++ b/src/arg-counter.h
@@ -51,7 +51,9 @@ struct counters {
  */
 void counters_shift(struct counters* counters);
 
-r_obj* reduce(r_obj* current, struct vctrs_arg* current_arg,
+r_obj* reduce(r_obj* current,
+              struct vctrs_arg* p_current_arg,
+              struct vctrs_arg* p_parent_arg,
               r_obj* rest,
               r_obj* (*impl)(r_obj* current, r_obj* next, struct counters* counters, void* data),
               void* data);

--- a/src/arg.h
+++ b/src/arg.h
@@ -36,6 +36,7 @@ struct vctrs_arg new_lazy_arg(struct r_lazy* data);
 // Wrapper around a counter representing the current position of the
 // argument
 struct arg_data_counter {
+  struct vctrs_arg* p_parent;
   r_ssize* i;
   r_obj** names;
   r_ssize* names_i;
@@ -44,7 +45,8 @@ struct arg_data_counter {
 struct vctrs_arg new_counter_arg(struct vctrs_arg* parent,
                                  struct arg_data_counter* data);
 
-struct arg_data_counter new_counter_arg_data(r_ssize* i,
+struct arg_data_counter new_counter_arg_data(struct vctrs_arg* p_parent,
+                                             r_ssize* i,
                                              r_obj** names,
                                              r_ssize* names_i);
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -107,6 +107,7 @@ static SEXP vec_rbind(SEXP xs,
                               ptype,
                               DF_FALLBACK_DEFAULT,
                               S3_FALLBACK_true,
+                              args_empty,
                               r_lazy_null);
   PROTECT_N(xs, &n_prot);
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -64,6 +64,7 @@ static SEXP vec_rbind(SEXP xs,
                                   ptype,
                                   DF_FALLBACK_DEFAULT,
                                   S3_FALLBACK_true,
+                                  args_empty,
                                   r_lazy_null);
   PROTECT_N(ptype, &n_prot);
 
@@ -376,6 +377,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
                                               ptype,
                                               DF_FALLBACK_DEFAULT,
                                               S3_FALLBACK_false,
+                                              args_empty,
                                               r_lazy_null));
   if (type == R_NilValue) {
     type = new_data_frame(vctrs_shared_empty_list, 0);

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -70,6 +70,7 @@ static SEXP vec_unchop(SEXP xs,
                                           ptype,
                                           DF_FALLBACK_DEFAULT,
                                           S3_FALLBACK_true,
+                                          args_empty,
                                           r_lazy_null));
 
   if (needs_vec_c_fallback(ptype)) {

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -90,7 +90,7 @@ static SEXP vec_unchop(SEXP xs,
     return R_NilValue;
   }
 
-  xs = PROTECT(vec_cast_common(xs, ptype, r_lazy_null));
+  xs = PROTECT(vec_cast_common(xs, ptype, args_empty, r_lazy_null));
 
   bool assign_names = !Rf_inherits(name_spec, "rlang_zap");
   SEXP xs_names = PROTECT(r_names(xs));

--- a/src/cast.h
+++ b/src/cast.h
@@ -14,6 +14,7 @@ struct cast_opts {
 };
 
 struct cast_common_opts {
+  struct vctrs_arg* p_arg;
   struct r_lazy call;
   struct fallback_opts fallback;
 };
@@ -59,6 +60,7 @@ r_obj* vec_cast_params(r_obj* x,
 
 r_obj* vec_cast_common(r_obj* xs,
                        r_obj* to,
+                       struct vctrs_arg* p_arg,
                        struct r_lazy call);
 
 r_obj* vec_cast_common_opts(r_obj* xs,
@@ -69,6 +71,7 @@ r_obj* vec_cast_common_params(r_obj* xs,
                               r_obj* to,
                               enum df_fallback df_fallback,
                               enum s3_fallback s3_fallback,
+                              struct vctrs_arg* p_arg,
                               struct r_lazy call);
 
 struct cast_opts new_cast_opts(r_obj* x,

--- a/src/decl/arg-counter-decl.h
+++ b/src/decl/arg-counter-decl.h
@@ -1,6 +1,7 @@
 static
 r_obj* reduce_impl(r_obj* current,
                    r_obj* rest,
+                   struct vctrs_arg* p_parent_arg,
                    struct counters* counters,
                    bool spliced,
                    r_obj* (*impl)(r_obj* current,
@@ -12,6 +13,7 @@ r_obj* reduce_impl(r_obj* current,
 static
 r_obj* reduce_splice_box(r_obj* current,
                          r_obj* rest,
+                         struct vctrs_arg* p_parent_arg,
                          struct counters* counters,
                          r_obj* (*impl)(r_obj* current,
                                         r_obj* rest,

--- a/src/globals.c
+++ b/src/globals.c
@@ -5,6 +5,7 @@ struct syms syms;
 
 void vctrs_init_globals(r_obj* ns) {
   syms.arg = r_sym("arg");
+  syms.dot_arg = r_sym(".arg");
   syms.dot_call = r_sym(".call");
   syms.haystack_arg = r_sym("haystack_arg");
   syms.needles_arg = r_sym("needles_arg");

--- a/src/globals.h
+++ b/src/globals.h
@@ -5,6 +5,7 @@
 
 struct syms {
   r_obj* arg;
+  r_obj* dot_arg;
   r_obj* dot_call;
   r_obj* haystack_arg;
   r_obj* needles_arg;

--- a/src/ptype-common.h
+++ b/src/ptype-common.h
@@ -5,6 +5,7 @@
 
 struct ptype_common_opts {
   struct r_lazy call;
+  struct vctrs_arg* p_arg;
   struct fallback_opts fallback;
 };
 
@@ -17,6 +18,7 @@ r_obj* vec_ptype_common_params(r_obj* dots,
                                r_obj* ptype,
                                enum df_fallback df_fallback,
                                enum s3_fallback s3_fallback,
+                               struct vctrs_arg* p_arg,
                                struct r_lazy call);
 
 r_obj* vec_ptype_common_opts(r_obj* dots,

--- a/src/size-common.c
+++ b/src/size-common.c
@@ -40,7 +40,7 @@ static
 SEXP vctrs_size2_common(SEXP x, SEXP y, struct counters* counters, void* data);
 
 r_ssize vec_size_common(r_obj* xs, r_ssize absent) {
-  r_obj* common = KEEP(reduce(R_NilValue, args_empty, xs, &vctrs_size2_common, NULL));
+  r_obj* common = KEEP(reduce(R_NilValue, args_empty, NULL, xs, &vctrs_size2_common, NULL));
   r_ssize out;
 
   if (common == r_null) {

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -362,6 +362,34 @@
 ---
 
     Code
+      (expect_error(my_function(my_arg = 1.5, .to = int(), .arg = "my_arg")))
+    Output
+      <error/vctrs_error_cast_lossy>
+      Error in `my_function()`:
+      ! Can't convert from `my_arg$my_arg` <double> to <integer> due to loss of precision.
+      * Locations: 1
+
+---
+
+    Code
+      (expect_error(my_function(this_arg = 1, that_arg = "foo", .arg = "my_arg")))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `my_function()`:
+      ! Can't combine `my_arg$this_arg` <double> and `my_arg$that_arg` <character>.
+
+---
+
+    Code
+      (expect_error(my_function(1, "foo", .arg = "my_arg")))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `my_function()`:
+      ! Can't combine `my_arg[[1]]` <double> and `my_arg[[2]]` <character>.
+
+---
+
+    Code
       (expect_error(my_function(this_arg = x, that_arg = y)))
     Output
       <error/vctrs_error_incompatible_type>

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -377,3 +377,21 @@
       Error in `my_function()`:
       ! Can't combine `this_arg` <double> and `that_arg` <character>.
 
+---
+
+    Code
+      (expect_error(my_function(this_arg = 1, that_arg = "foo", .arg = "my_arg")))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `my_function()`:
+      ! Can't combine `my_arg$this_arg` <double> and `my_arg$that_arg` <character>.
+
+---
+
+    Code
+      (expect_error(my_function(1, "foo", .arg = "my_arg")))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `my_function()`:
+      ! Can't combine `my_arg[[1]]` <double> and `my_arg[[2]]` <character>.
+

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -161,4 +161,6 @@ test_that("vec_cast_common() reports error context", {
 test_that("vec_ptype_common() reports error context", {
   my_function <- function(...) vec_ptype_common(...)
   expect_snapshot((expect_error(my_function(this_arg = 1, that_arg = "foo"))))
+  expect_snapshot((expect_error(my_function(this_arg = 1, that_arg = "foo", .arg = "my_arg"))))
+  expect_snapshot((expect_error(my_function(1, "foo", .arg = "my_arg"))))
 })

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -152,6 +152,9 @@ test_that("vec_size() reports error context", {
 test_that("vec_cast_common() reports error context", {
   my_function <- function(...) vec_cast_common(...)
   expect_snapshot((expect_error(my_function(my_arg = 1.5, .to = int()))))
+  expect_snapshot((expect_error(my_function(my_arg = 1.5, .to = int(), .arg = "my_arg"))))
+  expect_snapshot((expect_error(my_function(this_arg = 1, that_arg = "foo", .arg = "my_arg"))))
+  expect_snapshot((expect_error(my_function(1, "foo", .arg = "my_arg"))))
 
   x <- data.frame(x = "a")
   y <- data.frame(x = 1, y = 2)


### PR DESCRIPTION
```r
manip <- function(xs, arg = caller_arg(xs)) {
  vec_ptype_common(!!!xs, .arg = arg)
}

manip(list(1, list()), arg = "foo")
#> Error in `manip()`:
#> ! Can't combine `foo[[1]]` <double> and `foo[[2]]` <list>.

manip(list(x = 1, y = list()), arg = "foo")
#> Error in `manip()`:
#> ! Can't combine `foo$x` <double> and `foo$y` <list>.
```