### PR TITLE
Speed up `r_lgl_which()`

### DIFF
--- a/src/rlang/vec-lgl.c
+++ b/src/rlang/vec-lgl.c
@@ -64,7 +64,7 @@ r_obj* r_lgl_which(r_obj* x, bool na_propagate) {
       }
     }
 
-    FREE(2);
+    FREE(1);
     return which;
   }
 


### PR DESCRIPTION
In the current implementation `r_lgl_which()` iterates twice over the whole input `x`:

1. get the output size
2. calculate the actual output

This PR estimates the output size by visiting ~2% of the elements of `x` (for long `x`, still all for short `x`). In some cases the output estimate won't be sufficient so it has to resize but this should be rare. Overall this needs a little bit more memory but it quite a bit faster:

``` r
library(vctrs)
set.seed(1)

n <- 100e6
all_true <- vec_rep(TRUE, n)
all_false <- vec_rep(FALSE, n)
true_90 <- runif(n) < 0.9
true_50 <- runif(n) < 0.5
true_10 <- runif(n) < 0.1
true_1 <- runif(n) < 0.01


bench::mark(
  all_true = vec_as_location(all_true, n),
  all_false = vec_as_location(all_false, n),
  true_90 = vec_as_location(true_90, n),
  true_50 = vec_as_location(true_50, n),
  true_10 = vec_as_location(true_10, n),
  true_1 = vec_as_location(true_1, n),
  check = FALSE,
  min_iterations = 10
)
# Before
#> # A tibble: 6 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 all_true    177.9ms  186.7ms      4.46  381.48MB    2.97 
#> 2 all_false    82.4ms   89.9ms     10.6         0B    0    
#> 3 true_90       240ms  247.4ms      3.80  343.32MB    0.951
#> 4 true_50     504.3ms  575.6ms      1.82  190.73MB    0.202
#> 5 true_10     197.4ms  213.2ms      4.70   38.14MB    0.523
#> 6 true_1       93.5ms   97.7ms     10.2     3.82MB    0

# After
#> # A tibble: 6 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 all_true    115.9ms  122.4ms      6.42  381.48MB    2.75 
#> 2 all_false    36.8ms   38.6ms     25.8     1.91MB    0    
#> 3 true_90     185.6ms  195.4ms      5.12  381.47MB    2.20 
#> 4 true_50     472.1ms  491.6ms      2.00  199.13MB    0.500
#> 5 true_10     158.5ms  180.7ms      5.48   54.93MB    0    
#> 6 true_1       50.6ms     56ms     15.6     9.13MB    0
```

<sup>Created on 2022-07-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Currently, this PR is only a proof of concept. It uses some magic numbers I just came up with without any testing at all. Maybe it would also make sense to not have a fixed jump size to avoid some very bad estimates.