### PR TITLE
Treat bare `AsIs` lists as lists in `vec_is_list()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `vec_is_list()` now returns `TRUE` for `AsIs` lists (#1463).
+
 * `vec_assert()`, `vec_ptype2()`, `vec_cast()`, and `vec_as_location()`
   now use `caller_arg()` to infer a default `arg` value from the
   caller.

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -105,8 +105,11 @@ bool vec_is_list(r_obj* x) {
     return true;
   }
 
+  const enum vctrs_class_type type = class_type(x);
+
   // Classed R_TYPE_list are only lists if the last class is explicitly `"list"`
-  return class_type(x) == VCTRS_CLASS_list;
+  // or if it is a bare "AsIs" type
+  return (type == VCTRS_CLASS_list) || (type == VCTRS_CLASS_bare_asis);
 }
 
 // [[ register() ]]

--- a/src/utils-dispatch.c
+++ b/src/utils-dispatch.c
@@ -43,6 +43,8 @@ enum vctrs_class_type class_type_impl(r_obj* class) {
       return VCTRS_CLASS_bare_factor;
     } else if (p0 == strings_date) {
       return VCTRS_CLASS_bare_date;
+    } else if (p0 == strings.AsIs) {
+      return VCTRS_CLASS_bare_asis;
     }
 
     break;
@@ -94,6 +96,7 @@ const char* class_type_as_str(enum vctrs_class_type type) {
   switch (type) {
   case VCTRS_CLASS_list: return "list";
   case VCTRS_CLASS_data_frame: return "data_frame";
+  case VCTRS_CLASS_bare_asis: return "bare_asis";
   case VCTRS_CLASS_bare_data_frame: return "bare_data_frame";
   case VCTRS_CLASS_bare_tibble: return "bare_tibble";
   case VCTRS_CLASS_bare_factor: return "bare_factor";

--- a/src/utils-dispatch.h
+++ b/src/utils-dispatch.h
@@ -6,6 +6,7 @@
 enum vctrs_class_type {
   VCTRS_CLASS_list,
   VCTRS_CLASS_data_frame,
+  VCTRS_CLASS_bare_asis,
   VCTRS_CLASS_bare_data_frame,
   VCTRS_CLASS_bare_tibble,
   VCTRS_CLASS_bare_factor,

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -246,6 +246,7 @@ test_that("bare lists are lists", {
 
 test_that("AsIs lists are lists (#1463)", {
   expect_true(vec_is_list(I(list())))
+  expect_true(vec_is_list(I(list_of(1))))
   expect_false(vec_is_list(I(double())))
 })
 

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -244,6 +244,11 @@ test_that("bare lists are lists", {
   expect_true(vec_is_list(list()))
 })
 
+test_that("AsIs lists are lists (#1463)", {
+  expect_true(vec_is_list(I(list())))
+  expect_false(vec_is_list(I(double())))
+})
+
 test_that("list_of are lists", {
   expect_true(vec_is_list(new_list_of()))
 })

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -271,6 +271,11 @@ test_that("`x` and `indices` must be lists of the same size", {
   expect_error(vec_unchop(list(1, 2), list(1)), "`x` and `indices` must be lists of the same size")
 })
 
+test_that("can unchop with an AsIs list (#1463)", {
+  x <- I(list(1, 2))
+  expect_identical(vec_unchop(x), c(1, 2))
+})
+
 test_that("can unchop empty vectors", {
   expect_null(vec_unchop(list()))
   expect_null(vec_unchop(list(), list()))

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -136,6 +136,10 @@ test_that("class_type() detects classes", {
   expect_identical(class_type(foobar(list())), "unknown")
   expect_identical(class_type(structure(list(), class = "list")), "list")
   expect_identical(class_type(subclass(structure(list(), class = "list"))), "list")
+  expect_identical(class_type(I(subclass(structure(list(), class = "list")))), "list")
+
+  expect_identical(class_type(I(list())), "bare_asis")
+  expect_identical(class_type(I(1)), "bare_asis")
 
   expect_identical(class_type(data.frame()), "bare_data_frame")
   expect_identical(class_type(tibble::tibble()), "bare_tibble")


### PR DESCRIPTION
Closes #1463 
Closes #1529 (Alternative approach)