### PR TITLE
Improve size checking

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* Lossy cast errors now inherit from incompatible type errors.
+
 * `vec_is_list()` now returns `TRUE` for `AsIs` lists (#1463).
 
 * `vec_assert()`, `vec_ptype2()`, `vec_cast()`, and `vec_as_location()`

--- a/R/size.R
+++ b/R/size.R
@@ -144,3 +144,9 @@ vec_seq_along <- function(x) {
 vec_init_along <- function(x, y = x) {
   vec_slice(x, rep_len(NA_integer_, vec_size(y)))
 }
+
+vec_as_short_length <- function(n,
+                                arg = caller_arg(n),
+                                call = caller_env()) {
+  .Call(ffi_as_short_length, n, environment())
+}

--- a/man/vctrs-conditions.Rd
+++ b/man/vctrs-conditions.Rd
@@ -104,7 +104,7 @@ testing easier.
 # Most of the time, `maybe_lossy_cast()` returns its input normally:
 maybe_lossy_cast(
   c("foo", "bar"),
-  NULL,
+  NA,
   "",
   lossy = c(FALSE, FALSE),
   x_arg = "",
@@ -114,7 +114,7 @@ maybe_lossy_cast(
 # If `lossy` has any `TRUE`, an error is thrown:
 try(maybe_lossy_cast(
   c("foo", "bar"),
-  NULL,
+  NA,
   "",
   lossy = c(FALSE, TRUE),
   x_arg = "",
@@ -125,7 +125,7 @@ try(maybe_lossy_cast(
 allow_lossy_cast(
   maybe_lossy_cast(
     c("foo", "bar"),
-    NULL,
+    NA,
     "",
     lossy = c(FALSE, TRUE),
     x_arg = "",

--- a/src/bind.c
+++ b/src/bind.c
@@ -390,7 +390,7 @@ static SEXP vec_cbind(SEXP xs, SEXP ptype, SEXP size, struct name_repair_opts* n
   if (size == R_NilValue) {
     nrow = vec_size_common(xs, 0);
   } else {
-    nrow = check_size(size, vec_args.dot_size, call);
+    nrow = vec_as_short_length(size, vec_args.dot_size, call);
   }
 
   if (rownames != R_NilValue && Rf_length(rownames) != nrow) {

--- a/src/cast.c
+++ b/src/cast.c
@@ -221,7 +221,7 @@ r_obj* vec_cast_e(const struct cast_opts* opts,
 
   *err = r_try_catch(&vec_cast_e_cb,
                      &data,
-                     syms_vctrs_error_cast_lossy,
+                     syms_vctrs_error_incompatible_type,
                      NULL,
                      NULL);
   return data.out;

--- a/src/decl/rlang-dev-decl.h
+++ b/src/decl/rlang-dev-decl.h
@@ -1,0 +1,3 @@
+const char* r_friendly_type_of_opts(r_obj* x,
+                                    bool value,
+                                    bool length);

--- a/src/init.c
+++ b/src/init.c
@@ -146,6 +146,7 @@ extern r_obj* ffi_interval_complement(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_check_list(r_obj*, r_obj*);
 extern r_obj* ffi_list_all_vectors(r_obj*);
 extern r_obj* ffi_list_check_all_vectors(r_obj*, r_obj*);
+extern r_obj* ffi_as_short_length(r_obj*, r_obj*);
 
 
 // Maturing
@@ -313,6 +314,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"ffi_check_list",                        (DL_FUNC) &ffi_check_list, 2},
   {"ffi_list_all_vectors",                  (DL_FUNC) &ffi_list_all_vectors, 2},
   {"ffi_list_check_all_vectors",            (DL_FUNC) &ffi_list_check_all_vectors, 2},
+  {"ffi_as_short_length",                   (DL_FUNC) &ffi_as_short_length, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/ptype2.c
+++ b/src/ptype2.c
@@ -168,12 +168,13 @@ r_obj* vec_ptype2_from_unspecified(const struct ptype2_opts* opts,
 struct is_coercible_data {
   const struct ptype2_opts* opts;
   int* dir;
+  r_obj* out;
 };
 
 static
 void vec_is_coercible_cb(void* data_) {
   struct is_coercible_data* data = (struct is_coercible_data*) data_;
-  vec_ptype2_opts(data->opts, data->dir);
+  data->out = vec_ptype2_opts(data->opts, data->dir);
 }
 
 static
@@ -183,6 +184,7 @@ void vec_is_coercible_e(const struct ptype2_opts* opts,
   struct is_coercible_data data = {
     .opts = opts,
     .dir = dir,
+    .out = r_null
   };
 
   *err = r_try_catch(&vec_is_coercible_cb,
@@ -197,6 +199,24 @@ bool vec_is_coercible(const struct ptype2_opts* opts,
   ERR err = NULL;
   vec_is_coercible_e(opts, dir, &err);
   return !err;
+}
+
+r_obj* vec_ptype2_e(const struct ptype2_opts* opts,
+                    int* dir,
+                    ERR* err) {
+  struct is_coercible_data data = {
+    .opts = opts,
+    .dir = dir,
+    .out = r_null
+  };
+
+  *err = r_try_catch(&vec_is_coercible_cb,
+                     &data,
+                     syms_vctrs_error_incompatible_type,
+                     NULL,
+                     NULL);
+
+  return data.out;
 }
 
 // [[ register() ]]

--- a/src/ptype2.h
+++ b/src/ptype2.h
@@ -78,6 +78,10 @@ r_obj* vec_ptype2(r_obj* x,
 
 bool vec_is_coercible(const struct ptype2_opts* opts, int* dir);
 
+r_obj* vec_ptype2_e(const struct ptype2_opts* opts,
+                    int* dir,
+                    ERR* err);
+
 struct ptype2_opts new_ptype2_opts(r_obj* x,
                                    r_obj* y,
                                    struct vctrs_arg* x_arg,

--- a/src/rlang-dev.c
+++ b/src/rlang-dev.c
@@ -1,8 +1,19 @@
 #include "vctrs.h"
+#include "decl/rlang-dev-decl.h"
 
 const char* r_friendly_type_of(r_obj* x) {
-  r_obj* call = KEEP(r_parse("friendly_type_of(x)"));
-  r_obj* ffi_out = KEEP(r_eval_with_x(call, x, vctrs_ns_env));
+  return r_friendly_type_of_opts(x, true, false);
+}
+
+const char* r_friendly_type_of_length(r_obj* x) {
+  return r_friendly_type_of_opts(x, true, true);
+}
+
+const char* r_friendly_type_of_opts(r_obj* x,
+                                    bool value,
+                                    bool length) {
+  r_obj* call = KEEP(r_parse("friendly_type_of(x, value = y, length = z)"));
+  r_obj* ffi_out = KEEP(r_eval_with_xyz(call, x, r_lgl(value), r_lgl(length), vctrs_ns_env));
 
   const char* out_str = r_chr_get_c_string(ffi_out, 0);
   int n = strlen(out_str) + 1;

--- a/src/rlang-dev.h
+++ b/src/rlang-dev.h
@@ -47,6 +47,7 @@ const char* r_c_str_format_error_arg(const char* x) {
 
 // vmax-protected result
 const char* r_friendly_type_of(r_obj* x);
+const char* r_friendly_type_of_length(r_obj* x);
 
 
 #endif

--- a/src/size-common.c
+++ b/src/size-common.c
@@ -13,7 +13,7 @@ r_obj* ffi_size_common(r_obj* ffi_call, r_obj* op, r_obj* args, r_obj* env) {
   r_obj* absent = r_node_car(args);
 
   if (size != r_null) {
-    r_ssize out = check_size(size, vec_args.dot_size, call);
+    r_ssize out = vec_as_short_length(size, vec_args.dot_size, call);
     return r_int(out);
   }
 
@@ -105,7 +105,7 @@ r_obj* ffi_recycle_common(r_obj* ffi_call, r_obj* op, r_obj* args, r_obj* env) {
 
   r_ssize common;
   if (size != r_null) {
-    common = check_size(size, vec_args.dot_size, call);
+    common = vec_as_short_length(size, vec_args.dot_size, call);
   } else {
     common = vec_size_common(xs, -1);
   }

--- a/src/size.c
+++ b/src/size.c
@@ -239,22 +239,24 @@ r_ssize check_size(r_obj* size,
                    struct r_lazy call) {
   size = vec_cast(size,
                   vctrs_shared_empty_int,
-                  args_empty,
+                  p_arg,
                   args_empty,
                   call);
 
   if (r_length(size) != 1) {
     r_abort_lazy_call(call,
-                      "%s must be a single integer.",
-                      vec_arg_format(p_arg));
+                      "%s must be a single integer, not %s.",
+                      vec_arg_format(p_arg),
+                      r_friendly_type_of_length(size));
   }
 
   int out = r_int_get(size, 0);
 
   if (out == r_globals.na_int) {
     r_abort_lazy_call(call,
-                      "`%s` can't be missing.",
-                      vec_arg_format(p_arg));
+                      "%s must be a single number, not %s.",
+                      vec_arg_format(p_arg),
+                      r_friendly_type_of(size));
   }
 
   return out;

--- a/src/size.c
+++ b/src/size.c
@@ -281,6 +281,7 @@ r_ssize vec_as_ssize(r_obj* n,
       goto invalid;
     }
   }
+  KEEP(n);
 
   switch (r_typeof(n)) {
 
@@ -301,24 +302,26 @@ r_ssize vec_as_ssize(r_obj* n,
 
     if (out > R_SSIZE_MAX) {
       r_abort_lazy_call(call,
-                        "%s is too large a number and long vectors are not supported.",
+                        "%s is too large a number.",
                         vec_arg_format(p_arg));
     }
 
-    return (r_ssize) floor(out);
+    FREE(1);
+    return (r_ssize) out;
   }
 
   case R_TYPE_integer: {
     if (r_length(n) != 1) {
       goto invalid;
     }
-    int out = (r_ssize) r_int_get(n, 0);
+    int out = r_int_get(n, 0);
 
     if (out == r_globals.na_int) {
       goto invalid;
     }
 
-    return out;
+    FREE(1);
+    return (r_ssize) out;
   }
 
   invalid:

--- a/src/size.h
+++ b/src/size.h
@@ -5,9 +5,13 @@
 
 r_ssize vec_size(r_obj* x);
 
-r_ssize check_size(r_obj* size,
-                   struct vctrs_arg* p_arg,
-                   struct r_lazy call);
+r_ssize vec_as_short_length(r_obj* size,
+                            struct vctrs_arg* p_arg,
+                            struct r_lazy call);
+
+r_ssize vec_as_ssize(r_obj* n,
+                     struct vctrs_arg* arg,
+                     struct r_lazy call);
 
 r_obj* vec_recycle2(r_obj* x,
                     r_ssize size,

--- a/src/slice.c
+++ b/src/slice.c
@@ -440,21 +440,12 @@ r_obj* vec_init(r_obj* x, r_ssize n) {
 
 // [[ register() ]]
 r_obj* ffi_init(r_obj* x, r_obj* ffi_n, r_obj* ffi_frame) {
-  struct r_lazy frame = { .x = ffi_frame, .env = r_null };
+  struct r_lazy call = { .x = ffi_frame, .env = r_null };
+  r_ssize n = vec_as_short_length(ffi_n, args_n, call);
 
-  ffi_n = KEEP(vec_cast(ffi_n,
-                        vctrs_shared_empty_int,
-                        args_n,
-                        args_empty,
-                        frame));
-  // TODO! Pass `frame`
-  vec_check_size(ffi_n, 1, args_n);
-
-  // TODO! Pass `frame`
-  r_ssize n = r_int_get(ffi_n, 0);
+  // TODO! Pass `call`
   r_obj* out = vec_init(x, n);
 
-  FREE(1);
   return out;
 }
 

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -198,7 +198,7 @@ SEXP vctrs_data_frame(SEXP x, SEXP size, SEXP name_repair) {
   if (size == R_NilValue) {
     c_size = vec_size_common(x, 0);
   } else {
-    c_size = check_size(size, vec_args.dot_size, call);
+    c_size = vec_as_short_length(size, vec_args.dot_size, call);
   }
 
   SEXP out = data_frame(x, c_size, &name_repair_opts);
@@ -232,7 +232,7 @@ SEXP vctrs_df_list(SEXP x, SEXP size, SEXP name_repair) {
   if (size == R_NilValue) {
     c_size = vec_size_common(x, 0);
   } else {
-    c_size = check_size(size, vec_args.dot_size, call);
+    c_size = vec_as_short_length(size, vec_args.dot_size, call);
   }
 
   SEXP out = df_list(x, c_size, &name_repair_opts);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1638,6 +1638,7 @@ void c_print_backtrace() {
 #endif
 }
 
+
 struct r_lazy r_lazy_null;
 
 void vctrs_init_utils(SEXP ns) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -401,7 +401,6 @@ static inline const void* vec_type_missing_value(enum vctrs_type type) {
 
 void c_print_backtrace();
 
-
 SEXP chr_c(SEXP x, SEXP y);
 
 

--- a/tests/testthat/_snaps/size.md
+++ b/tests/testthat/_snaps/size.md
@@ -1,3 +1,24 @@
+# vec_size_common() checks inputs
+
+    Code
+      (expect_error(vec_size_common(.size = "foo")))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `vec_size_common()`:
+      ! Can't convert `.size` <character> to <integer>.
+    Code
+      (expect_error(vec_size_common(.size = 1:2)))
+    Output
+      <error/rlang_error>
+      Error in `vec_size_common()`:
+      ! `.size` must be a single integer, not an integer vector of length 2.
+    Code
+      (expect_error(vec_size_common(.size = NA)))
+    Output
+      <error/rlang_error>
+      Error in `vec_size_common()`:
+      ! `.size` must be a single number, not an integer `NA`.
+
 # `.absent` must be supplied when `...` is empty
 
     Code

--- a/tests/testthat/_snaps/size.md
+++ b/tests/testthat/_snaps/size.md
@@ -53,7 +53,7 @@
     Output
       <error/rlang_error>
       Error in `vec_as_short_length()`:
-      ! `my_arg` is too large a number and long vectors are not supported.
+      ! `my_arg` is too large a number.
 
 # vec_size_common() checks inputs
 

--- a/tests/testthat/_snaps/size.md
+++ b/tests/testthat/_snaps/size.md
@@ -1,23 +1,74 @@
+# vec_as_short_length() checks inputs
+
+    Code
+      (expect_error(my_function(-1)))
+    Output
+      <error/rlang_error>
+      Error in `vec_as_short_length()`:
+      ! `my_arg` must be a positive number or zero.
+    Code
+      (expect_error(my_function(1:2)))
+    Output
+      <error/rlang_error>
+      Error in `vec_as_short_length()`:
+      ! `my_arg` must be a single number, not an integer vector of length 2.
+    Code
+      (expect_error(my_function(1.5)))
+    Output
+      <error/rlang_error>
+      Error in `vec_as_short_length()`:
+      ! `my_arg` must be a whole number, not a fractional number.
+    Code
+      (expect_error(my_function(NA)))
+    Output
+      <error/rlang_error>
+      Error in `vec_as_short_length()`:
+      ! `my_arg` must be a single number, not `NA`.
+    Code
+      (expect_error(my_function(na_int)))
+    Output
+      <error/rlang_error>
+      Error in `vec_as_short_length()`:
+      ! `my_arg` must be a single number, not an integer `NA`.
+    Code
+      (expect_error(my_function("foo")))
+    Output
+      <error/rlang_error>
+      Error in `vec_as_short_length()`:
+      ! `my_arg` must be a single number, not a string.
+    Code
+      (expect_error(my_function(foobar(1:2))))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `vec_as_short_length()`:
+      ! Can't convert `my_arg` <vctrs_foobar> to <double>.
+    Code
+      (expect_error(my_function(.Machine$integer.max + 1)))
+    Output
+      <error/rlang_error>
+      Error in `vec_as_short_length()`:
+      ! `my_arg` is too large a number and long vectors are not supported.
+    Code
+      (expect_error(my_function(.Machine$double.xmax)))
+    Output
+      <error/rlang_error>
+      Error in `vec_as_short_length()`:
+      ! `my_arg` is too large a number and long vectors are not supported.
+
 # vec_size_common() checks inputs
 
     Code
       (expect_error(vec_size_common(.size = "foo")))
     Output
-      <error/vctrs_error_incompatible_type>
+      <error/rlang_error>
       Error in `vec_size_common()`:
-      ! Can't convert `.size` <character> to <integer>.
+      ! `.size` must be a single number, not a string.
     Code
       (expect_error(vec_size_common(.size = 1:2)))
     Output
       <error/rlang_error>
       Error in `vec_size_common()`:
-      ! `.size` must be a single integer, not an integer vector of length 2.
-    Code
-      (expect_error(vec_size_common(.size = NA)))
-    Output
-      <error/rlang_error>
-      Error in `vec_size_common()`:
-      ! `.size` must be a single number, not an integer `NA`.
+      ! `.size` must be a single number, not an integer vector of length 2.
 
 # `.absent` must be supplied when `...` is empty
 

--- a/tests/testthat/_snaps/size.md
+++ b/tests/testthat/_snaps/size.md
@@ -39,9 +39,9 @@
     Code
       (expect_error(my_function(foobar(1:2))))
     Output
-      <error/vctrs_error_incompatible_type>
+      <error/rlang_error>
       Error in `vec_as_short_length()`:
-      ! Can't convert `my_arg` <vctrs_foobar> to <double>.
+      ! `my_arg` must be a single number, not NULL.
     Code
       (expect_error(my_function(.Machine$integer.max + 1)))
     Output

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -121,3 +121,36 @@
       ! Can't subset elements past the end.
       x Elements `A`, `B`, `C`, `D`, `E`, etc. don't exist.
 
+# vec_init() validates `n`
+
+    Code
+      (expect_error(vec_init(1L, 1.5)))
+    Output
+      <error/rlang_error>
+      Error in `vec_init()`:
+      ! `n` must be a whole number, not a fractional number.
+    Code
+      (expect_error(vec_init(1L, c(1, 2))))
+    Output
+      <error/rlang_error>
+      Error in `vec_init()`:
+      ! `n` must be a single number, not a double vector of length 2.
+    Code
+      (expect_error(vec_init(1L, -1L)))
+    Output
+      <error/rlang_error>
+      Error in `vec_init()`:
+      ! `n` must be a positive number or zero.
+    Code
+      (expect_error(vec_init(1L, NA)))
+    Output
+      <error/rlang_error>
+      Error in `vec_init()`:
+      ! `n` must be a single number, not `NA`.
+    Code
+      (expect_error(vec_init(1L, NA_integer_)))
+    Output
+      <error/rlang_error>
+      Error in `vec_init()`:
+      ! `n` must be a single number, not an integer `NA`.
+

--- a/tests/testthat/test-size.R
+++ b/tests/testthat/test-size.R
@@ -1,3 +1,21 @@
+test_that("vec_as_short_length() checks inputs", {
+  expect_equal(vec_as_short_length(0), 0)
+  expect_equal(vec_as_short_length(1L), 1)
+
+  my_function <- function(my_arg) vec_as_short_length(my_arg)
+  expect_snapshot({
+    (expect_error(my_function(-1)))
+    (expect_error(my_function(1:2)))
+    (expect_error(my_function(1.5)))
+    (expect_error(my_function(NA)))
+    (expect_error(my_function(na_int)))
+    (expect_error(my_function("foo")))
+    (expect_error(my_function(foobar(1:2))))
+    (expect_error(my_function(.Machine$integer.max + 1)))
+    (expect_error(my_function(.Machine$double.xmax)))
+  })
+})
+
 
 # vec_size -----------------------------------------------------------------
 
@@ -60,7 +78,6 @@ test_that("vec_size_common() checks inputs", {
   expect_snapshot({
     (expect_error(vec_size_common(.size = "foo")))
     (expect_error(vec_size_common(.size = 1:2)))
-    (expect_error(vec_size_common(.size = NA)))
   })
 })
 

--- a/tests/testthat/test-size.R
+++ b/tests/testthat/test-size.R
@@ -56,6 +56,14 @@ test_that("can take the size of unspecified objects", {
 
 # vec_size_common ---------------------------------------------------------
 
+test_that("vec_size_common() checks inputs", {
+  expect_snapshot({
+    (expect_error(vec_size_common(.size = "foo")))
+    (expect_error(vec_size_common(.size = 1:2)))
+    (expect_error(vec_size_common(.size = NA)))
+  })
+})
+
 test_that("vec_size_common with no input is 0L unless `.absent` is provided", {
   expect_identical(vec_size_common(), 0L)
   expect_identical(vec_size_common(NULL), 0L)

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -506,11 +506,15 @@ test_that("vec_init() works with Altrep classes", {
 })
 
 test_that("vec_init() validates `n`", {
-  expect_error(vec_init(1L, 1.5), class = "vctrs_error_cast_lossy")
-  expect_error(vec_init(1L, c(1, 2)), "`n` must have size 1, not size 2.")
-  expect_error(vec_init(1L, -1L), "positive integer")
-  expect_error(vec_init(1L, NA_integer_), "positive integer")
+  expect_snapshot({
+    (expect_error(vec_init(1L, 1.5)))
+    (expect_error(vec_init(1L, c(1, 2))))
+    (expect_error(vec_init(1L, -1L)))
+    (expect_error(vec_init(1L, NA)))
+    (expect_error(vec_init(1L, NA_integer_)))
+  })
 })
+
 
 # vec_slice + compact_rep -------------------------------------------------
 


### PR DESCRIPTION
- New `vec_as_ssize()` adapted from `r_arg_as_ssize()`. It takes `arg` and `call` arguments. It now casts the input to double and checks for `R_SSIZE_MAX`.

- New `vec_as_short_length()` which calls `vec_as_ssize()` and checks for `INT_MAX` and negative values. (ssize can be negative). When we switch to long vector support, we'll use a new `vec_as_length()` wrapper.

- `vec_init()` uses `vec_as_short_length()`, closes #1437.

- To support the casting, `vec_cast_e()` now catches `vctrs_error_incompatible_type` instead of lossy cast errors. To make this work, lossy cast errors are now a subclass of cast errors. This changes the internal structure a bit but a quick CRAN search suggest this shouldn't cause issues (to be confirmed in revdep checks).