### PR TITLE
Protect `shelter` objects in `df_ptype2_loop()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* Fixed a memory protection issue related to the data frame method for
+  `vec_ptype2()` (#1551).
+
 # vctrs 0.4.0
 
 * New experimental `vec_locate_sorted_groups()` for returning the locations of

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -624,8 +624,12 @@ r_obj* df_ptype2_loop(const struct ptype2_opts* opts,
   r_attrib_poke(out, r_syms.names, names);
 
   r_ssize i = 0;
+
   struct vctrs_arg* named_x_arg = new_subscript_arg_vec(opts->p_x_arg, out, &i);
+  KEEP(named_x_arg->shelter);
+
   struct vctrs_arg* named_y_arg = new_subscript_arg_vec(opts->p_y_arg, out, &i);
+  KEEP(named_y_arg->shelter);
 
   for (; i < len; ++i) {
     struct ptype2_opts col_opts = *opts;
@@ -642,7 +646,7 @@ r_obj* df_ptype2_loop(const struct ptype2_opts* opts,
 
   init_data_frame(out, 0);
 
-  FREE(1);
+  FREE(3);
   return out;
 }
 


### PR DESCRIPTION
Closes #1551 

A minimal ish reprex that uses `gctorture()` to identify this:

```r
library(vctrs)
library(tibble)
library(labelled)

test_tibble <-
  tibble(a = 202201) %>%
  set_value_labels(a = c("Jan 2022" = 202201)) %>%
  set_variable_labels(a = "Month")

gctorture()

vec_rbind(test_tibble, test_tibble)
```

That combined with this (actually useful!) traceback report from running the code in a vanilla R session helped me track this down:

```
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   vctrs.so                      	       0x115a96227 fill_arg_buffer + 23 (arg.c:65)
1   vctrs.so                      	       0x115a9623e fill_arg_buffer + 46 (arg.c:66)
2   vctrs.so                      	       0x115a9623e fill_arg_buffer + 46 (arg.c:66)
3   vctrs.so                      	       0x115a961cd vctrs_arg + 125 (arg.c:37)
4   vctrs.so                      	       0x115abadac vec_ptype2_dispatch_s3 + 316 (ptype2-dispatch.c:115)
5   vctrs.so                      	       0x115abb77c vec_ptype2_opts_impl + 684 (ptype2.c:81)
6   vctrs.so                      	       0x115ad95f4 df_ptype2_loop + 241 (type-data-frame.c:638) [inlined]
7   vctrs.so                      	       0x115ad95f4 df_ptype2 + 404 (type-data-frame.c:507)
8   vctrs.so                      	       0x115add04b tib_ptype2 + 11 (type-tibble.c:6)
9   vctrs.so                      	       0x115abb6d0 vec_ptype2_opts_impl + 512 (ptype2.c:68)
10  vctrs.so                      	       0x115aba30a ptype2_common + 74 (ptype-common.c:107)
11  vctrs.so                      	       0x115a95f04 reduce_impl + 379 (arg-counter.c:161) [inlined]
12  vctrs.so                      	       0x115a95f04 reduce + 580 (arg-counter.c:128)
13  vctrs.so                      	       0x115aba201 vec_ptype_common_opts + 193 (ptype-common.c:59)
14  vctrs.so                      	       0x115aba063 vec_ptype_common_params + 35 (ptype-common.c:86)
15  vctrs.so                      	       0x115a96e8e vec_rbind + 239 (bind.c:68) [inlined]
16  vctrs.so                      	       0x115a96e8e ffi_rbind + 590 (bind.c:35)
17  libR.dylib                    	       0x10a5b1d48 do_External + 296 (dotcode.c:573)
18  libR.dylib                    	       0x10a5eb9d5 bcEval + 28581 (eval.c:7117)
19  libR.dylib                    	       0x10a5e4381 Rf_eval + 385 (eval.c:729)
20  libR.dylib                    	       0x10a6041f9 R_execClosure + 2169
21  libR.dylib                    	       0x10a602fe7 Rf_applyClosure + 471 (eval.c:1825)
22  libR.dylib                    	       0x10a5e483b Rf_eval + 1595 (eval.c:852)
23  libR.dylib                    	       0x10a639f81 R_ReplDLLdo1 + 449 (main.c:399)
24  R                             	       0x109f42155 run_REngineRmainloop + 261
25  R                             	       0x109f36d6f -[REngine runREPL] + 143
26  R                             	       0x109f26738 main + 792
27  dyld                          	       0x10bb004fe start + 462
```