### PR TITLE
Early exit for empty index in `vec_assign()`

### DIFF
--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -27,6 +27,11 @@ r_obj* vec_assign_opts(r_obj* x,
                                        KEEP(vec_names(x)),
                                        &location_opts));
 
+  if (vec_size(index) == 0) {
+    FREE(2);
+    return x;
+  }
+
   // Cast and recycle `value`
   value = KEEP(vec_cast(value, x, opts.value_arg, opts.x_arg, opts.call));
   value = KEEP(vec_check_recycle(value, vec_size(index), opts.value_arg, opts.call));


### PR DESCRIPTION
Closes #1408.

For example this is relevant for `coalesce()` like uses, e.g.  `vec_assign(x, is.na(x), 1L)`.

I only added this optimisation for `vec_assign_opts()` and not for other functions in `slice-assign.h` e.g. `vec_proxy_assign_opts()`.  I only saw `vec_proxy_assign_opts()` being called in `unchop()` and `vec_c()` but it don't think one would encounter an empty index there.

Do you want an explicit test that `vec_assign(x, integer(), -1L)` works? It is currently tested "indirectly" via `vec_slice(x, FALSE) <- 2L`.

``` r
library(rlang)
library(vctrs)

n <- 10e6
x <- 0L + 1:n
idx <- vec_rep(FALSE, n)

bench::mark(
  false_n = vec_assign(x, idx, -1L),
  false = vec_assign(x, FALSE, -1L),
  empty = vec_assign(x, integer(), -1L),
  check = FALSE,
  min_iterations = 20
)

# Before
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 false_n     13.98ms  14.58ms      62.8    38.1MB     68.1
#> 2 false        5.07ms   5.49ms     179.     38.1MB    172. 
#> 3 empty        5.03ms   5.59ms     177.     38.1MB    171.

# After
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 false_n      8.37ms   9.01ms      109.     3.5KB      0  
#> 2 false        1.74µs   1.86µs   371996.        0B     37.2
#> 3 empty        2.11µs   2.29µs   341040.        0B      0
```

<sup>Created on 2022-07-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>