### PR TITLE
Revert #1532 for the next release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,8 +13,6 @@
 * The `vec_proxy_equal()`, `vec_proxy_compare()`, and `vec_proxy_order()`
   methods for `vctrs_rcrd` are now applied recursively over the fields (#1503).
 
-* `vec_unique()` now drops all names from the result (#1442).
-
 * Lossy cast errors now inherit from incompatible type errors.
 
 * `vec_is_list()` now returns `TRUE` for `AsIs` lists (#1463).

--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -161,7 +161,7 @@ vec_duplicate_id <- function(x) {
 #' @param x A vector (including a data frame).
 #' @return
 #' * `vec_unique()`: a vector the same type as `x` containing only unique
-#'    values. Names from `x` are dropped.
+#'    values.
 #' * `vec_unique_loc()`: an integer vector, giving locations of unique values.
 #' * `vec_unique_count()`: an integer vector of length 1, giving the
 #'   number of unique values.
@@ -189,7 +189,6 @@ vec_duplicate_id <- function(x) {
 #' # But they are for the purposes of considering uniqueness
 #' vec_unique(c(NA, NA, NA, NA, 1, 2, 1))
 vec_unique <- function(x) {
-  x <- vec_set_names(x, NULL)
   vec_slice(x, vec_unique_loc(x))
 }
 

--- a/man/vec_unique.Rd
+++ b/man/vec_unique.Rd
@@ -18,7 +18,7 @@ vec_unique_count(x)
 \value{
 \itemize{
 \item \code{vec_unique()}: a vector the same type as \code{x} containing only unique
-values. Names from \code{x} are dropped.
+values.
 \item \code{vec_unique_loc()}: an integer vector, giving locations of unique values.
 \item \code{vec_unique_count()}: an integer vector of length 1, giving the
 number of unique values.

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -152,7 +152,7 @@ test_that("unique functions treat positive and negative 0 as equivalent (#637)",
 test_that("unique functions work with different encodings", {
   encs <- encodings()
 
-  expect_equal(vec_unique(encs), unname(encs[1]))
+  expect_equal(vec_unique(encs), encs[1])
   expect_equal(vec_unique_count(encs), 1L)
   expect_equal(vec_unique_loc(encs), 1L)
 })
@@ -196,14 +196,6 @@ test_that("vec_unique() works with glm objects (#643)", {
 test_that("can take the unique locations of dfs with list-cols", {
   df <- tibble(x = list(1, 2, 1, 3), y = list(1, 2, 1, 3))
   expect_identical(vec_unique_loc(df), c(1L, 2L, 4L))
-})
-
-test_that("vec_unique() drops names (#1442)", {
-  x <- c(a = 1, 1)
-  y <- c(1, a = 1)
-
-  expect_identical(vec_unique(x), 1)
-  expect_identical(vec_unique(y), 1)
 })
 
 # matching ----------------------------------------------------------------


### PR DESCRIPTION
Since dplyr relies on this in the internals of `relocate()`

Follow-up to #1532 
Re-opens #1442 