### PR TITLE
Improve `vec_equal_na(<df>)` algorithm based on a narrowing location vector

### DIFF
--- a/src/decl/missing-decl.h
+++ b/src/decl/missing-decl.h
@@ -21,37 +21,37 @@ r_obj* df_equal_na(r_obj* x);
 
 static inline
 r_ssize col_equal_na(r_obj* x,
-                     r_ssize count,
-                     r_ssize* v_loc);
+                     r_ssize* v_loc,
+                     r_ssize loc_size);
 
 static inline
 r_ssize lgl_col_equal_na(r_obj* x,
-                         r_ssize count,
-                         r_ssize* v_loc);
+                         r_ssize* v_loc,
+                         r_ssize loc_size);
 static inline
 r_ssize int_col_equal_na(r_obj* x,
-                         r_ssize count,
-                         r_ssize* v_loc);
+                         r_ssize* v_loc,
+                         r_ssize loc_size);
 static inline
 r_ssize dbl_col_equal_na(r_obj* x,
-                         r_ssize count,
-                         r_ssize* v_loc);
+                         r_ssize* v_loc,
+                         r_ssize loc_size);
 static inline
 r_ssize cpl_col_equal_na(r_obj* x,
-                         r_ssize count,
-                         r_ssize* v_loc);
+                         r_ssize* v_loc,
+                         r_ssize loc_size);
 static inline
 r_ssize raw_col_equal_na(r_obj* x,
-                         r_ssize count,
-                         r_ssize* v_loc);
+                         r_ssize* v_loc,
+                         r_ssize loc_size);
 static inline
 r_ssize chr_col_equal_na(r_obj* x,
-                         r_ssize count,
-                         r_ssize* v_loc);
+                         r_ssize* v_loc,
+                         r_ssize loc_size);
 static inline
 r_ssize list_col_equal_na(r_obj* x,
-                          r_ssize count,
-                          r_ssize* v_loc);
+                          r_ssize* v_loc,
+                          r_ssize loc_size);
 
 static inline
 const unsigned char* r_uchar_cbegin(r_obj* x);

--- a/src/decl/missing-decl.h
+++ b/src/decl/missing-decl.h
@@ -20,38 +20,38 @@ static inline
 r_obj* df_equal_na(r_obj* x);
 
 static inline
-void col_equal_na(r_obj* x,
-                  int* v_out,
-                  struct df_short_circuit_info* p_info);
+r_ssize col_equal_na(r_obj* x,
+                     r_ssize count,
+                     r_ssize* v_loc);
 
 static inline
-void lgl_col_equal_na(r_obj* x,
-                      int* v_out,
-                      struct df_short_circuit_info* p_info);
+r_ssize lgl_col_equal_na(r_obj* x,
+                         r_ssize count,
+                         r_ssize* v_loc);
 static inline
-void int_col_equal_na(r_obj* x,
-                      int* v_out,
-                      struct df_short_circuit_info* p_info);
+r_ssize int_col_equal_na(r_obj* x,
+                         r_ssize count,
+                         r_ssize* v_loc);
 static inline
-void dbl_col_equal_na(r_obj* x,
-                      int* v_out,
-                      struct df_short_circuit_info* p_info);
+r_ssize dbl_col_equal_na(r_obj* x,
+                         r_ssize count,
+                         r_ssize* v_loc);
 static inline
-void cpl_col_equal_na(r_obj* x,
-                      int* v_out,
-                      struct df_short_circuit_info* p_info);
+r_ssize cpl_col_equal_na(r_obj* x,
+                         r_ssize count,
+                         r_ssize* v_loc);
 static inline
-void raw_col_equal_na(r_obj* x,
-                      int* v_out,
-                      struct df_short_circuit_info* p_info);
+r_ssize raw_col_equal_na(r_obj* x,
+                         r_ssize count,
+                         r_ssize* v_loc);
 static inline
-void chr_col_equal_na(r_obj* x,
-                      int* v_out,
-                      struct df_short_circuit_info* p_info);
+r_ssize chr_col_equal_na(r_obj* x,
+                         r_ssize count,
+                         r_ssize* v_loc);
 static inline
