### PR TITLE
Drop names in `vec_unique()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `vec_unique()` now drops all names from the result (#1442).
+
 * Lossy cast errors now inherit from incompatible type errors.
 
 * `vec_is_list()` now returns `TRUE` for `AsIs` lists (#1463).

--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -161,7 +161,7 @@ vec_duplicate_id <- function(x) {
 #' @param x A vector (including a data frame).
 #' @return
 #' * `vec_unique()`: a vector the same type as `x` containing only unique
-#'    values.
+#'    values. Names from `x` are dropped.
 #' * `vec_unique_loc()`: an integer vector, giving locations of unique values.
 #' * `vec_unique_count()`: an integer vector of length 1, giving the
 #'   number of unique values.
@@ -189,6 +189,7 @@ vec_duplicate_id <- function(x) {
 #' # But they are for the purposes of considering uniqueness
 #' vec_unique(c(NA, NA, NA, NA, 1, 2, 1))
 vec_unique <- function(x) {
+  x <- vec_set_names(x, NULL)
   vec_slice(x, vec_unique_loc(x))
 }
 

--- a/man/vec_unique.Rd
+++ b/man/vec_unique.Rd
@@ -18,7 +18,7 @@ vec_unique_count(x)
 \value{
 \itemize{
 \item \code{vec_unique()}: a vector the same type as \code{x} containing only unique
-values.
+values. Names from \code{x} are dropped.
 \item \code{vec_unique_loc()}: an integer vector, giving locations of unique values.
 \item \code{vec_unique_count()}: an integer vector of length 1, giving the
 number of unique values.

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -152,16 +152,16 @@ test_that("unique functions treat positive and negative 0 as equivalent (#637)",
 test_that("unique functions work with different encodings", {
   encs <- encodings()
 
-  expect_equal(vec_unique(encs), encs[1])
+  expect_equal(vec_unique(encs), unname(encs[1]))
   expect_equal(vec_unique_count(encs), 1L)
   expect_equal(vec_unique_loc(encs), 1L)
 })
 
 test_that("unique functions can handle scalar types in lists", {
-  x <- list(x = a ~ b, y = a ~ b, z = a ~ c)
+  x <- list(a ~ b, a ~ b, a ~ c)
   expect_equal(vec_unique(x), vec_slice(x, c(1, 3)))
 
-  x <- list(x = call("x"), y = call("y"), z = call("x"))
+  x <- list(call("x"), call("y"), call("x"))
   expect_equal(vec_unique(x), vec_slice(x, c(1, 2)))
 })
 
@@ -198,6 +198,13 @@ test_that("can take the unique locations of dfs with list-cols", {
   expect_identical(vec_unique_loc(df), c(1L, 2L, 4L))
 })
 
+test_that("vec_unique() drops names (#1442)", {
+  x <- c(a = 1, 1)
+  y <- c(1, a = 1)
+
+  expect_identical(vec_unique(x), 1)
+  expect_identical(vec_unique(y), 1)
+})
 
 # matching ----------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1442 

I looked through our list of functions and I don't think there are any others where we want to do this.