### PR TITLE
Use `names<-` on base types in `vec_set_names()`

### DIFF
--- a/R/names.R
+++ b/R/names.R
@@ -436,13 +436,13 @@ bullets <- function(..., header = NULL) {
 }
 
 # Used in names.c
-set_rownames_fallback <- function(x, names) {
+set_rownames_dispatch <- function(x, names) {
   rownames(x) <- names
   x
 }
 
 # Used in names.c
-set_names_fallback <- function(x, names) {
+set_names_dispatch <- function(x, names) {
   names(x) <- names
   x
 }

--- a/src/names.c
+++ b/src/names.c
@@ -813,8 +813,15 @@ SEXP vec_set_names_impl(SEXP x, SEXP names, bool proxy, const enum vctrs_owned o
     return x;
   }
 
-  x = PROTECT(vec_clone_referenced(x, owned));
-  Rf_setAttrib(x, R_NamesSymbol, names);
+  if (owned) {
+    // Possibly skip the cloning altogether
+    x = PROTECT(vec_clone_referenced(x, owned));
+    Rf_setAttrib(x, R_NamesSymbol, names);
+  } else {
+    // We need to clone, but to do this we will use `names<-`
+    // which can perform a cheaper ALTREP shallow duplication
+    x = PROTECT(set_names_dispatch(x, names));
+  }
 
   UNPROTECT(1);
   return x;

--- a/src/names.c
+++ b/src/names.c
@@ -687,21 +687,21 @@ SEXP r_seq_chr(const char* prefix, R_len_t n) {
 
 
 // Initialised at load time
-SEXP syms_set_rownames_fallback = NULL;
-SEXP fns_set_rownames_fallback = NULL;
+SEXP syms_set_rownames_dispatch = NULL;
+SEXP fns_set_rownames_dispatch = NULL;
 
-static SEXP set_rownames_fallback(SEXP x, SEXP names) {
-  return vctrs_dispatch2(syms_set_rownames_fallback, fns_set_rownames_fallback,
+static SEXP set_rownames_dispatch(SEXP x, SEXP names) {
+  return vctrs_dispatch2(syms_set_rownames_dispatch, fns_set_rownames_dispatch,
                          syms_x, x,
                          syms_names, names);
 }
 
 // Initialised at load time
-SEXP syms_set_names_fallback = NULL;
-SEXP fns_set_names_fallback = NULL;
+SEXP syms_set_names_dispatch = NULL;
+SEXP fns_set_names_dispatch = NULL;
 
-static SEXP set_names_fallback(SEXP x, SEXP names) {
-  return vctrs_dispatch2(syms_set_names_fallback, fns_set_names_fallback,
+static SEXP set_names_dispatch(SEXP x, SEXP names) {
+  return vctrs_dispatch2(syms_set_names_dispatch, fns_set_names_dispatch,
                          syms_x, x,
                          syms_names, names);
 }
@@ -734,7 +734,7 @@ static void check_names(SEXP x, SEXP names) {
 
 SEXP vec_set_rownames(SEXP x, SEXP names, bool proxy, const enum vctrs_owned owned) {
   if (!proxy && OBJECT(x)) {
-    return set_rownames_fallback(x, names);
+    return set_rownames_dispatch(x, names);
   }
 
   int nprot = 0;
@@ -805,7 +805,7 @@ SEXP vec_set_names_impl(SEXP x, SEXP names, bool proxy, const enum vctrs_owned o
   }
 
   if (!proxy && OBJECT(x)) {
-    return set_names_fallback(x, names);
+    return set_names_dispatch(x, names);
   }
 
   // Early exit if no new names and no existing names
@@ -956,13 +956,13 @@ struct name_repair_opts unique_repair_silent_opts;
 struct name_repair_opts no_repair_opts;
 
 void vctrs_init_names(SEXP ns) {
-  syms_set_rownames_fallback = Rf_install("set_rownames_fallback");
-  syms_set_names_fallback = Rf_install("set_names_fallback");
+  syms_set_rownames_dispatch = Rf_install("set_rownames_dispatch");
+  syms_set_names_dispatch = Rf_install("set_names_dispatch");
   syms_as_universal_names = Rf_install("as_universal_names");
   syms_check_unique_names = Rf_install("validate_unique");
 
-  fns_set_rownames_fallback = r_env_get(ns, syms_set_rownames_fallback);
-  fns_set_names_fallback = r_env_get(ns, syms_set_names_fallback);
+  fns_set_rownames_dispatch = r_env_get(ns, syms_set_rownames_dispatch);
+  fns_set_names_dispatch = r_env_get(ns, syms_set_names_dispatch);
   fns_as_universal_names = r_env_get(ns, syms_as_universal_names);
   fns_check_unique_names = r_env_get(ns, syms_check_unique_names);
 

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -129,7 +129,7 @@
       ints <- rep(list(set_names(1:3, letters[1:3])), 100)
       with_memory_prof(vec_unchop(ints))
     Output
-      [1] 5.27KB
+      [1] 4.05KB
     Code
       # Named matrices
       mat <- matrix(1:4, 2, dimnames = list(c("foo", "bar")))


### PR DESCRIPTION
In the case of `vec_set_names()` with `owned = false`, we know we 100% need to clone the input to be able to tweak the names. When you are in this case and are working with an unclassed base type, it is often faster to use `names<-` rather than cloning + `Rf_setAttrib()`. This is because `names<-` can create an ALTREP shallow duplication wrapper, which is essentially free, but the C API for this isn't exported.

`rlang::set_names()` does the same kind of thing 
https://github.com/r-lib/rlang/blob/b3327104bac9c9fec90fa081fdd9cb321c3f29bb/src/internal/attr.c#L163

``` r
library(vctrs)

small <- 1:5 + 0L
names(small) <- as.character(small)
small <- small + 0L

bench::mark(vec_set_names(small, NULL), iterations = 100)
# before
#> # A tibble: 1 × 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_set_names(small, NULL)   1.26µs   1.32µs   581250.    4.02KB        0

# after
#> # A tibble: 1 × 6
#>   expression                      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                 <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_set_names(small, NULL)   3.51µs   3.75µs   194964.    4.02KB        0

big <- 1:1e7 + 0L
names(big) <- as.character(big)
big <- big + 0L

bench::mark(vec_set_names(big, NULL), iterations = 100)
# before
#> # A tibble: 1 × 6
#>   expression                    min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>               <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_set_names(big, NULL)   6.92ms   7.09ms      126.    38.1MB     131.

# after
#> # A tibble: 1 × 6
#>   expression                    min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>               <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_set_names(big, NULL)   3.46µs   3.59µs   269238.        0B        0
```

This is a little tricky, because for "small" objects [the ALTREP wrapper isn't used](https://github.com/wch/r-source/blob/79298c499218846d14500255efd622b5021c10ec/src/main/duplicate.c#L576), so we end up not saving any time at all because the duplication is still done (which is we why got slower in the benchmark above). You can see that here, where `names<-` was used but we still got a non-ALTREP object for `small`

``` r
.Internal(inspect(vec_set_names(small, NULL)))
#> @7fd0c9148188 13 INTSXP g0c3 [] (len=5, tl=0) 1,2,3,4,5
```

``` r
.Internal(inspect(vec_set_names(big, NULL)))
#> @7fd0b84ccd88 13 INTSXP g0c0 []  wrapper [srt=-2147483648,no_na=0]
#>   @7fd0c1526000 13 INTSXP g0c7 [REF(11),ATT] (len=10000000, tl=0) 1,2,3,4,5,...
#>   ATTRIB:
#>     @7fd0dac3ffc8 02 LISTSXP g0c0 [REF(1)] 
#>       TAG: @7fd13f00fa90 01 SYMSXP g1c0 [MARK,REF(65535),LCK,gp=0x4000] "names" (has value)
#>       @7fd0dbb3ce10 16 STRSXP g0c0 [REF(65535)]   <deferred string conversion>
#>  @7fd12c800000 13 INTSXP g0c7 [REF(65535)] (len=10000000, tl=0) 1,2,3,4,5,...
```

I suppose we could also check the length when deciding on the code path to take, but that felt like overkill since we don't control the length threshold that R uses