### PR TITLE
Pass error call through in `vec_init()`

### DIFF
--- a/src/bind.c
+++ b/src/bind.c
@@ -124,7 +124,7 @@ static SEXP vec_rbind(SEXP xs,
   }
 
   PROTECT_INDEX out_pi;
-  SEXP out = vec_init(proxy, n_rows);
+  SEXP out = vec_init(proxy, n_rows, r_lazy_null);
   PROTECT_WITH_INDEX(out, &out_pi);
   ++n_prot;
 

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -114,7 +114,7 @@ static SEXP vec_unchop(SEXP xs,
   PROTECT_INDEX proxy_pi;
   PROTECT_WITH_INDEX(proxy, &proxy_pi);
 
-  proxy = vec_init(proxy, out_size);
+  proxy = vec_init(proxy, out_size, r_lazy_null);
   REPROTECT(proxy, proxy_pi);
 
   SEXP out_names = R_NilValue;

--- a/src/c.c
+++ b/src/c.c
@@ -101,7 +101,7 @@ SEXP vec_c_opts(SEXP xs,
     p_sizes[i] = size;
   }
 
-  SEXP out = vec_init(ptype, out_size);
+  SEXP out = vec_init(ptype, out_size, r_lazy_null);
   PROTECT_INDEX out_pi;
   PROTECT_WITH_INDEX(out, &out_pi);
 

--- a/src/cast.c
+++ b/src/cast.c
@@ -40,7 +40,7 @@ r_obj* vec_cast_opts(const struct cast_opts* opts) {
   enum vctrs_type to_type = vec_typeof(to);
 
   if (x_type == vctrs_type_unspecified) {
-    return vec_init(to, vec_size(x));
+    return vec_init(to, vec_size(x), opts->call);
   }
 
   if (x_type == vctrs_type_scalar) {

--- a/src/slice.c
+++ b/src/slice.c
@@ -424,11 +424,11 @@ r_obj* vec_slice_opts(r_obj* x,
   return out;
 }
 
-r_obj* vec_init(r_obj* x, r_ssize n) {
-  vec_check_vector(x, NULL, r_lazy_null);
+r_obj* vec_init(r_obj* x, r_ssize n, struct r_lazy call) {
+  vec_check_vector(x, NULL, call);
 
   if (n < 0) {
-    r_abort("`n` must be a positive integer.");
+    r_abort_lazy_call(call, "`n` must be a positive integer.");
   }
 
   r_obj* i = KEEP(compact_rep(r_globals.na_int, n));
@@ -452,7 +452,7 @@ r_obj* ffi_init(r_obj* x, r_obj* ffi_n, r_obj* ffi_frame) {
 
   // TODO! Pass `frame`
   r_ssize n = r_int_get(ffi_n, 0);
-  r_obj* out = vec_init(x, n);
+  r_obj* out = vec_init(x, n, frame);
 
   FREE(1);
   return out;

--- a/src/slice.h
+++ b/src/slice.h
@@ -24,7 +24,7 @@ r_obj* vec_slice(r_obj* x, r_obj* i) {
   return vec_slice_opts(x, i, &opts);
 }
 
-r_obj* vec_init(r_obj* x, r_ssize n);
+r_obj* vec_init(r_obj* x, r_ssize n, struct r_lazy call);
 
 r_obj* vec_slice_unsafe(r_obj* x, r_obj* i);
 

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -722,7 +722,7 @@ static SEXP df_cast_match(const struct cast_opts* opts,
     SEXP col;
     if (pos == NA_INTEGER) {
       SEXP to_col = VECTOR_ELT(to, i);
-      col = vec_init(to_col, size);
+      col = vec_init(to_col, size, opts->call);
 
       // FIXME: Need to initialise the vector because we currently use
       // `vec_assign()` in `vec_rbind()` before falling back. Attach

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -121,3 +121,40 @@
       ! Can't subset elements past the end.
       x Elements `A`, `B`, `C`, `D`, `E`, etc. don't exist.
 
+# vec_init() asserts vectorness (#301)
+
+    Code
+      (expect_error(vec_init(NULL, 1L), class = "vctrs_error_scalar_type"))
+    Output
+      <error/vctrs_error_scalar_type>
+      Error in `vec_init()`:
+      ! Input must be a vector, not NULL.
+
+# vec_init() validates `n`
+
+    Code
+      (expect_error(vec_init(1L, 1.5), class = "vctrs_error_cast_lossy"))
+    Output
+      <error/vctrs_error_cast_lossy>
+      Error in `vec_init()`:
+      ! Can't convert from `n` <double> to <integer> due to loss of precision.
+      * Locations: 1
+    Code
+      (expect_error(vec_init(1L, c(1, 2))))
+    Output
+      <error/vctrs_error_assert_size>
+      Error:
+      ! `n` must have size 1, not size 2.
+    Code
+      (expect_error(vec_init(1L, -1L)))
+    Output
+      <error/rlang_error>
+      Error in `vec_init()`:
+      ! `n` must be a positive integer.
+    Code
+      (expect_error(vec_init(1L, NA_integer_)))
+    Output
+      <error/rlang_error>
+      Error in `vec_init()`:
+      ! `n` must be a positive integer.
+

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -494,7 +494,9 @@ test_that("na of list-array is 1d slice", {
 })
 
 test_that("vec_init() asserts vectorness (#301)", {
-  expect_error(vec_init(NULL, 1L), class = "vctrs_error_scalar_type")
+  expect_snapshot(
+    (expect_error(vec_init(NULL, 1L), class = "vctrs_error_scalar_type"))
+  )
 })
 
 test_that("vec_init() works with Altrep classes", {
@@ -506,10 +508,12 @@ test_that("vec_init() works with Altrep classes", {
 })
 
 test_that("vec_init() validates `n`", {
-  expect_error(vec_init(1L, 1.5), class = "vctrs_error_cast_lossy")
-  expect_error(vec_init(1L, c(1, 2)), "`n` must have size 1, not size 2.")
-  expect_error(vec_init(1L, -1L), "positive integer")
-  expect_error(vec_init(1L, NA_integer_), "positive integer")
+  expect_snapshot({
+    (expect_error(vec_init(1L, 1.5), class = "vctrs_error_cast_lossy"))
+    (expect_error(vec_init(1L, c(1, 2))))
+    (expect_error(vec_init(1L, -1L)))
+    (expect_error(vec_init(1L, NA_integer_)))
+  })
 })
 
 # vec_slice + compact_rep -------------------------------------------------


### PR DESCRIPTION
This builds on top of previous `vec_init()` work. We now pass the error call all the way through to checks like `vec_check_vector()` and the check that ensures that `n` is positive. We will also eventually pass the error call through to the `n > R_LEN_T_MAX` check that I will add in a follow up PR