### PR TITLE
Rewrite `vec_joint_proxy_order()` with a more conservative heuristic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # vctrs (development version)
 
+* `vec_locate_matches()` now uses a more conservative heuristic when taking the
+  joint ordering proxy. This allows it to work correctly with sf's sfc vectors
+  and the classes from the bignum package (#1558).
+  
+* An sfc method for `vec_proxy_order()` was added to better support the sf
+  package. These vectors are generally treated like list-columns even though
+  they don't explicitly have a `"list"` class, and the `vec_proxy_order()`
+  method now forwards to the list method to reflect that (#1558).
+
 * `vec_proxy_compare()` now works correctly for raw vectors wrapped in `I()`.
   `vec_proxy_order()` now works correctly for raw and list vectors wrapped in
   `I()` (#1557).
@@ -11,7 +20,6 @@
 
 * Fixed memory protection issues related to common type
   determination (#1551, tidyverse/tidyr#1348).
-
 
 # vctrs 0.4.0
 

--- a/R/type-sf.R
+++ b/R/type-sf.R
@@ -128,6 +128,12 @@ vec_cast.data.frame.sf = function(x, to, ...) {
 	df_cast(x, to, ...)
 }
 
+vec_proxy_order.sfc <- function(x, ...) {
+  # These are list columns, so they need to use the order-by-appearance proxy
+  # that is defined by `vec_proxy_order.list()`
+  x <- unstructure(x)
+  vec_proxy_order(x)
+}
 
 # take conservative approach of requiring equal CRS and precision
 common_crs = function(x, y) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -89,6 +89,9 @@
       s3_register("vctrs::vec_cast", "sf.data.frame")
       s3_register("vctrs::vec_cast", "data.frame.sf")
     }
+    if (!env_has(ns_env("sf"), "vec_proxy_order.sfc")) {
+      s3_register("vctrs::vec_proxy_order", "sfc")
+    }
   })
 
   utils::globalVariables("vec_set_attributes")

--- a/src/decl/match-joint-decl.h
+++ b/src/decl/match-joint-decl.h
@@ -1,0 +1,5 @@
+static inline r_obj* vec_joint_proxy_order(r_obj* x, r_obj* y);
+static inline r_obj* vec_joint_proxy_order_independent(r_obj* x, r_obj* y);
+static inline r_obj* vec_joint_proxy_order_dependent(r_obj* x, r_obj* y);
+static inline r_obj* vec_joint_proxy_order_s3(r_obj* x, r_obj* y);
+static inline r_obj* df_joint_proxy_order(r_obj* x, r_obj* y);

--- a/src/match-joint.c
+++ b/src/match-joint.c
@@ -263,6 +263,8 @@ r_obj* vec_joint_proxy_order(r_obj* x, r_obj* y) {
     stop_unimplemented_vctrs_type("vec_joint_proxy_order", vec_typeof(x));
   }
   }
+
+  r_stop_unreachable();
 }
 
 static inline
@@ -340,6 +342,8 @@ r_obj* vec_joint_proxy_order_s3(r_obj* x, r_obj* y) {
     r_stop_internal("Unclassed objects should have been handled earlier.");
   }
   }
+
+  r_stop_unreachable();
 }
 
 static inline

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -14,8 +14,6 @@ SEXP fns_vec_proxy_equal_array = NULL;
 SEXP fns_vec_proxy_compare_array = NULL;
 SEXP fns_vec_proxy_order_array = NULL;
 
-static SEXP vec_proxy_unwrap(SEXP x);
-
 SEXP vec_proxy_method(SEXP x);
 SEXP vec_proxy_invoke(SEXP x, SEXP method);
 
@@ -67,133 +65,6 @@ SEXP vec_proxy_order(SEXP x) {
   UNPROTECT(1);
   return out;
 }
