### PR TITLE
Early exit for only `TRUE` in `vec_slice()`

### DIFF
--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -27,6 +27,11 @@ r_obj* vec_assign_opts(r_obj* x,
                                        KEEP(vec_names(x)),
                                        &location_opts));
 
+  if (is_compact(index)) {
+    index = compact_materialize(index);
+  }
+  KEEP(index);
+
   // Cast and recycle `value`
   value = KEEP(vec_cast(value, x, opts.value_arg, opts.x_arg, opts.call));
   value = KEEP(vec_check_recycle(value, vec_size(index), opts.value_arg, opts.call));
@@ -37,7 +42,7 @@ r_obj* vec_assign_opts(r_obj* x,
 
   r_obj* out = vec_restore(proxy, x, r_null, owned);
 
-  FREE(6);
+  FREE(7);
   return out;
 }
 

--- a/src/slice.c
+++ b/src/slice.c
@@ -280,6 +280,10 @@ r_obj* slice_rownames(r_obj* names, r_obj* subscript) {
 }
 
 r_obj* vec_slice_unsafe(r_obj* x, r_obj* subscript) {
+  if (is_full_compact_seq(subscript, vec_size(x))) {
+    return x;
+  }
+
   int nprot = 0;
 
   r_obj* restore_size = KEEP_N(r_int(vec_subscript_size(subscript)), &nprot);

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -67,7 +67,22 @@ r_obj* lgl_as_location(r_obj* subscript,
   }
 
   if (subscript_n == n) {
-    r_obj* out = KEEP(r_lgl_which(subscript, true));
+    const int* p_x = r_lgl_cbegin(subscript);
+    bool all_true = true;
+    for (r_ssize i = 0; i < n; ++i) {
+      int x_i = p_x[i];
+      if (x_i != 1) {
+        all_true = false;
+        break;
+      }
+    }
+
+    r_obj* out;
+    if (all_true) {
+      out = KEEP(compact_seq(0, n, true));
+    } else {
+      out = KEEP(r_lgl_which(subscript, true));
+    }
 
     r_obj* nms = KEEP(r_names(subscript));
     if (nms != R_NilValue) {
@@ -402,7 +417,10 @@ r_obj* ffi_as_location(r_obj* subscript,
     .loc_zero       = parse_loc_zero(loc_zero, call)
   };
 
-  return vec_as_location_opts(subscript, n, names, &opts);
+  r_obj* out = KEEP(vec_as_location_opts(subscript, n, names, &opts));
+  out = compact_materialize(out);
+  FREE(1);
+  return out;
 }
 
 static

--- a/src/utils.c
+++ b/src/utils.c
@@ -857,6 +857,18 @@ bool is_compact_seq(SEXP x) {
   return ATTRIB(x) == compact_seq_attrib;
 }
 
+bool is_full_compact_seq(SEXP x, r_ssize n_all) {
+  if (is_compact_seq(x)) {
+    int* x_data = r_int_begin(x);
+    r_ssize start = x_data[0];
+    r_ssize n = x_data[1];
+    r_ssize step = x_data[2];
+    return start == 0 && n == n_all && step == 1;
+  }
+
+  return false;
+}
+
 // Materialize a 1-based sequence
 SEXP compact_seq_materialize(SEXP x) {
   int* p = INTEGER(x);

--- a/src/utils.h
+++ b/src/utils.h
@@ -185,6 +185,7 @@ SEXP list_pluck(SEXP xs, R_len_t i);
 void init_compact_seq(int* p, R_len_t start, R_len_t size, bool increasing);
 SEXP compact_seq(R_len_t start, R_len_t size, bool increasing);
 bool is_compact_seq(SEXP x);
+bool is_full_compact_seq(SEXP x, r_ssize n_all);
 
 void init_compact_rep(int* p, R_len_t i, R_len_t n);
 SEXP compact_rep(R_len_t i, R_len_t n);

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -63,6 +63,10 @@ test_that("can subset with a recycled TRUE", {
   expect_identical(vec_as_location(TRUE, 2), 1:2)
 })
 
+test_that("can subset with a vector of TRUE", {
+  expect_identical(vec_slice(1:3, c(TRUE, TRUE, TRUE)), 1:3)
+})
+
 test_that("can subset with a recycled FALSE", {
   expect_identical(vec_slice(1:3, FALSE), int())
   expect_identical(vec_slice(mtcars, FALSE), mtcars[NULL, ])

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -196,6 +196,13 @@ test_that("vec_as_location() handles NULL", {
   )
 })
 
+test_that("vec_as_location() handles vector of TRUE", {
+  expect_identical(
+    vec_as_location(c(TRUE, TRUE), 2),
+    vec_as_location(1:2, 10),
+  )
+})
+
 test_that("vec_as_location() checks for mix of negative and missing locations", {
   expect_snapshot({
     (expect_error(


### PR DESCRIPTION
Useful e.g. in `vec_slice(x, !is.na(x))`

``` r
library(rlang)
library(vctrs)

n <- 10e6
x <- 0L + 1:n
idx <- vec_rep(TRUE, n)

bench::mark(
  false_n = vec_slice(x, idx),
  check = FALSE,
  min_iterations = 20
)
# Before
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 false_n      29.6ms   30.6ms      28.9    76.3MB     30.3

# After
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 false_n      7.39ms   7.91ms      121.    3.73KB        0
```

<sup>Created on 2022-07-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>