### PR TITLE
Add error helpers on the C side

### DIFF
--- a/R/compat-friendly-type.R
+++ b/R/compat-friendly-type.R
@@ -1,6 +1,33 @@
-# nocov start --- r-lib/rlang compat-friendly-type --- 2021-03-25 Thu 09:25
+# nocov start --- r-lib/rlang compat-friendly-type
+#
+# Changelog
+# =========
+#
+# 2021-12-20:
+# - Added support for scalar values and empty vectors.
+# - Added `stop_input_type()`
+#
+# 2021-06-30:
+# - Added support for missing arguments.
+#
+# 2021-04-19:
+# - Added support for matrices and arrays (#141).
+# - Added documentation.
+# - Added changelog.
 
-friendly_type_of <- function(x, length = FALSE) {
+
+#' Return English-friendly type
+#' @param x Any R object.
+#' @param value Whether to describe the value of `x`.
+#' @param length Whether to mention the length of vectors and lists.
+#' @return A string describing the type. Starts with an indefinite
+#'   article, e.g. "an integer vector".
+#' @noRd
+friendly_type_of <- function(x, value = TRUE, length = FALSE) {
+  if (is_missing(x)) {
+    return("absent")
+  }
+
   if (is.object(x)) {
     if (inherits(x, "quosure")) {
       type <- "quosure"
@@ -10,25 +37,97 @@ friendly_type_of <- function(x, length = FALSE) {
     return(sprintf("a <%s> object", type))
   }
 
-  friendly <- as_friendly_type(typeof(x))
-
-  if (length && rlang::is_vector(x)) {
-    friendly <- paste0(friendly, sprintf(" of length %s", length(x)))
+  if (!rlang::is_vector(x)) {
+    return(.rlang_as_friendly_type(typeof(x)))
   }
 
-  friendly
+  n_dim <- length(dim(x))
+
+  if (value && !n_dim) {
+    if (is_na(x)) {
+      return(switch(
+        typeof(x),
+        logical = "`NA`",
+        integer = "an integer `NA`",
+        double = "a numeric `NA`",
+        complex = "a complex `NA`",
+        character = "a character `NA`",
+        .rlang_stop_unexpected_typeof(x)
+      ))
+    }
+    if (length(x) == 1 && !is_list(x)) {
+      return(switch(
+        typeof(x),
+        logical = if (x) "`TRUE`" else "`FALSE`",
+        integer = "an integer",
+        double = "a number",
+        complex = "a complex number",
+        character = if (nzchar(x)) "a string" else "`\"\"`",
+        raw = "a raw value",
+        .rlang_stop_unexpected_typeof(x)
+      ))
+    }
+    if (length(x) == 0) {
+      return(switch(
+        typeof(x),
+        logical = "an empty logical vector",
+        integer = "an empty integer vector",
+        double = "an empty numeric vector",
+        complex = "an empty complex vector",
+        character = "an empty character vector",
+        raw = "an empty raw vector",
+        list = "an empty list",
+        .rlang_stop_unexpected_typeof(x)
+      ))
+    }
+  }
+
+  type <- .rlang_as_friendly_vector_type(typeof(x), n_dim)
+
+  if (length && !n_dim) {
+    type <- paste0(type, sprintf(" of length %s", length(x)))
+  }
+
+  type
 }
 
-as_friendly_type <- function(type) {
-  switch(type,
-    logical = "a logical vector",
-    integer = "an integer vector",
+.rlang_as_friendly_vector_type <- function(type, n_dim) {
+  if (type == "list") {
+    if (n_dim < 2) {
+      return("a list")
+    } else if (n_dim == 2) {
+      return("a list matrix")
+    } else {
+      return("a list array")
+    }
+  }
+
+  type <- switch(
+    type,
+    logical = "a logical %s",
+    integer = "an integer %s",
     numeric = ,
-    double = "a double vector",
-    complex = "a complex vector",
-    character = "a character vector",
-    raw = "a raw vector",
-    string = "a string",
+    double = "a double %s",
+    complex = "a complex %s",
+    character = "a character %s",
+    raw = "a raw %s",
+    type = paste0("a ", type, " %s")
+  )
+
+  if (n_dim < 2) {
+    kind <- "vector"
+  } else if (n_dim == 2) {
+    kind <- "matrix"
+  } else {
+    kind <- "array"
+  }
+  sprintf(type, kind)
+}
+
+.rlang_as_friendly_type <- function(type) {
+  switch(
+    type,
+
     list = "a list",
 
     NULL = "NULL",
@@ -42,8 +141,6 @@ as_friendly_type <- function(type) {
     language = "a call",
     pairlist = "a pairlist node",
     expression = "an expression vector",
-    quosure = "a quosure",
-    formula = "a formula",
 
     char = "an internal string",
     promise = "an internal promise",
@@ -58,6 +155,43 @@ as_friendly_type <- function(type) {
 
     type
   )
+}
+
+.rlang_stop_unexpected_typeof <- function(x, call = rlang::caller_env()) {
+  rlang::abort(
+    sprintf("Unexpected type <%s>.", typeof(x)),
+    call = call
+  )
+}
+
+#' @param x The object type which does not conform to `what`. Its
+#'   `friendly_type_of()` is taken and mentioned in the error message.
+#' @param what The friendly expected type.
+#' @param ... Arguments passed to [abort()].
+#' @inheritParams args_error_context
+#' @noRd
+stop_input_type <- function(x,
+                            what,
+                            ...,
+                            arg = rlang::caller_arg(x),
+                            call = rlang::caller_env()) {
+  # From compat-cli.R
+  format_arg <- rlang::env_get(
+    nm = "format_arg",
+    last = topenv(),
+    default = NULL
+  )
+  if (!is.function(format_arg)) {
+    format_arg <- function(x) sprintf("`%s`", x)
+  }
+
+  message <- sprintf(
+    "%s must be %s, not %s.",
+    format_arg(arg),
+    what,
+    friendly_type_of(x)
+  )
+  rlang::abort(message, ..., call = call)
 }
 
 # nocov end

--- a/src/arg.c
+++ b/src/arg.c
@@ -42,6 +42,14 @@ r_obj* vctrs_arg(struct vctrs_arg* arg) {
   return out;
 }
 
+// vmax-protected
+const char* vec_arg_format(struct vctrs_arg* p_arg) {
+  r_obj* arg = KEEP(vctrs_arg(p_arg));
+  const char* out = r_format_error_arg(arg);
+  FREE(1);
+  return out;
+}
+
 /**
  * Takes a `struct vctrs_arg{}` linked list and a buffer and calls the
  * `fill()` method on each of those, recursively. Unless an error

--- a/src/arg.h
+++ b/src/arg.h
@@ -4,6 +4,13 @@
 #include "vctrs-core.h"
 
 
+// Materialise an argument tag as a CHARSXP.
+r_obj* vctrs_arg(struct vctrs_arg* arg);
+
+// Materialise an argument tag as a vmax-protected C string.
+const char* vec_arg_format(struct vctrs_arg* p_arg);
+
+
 // Simple wrapper around a string
 struct vctrs_arg new_wrapper_arg(struct vctrs_arg* parent,
                                  const char* arg);
@@ -38,9 +45,6 @@ struct vctrs_arg* new_subscript_arg(struct vctrs_arg* parent,
                                     r_obj* names,
                                     r_ssize n,
                                     r_ssize* p_i);
-
-// Materialise an argument tag as a CHARSXP.
-r_obj* vctrs_arg(struct vctrs_arg* arg);
 
 
 #endif

--- a/src/rlang-dev.c
+++ b/src/rlang-dev.c
@@ -1,0 +1,16 @@
+#include "vctrs.h"
+
+const char* r_friendly_type_of(r_obj* x) {
+  r_obj* call = KEEP(r_parse("friendly_type_of(x)"));
+  r_obj* ffi_out = KEEP(r_eval_with_x(call, x, vctrs_ns_env));
+
+  const char* out_str = r_chr_get_c_string(ffi_out, 0);
+  int n = strlen(out_str) + 1;
+
+  // Uses the vmax protection stack.
+  char* out = R_alloc(n, sizeof(char));
+  memcpy(out, out_str, n);
+
+  FREE(2);
+  return out;
+}

--- a/src/rlang-dev.h
+++ b/src/rlang-dev.h
@@ -45,5 +45,8 @@ const char* r_c_str_format_error_arg(const char* x) {
   return out;
 }
 
+// vmax-protected result
+const char* r_friendly_type_of(r_obj* x);
+
 
 #endif

--- a/src/rlang-dev.h
+++ b/src/rlang-dev.h
@@ -36,4 +36,14 @@ r_obj* r_lazy_eval_protect(struct r_lazy lazy) {
 #define r_abort_lazy_call(LAZY, ...) \
   r_abort_call(KEEP(r_lazy_eval(LAZY)), __VA_ARGS__)
 
+
+static inline
+const char* r_c_str_format_error_arg(const char* x) {
+  r_obj* ffi_x = KEEP(r_chr(x));
+  const char* out = r_format_error_arg(ffi_x);
+  FREE(1);
+  return out;
+}
+
+
 #endif

--- a/src/size.c
+++ b/src/size.c
@@ -77,7 +77,9 @@ r_obj* ffi_list_sizes(r_obj* x, r_obj* frame) {
 static
 r_obj* list_sizes(r_obj* x, const struct vec_error_info* opts) {
   if (!vec_is_list(x)) {
-    r_abort_lazy_call(opts->call, "`x` must be a list.");
+    r_abort_lazy_call(opts->call,
+                      "%s must be a list.",
+                      r_c_str_format_error_arg("x"));
   }
 
   r_ssize size = vec_size(x);
@@ -242,13 +244,17 @@ r_ssize size_validate(r_obj* size, const char* arg) {
                   call);
 
   if (r_length(size) != 1) {
-    r_abort_lazy_call(call, "`%s` must be a single integer.", arg);
+    r_abort_lazy_call(call,
+                      "%s must be a single integer.",
+                      r_c_str_format_error_arg(arg));
   }
 
   int out = r_int_get(size, 0);
 
   if (out == r_globals.na_int) {
-    r_abort_lazy_call(call, "`%s` can't be missing.", arg);
+    r_abort_lazy_call(call,
+                      "`%s` can't be missing.",
+                      r_c_str_format_error_arg(arg));
   }
 
   return out;

--- a/src/size.c
+++ b/src/size.c
@@ -78,8 +78,9 @@ static
 r_obj* list_sizes(r_obj* x, const struct vec_error_info* opts) {
   if (!vec_is_list(x)) {
     r_abort_lazy_call(opts->call,
-                      "%s must be a list.",
-                      r_c_str_format_error_arg("x"));
+                      "%s must be a list, not %s.",
+                      r_c_str_format_error_arg("x"),
+                      r_friendly_type_of(x));
   }
 
   r_ssize size = vec_size(x);

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -338,7 +338,7 @@
     Output
       <error/rlang_error>
       Error in `list_sizes()`:
-      ! `x` must be a list.
+      ! `x` must be a list, not a <vctrs_foobar> object.
     Code
       (expect_error(list_sizes(list(env()))))
     Output


### PR DESCRIPTION
- `vec_arg_format()` which takes a vctrs arg and returns a vmax-protected C string formatted by cli via `r_format_error_arg()`.

- `r_c_str_format_error_arg()` which is like `r_format_error_arg()` but takes a C string. The result is also vmax-protected.

- `r_friendly_type_of()` in `rlang-dev.c` which returns a friendly type as a vmax-protected string. I've also updated the compat file that supports it.

This should make it easier to create well formatted errors from C, using `r_abort_call()` and `r_abort_lazy_call()`.