### PR TITLE
Improve pluralisation in OOB errors

### DIFF
--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -490,7 +490,8 @@ cnd_body_vctrs_error_subscript_oob_location <- function(cnd, ...) {
 
   # TODO: Switch to `format_inline()` and format bullets lazily through rlang
   cli::format_error(c(
-    "i" = "{cli::qty(n_loc)} Location{?s} {oob_enum} do{?esn't/n't} exist, there {cli::qty(n)} {?is/are} only {elt}."
+    "i" = "{cli::qty(n_loc)} Location{?s} {oob_enum} do{?esn't/n't} exist.",
+    "i" = "There {cli::qty(n)} {?is/are} only {elt}."
   ))
 }
 cnd_body_vctrs_error_subscript_oob_name <- function(cnd, ...) {

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -474,7 +474,6 @@ cnd_body.vctrs_error_subscript_oob <- function(cnd, ...) {
 }
 cnd_body_vctrs_error_subscript_oob_location <- function(cnd, ...) {
   i <- cnd$i
-  elt <- cnd_subscript_element(cnd)
 
   # In case of negative indexing
   i <- abs(i)
@@ -483,19 +482,15 @@ cnd_body_vctrs_error_subscript_oob_location <- function(cnd, ...) {
   i <- i[!is.na(i)]
 
   oob <- i[i > cnd$size]
-  oob_enum <- enumerate(oob)
+  oob_enum <- vctrs_cli_vec(oob)
 
-  format_error_bullets(c(
-    x = glue::glue(ngettext(
-      length(oob),
-      "Location {oob_enum} doesn't exist.",
-      "Locations {oob_enum} don't exist."
-    )),
-    i = glue::glue(ngettext(
-      cnd$size,
-      "There are only {cnd$size} {elt[[1]]}.",
-      "There are only {cnd$size} {elt[[2]]}.",
-    ))
+  n_loc <- length(oob)
+  n <- cnd$size
+  elt <- cnd_subscript_element_cli(n, cnd)
+
+  # TODO: Switch to `format_inline()` and format bullets lazily through rlang
+  cli::format_error(c(
+    "i" = "{cli::qty(n_loc)} Location{?s} {oob_enum} do{?esn't/n't} exist, there {cli::qty(n)} {?is/are} only {elt}."
   ))
 }
 cnd_body_vctrs_error_subscript_oob_name <- function(cnd, ...) {
@@ -510,6 +505,10 @@ cnd_body_vctrs_error_subscript_oob_name <- function(cnd, ...) {
       "{elt[[2]]} {oob_enum} don't exist."
     ))
   ))
+}
+
+vctrs_cli_vec <- function(x, ..., vec_trunc = 5) {
+  cli::cli_vec(as.character(x), list(..., vec_trunc = vec_trunc))
 }
 
 stop_location_oob_non_consecutive <- function(i,

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -455,7 +455,11 @@ cnd_header.vctrs_error_subscript_oob <- function(cnd, ...) {
   elt <- cnd_subscript_element(cnd)
   action <- cnd_subscript_action(cnd)
 
-  glue::glue("Can't {action} {elt[[2]]} that don't exist.")
+  if (action == "rename") {
+    glue::glue("Can't rename {elt[[2]]} that don't exist.")
+  } else {
+    glue::glue("Can't {action} {elt[[2]]} past the end.")
+  }
 }
 
 #' @export

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -295,7 +295,8 @@ cnd_subscript_element <- function(cnd, capital = FALSE) {
   }
 
   if (capital) {
-    switch(elt,
+    switch(
+      elt,
       element = c("Element", "Elements"),
       row = c("Row", "Rows"),
       column = c("Column", "Columns"),
@@ -309,6 +310,37 @@ cnd_subscript_element <- function(cnd, capital = FALSE) {
       table = c("table", "tables")
     )
   }
+}
+
+cnd_subscript_element_cli <- function(n, cnd, capital = FALSE) {
+  elt <- cnd$subscript_elt %||% "element"
+
+  if (!is_string(elt, c("element", "row", "column", "table"))) {
+    abort(paste0(
+      "Internal error: `cnd$subscript_elt` must be one of ",
+      "`element`, `row`, `column` or `table`."
+    ))
+  }
+
+  if (capital) {
+    elt <- switch(
+      elt,
+      element = "Element{?s}",
+      row = "Row{?s}",
+      column = "Column{?s}",
+      table = "Table{?s}"
+    )
+  } else {
+    elt <- switch(
+      elt,
+      element = "element{?s}",
+      row = "row{?s}",
+      column = "column{?s}",
+      table = "table{?s}"
+    )
+  }
+
+  cli::pluralize("{n} ", elt)
 }
 
 subscript_actions <- c(

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -22,7 +22,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       x Element `foo` doesn't exist.
     Code
       (expect_error(with_subscript_data(vec_slice(set_names(letters), "foo"), quote(
@@ -30,7 +30,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       x Element `foo` doesn't exist.
     Code
       (expect_error(with_subscript_data(vec_slice(set_names(letters), "foo"), quote(
@@ -38,7 +38,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       x Element `foo` doesn't exist.
 
 # scalar type errors are informative

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -190,8 +190,7 @@
       <error/vctrs_error_subscript_oob>
       Error in `my_function()`:
       ! Can't subset elements that don't exist.
-      x Location 10 doesn't exist.
-      i There are only 2 elements.
+      i Location 10 doesn't exist, there are only 2 elements.
 
 ---
 

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -189,7 +189,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `my_function()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       i Location 10 doesn't exist.
       i There are only 2 elements.
 

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -190,7 +190,8 @@
       <error/vctrs_error_subscript_oob>
       Error in `my_function()`:
       ! Can't subset elements that don't exist.
-      i Location 10 doesn't exist, there are only 2 elements.
+      i Location 10 doesn't exist.
+      i There are only 2 elements.
 
 ---
 

--- a/tests/testthat/_snaps/slice-assign.md
+++ b/tests/testthat/_snaps/slice-assign.md
@@ -40,7 +40,8 @@
       <error/vctrs_error_subscript_oob>
       Error:
       ! Can't assign to elements that don't exist.
-      i Location 5 doesn't exist, there are only 3 elements.
+      i Location 5 doesn't exist.
+      i There are only 3 elements.
     Code
       (expect_error(vec_assign(1:3, "foo", 10), "unnamed vector"))
     Output
@@ -54,7 +55,8 @@
       <error/vctrs_error_subscript_oob>
       Error:
       ! Can't negate elements that don't exist.
-      i Location 100 doesn't exist, there are only 26 elements.
+      i Location 100 doesn't exist.
+      i There are only 26 elements.
     Code
       (expect_error(vec_assign(set_names(letters), "foo", "bar"), class = "vctrs_error_subscript_oob")
       )

--- a/tests/testthat/_snaps/slice-assign.md
+++ b/tests/testthat/_snaps/slice-assign.md
@@ -40,8 +40,7 @@
       <error/vctrs_error_subscript_oob>
       Error:
       ! Can't assign to elements that don't exist.
-      x Location 5 doesn't exist.
-      i There are only 3 elements.
+      i Location 5 doesn't exist, there are only 3 elements.
     Code
       (expect_error(vec_assign(1:3, "foo", 10), "unnamed vector"))
     Output
@@ -55,8 +54,7 @@
       <error/vctrs_error_subscript_oob>
       Error:
       ! Can't negate elements that don't exist.
-      x Location 100 doesn't exist.
-      i There are only 26 elements.
+      i Location 100 doesn't exist, there are only 26 elements.
     Code
       (expect_error(vec_assign(set_names(letters), "foo", "bar"), class = "vctrs_error_subscript_oob")
       )

--- a/tests/testthat/_snaps/slice-assign.md
+++ b/tests/testthat/_snaps/slice-assign.md
@@ -39,7 +39,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error:
-      ! Can't assign to elements that don't exist.
+      ! Can't assign to elements past the end.
       i Location 5 doesn't exist.
       i There are only 3 elements.
     Code
@@ -54,7 +54,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error:
-      ! Can't negate elements that don't exist.
+      ! Can't negate elements past the end.
       i Location 100 doesn't exist.
       i There are only 26 elements.
     Code
@@ -63,7 +63,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error:
-      ! Can't assign to elements that don't exist.
+      ! Can't assign to elements past the end.
       x Element `foo` doesn't exist.
 
 # must assign with proper negative locations

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -24,7 +24,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       i Location 3 doesn't exist.
       i There are only 2 elements.
     Code
@@ -32,7 +32,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
-      ! Can't negate elements that don't exist.
+      ! Can't negate elements past the end.
       i Location 3 doesn't exist.
       i There are only 2 elements.
 
@@ -80,7 +80,7 @@
       vec_slice(c(bar = 1), "foo")
     Condition
       Error in `vec_slice()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       x Element `foo` doesn't exist.
 
 ---
@@ -89,7 +89,7 @@
       vec_slice(letters, c(100, 1000))
     Condition
       Error in `vec_slice()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       i Locations 100 and 1000 don't exist.
       i There are only 26 elements.
 
@@ -99,7 +99,7 @@
       vec_slice(letters, c(1, 100:103, 2, 104:110))
     Condition
       Error in `vec_slice()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       i Locations 100, 101, 102, 103, 104, ... don't exist.
       i There are only 26 elements.
 
@@ -109,7 +109,7 @@
       vec_slice(set_names(letters), c("foo", "bar"))
     Condition
       Error in `vec_slice()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       x Elements `foo` and `bar` don't exist.
 
 ---
@@ -118,6 +118,6 @@
       vec_slice(set_names(letters), toupper(letters))
     Condition
       Error in `vec_slice()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       x Elements `A`, `B`, `C`, `D`, `E`, etc. don't exist.
 

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -25,14 +25,16 @@
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
       ! Can't subset elements that don't exist.
-      i Location 3 doesn't exist, there are only 2 elements.
+      i Location 3 doesn't exist.
+      i There are only 2 elements.
     Code
       (expect_error(vec_slice(1:2, -3L), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
       ! Can't negate elements that don't exist.
-      i Location 3 doesn't exist, there are only 2 elements.
+      i Location 3 doesn't exist.
+      i There are only 2 elements.
 
 # can slice with double indices
 
@@ -88,7 +90,8 @@
     Condition
       Error in `vec_slice()`:
       ! Can't subset elements that don't exist.
-      i Locations 100 and 1000 don't exist, there are only 26 elements.
+      i Locations 100 and 1000 don't exist.
+      i There are only 26 elements.
 
 ---
 
@@ -97,7 +100,8 @@
     Condition
       Error in `vec_slice()`:
       ! Can't subset elements that don't exist.
-      i Locations 100, 101, 102, 103, 104, ... don't exist, there are only 26 elements.
+      i Locations 100, 101, 102, 103, 104, ... don't exist.
+      i There are only 26 elements.
 
 ---
 

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -25,16 +25,14 @@
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
       ! Can't subset elements that don't exist.
-      x Location 3 doesn't exist.
-      i There are only 2 elements.
+      i Location 3 doesn't exist, there are only 2 elements.
     Code
       (expect_error(vec_slice(1:2, -3L), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
       ! Can't negate elements that don't exist.
-      x Location 3 doesn't exist.
-      i There are only 2 elements.
+      i Location 3 doesn't exist, there are only 2 elements.
 
 # can slice with double indices
 
@@ -90,8 +88,7 @@
     Condition
       Error in `vec_slice()`:
       ! Can't subset elements that don't exist.
-      x Locations 100 and 1000 don't exist.
-      i There are only 26 elements.
+      i Locations 100 and 1000 don't exist, there are only 26 elements.
 
 ---
 
@@ -100,8 +97,7 @@
     Condition
       Error in `vec_slice()`:
       ! Can't subset elements that don't exist.
-      x Locations 100, 101, 102, 103, 104, etc. don't exist.
-      i There are only 26 elements.
+      i Locations 100, 101, 102, 103, 104, ... don't exist, there are only 26 elements.
 
 ---
 

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -214,24 +214,21 @@
       <error/vctrs_error_subscript_oob>
       Error:
       ! Can't subset elements that don't exist.
-      x Location 10 doesn't exist.
-      i There are only 2 elements.
+      i Location 10 doesn't exist, there are only 2 elements.
     Code
       (expect_error(vec_as_location(-10L, 2L), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
       Error:
       ! Can't negate elements that don't exist.
-      x Location 10 doesn't exist.
-      i There are only 2 elements.
+      i Location 10 doesn't exist, there are only 2 elements.
     Code
       (expect_error(vec_as_location2(10L, 2L), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_as_location2_result()`:
       ! Can't subset elements that don't exist.
-      x Location 10 doesn't exist.
-      i There are only 2 elements.
+      i Location 10 doesn't exist, there are only 2 elements.
     Code
       # Character indexing
       (expect_error(vec_as_location("foo", 1L, names = "bar"), class = "vctrs_error_subscript_oob")
@@ -512,8 +509,7 @@
       <error/vctrs_error_subscript_oob>
       Error:
       ! Can't subset elements that don't exist.
-      x Locations 2 and 3 don't exist.
-      i There are only 1 element.
+      i Locations 2 and 3 don't exist, there is only 1 element.
     Code
       (expect_error(num_as_location(c(1, NA, 3), 1, oob = "extend"), class = "vctrs_error_subscript_oob")
       )
@@ -783,8 +779,7 @@
       <error/vctrs_error_subscript_oob>
       Error in `my_function()`:
       ! Can't subset elements that don't exist.
-      x Location 30 doesn't exist.
-      i There are only 26 elements.
+      i Location 30 doesn't exist, there are only 26 elements.
     Code
       (expect_error(vec_as_location("foo", NULL, letters, arg = "foo", call = call(
         "my_function")), class = "vctrs_error_subscript_oob"))
@@ -809,8 +804,7 @@
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
       ! Can't rename columns that don't exist.
-      x Location 30 doesn't exist.
-      i There are only 26 columns.
+      i Location 30 doesn't exist, there are only 26 columns.
     Code
       (expect_error(with_tibble_cols(vec_slice(set_names(letters), -30)), class = "vctrs_error_subscript_oob")
       )
@@ -818,8 +812,7 @@
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
       ! Can't rename columns that don't exist.
-      x Location 30 doesn't exist.
-      i There are only 26 columns.
+      i Location 30 doesn't exist, there are only 26 columns.
     Code
       # With tibble rows
       (expect_error(with_tibble_rows(vec_slice(set_names(letters), c("foo", "bar"))),
@@ -836,8 +829,7 @@
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
       ! Can't remove rows that don't exist.
-      x Locations 27, 28, 29, and 30 don't exist.
-      i There are only 26 rows.
+      i Locations 27, 28, 29, and 30 don't exist, there are only 26 rows.
     Code
       (expect_error(with_tibble_rows(vec_slice(set_names(letters), -(1:30))), class = "vctrs_error_subscript_oob")
       )
@@ -845,8 +837,7 @@
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
       ! Can't remove rows that don't exist.
-      x Locations 27, 28, 29, and 30 don't exist.
-      i There are only 26 rows.
+      i Locations 27, 28, 29, and 30 don't exist, there are only 26 rows.
 
 # vec_as_location() checks dimensionality
 

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -213,7 +213,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       i Location 10 doesn't exist.
       i There are only 2 elements.
     Code
@@ -221,7 +221,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error:
-      ! Can't negate elements that don't exist.
+      ! Can't negate elements past the end.
       i Location 10 doesn't exist.
       i There are only 2 elements.
     Code
@@ -229,7 +229,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_as_location2_result()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       i Location 10 doesn't exist.
       i There are only 2 elements.
     Code
@@ -239,7 +239,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       x Element `foo` doesn't exist.
     Code
       (expect_error(vec_as_location2("foo", 1L, names = "bar"), class = "vctrs_error_subscript_oob")
@@ -247,7 +247,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_as_location2_result()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       x Element `foo` doesn't exist.
 
 # vec_as_location2() requires length 1 inputs
@@ -511,7 +511,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       i Locations 2 and 3 don't exist.
       i There is only 1 element.
     Code
@@ -773,7 +773,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       x Element `foo` doesn't exist.
     Code
       # With custom `arg`
@@ -782,7 +782,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `my_function()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       i Location 30 doesn't exist.
       i There are only 26 elements.
     Code
@@ -791,7 +791,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `my_function()`:
-      ! Can't subset elements that don't exist.
+      ! Can't subset elements past the end.
       x Element `foo` doesn't exist.
     Code
       # With tibble columns
@@ -827,7 +827,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
-      ! Can't remove rows that don't exist.
+      ! Can't remove rows past the end.
       x Rows `foo` and `bar` don't exist.
     Code
       (expect_error(with_tibble_rows(vec_slice(set_names(letters), 1:30)), class = "vctrs_error_subscript_oob")
@@ -835,7 +835,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
-      ! Can't remove rows that don't exist.
+      ! Can't remove rows past the end.
       i Locations 27, 28, 29, and 30 don't exist.
       i There are only 26 rows.
     Code
@@ -844,7 +844,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
-      ! Can't remove rows that don't exist.
+      ! Can't remove rows past the end.
       i Locations 27, 28, 29, and 30 don't exist.
       i There are only 26 rows.
 

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -214,21 +214,24 @@
       <error/vctrs_error_subscript_oob>
       Error:
       ! Can't subset elements that don't exist.
-      i Location 10 doesn't exist, there are only 2 elements.
+      i Location 10 doesn't exist.
+      i There are only 2 elements.
     Code
       (expect_error(vec_as_location(-10L, 2L), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
       Error:
       ! Can't negate elements that don't exist.
-      i Location 10 doesn't exist, there are only 2 elements.
+      i Location 10 doesn't exist.
+      i There are only 2 elements.
     Code
       (expect_error(vec_as_location2(10L, 2L), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
       Error in `vec_as_location2_result()`:
       ! Can't subset elements that don't exist.
-      i Location 10 doesn't exist, there are only 2 elements.
+      i Location 10 doesn't exist.
+      i There are only 2 elements.
     Code
       # Character indexing
       (expect_error(vec_as_location("foo", 1L, names = "bar"), class = "vctrs_error_subscript_oob")
@@ -509,7 +512,8 @@
       <error/vctrs_error_subscript_oob>
       Error:
       ! Can't subset elements that don't exist.
-      i Locations 2 and 3 don't exist, there is only 1 element.
+      i Locations 2 and 3 don't exist.
+      i There is only 1 element.
     Code
       (expect_error(num_as_location(c(1, NA, 3), 1, oob = "extend"), class = "vctrs_error_subscript_oob")
       )
@@ -779,7 +783,8 @@
       <error/vctrs_error_subscript_oob>
       Error in `my_function()`:
       ! Can't subset elements that don't exist.
-      i Location 30 doesn't exist, there are only 26 elements.
+      i Location 30 doesn't exist.
+      i There are only 26 elements.
     Code
       (expect_error(vec_as_location("foo", NULL, letters, arg = "foo", call = call(
         "my_function")), class = "vctrs_error_subscript_oob"))
@@ -804,7 +809,8 @@
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
       ! Can't rename columns that don't exist.
-      i Location 30 doesn't exist, there are only 26 columns.
+      i Location 30 doesn't exist.
+      i There are only 26 columns.
     Code
       (expect_error(with_tibble_cols(vec_slice(set_names(letters), -30)), class = "vctrs_error_subscript_oob")
       )
@@ -812,7 +818,8 @@
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
       ! Can't rename columns that don't exist.
-      i Location 30 doesn't exist, there are only 26 columns.
+      i Location 30 doesn't exist.
+      i There are only 26 columns.
     Code
       # With tibble rows
       (expect_error(with_tibble_rows(vec_slice(set_names(letters), c("foo", "bar"))),
@@ -829,7 +836,8 @@
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
       ! Can't remove rows that don't exist.
-      i Locations 27, 28, 29, and 30 don't exist, there are only 26 rows.
+      i Locations 27, 28, 29, and 30 don't exist.
+      i There are only 26 rows.
     Code
       (expect_error(with_tibble_rows(vec_slice(set_names(letters), -(1:30))), class = "vctrs_error_subscript_oob")
       )
@@ -837,7 +845,8 @@
       <error/vctrs_error_subscript_oob>
       Error in `vec_slice()`:
       ! Can't remove rows that don't exist.
-      i Locations 27, 28, 29, and 30 don't exist, there are only 26 rows.
+      i Locations 27, 28, 29, and 30 don't exist.
+      i There are only 26 rows.
 
 # vec_as_location() checks dimensionality
 


### PR DESCRIPTION
- Fix a pluralisation bug.
- Use cli for pluralisation and collapsing.
- Use more compact info bullet instead of two bullets. It uses the same sort of structure as ``"`foo` must be a bar, not a baz."``.

Before:

```r
vec_assign(1, 2, 0)
#> Error:
#> ! Can't assign to elements that don't exist.
#> ✖ Location 2 doesn't exist.
#> ℹ There are only 1 element.
```

After

```r
vec_assign(1, 2, 0)
#> Error:
#> ! Can't assign to elements that don't exist.
#> ℹ Location 2 doesn't exist, there is only 1 element.
```