### PR TITLE
Improve `vec_as_location2()` and `vec_as_subscript2()` usage of `call`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* `vec_as_location2()` and `vec_as_subscript2()` more correctly utilize their
+  `call` arguments (#1605).
+
 * `vec_count(sort = "count")` now uses a stable sorting method. This ensures
   that different keys with the same count are sorted in the order that they
   originally appeared in (#1588).

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -239,7 +239,7 @@ vec_as_location2_result <- function(i,
   # FIXME: Use result approach in internal implementation?
   err <- NULL
   i <- tryCatch(
-    vec_as_location(i, n, names = names, arg = arg),
+    vec_as_location(i, n, names = names, arg = arg, call = call),
     vctrs_error_subscript_type = function(err) {
       err <<- err
       i

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -114,7 +114,8 @@ vec_as_subscript2_result <- function(i,
       numeric = numeric,
       character = character,
       subscript_arg = arg,
-      body = bullets
+      body = bullets,
+      call = call
     )
 
     return(result)

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -130,7 +130,8 @@ vec_as_subscript2_result <- function(i,
       numeric = numeric,
       character = character,
       subscript_arg = arg,
-      body = cnd_body.vctrs_error_subscript_type
+      body = cnd_body.vctrs_error_subscript_type,
+      call = call
     )))
   }
 

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -205,7 +205,7 @@
       ! Must subset elements with a valid subscript vector.
       x Can't convert from `foo` <double> to <integer> due to loss of precision.
 
-# vec_as_location() and variants check for OOB elements
+# vec_as_location() and variants check for OOB elements (#1605)
 
     Code
       # Numeric indexing
@@ -228,7 +228,7 @@
       (expect_error(vec_as_location2(10L, 2L), class = "vctrs_error_subscript_oob"))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `vec_as_location2_result()`:
+      Error:
       ! Can't subset elements past the end.
       i Location 10 doesn't exist.
       i There are only 2 elements.
@@ -246,7 +246,15 @@
       )
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `vec_as_location2_result()`:
+      Error:
+      ! Can't subset elements that don't exist.
+      x Element `foo` doesn't exist.
+    Code
+      (expect_error(vec_as_location2("foo", 1L, names = "bar", call = call("baz")),
+      class = "vctrs_error_subscript_oob"))
+    Output
+      <error/vctrs_error_subscript_oob>
+      Error in `baz()`:
       ! Can't subset elements that don't exist.
       x Element `foo` doesn't exist.
 

--- a/tests/testthat/_snaps/subscript.md
+++ b/tests/testthat/_snaps/subscript.md
@@ -139,3 +139,23 @@
       x Subscript has the wrong type `logical`.
       i It must be numeric or character.
 
+# vec_as_subscript2() retains the call when throwing vec_as_subscript() errors (#1605)
+
+    Code
+      vec_as_subscript2(1L, numeric = "error", call = call("foo"))
+    Condition
+      Error in `foo()`:
+      ! Must extract element with a single valid subscript.
+      x Subscript has the wrong type `integer`.
+      i It must be logical or character.
+
+---
+
+    Code
+      vec_as_subscript2(1.5, call = call("foo"))
+    Condition
+      Error in `foo()`:
+      ! Must extract element with a single valid subscript.
+      x Subscript has the wrong type `double`.
+      i It must be logical, numeric, or character.
+

--- a/tests/testthat/_snaps/subscript.md
+++ b/tests/testthat/_snaps/subscript.md
@@ -159,3 +159,13 @@
       x Subscript has the wrong type `double`.
       i It must be logical, numeric, or character.
 
+# vec_as_subscript2() retains the call when erroring on logical input (#1605)
+
+    Code
+      vec_as_subscript2(TRUE, call = call("foo"))
+    Condition
+      Error in `foo()`:
+      ! Must extract element with a single valid subscript.
+      x Subscript has the wrong type `logical`.
+      i It must be logical, numeric, or character.
+

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -62,7 +62,7 @@ test_that("vec_as_location2() and vec_as_location() require integer- or characte
   expect_identical(vec_as_location(foobar(FALSE), 10L), int())
 })
 
-test_that("vec_as_location() and variants check for OOB elements", {
+test_that("vec_as_location() and variants check for OOB elements (#1605)", {
   expect_snapshot({
     "Numeric indexing"
     (expect_error(vec_as_location(10L, 2L), class = "vctrs_error_subscript_oob"))
@@ -72,6 +72,7 @@ test_that("vec_as_location() and variants check for OOB elements", {
     "Character indexing"
     (expect_error(vec_as_location("foo", 1L, names = "bar"), class = "vctrs_error_subscript_oob"))
     (expect_error(vec_as_location2("foo", 1L, names = "bar"), class = "vctrs_error_subscript_oob"))
+    (expect_error(vec_as_location2("foo", 1L, names = "bar", call = call("baz")), class = "vctrs_error_subscript_oob"))
   })
 
   expect_error(num_as_location(10L, 2L), class = "vctrs_error_subscript_oob")

--- a/tests/testthat/test-subscript.R
+++ b/tests/testthat/test-subscript.R
@@ -86,6 +86,11 @@ test_that("vec_as_subscript2() forbids subscript types", {
   expect_snapshot(error = TRUE, vec_as_subscript2(TRUE, logical = "error"))
 })
 
+test_that("vec_as_subscript2() retains the call when throwing vec_as_subscript() errors (#1605)", {
+  expect_snapshot(error = TRUE, vec_as_subscript2(1L, numeric = "error", call = call("foo")))
+  expect_snapshot(error = TRUE, vec_as_subscript2(1.5, call = call("foo")))
+})
+
 test_that("vec_as_subscript() evaluates arg lazily", {
   expect_silent(vec_as_subscript(1L, arg = print("oof")))
   expect_silent(vec_as_subscript_result(1L, arg = print("oof"), NULL, logical = "error", numeric = "cast", character = "error"))

--- a/tests/testthat/test-subscript.R
+++ b/tests/testthat/test-subscript.R
@@ -91,6 +91,10 @@ test_that("vec_as_subscript2() retains the call when throwing vec_as_subscript()
   expect_snapshot(error = TRUE, vec_as_subscript2(1.5, call = call("foo")))
 })
 
+test_that("vec_as_subscript2() retains the call when erroring on logical input (#1605)", {
+  expect_snapshot(error = TRUE, vec_as_subscript2(TRUE, call = call("foo")))
+})
+
 test_that("vec_as_subscript() evaluates arg lazily", {
   expect_silent(vec_as_subscript(1L, arg = print("oof")))
   expect_silent(vec_as_subscript_result(1L, arg = print("oof"), NULL, logical = "error", numeric = "cast", character = "error"))


### PR DESCRIPTION
Closes #1605 