-void list_col_equal_na(r_obj* x,
-                       int* v_out,
-                       struct df_short_circuit_info* p_info);
+r_ssize list_col_equal_na(r_obj* x,
+                          r_ssize count,
+                          r_ssize* v_loc);
 
 static inline
 const unsigned char* r_uchar_cbegin(r_obj* x);

--- a/src/missing.c
+++ b/src/missing.c
@@ -95,23 +95,23 @@ r_obj* df_equal_na(r_obj* x) {
   const r_ssize size = vec_size(x);
   r_obj* const* v_x = r_list_cbegin(x);
 
-  // A counter and location vector to track rows where we still need to check
-  // for missing values. After we iterate through all columns, `v_loc` points
-  // to the missing rows.
-  r_ssize count = size;
-  r_ssize* v_loc = (r_ssize*) R_alloc(size, sizeof(r_ssize));
+  // A location vector to track rows where we still need to check for missing
+  // values. After we iterate through all columns, `v_loc` points to the missing
+  // rows.
+  r_ssize loc_size = size;
+  r_ssize* v_loc = (r_ssize*) R_alloc(loc_size, sizeof(r_ssize));
 
-  for (r_ssize i = 0; i < size; ++i) {
+  for (r_ssize i = 0; i < loc_size; ++i) {
     v_loc[i] = i;
   }
 
   for (r_ssize i = 0; i < n_col; ++i) {
     r_obj* col = v_x[i];
 
-    count = col_equal_na(col, count, v_loc);
+    loc_size = col_equal_na(col, v_loc, loc_size);
 
     // If all rows have at least one non-missing value, break
-    if (count == 0) {
+    if (loc_size == 0) {
       break;
     }
   }
@@ -120,7 +120,7 @@ r_obj* df_equal_na(r_obj* x) {
   int* v_out = r_lgl_begin(out);
   r_p_lgl_fill(v_out, 0, size);
 
-  for (r_ssize i = 0; i < count; ++i) {
+  for (r_ssize i = 0; i < loc_size; ++i) {
     const r_ssize loc = v_loc[i];
     v_out[loc] = 1;
   }
@@ -133,18 +133,18 @@ r_obj* df_equal_na(r_obj* x) {
 
 static inline
 r_ssize col_equal_na(r_obj* x,
-                     r_ssize count,
-                     r_ssize* v_loc) {
+                     r_ssize* v_loc,
+                     r_ssize loc_size) {
   const enum vctrs_type type = vec_proxy_typeof(x);
 
   switch (type) {
-  case vctrs_type_logical: return lgl_col_equal_na(x, count, v_loc);
-  case vctrs_type_integer: return int_col_equal_na(x, count, v_loc);
-  case vctrs_type_double: return dbl_col_equal_na(x, count, v_loc);
-  case vctrs_type_complex: return cpl_col_equal_na(x, count, v_loc);
-  case vctrs_type_raw: return raw_col_equal_na(x, count, v_loc);
-  case vctrs_type_character: return chr_col_equal_na(x, count, v_loc);
-  case vctrs_type_list: return list_col_equal_na(x, count, v_loc);
+  case vctrs_type_logical: return lgl_col_equal_na(x, v_loc, loc_size);
+  case vctrs_type_integer: return int_col_equal_na(x, v_loc, loc_size);
+  case vctrs_type_double: return dbl_col_equal_na(x, v_loc, loc_size);
+  case vctrs_type_complex: return cpl_col_equal_na(x, v_loc, loc_size);
+  case vctrs_type_raw: return raw_col_equal_na(x, v_loc, loc_size);
+  case vctrs_type_character: return chr_col_equal_na(x, v_loc, loc_size);
+  case vctrs_type_list: return list_col_equal_na(x, v_loc, loc_size);
   case vctrs_type_dataframe: r_stop_internal("Data frame columns should have been flattened by now.");
   case vctrs_type_null: r_abort("Unexpected `NULL` column found in a data frame.");
   case vctrs_type_scalar: stop_scalar_type(x, vec_args.empty, r_lazy_null);
@@ -156,57 +156,57 @@ r_ssize col_equal_na(r_obj* x,
 
 #define COL_EQUAL_NA(CTYPE, CBEGIN, IS_MISSING) do { \
   CTYPE const* v_x = CBEGIN(x);                      \
-  r_ssize new_count = 0;                             \
+  r_ssize new_loc_size = 0;                          \
                                                      \
-  for (r_ssize i = 0; i < count; ++i) {              \
+  for (r_ssize i = 0; i < loc_size; ++i) {           \
     const r_ssize loc = v_loc[i];                    \
-    v_loc[new_count] = loc;                          \
-    new_count += IS_MISSING(v_x[loc]);               \
+    v_loc[new_loc_size] = loc;                       \
+    new_loc_size += IS_MISSING(v_x[loc]);            \
   }                                                  \
                                                      \
-  return new_count;                                  \
+  return new_loc_size;                               \
 } while (0)
 
 static inline
 r_ssize lgl_col_equal_na(r_obj* x,
-                         r_ssize count,
-                         r_ssize* v_loc) {
+                         r_ssize* v_loc,
+                         r_ssize loc_size) {
   COL_EQUAL_NA(int, r_lgl_cbegin, lgl_is_missing);
 }
 static inline
 r_ssize int_col_equal_na(r_obj* x,
-                         r_ssize count,
-                         r_ssize* v_loc) {
+                         r_ssize* v_loc,
+                         r_ssize loc_size) {
   COL_EQUAL_NA(int, r_int_cbegin, int_is_missing);
 }
 static inline
 r_ssize dbl_col_equal_na(r_obj* x,
-                         r_ssize count,
-                         r_ssize* v_loc) {
+                         r_ssize* v_loc,
+                         r_ssize loc_size) {
   COL_EQUAL_NA(double, r_dbl_cbegin, dbl_is_missing);
 }
 static inline
 r_ssize cpl_col_equal_na(r_obj* x,
-                         r_ssize count,
-                         r_ssize* v_loc) {
+                         r_ssize* v_loc,
+                         r_ssize loc_size) {
   COL_EQUAL_NA(r_complex, r_cpl_cbegin, cpl_is_missing);
 }
 static inline
 r_ssize raw_col_equal_na(r_obj* x,
-                         r_ssize count,
-                         r_ssize* v_loc) {
+                         r_ssize* v_loc,
+                         r_ssize loc_size) {
   COL_EQUAL_NA(unsigned char, r_uchar_cbegin, raw_is_missing);
 }
 static inline
 r_ssize chr_col_equal_na(r_obj* x,
-                         r_ssize count,
-                         r_ssize* v_loc) {
+                         r_ssize* v_loc,
+                         r_ssize loc_size) {
   COL_EQUAL_NA(r_obj*, r_chr_cbegin, chr_is_missing);
 }
 static inline
 r_ssize list_col_equal_na(r_obj* x,
-                          r_ssize count,
-                          r_ssize* v_loc) {
+                          r_ssize* v_loc,
+                          r_ssize loc_size) {
   COL_EQUAL_NA(r_obj*, r_list_cbegin, list_is_missing);
 }
 

--- a/src/missing.c
+++ b/src/missing.c
@@ -99,7 +99,8 @@ r_obj* df_equal_na(r_obj* x) {
   // values. After we iterate through all columns, `v_loc` points to the missing
   // rows.
   r_ssize loc_size = size;
-  r_ssize* v_loc = (r_ssize*) R_alloc(loc_size, sizeof(r_ssize));
+  r_obj* loc_shelter = KEEP_N(r_alloc_raw(loc_size * sizeof(r_ssize)), &n_prot);
+  r_ssize* v_loc = (r_ssize*) r_raw_begin(loc_shelter);
 
   for (r_ssize i = 0; i < loc_size; ++i) {
     v_loc[i] = i;

--- a/tests/testthat/test-missing.R
+++ b/tests/testthat/test-missing.R
@@ -39,6 +39,21 @@ test_that("works recursively with data frame columns", {
   expect_equal(vec_equal_na(df), c(FALSE, FALSE, FALSE, TRUE))
 })
 
+test_that("0 row, N col data frame always returns `logical()` (#1585)", {
+  expect_identical(vec_equal_na(data_frame()), logical())
+  expect_identical(vec_equal_na(data_frame(x = integer(), y = double())), logical())
+})
+
+test_that(">0 row, 0 col data frame always returns `TRUE` for each row (#1585)", {
+  # `vec_equal_na()` returns `TRUE` for each row because it (in theory) does
+  # `all()` on each row, and since there are 0 columns we get
+  # `all(logical()) == TRUE` for each row.
+  expect_identical(
+    vec_equal_na(data_frame(.size = 2L)),
+    c(TRUE, TRUE)
+  )
+})
+
 test_that("works with `NULL` input (#1494)", {
   expect_identical(vec_equal_na(NULL), logical())
 })


### PR DESCRIPTION
I've worked out a way to improve on how `vec_equal_na()` work with data frames. I was able to remove all of the if branches from within the innermost loop, and we now better use information about the previous columns. We now track locations (rows) that we still need to check for missingness using `r_ssize* v_loc`. This narrows to a smaller and smaller vector as we iterate through the columns, and after we process all the columns it tells us exactly where the missing values are. It works like this:

``` r
df <- data.frame(
  x = c(1,  NA, NA, 2, NA, 3),
  y = c(NA, NA, 1,  2, NA, 4)
)
df
#>    x  y
#> 1  1 NA
#> 2 NA NA
#> 3 NA  1
#> 4  2  2
#> 5 NA NA
#> 6  3  4

# Initially any row could be missing
count <- 6
loc <- 1:6

# After processing first column, only rows 2, 3, and 5 could be missing
count <- 3
loc <- c(2, 3, 5)

# After processing second column, only 2 and 5 could be missing
# This is the last column, so these are the missing rows
count <- 2
loc <- c(2, 5)
```

## Performance

- This improves performance up to 70% over the current implementation, with the most improvements coming from when there is a moderate amount of missingness.
- There is a small drop in performance when there is 0% missingness, which is a common case. I have a plan to easily improve that with `vec_any_missing()`. We will do a preemptive check on the first column to see if there are any missing values. This should be extremely fast and will tell us if we have to do any work at all.
- There is also a drop in performance at 100% missingness. I'm not quite sure why this happens, but I think this is much rarer. I've added some benchmarks below to show that it really only happens at 100% missing.
- This method does allocate more memory. We use a vector of `r_ssize` rather than a vector of `bool` to track locations now, and that is more expensive. But I think it improves performance enough to be worth it, and it will only be needed with data frames.

The data frame used in the below images looked like this, with varying amounts of missingness:

``` r
head(data[[10]], 10)
#>       a    b    c    d    e
#> 1  TRUE TRUE TRUE TRUE TRUE
#> 2    NA   NA   NA   NA   NA
#> 3  TRUE TRUE TRUE TRUE TRUE
#> 4  TRUE TRUE TRUE TRUE TRUE
#> 5  TRUE TRUE TRUE TRUE TRUE
#> 6    NA   NA   NA   NA   NA
#> 7  TRUE TRUE TRUE TRUE TRUE
#> 8  TRUE TRUE TRUE TRUE TRUE
#> 9  TRUE TRUE TRUE TRUE TRUE
#> 10   NA   NA   NA   NA   NA
```

![](https://i.imgur.com/L9a8Anq.png)

![](https://i.imgur.com/uMBoghl.png)

You might notice the big drop in performance in the new method at 100% missing. I'm not entirely sure what causes this, but it really does only happen at 100% missing (see below). I'm not really worried about that case too much.

Here is 98, 99, and 100% with the new method:

``` r
# 98% NA
df <- make_data(n_na = 98, n_total = 100, size = 1e7)
bench::mark(vec_equal_na(df), iterations = 100)
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(df)   66.4ms   76.2ms      12.4     114MB    0.650

# 99% NA
df <- make_data(n_na = 99, n_total = 100, size = 1e7)
bench::mark(vec_equal_na(df), iterations = 100)
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(df)     67ms   78.5ms      11.5     114MB    0.479

# 100% NA
df <- make_data(n_na = 100, n_total = 100, size = 1e7)
bench::mark(vec_equal_na(df), iterations = 100)
#> # A tibble: 1 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_equal_na(df)    120ms    123ms      7.68     114MB    0.404
```