### PR TITLE
Add `caller_arg()` defaults to input validators

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # vctrs (development version)
 
+* `vec_assert()`, `vec_ptype2()`, `vec_cast()`, and `vec_as_location()`
+  now use `caller_arg()` to infer a default `arg` value from the
+  caller.
+
+  This may result in unhelpful arguments being mentioned in error
+  messages. In general, you should consider snapshotting vctrs error
+  messages thrown in your package and supply `arg` and `call`
+  arguments if the error context is not adequately reported to your
+  users.
+
 * `vec_ptype_common()` and `vec_cast_common()` gain `call` and `arg`
   arguments for specifying an error context.
 

--- a/R/cast.R
+++ b/R/cast.R
@@ -67,7 +67,7 @@ vec_cast <- function(x,
                      to,
                      ...,
                      x_arg = caller_arg(x),
-                     to_arg = caller_arg(to),
+                     to_arg = "",
                      call = caller_env()) {
   if (!missing(...)) {
     check_ptype2_dots_empty(...)

--- a/R/cast.R
+++ b/R/cast.R
@@ -66,8 +66,8 @@
 vec_cast <- function(x,
                      to,
                      ...,
-                     x_arg = "",
-                     to_arg = "",
+                     x_arg = caller_arg(x),
+                     to_arg = caller_arg(to),
                      call = caller_env()) {
   if (!missing(...)) {
     check_ptype2_dots_empty(...)

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -60,7 +60,7 @@ vec_as_location <- function(i,
                             names = NULL,
                             ...,
                             missing = c("propagate", "error"),
-                            arg = NULL,
+                            arg = caller_arg(i),
                             call = caller_env()) {
   check_dots_empty0(...)
 
@@ -93,7 +93,7 @@ num_as_location <- function(i,
                             negative = c("invert", "error", "ignore"),
                             oob = c("error", "extend"),
                             zero = c("remove", "error", "ignore"),
-                            arg = NULL,
+                            arg = caller_arg(i),
                             call = caller_env()) {
   check_dots_empty0(...)
 
@@ -120,7 +120,7 @@ vec_as_location2 <- function(i,
                              names = NULL,
                              ...,
                              missing = c("error", "propagate"),
-                             arg = NULL,
+                             arg = caller_arg(i),
                              call = caller_env()) {
   check_dots_empty0(...)
   result_get(vec_as_location2_result(
@@ -142,7 +142,7 @@ num_as_location2 <- function(i,
                              ...,
                              negative = c("error", "ignore"),
                              missing = c("error", "propagate"),
-                             arg = NULL,
+                             arg = caller_arg(i),
                              call = caller_env()) {
   check_dots_empty0(...)
 

--- a/R/type2.R
+++ b/R/type2.R
@@ -31,8 +31,8 @@
 vec_ptype2 <- function(x,
                        y,
                        ...,
-                       x_arg = "",
-                       y_arg = "",
+                       x_arg = caller_arg(x),
+                       y_arg = caller_arg(y),
                        call = caller_env()) {
   if (!missing(...)) {
     check_ptype2_dots_empty(...)

--- a/man/howto-faq-coercion.Rd
+++ b/man/howto-faq-coercion.Rd
@@ -99,11 +99,11 @@ Our natural number class is conceptually a parent of \verb{<logical>} and a
 child of \verb{<integer>}, but the class is not compatible with logical,
 integer, or double vectors yet:\if{html}{\out{<div class="sourceCode r">}}\preformatted{vec_ptype2(TRUE, new_natural(2:3))
 #> Error:
-#> ! Can't combine <logical> and <my_natural>.
+#> ! Can't combine `TRUE` <logical> and `new_natural(2:3)` <my_natural>.
 
 vec_ptype2(new_natural(1), 2:3)
 #> Error:
-#> ! Can't combine <my_natural> and <integer>.
+#> ! Can't combine `new_natural(1)` <my_natural> and `2:3` <integer>.
 }\if{html}{\out{</div>}}
 
 We’ll specify the twin methods for each of these classes, returning the

--- a/man/theory-faq-coercion.Rd
+++ b/man/theory-faq-coercion.Rd
@@ -98,7 +98,7 @@ vec_ptype2(factor("a"), "b")
 # But they are incompatible with integers
 vec_ptype2(factor("a"), 1L)
 #> Error:
-#> ! Can't combine <factor<4d52a>> and <integer>.
+#> ! Can't combine `factor("a")` <factor<4d52a>> and `1L` <integer>.
 }\if{html}{\out{</div>}}
 }
 

--- a/man/vec_as_location.Rd
+++ b/man/vec_as_location.Rd
@@ -13,7 +13,7 @@ vec_as_location(
   names = NULL,
   ...,
   missing = c("propagate", "error"),
-  arg = NULL,
+  arg = caller_arg(i),
   call = caller_env()
 )
 
@@ -25,7 +25,7 @@ num_as_location(
   negative = c("invert", "error", "ignore"),
   oob = c("error", "extend"),
   zero = c("remove", "error", "ignore"),
-  arg = NULL,
+  arg = caller_arg(i),
   call = caller_env()
 )
 
@@ -35,7 +35,7 @@ vec_as_location2(
   names = NULL,
   ...,
   missing = c("error", "propagate"),
-  arg = NULL,
+  arg = caller_arg(i),
   call = caller_env()
 )
 
@@ -45,7 +45,7 @@ num_as_location2(
   ...,
   negative = c("error", "ignore"),
   missing = c("error", "propagate"),
-  arg = NULL,
+  arg = caller_arg(i),
   call = caller_env()
 )
 }

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -12,14 +12,7 @@
 \alias{vec_cast.list}
 \title{Cast a vector to a specified type}
 \usage{
-vec_cast(
-  x,
-  to,
-  ...,
-  x_arg = caller_arg(x),
-  to_arg = caller_arg(to),
-  call = caller_env()
-)
+vec_cast(x, to, ..., x_arg = caller_arg(x), to_arg = "", call = caller_env())
 
 vec_cast_common(..., .to = NULL, .arg = "", .call = caller_env())
 

--- a/man/vec_cast.Rd
+++ b/man/vec_cast.Rd
@@ -12,7 +12,14 @@
 \alias{vec_cast.list}
 \title{Cast a vector to a specified type}
 \usage{
-vec_cast(x, to, ..., x_arg = "", to_arg = "", call = caller_env())
+vec_cast(
+  x,
+  to,
+  ...,
+  x_arg = caller_arg(x),
+  to_arg = caller_arg(to),
+  call = caller_env()
+)
 
 vec_cast_common(..., .to = NULL, .arg = "", .call = caller_env())
 

--- a/man/vec_ptype2.Rd
+++ b/man/vec_ptype2.Rd
@@ -25,7 +25,14 @@
 
 \method{vec_ptype2}{list}(x, y, ..., x_arg = "", y_arg = "")
 
-vec_ptype2(x, y, ..., x_arg = "", y_arg = "", call = caller_env())
+vec_ptype2(
+  x,
+  y,
+  ...,
+  x_arg = caller_arg(x),
+  y_arg = caller_arg(y),
+  call = caller_env()
+)
 }
 \arguments{
 \item{x, y}{Vector types.}

--- a/tests/testthat/_snaps/assert.md
+++ b/tests/testthat/_snaps/assert.md
@@ -179,14 +179,14 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error in `vec_assert()`:
-      ! Can't convert from `size` <double> to `integer()` <integer> due to loss of precision.
+      ! Can't convert from `size` <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
       (expect_error(vec_assert(1, size = "x")))
     Output
       <error/vctrs_error_incompatible_type>
       Error in `vec_assert()`:
-      ! Can't convert `size` <character> to match type of `integer()` <integer>.
+      ! Can't convert `size` <character> to <integer>.
 
 # list_all_vectors() works
 

--- a/tests/testthat/_snaps/assert.md
+++ b/tests/testthat/_snaps/assert.md
@@ -179,14 +179,14 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error in `vec_assert()`:
-      ! Can't convert from `size` <double> to <integer> due to loss of precision.
+      ! Can't convert from `size` <double> to `integer()` <integer> due to loss of precision.
       * Locations: 1
     Code
       (expect_error(vec_assert(1, size = "x")))
     Output
       <error/vctrs_error_incompatible_type>
       Error in `vec_assert()`:
-      ! Can't convert `size` <character> to <integer>.
+      ! Can't convert `size` <character> to match type of `integer()` <integer>.
 
 # list_all_vectors() works
 

--- a/tests/testthat/_snaps/cast.md
+++ b/tests/testthat/_snaps/cast.md
@@ -12,7 +12,7 @@
       vec_cast(1, "", x_arg = "foo")
     Condition
       Error:
-      ! Can't convert `foo` <double> to <character>.
+      ! Can't convert `foo` <double> to match type of `""` <character>.
 
 # cast errors create helpful messages (#57, #225)
 
@@ -20,7 +20,7 @@
       vec_cast(1.5, 10L)
     Condition
       Error:
-      ! Can't convert from <double> to <integer> due to loss of precision.
+      ! Can't convert from `1.5` <double> to `10L` <integer> due to loss of precision.
       * Locations: 1
 
 ---
@@ -29,7 +29,7 @@
       vec_cast(factor("foo"), 10)
     Condition
       Error:
-      ! Can't convert <factor<c1562>> to <double>.
+      ! Can't convert `factor("foo")` <factor<c1562>> to match type of `10` <double>.
 
 ---
 
@@ -39,7 +39,7 @@
       vec_cast(x, y)
     Condition
       Error:
-      ! Can't convert from `a$b` <double> to `a$b` <integer> due to loss of precision.
+      ! Can't convert from `x$a$b` <double> to `y$a$b` <integer> due to loss of precision.
       * Locations: 1
 
 ---
@@ -50,7 +50,7 @@
       vec_cast(x, y)
     Condition
       Error:
-      ! Can't convert `a$b` <factor<c1562>> to match type of `a$b` <double>.
+      ! Can't convert `x$a$b` <factor<c1562>> to match type of `y$a$b` <double>.
 
 ---
 

--- a/tests/testthat/_snaps/cast.md
+++ b/tests/testthat/_snaps/cast.md
@@ -12,7 +12,7 @@
       vec_cast(1, "", x_arg = "foo")
     Condition
       Error:
-      ! Can't convert `foo` <double> to match type of `""` <character>.
+      ! Can't convert `foo` <double> to <character>.
 
 # cast errors create helpful messages (#57, #225)
 
@@ -20,7 +20,7 @@
       vec_cast(1.5, 10L)
     Condition
       Error:
-      ! Can't convert from `1.5` <double> to `10L` <integer> due to loss of precision.
+      ! Can't convert from `1.5` <double> to <integer> due to loss of precision.
       * Locations: 1
 
 ---
@@ -29,7 +29,7 @@
       vec_cast(factor("foo"), 10)
     Condition
       Error:
-      ! Can't convert `factor("foo")` <factor<c1562>> to match type of `10` <double>.
+      ! Can't convert `factor("foo")` <factor<c1562>> to <double>.
 
 ---
 
@@ -39,7 +39,7 @@
       vec_cast(x, y)
     Condition
       Error:
-      ! Can't convert from `x$a$b` <double> to `y$a$b` <integer> due to loss of precision.
+      ! Can't convert from `x$a$b` <double> to `a$b` <integer> due to loss of precision.
       * Locations: 1
 
 ---
@@ -50,7 +50,7 @@
       vec_cast(x, y)
     Condition
       Error:
-      ! Can't convert `x$a$b` <factor<c1562>> to match type of `y$a$b` <double>.
+      ! Can't convert `x$a$b` <factor<c1562>> to match type of `a$b` <double>.
 
 ---
 

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -146,7 +146,7 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error:
-      ! Can't convert from <character> to <factor<9b7e3>> due to loss of generality.
+      ! Can't convert from `"a"` <character> to `factor("b")` <factor<9b7e3>> due to loss of generality.
       * Locations: 1
 
 # ordered cast failures mention conversion
@@ -157,7 +157,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error:
-      ! Can't convert <ordered<bf275>> to <ordered<fd1ad>>.
+      ! Can't convert `ordered("x")` <ordered<bf275>> to match type of `ordered("y")` <ordered<fd1ad>>.
 
 # incompatible size errors
 

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -146,7 +146,7 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error:
-      ! Can't convert from `"a"` <character> to `factor("b")` <factor<9b7e3>> due to loss of generality.
+      ! Can't convert from `"a"` <character> to <factor<9b7e3>> due to loss of generality.
       * Locations: 1
 
 # ordered cast failures mention conversion
@@ -157,7 +157,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error:
-      ! Can't convert `ordered("x")` <ordered<bf275>> to match type of `ordered("y")` <ordered<fd1ad>>.
+      ! Can't convert `ordered("x")` <ordered<bf275>> to <ordered<fd1ad>>.
 
 # incompatible size errors
 

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -201,7 +201,7 @@
       <error/vctrs_error_subscript_type>
       Error in `my_function()`:
       ! Must subset elements with a valid subscript vector.
-      x Can't convert from <double> to <integer> due to loss of precision.
+      x Can't convert from `my_arg` <double> to <integer> due to loss of precision.
 
 ---
 
@@ -221,7 +221,7 @@
       <error/vctrs_error_subscript_type>
       Error in `my_function()`:
       ! Must subset elements with a valid subscript vector.
-      x Subscript has the wrong type `list`.
+      x Subscript `my_arg` has the wrong type `list`.
       i It must be logical, numeric, or character.
 
 ---

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -14,7 +14,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error in `my_function()`:
-      ! Can't convert `2` <double> to match type of `chr()` <character>.
+      ! Can't convert `2` <double> to <character>.
 
 # lossy cast reports correct error call
 
@@ -23,7 +23,7 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error in `my_function()`:
-      ! Can't convert from `2` <double> to `lgl()` <logical> due to loss of precision.
+      ! Can't convert from `2` <double> to <logical> due to loss of precision.
       * Locations: 1
 
 # failing common size reports correct error call
@@ -97,7 +97,7 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error in `my_function()`:
-      ! Can't convert from `1.5` <double> to `int()` <integer> due to loss of precision.
+      ! Can't convert from `1.5` <double> to <integer> due to loss of precision.
       * Locations: 1
 
 ---
@@ -107,7 +107,7 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error in `my_function()`:
-      ! Can't convert from `1.5` <double> to `lgl()` <logical> due to loss of precision.
+      ! Can't convert from `1.5` <double> to <logical> due to loss of precision.
       * Locations: 1
 
 ---
@@ -117,7 +117,7 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error in `my_function()`:
-      ! Can't convert from `2L` <integer> to `lgl()` <logical> due to loss of precision.
+      ! Can't convert from `2L` <integer> to <logical> due to loss of precision.
       * Locations: 1
 
 ---
@@ -127,7 +127,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error in `my_function()`:
-      ! Can't convert `matrix(TRUE)` <double[,1]> to match type of `dbl()` <double>.
+      ! Can't convert `matrix(TRUE)` <double[,1]> to <double>.
       Cannot decrease dimensions.
 
 # base S3 casts report correct error call
@@ -137,7 +137,7 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error in `my_function()`:
-      ! Can't convert from `"a"` <character> to `factor("b")` <factor<9b7e3>> due to loss of generality.
+      ! Can't convert from `"a"` <character> to <factor<9b7e3>> due to loss of generality.
       * Locations: 1
 
 # names validation reports correct error call
@@ -279,7 +279,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error in `foo()`:
-      ! Can't convert `1` <double> to match type of `list()` <list>.
+      ! Can't convert `1` <double> to <list>.
     Code
       (expect_error(vec_slice(env(), list())))
     Output

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -5,7 +5,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error in `my_function()`:
-      ! Can't combine <double> and <character>.
+      ! Can't combine `2` <double> and `chr()` <character>.
 
 # failing cast reports correct error call
 

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -14,7 +14,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error in `my_function()`:
-      ! Can't convert <double> to <character>.
+      ! Can't convert `2` <double> to match type of `chr()` <character>.
 
 # lossy cast reports correct error call
 
@@ -23,7 +23,7 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error in `my_function()`:
-      ! Can't convert from <double> to <logical> due to loss of precision.
+      ! Can't convert from `2` <double> to `lgl()` <logical> due to loss of precision.
       * Locations: 1
 
 # failing common size reports correct error call
@@ -97,7 +97,7 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error in `my_function()`:
-      ! Can't convert from <double> to <integer> due to loss of precision.
+      ! Can't convert from `1.5` <double> to `int()` <integer> due to loss of precision.
       * Locations: 1
 
 ---
@@ -107,7 +107,7 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error in `my_function()`:
-      ! Can't convert from <double> to <logical> due to loss of precision.
+      ! Can't convert from `1.5` <double> to `lgl()` <logical> due to loss of precision.
       * Locations: 1
 
 ---
@@ -117,7 +117,7 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error in `my_function()`:
-      ! Can't convert from <integer> to <logical> due to loss of precision.
+      ! Can't convert from `2L` <integer> to `lgl()` <logical> due to loss of precision.
       * Locations: 1
 
 ---
@@ -127,7 +127,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error in `my_function()`:
-      ! Can't convert <double[,1]> to <double>.
+      ! Can't convert `matrix(TRUE)` <double[,1]> to match type of `dbl()` <double>.
       Cannot decrease dimensions.
 
 # base S3 casts report correct error call
@@ -137,7 +137,7 @@
     Output
       <error/vctrs_error_cast_lossy>
       Error in `my_function()`:
-      ! Can't convert from <character> to <factor<9b7e3>> due to loss of generality.
+      ! Can't convert from `"a"` <character> to `factor("b")` <factor<9b7e3>> due to loss of generality.
       * Locations: 1
 
 # names validation reports correct error call
@@ -279,7 +279,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error in `foo()`:
-      ! Can't convert <double> to <list>.
+      ! Can't convert `1` <double> to match type of `list()` <list>.
     Code
       (expect_error(vec_slice(env(), list())))
     Output

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -44,7 +44,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must subset elements with a valid subscript vector.
-      x Can't convert from <double> to <integer> due to loss of precision.
+      x Can't convert from `2^31` <double> to <integer> due to loss of precision.
 
 # Unnamed vector with character subscript is caught
 

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -7,7 +7,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must extract element with a single valid subscript.
-      x Subscript has the wrong type `logical`.
+      x Subscript `TRUE` has the wrong type `logical`.
       i It must be numeric or character.
     Code
       (expect_error(vec_as_location2(mtcars, 10L), class = "vctrs_error_subscript_type")
@@ -16,7 +16,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must extract element with a single valid subscript.
-      x Subscript has the wrong type `data.frame<
+      x Subscript `mtcars` has the wrong type `data.frame<
         mpg : double
         cyl : double
         disp: double
@@ -37,7 +37,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must extract element with a single valid subscript.
-      x Subscript has the wrong type `environment`.
+      x Subscript `env()` has the wrong type `environment`.
       i It must be numeric or character.
     Code
       (expect_error(vec_as_location2(foobar(), 10L), class = "vctrs_error_subscript_type")
@@ -46,7 +46,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must extract element with a single valid subscript.
-      x Subscript has the wrong type `vctrs_foobar`.
+      x Subscript `foobar()` has the wrong type `vctrs_foobar`.
       i It must be numeric or character.
     Code
       (expect_error(vec_as_location2(2.5, 10L), class = "vctrs_error_subscript_type"))
@@ -54,7 +54,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must extract element with a single valid subscript.
-      x Subscript has the wrong type `double`.
+      x Subscript `2.5` has the wrong type `double`.
       i It must be numeric or character.
     Code
       (expect_error(vec_as_location2(Inf, 10L), class = "vctrs_error_subscript_type"))
@@ -62,7 +62,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must extract element with a single valid subscript.
-      x Subscript has the wrong type `double`.
+      x Subscript `Inf` has the wrong type `double`.
       i It must be numeric or character.
     Code
       (expect_error(vec_as_location2(-Inf, 10L), class = "vctrs_error_subscript_type")
@@ -71,7 +71,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must extract element with a single valid subscript.
-      x Subscript has the wrong type `double`.
+      x Subscript `-Inf` has the wrong type `double`.
       i It must be numeric or character.
     Code
       # Idem with custom `arg`
@@ -111,7 +111,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must subset elements with a valid subscript vector.
-      x Subscript has the wrong type `data.frame<
+      x Subscript `mtcars` has the wrong type `data.frame<
         mpg : double
         cyl : double
         disp: double
@@ -132,7 +132,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must subset elements with a valid subscript vector.
-      x Subscript has the wrong type `environment`.
+      x Subscript `env()` has the wrong type `environment`.
       i It must be logical, numeric, or character.
     Code
       (expect_error(vec_as_location(foobar(), 10L), class = "vctrs_error_subscript_type")
@@ -141,7 +141,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must subset elements with a valid subscript vector.
-      x Subscript has the wrong type `vctrs_foobar`.
+      x Subscript `foobar()` has the wrong type `vctrs_foobar`.
       i It must be logical, numeric, or character.
     Code
       (expect_error(vec_as_location(2.5, 10L), class = "vctrs_error_subscript_type"))
@@ -149,7 +149,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must subset elements with a valid subscript vector.
-      x Can't convert from <double> to <integer> due to loss of precision.
+      x Can't convert from `2.5` <double> to <integer> due to loss of precision.
     Code
       (expect_error(vec_as_location(list(), 10L), class = "vctrs_error_subscript_type")
       )
@@ -157,7 +157,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must subset elements with a valid subscript vector.
-      x Subscript has the wrong type `list`.
+      x Subscript `list()` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       (expect_error(vec_as_location(function() NULL, 10L), class = "vctrs_error_subscript_type")
@@ -166,7 +166,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must subset elements with a valid subscript vector.
-      x Subscript has the wrong type `function`.
+      x Subscript `function() NULL` has the wrong type `function`.
       i It must be logical, numeric, or character.
     Code
       (expect_error(vec_as_location(Sys.Date(), 3L), class = "vctrs_error_subscript_type")
@@ -175,7 +175,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must subset elements with a valid subscript vector.
-      x Subscript has the wrong type `date`.
+      x Subscript `Sys.Date()` has the wrong type `date`.
       i It must be logical, numeric, or character.
     Code
       # Idem with custom `arg`
@@ -258,7 +258,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must extract element with a single valid subscript.
-      x Subscript has size 2 but must be size 1.
+      x Subscript `1:2` has size 2 but must be size 1.
     Code
       (expect_error(vec_as_location2(c("foo", "bar"), 2L, c("foo", "bar")), class = "vctrs_error_subscript_type")
       )
@@ -266,7 +266,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must extract element with a single valid subscript.
-      x Subscript has size 2 but must be size 1.
+      x Subscript `c("foo", "bar")` has size 2 but must be size 1.
     Code
       # Idem with custom `arg`
       (expect_error(vec_as_location2(1:2, 2L, arg = "foo", call = call("my_function")),
@@ -314,14 +314,14 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must extract element with a single valid subscript.
-      x Subscript has value 0 but must be a positive location.
+      x Subscript `0` has value 0 but must be a positive location.
     Code
       (expect_error(vec_as_location2(-1, 2L), class = "vctrs_error_subscript_type"))
     Output
       <error/vctrs_error_subscript_type>
       Error:
       ! Must extract element with a single valid subscript.
-      x Subscript has value -1 but must be a positive location.
+      x Subscript `-1` has value -1 but must be a positive location.
     Code
       # Idem with custom `arg`
       (expect_error(vec_as_location2(0, 2L, arg = "foo", call = call("my_function")),
@@ -341,7 +341,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must extract element with a single valid subscript.
-      x Subscript can't be `NA`.
+      x Subscript `na_int` can't be `NA`.
     Code
       (expect_error(vec_as_location2(na_chr, 1L, names = "foo"), class = "vctrs_error_subscript_type")
       )
@@ -349,7 +349,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must extract element with a single valid subscript.
-      x Subscript can't be `NA`.
+      x Subscript `na_chr` can't be `NA`.
     Code
       # Idem with custom `arg`
       (expect_error(vec_as_location2(na_int, 2L, arg = "foo", call = call(
@@ -369,7 +369,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must subset elements with a valid subscript vector.
-      x Subscript can't contain negative locations.
+      x Subscript `dbl(1, -1)` can't contain negative locations.
 
 # num_as_location() optionally forbids zero indices
 
@@ -380,7 +380,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must subset elements with a valid subscript vector.
-      x Subscript can't contain `0` values.
+      x Subscript `0L` can't contain `0` values.
       i It has a `0` value at location 1.
     Code
       (expect_error(num_as_location(c(0, 0, 0, 0, 0, 0), 1, zero = "error"), class = "vctrs_error_subscript_type")
@@ -389,7 +389,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must subset elements with a valid subscript vector.
-      x Subscript can't contain `0` values.
+      x Subscript `c(0, 0, 0, 0, 0, 0)` can't contain `0` values.
       i It has 6 `0` values at locations 1, 2, 3, 4, 5, etc.
 
 # vec_as_location() checks for mix of negative and missing locations
@@ -402,7 +402,7 @@
       Error:
       ! Must subset elements with a valid subscript vector.
       x Negative locations can't have missing values.
-      i Subscript has a missing value at location 2.
+      i Subscript `-c(1L, NA)` has a missing value at location 2.
     Code
       (expect_error(vec_as_location(-c(1L, rep(NA, 10)), 30), class = "vctrs_error_subscript_type")
       )
@@ -411,7 +411,7 @@
       Error:
       ! Must subset elements with a valid subscript vector.
       x Negative locations can't have missing values.
-      i Subscript has 10 missing values at locations 2, 3, 4, 5, 6, etc.
+      i Subscript `-c(1L, rep(NA, 10))` has 10 missing values at locations 2, 3, 4, 5, 6, etc.
 
 # vec_as_location() checks for mix of negative and positive locations
 
@@ -423,7 +423,7 @@
       Error:
       ! Must subset elements with a valid subscript vector.
       x Negative and positive locations can't be mixed.
-      i Subscript has a positive value at location 2.
+      i Subscript `c(-1L, 1L)` has a positive value at location 2.
     Code
       (expect_error(vec_as_location(c(-1L, rep(1L, 10)), 30), class = "vctrs_error_subscript_type")
       )
@@ -432,7 +432,7 @@
       Error:
       ! Must subset elements with a valid subscript vector.
       x Negative and positive locations can't be mixed.
-      i Subscript has 10 positive values at locations 2, 3, 4, 5, 6, etc.
+      i Subscript `c(-1L, rep(1L, 10))` has 10 positive values at locations 2, 3, 4, 5, 6, etc.
 
 # logical subscripts must match size of indexed vector
 
@@ -444,7 +444,7 @@
       Error:
       ! Must subset elements with a valid subscript vector.
       i Logical subscripts must match the size of the indexed input.
-      x Input has size 3 but subscript has size 2.
+      x Input has size 3 but subscript `c(TRUE, FALSE)` has size 2.
 
 # character subscripts require named vectors
 
@@ -465,7 +465,7 @@
       Error:
       ! Can't subset elements beyond the end with non-consecutive locations.
       i Input has size 1.
-      x Subscript contains non-consecutive location 3.
+      x Subscript `3` contains non-consecutive location 3.
     Code
       (expect_error(num_as_location(c(1, 3), 1, oob = "extend"), class = "vctrs_error_subscript_oob")
       )
@@ -474,7 +474,7 @@
       Error:
       ! Can't subset elements beyond the end with non-consecutive locations.
       i Input has size 1.
-      x Subscript contains non-consecutive location 3.
+      x Subscript `c(1, 3)` contains non-consecutive location 3.
     Code
       (expect_error(num_as_location(c(1:5, 7), 3, oob = "extend"), class = "vctrs_error_subscript_oob")
       )
@@ -483,7 +483,7 @@
       Error:
       ! Can't subset elements beyond the end with non-consecutive locations.
       i Input has size 3.
-      x Subscript contains non-consecutive locations 4 and 7.
+      x Subscript `c(1:5, 7)` contains non-consecutive locations 4 and 7.
     Code
       (expect_error(num_as_location(c(1:5, 7, 1), 3, oob = "extend"), class = "vctrs_error_subscript_oob")
       )
@@ -492,7 +492,7 @@
       Error:
       ! Can't subset elements beyond the end with non-consecutive locations.
       i Input has size 3.
-      x Subscript contains non-consecutive locations 4 and 7.
+      x Subscript `c(1:5, 7, 1)` contains non-consecutive locations 4 and 7.
     Code
       (expect_error(class = "vctrs_error_subscript_oob", num_as_location(c(1:5, 7, 1,
       10), 3, oob = "extend")))
@@ -501,7 +501,7 @@
       Error:
       ! Can't subset elements beyond the end with non-consecutive locations.
       i Input has size 3.
-      x Subscript contains non-consecutive locations 4, 7, and 10.
+      x Subscript `c(1:5, 7, 1, 10)` contains non-consecutive locations 4, 7, and 10.
 
 # missing values are supported in error formatters
 
@@ -522,7 +522,7 @@
       Error:
       ! Can't subset elements beyond the end with non-consecutive locations.
       i Input has size 1.
-      x Subscript contains non-consecutive location 3.
+      x Subscript `c(1, NA, 3)` contains non-consecutive location 3.
 
 # can disallow missing values
 
@@ -857,7 +857,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must subset elements with a valid subscript vector.
-      x Subscript must be a simple vector, not a matrix.
+      x Subscript `matrix(TRUE, nrow = 1)` must be a simple vector, not a matrix.
     Code
       (expect_error(vec_as_location(array(TRUE, dim = c(1, 1, 1)), 3L), class = "vctrs_error_subscript_type")
       )
@@ -865,7 +865,7 @@
       <error/vctrs_error_subscript_type>
       Error:
       ! Must subset elements with a valid subscript vector.
-      x Subscript must be a simple vector, not an array.
+      x Subscript `array(TRUE, dim = c(1, 1, 1))` must be a simple vector, not an array.
     Code
       (expect_error(with_tibble_rows(vec_as_location(matrix(TRUE, nrow = 1), 3L)),
       class = "vctrs_error_subscript_type"))

--- a/tests/testthat/_snaps/type-asis.md
+++ b/tests/testthat/_snaps/type-asis.md
@@ -6,7 +6,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error:
-      ! Can't combine <double> and <character>.
+      ! Can't combine `I(1)` <double> and `I("x")` <character>.
 
 # AsIs objects throw cast errors with their underlying types
 

--- a/tests/testthat/_snaps/type-asis.md
+++ b/tests/testthat/_snaps/type-asis.md
@@ -16,5 +16,5 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error:
-      ! Can't convert <double> to <factor<bf275>>.
+      ! Can't convert `I(1)` <double> to match type of `I(factor("x"))` <factor<bf275>>.
 

--- a/tests/testthat/_snaps/type-asis.md
+++ b/tests/testthat/_snaps/type-asis.md
@@ -16,5 +16,5 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error:
-      ! Can't convert `I(1)` <double> to match type of `I(factor("x"))` <factor<bf275>>.
+      ! Can't convert `I(1)` <double> to <factor<bf275>>.
 

--- a/tests/testthat/_snaps/type2.md
+++ b/tests/testthat/_snaps/type2.md
@@ -71,7 +71,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error:
-      ! Can't convert `foobar(1, bar = TRUE)` <vctrs_foobar> to match type of `foobar(2, baz = TRUE)` <vctrs_foobar>.
+      ! Can't convert `foobar(1, bar = TRUE)` <vctrs_foobar> to <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
       i See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
@@ -104,7 +104,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error:
-      ! Can't convert `foobar(1, bar = TRUE)` <vctrs_foobar> to match type of `foobar(2, baz = TRUE)` <vctrs_foobar>.
+      ! Can't convert `foobar(1, bar = TRUE)` <vctrs_foobar> to <vctrs_foobar>.
     Code
       (expect_error(with_foobar_ptype2(vec_ptype2(foobar(1, bar = TRUE), foobar(2,
         baz = TRUE))), class = "vctrs_error_incompatible_type"))

--- a/tests/testthat/_snaps/type2.md
+++ b/tests/testthat/_snaps/type2.md
@@ -17,7 +17,7 @@
       vec_ptype2("foo", 10)
     Condition
       Error:
-      ! Can't combine <character> and <double>.
+      ! Can't combine `"foo"` <character> and `10` <double>.
 
 ---
 
@@ -27,7 +27,7 @@
       vec_ptype2(df1, df2)
     Condition
       Error:
-      ! Can't combine `x$y$z` <double> and `x$y$z` <character>.
+      ! Can't combine `df1$x$y$z` <double> and `df2$x$y$z` <character>.
 
 # can override scalar vector error message for base scalar types
 
@@ -81,7 +81,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error:
-      ! Can't combine <vctrs_foobar> and <vctrs_foobar>.
+      ! Can't combine `foobar(1, bar = TRUE)` <vctrs_foobar> and `foobar(2, baz = TRUE)` <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
       i See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
@@ -111,7 +111,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error:
-      ! Can't combine <vctrs_foobar> and <vctrs_foobar>.
+      ! Can't combine `foobar(1, bar = TRUE)` <vctrs_foobar> and `foobar(2, baz = TRUE)` <vctrs_foobar>.
 
 # common type errors don't mention columns if they are compatible
 

--- a/tests/testthat/_snaps/type2.md
+++ b/tests/testthat/_snaps/type2.md
@@ -71,7 +71,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error:
-      ! Can't convert <vctrs_foobar> to <vctrs_foobar>.
+      ! Can't convert `foobar(1, bar = TRUE)` <vctrs_foobar> to match type of `foobar(2, baz = TRUE)` <vctrs_foobar>.
       x Some attributes are incompatible.
       i The author of the class should implement vctrs methods.
       i See <https://vctrs.r-lib.org/reference/faq-error-incompatible-attributes.html>.
@@ -104,7 +104,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error:
-      ! Can't convert <vctrs_foobar> to <vctrs_foobar>.
+      ! Can't convert `foobar(1, bar = TRUE)` <vctrs_foobar> to match type of `foobar(2, baz = TRUE)` <vctrs_foobar>.
     Code
       (expect_error(with_foobar_ptype2(vec_ptype2(foobar(1, bar = TRUE), foobar(2,
         baz = TRUE))), class = "vctrs_error_incompatible_type"))


### PR DESCRIPTION
This might cause unhelpful arg tags being displayed in error messages. I think we should make this change now while vctrs users are also focusing on proper error calls for rlang 1.0, so that both argument tags and error calls can be updated at the same time.

cc @hadley @DavisVaughan @krlmlr 