-
-
-static r_obj* df_joint_proxy_order(r_obj* x, r_obj* y);
-static r_obj* list_joint_proxy_order(r_obj* x, r_obj* y, r_obj* method);
-
-/*
- * Specialized internal variant of `vec_proxy_order()` used in
- * `vec_locate_matches()`. It generally just calls `vec_proxy_order()`, except
- * in the case where we are taking the order-proxy of a list. This generates a
- * proxy that orders by first appearance, so we need to combine `x` and `y` to
- * jointly compute the proxy for comparisons to be correct in
- * `vec_locate_matches()`.
- *
- * For example
- * x <- list(1.5, 2)
- * y <- list(2, 1.5)
- * vec_proxy_order(x)
- * # [1] 1 2
- * vec_proxy_order(y) # can't compare proxies when taken individually
- * # [1] 1 2
- * vec_proxy_order(c(x, y)) # jointly comparable
- * # [1] 1 2 2 1
- *
- * We don't anticipate any other classes having this issue. Most order-proxies
- * should be orderable by typical comparison operators.
- * If that assumption proves incorrect, we may need to expose a new proxy
- * generic for this so class authors can customize the joint order proxy
- * calculation as needed.
- */
-// [[ include("vctrs.h") ]]
-r_obj* vec_joint_proxy_order(r_obj* x, r_obj* y) {
-  if (r_typeof(x) != r_typeof(y)) {
-    r_stop_internal("`x` and `y` should have the same type.");
-  }
-
-  if (is_data_frame(x)) {
-    return df_joint_proxy_order(x, y);
-  }
-
-  r_obj* method = KEEP(vec_proxy_order_method(x));
-  r_obj* vec_proxy_order_list = KEEP(vec_proxy_order_method(vctrs_shared_empty_list));
-
-  if (method == vec_proxy_order_list) {
-    // Special case if the chosen proxy method is `vec_proxy_order.list()`
-    r_obj* out = list_joint_proxy_order(x, y, method);
-    FREE(2);
-    return out;
-  }
-
-  r_obj* out = KEEP(r_alloc_list(2));
-  r_list_poke(out, 0, vec_proxy_order_invoke(x, method));
-  r_list_poke(out, 1, vec_proxy_order_invoke(y, method));
-
-  FREE(3);
-  return out;
-}
-
-static
-r_obj* df_joint_proxy_order(r_obj* x, r_obj* y) {
-  x = KEEP(r_clone_referenced(x));
-  y = KEEP(r_clone_referenced(y));
-
-  r_ssize n_cols = r_length(x);
-  if (n_cols != r_length(y)) {
-    r_stop_internal(
-      "`x` and `y` must have the same number of columns."
-    );
-  }
-
-  r_obj* const* v_x = r_list_cbegin(x);
-  r_obj* const* v_y = r_list_cbegin(y);
-
-  for (r_ssize i = 0; i < n_cols; ++i) {
-    r_obj* proxies = vec_joint_proxy_order(v_x[i], v_y[i]);
-    r_list_poke(x, i, r_list_get(proxies, 0));
-    r_list_poke(y, i, r_list_get(proxies, 1));
-  }
-
-  x = KEEP(df_flatten(x));
-  x = KEEP(vec_proxy_unwrap(x));
-
-  y = KEEP(df_flatten(y));
-  y = KEEP(vec_proxy_unwrap(y));
-
-  r_obj* out = KEEP(r_alloc_list(2));
-  r_list_poke(out, 0, x);
-  r_list_poke(out, 1, y);
-
-  FREE(7);
-  return out;
-}
-
-static
-r_obj* list_joint_proxy_order(r_obj* x, r_obj* y, r_obj* method) {
-  r_ssize x_size = vec_size(x);
-  r_ssize y_size = vec_size(y);
-
-  r_obj* x_slicer = KEEP(compact_seq(0, x_size, true));
-  r_obj* y_slicer = KEEP(compact_seq(x_size, y_size, true));
-
-  r_obj* zap = KEEP(r_alloc_list(0));
-  r_attrib_poke_class(zap, r_chr("rlang_zap"));
-
-  r_obj* ptype = KEEP(vec_ptype(x, vec_args.empty, r_lazy_null));
-
-  r_obj* out = KEEP(r_alloc_list(2));
-  r_list_poke(out, 0, x);
-  r_list_poke(out, 1, y);
-
-  // Combine
-  // NOTE: Without long vector support, this limits the maximum allowed
-  // size of `vec_locate_matches()` input to
-  // `vec_size(x) + vec_size(y) <= INT_MAX`
-  // when list columns are used. Hitting this limit should be incredibly rare.
-  r_obj* combined = KEEP(vec_c(out, ptype, zap, p_no_repair_opts));
-
-  // Compute joint order-proxy
-  r_obj* proxy = KEEP(vec_proxy_order_invoke(combined, method));
-
-  // Separate and store back in `out`
-  r_list_poke(out, 0, vec_slice_unsafe(proxy, x_slicer));
-  r_list_poke(out, 1, vec_slice_unsafe(proxy, y_slicer));
-
-  FREE(7);
-  return out;
-}
-
 
 SEXP vec_proxy_method(SEXP x) {
   return s3_find_method("vec_proxy", x, vctrs_method_table);
@@ -315,8 +186,7 @@ SEXP vctrs_df_proxy(SEXP x, SEXP kind) {
   return df_proxy(x, c_kind);
 }
 
-
-static
+// [[ include("vctrs.h") ]]
 SEXP vec_proxy_unwrap(SEXP x) {
   if (TYPEOF(x) == VECSXP && XLENGTH(x) == 1 && is_data_frame(x)) {
     x = vec_proxy_unwrap(VECTOR_ELT(x, 0));

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -305,7 +305,7 @@ SEXP vec_proxy(SEXP x);
 SEXP vec_proxy_equal(SEXP x);
 SEXP vec_proxy_compare(SEXP x);
 SEXP vec_proxy_order(SEXP x);
-r_obj* vec_joint_proxy_order(r_obj* x, r_obj* y);
+SEXP vec_proxy_unwrap(SEXP x);
 SEXP vec_restore(SEXP x, SEXP to, SEXP n, const enum vctrs_owned owned);
 SEXP vec_restore_default(SEXP x, SEXP to, const enum vctrs_owned owned);
 SEXP vec_chop(SEXP x, SEXP indices);

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -516,8 +516,6 @@ test_that("Works with classed data frame columns", {
 })
 
 test_that("AsIs types are combined before order proxies are taken (#1557)", {
-  skip("Until #1557 is fixed")
-
   x <- I(list(5, 1))
   y <- I(list(8, 5, 5))
 

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -442,6 +442,91 @@ test_that("rcrd type incompleteness is handled correctly", {
 })
 
 # ------------------------------------------------------------------------------
+# vec_locate_matches() - S3
+
+test_that("S3 types with order proxies that depend on the data are combined before the proxy is taken", {
+  # i.e. `bignum:::vec_proxy_order.bignum_biginteger()`
+
+  x <- structure(c(5L, 1L), class = "foo")
+  y <- structure(c(8L, 5L), class = "foo")
+
+  local_methods(
+    vec_proxy_order.foo = function(x, ...) {
+      rank(unclass(x))
+    }
+  )
+
+  # Can't take the order proxies separately because they are the same!
+  expect_identical(vec_proxy_order(x), vec_proxy_order(y))
+
+  res <- vec_locate_matches(x, y)
+  expect_identical(res$needles, c(1L, 2L))
+  expect_identical(res$haystack, c(2L, NA))
+
+  x_df <- data_frame(a = x, b = x)
+  y_df <- data_frame(a = y, b = y)
+
+  res <- vec_locate_matches(x_df, y_df)
+  expect_identical(res$needles, c(1L, 2L))
+  expect_identical(res$haystack, c(2L, NA))
+})
+
+test_that("Works with base R S3 types we support natively", {
+  x <- new_factor(c(1L, 2L), levels = c("x", "y"))
+  y <- new_factor(c(3L, 1L, 1L), levels = c("x", "y", "z"))
+  res <- vec_locate_matches(x, y)
+  expect_identical(res$needles, c(1L, 1L, 2L))
+  expect_identical(res$haystack, c(2L, 3L, NA))
+
+  x <- new_ordered(c(1L, 2L), levels = c("x", "y"))
+  y <- new_ordered(c(2L, 1L, 1L), levels = c("x", "y"))
+  res <- vec_locate_matches(x, y)
+  expect_identical(res$needles, c(1L, 1L, 2L))
+  expect_identical(res$haystack, c(2L, 3L, 1L))
+
+  x <- new_date(c(1, 2))
+  y <- new_date(c(3, 1, 1))
+  res <- vec_locate_matches(x, y)
+  expect_identical(res$needles, c(1L, 1L, 2L))
+  expect_identical(res$haystack, c(2L, 3L, NA))
+
+  x <- new_datetime(c(1, 2))
+  y <- new_datetime(c(3, 1, 1))
+  res <- vec_locate_matches(x, y)
+  expect_identical(res$needles, c(1L, 1L, 2L))
+  expect_identical(res$haystack, c(2L, 3L, NA))
+
+  x <- as.POSIXlt(new_datetime(c(1, 2)))
+  y <- as.POSIXlt(new_datetime(c(3, 1, 1)))
+  res <- vec_locate_matches(x, y)
+  expect_identical(res$needles, c(1L, 1L, 2L))
+  expect_identical(res$haystack, c(2L, 3L, NA))
+})
+
+test_that("Works with classed data frame columns", {
+  x_col <- new_data_frame(list(a = c(1L, 2L), b = c(2, 3)), class = "foo")
+  y_col <- new_data_frame(list(a = c(1L, 1L, 1L), b = c(2, 4, 2)), class = "foo")
+
+  x <- new_data_frame(list(c = c(1L, 1L), d = x_col))
+  y <- new_data_frame(list(c = c(1L, 1L, 1L), d = y_col))
+
+  res <- vec_locate_matches(x, y)
+  expect_identical(res$needles, c(1L, 1L, 2L))
+  expect_identical(res$haystack, c(1L, 3L, NA))
+})
+
+test_that("AsIs types are combined before order proxies are taken (#1557)", {
+  skip("Until #1557 is fixed")
+
+  x <- I(list(5, 1))
+  y <- I(list(8, 5, 5))
+
+  res <- vec_locate_matches(x, y)
+  expect_identical(res$needles, c(1L, 1L, 2L))
+  expect_identical(res$haystack, c(2L, 3L, NA))
+})
+
+# ------------------------------------------------------------------------------
 # vec_locate_matches() - missing values
 
 test_that("integer missing values match with `==`, `>=`, and `<=` when `incomplete = 'compare'", {

--- a/tests/testthat/test-type-sf.R
+++ b/tests/testthat/test-type-sf.R
@@ -235,6 +235,26 @@ test_that("`precision` and `crs` attributes of `sfc` vectors are combined", {
 	# expect_error(vctrs::vec_c(x, y), "coordinate reference systems not equal")
 })
 
+test_that("`vec_locate_matches()` works with `sfc` vectors", {
+  x <- c(
+    st_sfc(st_point(c(0, 0))),
+    st_sfc(st_point(c(0, 1))),
+    st_sfc(st_point(c(2, 1))),
+    st_sfc(c(st_point(c(0, 1)), st_point(c(0, 1))))
+  )
+
+  y <- c(
+    st_sfc(c(st_point(c(0, 1)), st_point(c(0, 1)))),
+    st_sfc(st_point(c(0, 0))),
+    st_sfc(st_point(c(0, 3))),
+    st_sfc(st_point(c(0, 0))),
+    st_sfc(st_point(c(0, 1)))
+  )
+
+  out <- vec_locate_matches(x, y)
+  expect_identical(out$needles,  c(1L, 1L, 2L, 3L, 4L))
+  expect_identical(out$haystack, c(2L, 4L, 5L, NA, 1L))
+})
 
 # Local Variables:
 # indent-tabs-mode: t


### PR DESCRIPTION
There are two issues that can arise with the way `vec_joint_proxy_order()` works, both of which have to do with the fact that the "dependent" joint proxy is only ever computed for vectors that inherit from `"list"` explicitly.

- sfc vectors, which are list-columns without an explicit `"list"` class, pass through the proxy method and return a list, which is not a supported type in `vec_order()`. Ideally this would just forward to `vec_proxy_order.list()` through a `vec_proxy_order.sfc()` method, but then you'd also need the "dependent" joint proxy path to run, and it currently won't do that because it only runs for lists.
- bignum vectors, like biginteger, have a `vec_proxy_order()` method defined for them that depends on the data in the vector itself - it computes the ranks and uses that as the order proxy. This means that this also needs to run through the "dependent" joint proxy path (i.e. combine `x` and `y` together, take the proxy, split them apart)

I have fixed this by changing the way `vec_joint_proxy_order()` decides whether or not to combine `x` and `y` together before taking the proxy. We are now _much_ more conservative. The only way we ever take the proxies "independently" (i.e. don't combine them together) is if we are working with a base R atomic type (except list) or a base R S3 type that we support in vctrs (factor, date, etc). Otherwise we always fallback to a "dependent" joint proxy that combines them, because we have no way to know if the `vec_proxy_order()` method is dependent on the data or not.

That automatically fixed bignum, and then I just had to add a `vec_proxy_order.sfc()` method to fix sf. It should be more compatible with other classes in the long run as well.

The downside is that it:
- Is slower than the independent method because you have to combine `x` and `y` and then re-split them
- Limits the maximum size to `vec_size(x) + vec_size(y) <= INT_MAX`

But this only ever comes into play when a user defined S3 type is used, so I'm hoping that is acceptable.

Here are some examples of sfc and bignum problems which have been fixed with this:

```r
library(sf)
#> Linking to GEOS 3.9.1, GDAL 3.4.0, PROJ 8.1.1; sf_use_s2() is TRUE
library(vctrs)
​
x <- c(
  st_geometry(st_point(c(0, 0))),
  st_geometry(st_point(c(0, 1))),
  st_geometry(st_point(c(2, 1)))
)
​
y <- c(
  st_geometry(st_point(c(0, 1))),
  st_geometry(st_point(c(0, 0))),
  st_geometry(st_point(c(0, 3))),
  st_geometry(st_point(c(0, 1)))
)
​
x
#> Geometry set for 3 features 
#> Geometry type: POINT
#> Dimension:     XY
#> Bounding box:  xmin: 0 ymin: 0 xmax: 2 ymax: 1
#> CRS:           NA
#> POINT (0 0)
#> POINT (0 1)
#> POINT (2 1)
y
#> Geometry set for 4 features 
#> Geometry type: POINT
#> Dimension:     XY
#> Bounding box:  xmin: 0 ymin: 0 xmax: 0 ymax: 3
#> CRS:           NA
#> POINT (0 1)
#> POINT (0 0)
#> POINT (0 3)
#> POINT (0 1)
​
# Geometry sets are `sfc`s, or "sf columns", which are documented as list columns
# but they don't explicitly have a "list" class
class(x)
#> [1] "sfc_POINT" "sfc"
​
# The old way `left_join()` and friends worked
vec_match(x,y)
#> [1]  2  1 NA
​
# The new way
vec_locate_matches(x,y)
#> Error: This type is not supported by `vec_order()`.
```

```r
library(vctrs)
library(bignum)

x <- biginteger(5)
y <- biginteger(6)

# uh oh
vec_locate_matches(x, y)
#>   needles haystack
#> 1       1        1

vec_proxy_order(x)
#> [1] 1
vec_proxy_order(y)
#> [1] 1

bignum:::vec_proxy_order.bignum_biginteger
#> function (x, ...) 
#> {
#>     c_biginteger_rank(x)
#> }
#> <bytecode: 0x7fe647e42dc8>
#> <environment: namespace:bignum>
```