### PR TITLE
Fix inconsistent reporting of conflicting inputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* Fixed inconsistent reporting of conflicting inputs in
+  `vec_ptype_common()` (#1570).
+
 * `vec_ptype_abbr()` and `vec_ptype_full()` now suffix 1d arrays
   with `[1d]`.
 

--- a/src/ptype-common.c
+++ b/src/ptype-common.c
@@ -5,7 +5,7 @@
 r_obj* ffi_ptype_common(r_obj* ffi_call, r_obj* op, r_obj* args, r_obj* env) {
   args = r_node_cdr(args);
 
-  r_obj* types = KEEP(rlang_env_dots_values(env));
+  r_obj* types = KEEP(rlang_env_dots_list(env));
   r_obj* ptype = KEEP(r_eval(r_node_car(args), env));
 
   struct r_lazy call = { .x = syms.dot_call, .env = env };
@@ -27,7 +27,7 @@ r_obj* ffi_ptype_common(r_obj* ffi_call, r_obj* op, r_obj* args, r_obj* env) {
 r_obj* ffi_ptype_common_opts(r_obj* call, r_obj* op, r_obj* args, r_obj* env) {
   args = r_node_cdr(args);
 
-  r_obj* types = KEEP(rlang_env_dots_values(env));
+  r_obj* types = KEEP(rlang_env_dots_list(env));
   r_obj* ptype = KEEP(r_eval(r_node_car(args), env)); args = r_node_cdr(args);
   r_obj* opts = KEEP(r_eval(r_node_car(args), env));
 

--- a/tests/testthat/_snaps/type.md
+++ b/tests/testthat/_snaps/type.md
@@ -101,7 +101,7 @@
       vec_ptype_common(TRUE, !!!list(1, 2), "foo")
     Condition
       Error:
-      ! Can't combine `..2` <double> and `..5` <character>.
+      ! Can't combine `..2` <double> and `..4` <character>.
 
 ---
 
@@ -109,7 +109,7 @@
       vec_ptype_common(1, !!!list(TRUE, FALSE), "foo")
     Condition
       Error:
-      ! Can't combine `..1` <double> and `..5` <character>.
+      ! Can't combine `..1` <double> and `..4` <character>.
 
 ---
 
@@ -125,7 +125,7 @@
       vec_ptype_common(foo = TRUE, !!!list(bar = 1, "foo"))
     Condition
       Error:
-      ! Can't combine `bar` <double> and `..3` <character>.
+      ! Can't combine `foo` <double> and `..3` <character>.
 
 ---
 
@@ -150,4 +150,22 @@
     Condition
       Error:
       ! Can't combine `foo` <logical> and `baz` <character>.
+
+# vec_ptype_common() handles spliced names consistently (#1570)
+
+    Code
+      vec_ptype_common(a = "foo", b = "bar", y = NULL, z = 1)
+    Condition
+      Error:
+      ! Can't combine `a` <character> and `z` <double>.
+    Code
+      vec_ptype_common(!!!args1, !!!args2)
+    Condition
+      Error:
+      ! Can't combine `a` <character> and `z` <double>.
+    Code
+      vec_ptype_common(!!!args1, "{y_name}" := NULL, "{z_name}" := 1)
+    Condition
+      Error:
+      ! Can't combine `a` <character> and `z` <double>.
 

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -237,3 +237,31 @@ test_that("vec_ptype() preserves type of names and row names", {
   expect_identical(vec_ptype(mtcars), mtcars[0, ])
   expect_identical(vec_ptype(foobar(mtcars)), foobar(mtcars[0, ]))
 })
+
+test_that("vec_ptype_common() handles spliced names consistently (#1570)", {
+  args1 <- list(a = "foo", b = "bar")
+  args2 <- list(y = NULL, z = 1)
+
+  y_name <- "y"
+  z_name <- "z"
+
+  expect_snapshot(error = TRUE, {
+    vec_ptype_common(
+      a = "foo",
+      b = "bar",
+      y = NULL,
+      z = 1
+    )
+
+    vec_ptype_common(
+      !!!args1,
+      !!!args2
+    )
+
+    vec_ptype_common(
+      !!!args1,
+      "{y_name}" := NULL,
+      "{z_name}" := 1
+    )
+  })
+})


### PR DESCRIPTION
Closes #1570

Following these changes, since we now flatten spliced inputs into simple lists of arguments, we can simplify the arg counter code and remove any logic that supported splice box walking. I'll look into this another time though.