### PR TITLE
Add a `.call` argument to `vec_rbind()` and `vec_cbind()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `vec_rbind()` and `vec_cbind()` now have `.call` arguments (#1597).
+
 * `df_list()` has gained a new `.unpack` argument to optionally disable data
   frame unpacking (#1616).
 

--- a/R/bind.R
+++ b/R/bind.R
@@ -194,7 +194,8 @@ vec_rbind <- fn_inline_formals(vec_rbind, ".name_repair")
 vec_cbind <- function(...,
                       .ptype = NULL,
                       .size = NULL,
-                      .name_repair = c("unique", "universal", "check_unique", "minimal")) {
+                      .name_repair = c("unique", "universal", "check_unique", "minimal"),
+                      .call = current_env()) {
   .External2(ffi_cbind, .ptype, .size, .name_repair)
 }
 vec_cbind <- fn_inline_formals(vec_cbind, ".name_repair")

--- a/R/bind.R
+++ b/R/bind.R
@@ -29,6 +29,10 @@
 #'
 #' * `vec_size(vec_cbind(x, y)) == vec_size_common(x, y)`
 #' * `vec_ptype(vec_cbind(x, y)) == vec_cbind(vec_ptype(x), vec_ptype(x))`
+#'
+#' @inheritParams vec_c
+#' @inheritParams rlang::args_error_context
+#'
 #' @param ... Data frames or vectors.
 #'
 #'   When the inputs are named:
@@ -61,7 +65,7 @@
 #'   repair function after all inputs have been concatenated together
 #'   in a final data frame. Hence `vec_cbind()` allows the more
 #'   permissive minimal names repair.
-#' @inheritParams vec_c
+#'
 #' @return A data frame, or subclass of data frame.
 #'
 #'   If `...` is a mix of different data frame subclasses, `vec_ptype2()`
@@ -173,7 +177,8 @@ vec_rbind <- function(...,
                       .ptype = NULL,
                       .names_to = rlang::zap(),
                       .name_repair = c("unique", "universal", "check_unique"),
-                      .name_spec = NULL) {
+                      .name_spec = NULL,
+                      .call = current_env()) {
   .External2(ffi_rbind, .ptype, .names_to, .name_repair, .name_spec)
 }
 vec_rbind <- fn_inline_formals(vec_rbind, ".name_repair")

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -11,7 +11,8 @@ vec_rbind(
   .ptype = NULL,
   .names_to = rlang::zap(),
   .name_repair = c("unique", "universal", "check_unique"),
-  .name_spec = NULL
+  .name_spec = NULL,
+  .call = current_env()
 )
 
 vec_cbind(
@@ -70,6 +71,11 @@ for combining the outer inputs names in \code{...} and the inner row
 names of the inputs. This only has an effect when \code{.names_to} is
 set to \code{NULL}, which causes the input names to be assigned as row
 names.}
+
+\item{.call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 
 \item{.size}{If, \code{NULL}, the default, will determine the number of rows in
 \code{vec_cbind()} output by using the tidyverse \link[=vector_recycling_rules]{recycling rules}.

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -19,7 +19,8 @@ vec_cbind(
   ...,
   .ptype = NULL,
   .size = NULL,
-  .name_repair = c("unique", "universal", "check_unique", "minimal")
+  .name_repair = c("unique", "universal", "check_unique", "minimal"),
+  .call = current_env()
 )
 }
 \arguments{

--- a/src/bind.c
+++ b/src/bind.c
@@ -362,12 +362,12 @@ r_obj* cbind_names_to(bool has_names,
 
 
 // [[ register(external = TRUE) ]]
-r_obj* ffi_cbind(r_obj* ffi_call, r_obj* op, r_obj* args, r_obj* env) {
+r_obj* ffi_cbind(r_obj* ffi_call, r_obj* op, r_obj* args, r_obj* frame) {
   args = r_node_cdr(args);
 
-  struct r_lazy call = { .x = env, .env = r_null };
+  struct r_lazy call = { .x = syms_dot_call, .env = frame };
 
-  r_obj* xs = KEEP(rlang_env_dots_list(env));
+  r_obj* xs = KEEP(rlang_env_dots_list(frame));
   r_obj* ptype = r_node_car(args); args = r_node_cdr(args);
   r_obj* size = r_node_car(args); args = r_node_cdr(args);
   r_obj* name_repair = r_node_car(args);

--- a/src/bind.c
+++ b/src/bind.c
@@ -3,12 +3,12 @@
 #include "decl/bind-decl.h"
 
 // [[ register(external = TRUE) ]]
-r_obj* ffi_rbind(r_obj* ffi_call, r_obj* op, r_obj* args, r_obj* env) {
+r_obj* ffi_rbind(r_obj* ffi_call, r_obj* op, r_obj* args, r_obj* frame) {
   args = r_node_cdr(args);
 
-  struct r_lazy call = { .x = env, .env = r_null };
+  struct r_lazy call = { .x = syms_dot_call, .env = frame };
 
-  r_obj* xs = KEEP(rlang_env_dots_list(env));
+  r_obj* xs = KEEP(rlang_env_dots_list(frame));
   r_obj* ptype = r_node_car(args); args = r_node_cdr(args);
   r_obj* names_to = r_node_car(args); args = r_node_cdr(args);
   r_obj* name_repair = r_node_car(args); args = r_node_cdr(args);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1614,6 +1614,7 @@ SEXP syms_chr_proxy_collate = NULL;
 SEXP syms_actual = NULL;
 SEXP syms_required = NULL;
 SEXP syms_call = NULL;
+SEXP syms_dot_call = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -1898,6 +1899,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_actual = Rf_install("actual");
   syms_required = Rf_install("required");
   syms_call = Rf_install("call");
+  syms_dot_call = Rf_install(".call");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.h
+++ b/src/utils.h
@@ -514,6 +514,7 @@ extern SEXP syms_chr_proxy_collate;
 extern SEXP syms_actual;
 extern SEXP syms_required;
 extern SEXP syms_call;
+extern SEXP syms_dot_call;
 
 static const char * const c_strs_vctrs_common_class_fallback = "vctrs:::common_class_fallback";
 

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -1,24 +1,23 @@
 # incompatible columns throws common type error
 
     Code
-      vec_rbind(x_int, x_chr)
-    Condition
+      (expect_error(vec_rbind(x_int, x_chr), class = "vctrs_error_incompatible_type"))
+    Output
+      <error/vctrs_error_incompatible_type>
       Error in `vec_rbind()`:
       ! Can't combine `..1$x` <integer> and `..2$x` <character>.
-
----
-
     Code
-      vec_rbind(x_int, x_chr, .call = call("foo"))
-    Condition
+      (expect_error(vec_rbind(x_int, x_chr, .call = call("foo")), class = "vctrs_error_incompatible_type")
+      )
+    Output
+      <error/vctrs_error_incompatible_type>
       Error in `foo()`:
       ! Can't combine `..1$x` <integer> and `..2$x` <character>.
-
----
-
     Code
-      vec_rbind(x_int, x_chr, .ptype = x_chr, .call = call("foo"))
-    Condition
+      (expect_error(vec_rbind(x_int, x_chr, .ptype = x_chr, .call = call("foo")),
+      class = "vctrs_error_incompatible_type"))
+    Output
+      <error/vctrs_error_incompatible_type>
       Error in `foo()`:
       ! Can't convert `..1$x` <integer> to match type of `x` <character>.
 
@@ -59,16 +58,15 @@
 # vec_rbind() fails with arrays of dimensionality > 3
 
     Code
-      vec_rbind(array(NA, c(1, 1, 1)))
-    Condition
+      (expect_error(vec_rbind(array(NA, c(1, 1, 1)))))
+    Output
+      <error/rlang_error>
       Error in `vec_rbind()`:
       ! Can't bind arrays.
-
----
-
     Code
-      vec_rbind(array(NA, c(1, 1, 1)), .call = call("foo"))
-    Condition
+      (expect_error(vec_rbind(array(NA, c(1, 1, 1)), .call = call("foo"))))
+    Output
+      <error/rlang_error>
       Error in `foo()`:
       ! Can't bind arrays.
 
@@ -83,32 +81,27 @@
 # vec_cbind() reports error context
 
     Code
-      vec_cbind(foobar(list()))
-    Condition
+      (expect_error(vec_cbind(foobar(list()))))
+    Output
+      <error/vctrs_error_scalar_type>
       Error in `vec_cbind()`:
       ! `..1` must be a vector, not a <vctrs_foobar> object.
-
----
-
     Code
-      vec_cbind(foobar(list()), .call = call("foo"))
-    Condition
+      (expect_error(vec_cbind(foobar(list()), .call = call("foo"))))
+    Output
+      <error/vctrs_error_scalar_type>
       Error in `foo()`:
       ! `..1` must be a vector, not a <vctrs_foobar> object.
-
----
-
     Code
-      vec_cbind(a = 1:2, b = int())
-    Condition
+      (expect_error(vec_cbind(a = 1:2, b = int())))
+    Output
+      <error/vctrs_error_incompatible_size>
       Error in `vec_cbind()`:
       ! Can't recycle `a` (size 2) to match `b` (size 0).
-
----
-
     Code
-      vec_cbind(a = 1:2, b = int(), .call = call("foo"))
-    Condition
+      (expect_error(vec_cbind(a = 1:2, b = int(), .call = call("foo"))))
+    Output
+      <error/vctrs_error_incompatible_size>
       Error in `foo()`:
       ! Can't recycle `a` (size 2) to match `b` (size 0).
 
@@ -157,48 +150,42 @@
 # can supply `.names_to` to `vec_rbind()` (#229)
 
     Code
-      vec_rbind(.names_to = letters)
-    Condition
+      (expect_error(vec_rbind(.names_to = letters)))
+    Output
+      <error/rlang_error>
       Error in `vec_rbind()`:
       ! `.names_to` must be `NULL`, a string, or an `rlang::zap()` object.
-
----
-
     Code
-      vec_rbind(.names_to = 10)
-    Condition
+      (expect_error(vec_rbind(.names_to = 10)))
+    Output
+      <error/rlang_error>
       Error in `vec_rbind()`:
       ! `.names_to` must be `NULL`, a string, or an `rlang::zap()` object.
-
----
-
     Code
-      vec_rbind(.names_to = letters, .call = call("foo"))
-    Condition
+      (expect_error(vec_rbind(.names_to = letters, .call = call("foo"))))
+    Output
+      <error/rlang_error>
       Error in `foo()`:
       ! `.names_to` must be `NULL`, a string, or an `rlang::zap()` object.
 
 # vec_cbind() fails with arrays of dimensionality > 3
 
     Code
-      vec_cbind(a)
-    Condition
+      (expect_error(vec_cbind(a)))
+    Output
+      <error/rlang_error>
       Error in `vec_cbind()`:
       ! Can't bind arrays.
-
----
-
     Code
-      vec_cbind(a, .call = call("foo"))
-    Condition
+      (expect_error(vec_cbind(a, .call = call("foo"))))
+    Output
+      <error/rlang_error>
       Error in `foo()`:
       ! Can't bind arrays.
-
----
-
     Code
-      vec_cbind(x = a)
-    Condition
+      (expect_error(vec_cbind(x = a)))
+    Output
+      <error/rlang_error>
       Error in `vec_cbind()`:
       ! Can't bind arrays.
 
@@ -355,18 +342,19 @@
 # rbind repairs names of data frames (#704)
 
     Code
-      vec_rbind(df, df, .name_repair = "check_unique")
-    Condition
+      (expect_error(vec_rbind(df, df, .name_repair = "check_unique"), class = "vctrs_error_names_must_be_unique")
+      )
+    Output
+      <error/vctrs_error_names_must_be_unique>
       Error in `vec_rbind()`:
       ! Names must be unique.
       x These names are duplicated:
         * "x" at locations 1 and 2.
-
----
-
     Code
-      vec_rbind(df, df, .name_repair = "check_unique", .call = call("foo"))
-    Condition
+      (expect_error(vec_rbind(df, df, .name_repair = "check_unique", .call = call(
+        "foo")), class = "vctrs_error_names_must_be_unique"))
+    Output
+      <error/vctrs_error_names_must_be_unique>
       Error in `foo()`:
       ! Names must be unique.
       x These names are duplicated:
@@ -402,17 +390,16 @@
 # can't zap names when `.names_to` is supplied
 
     Code
-      vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap())
-    Condition
+      (expect_error(vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap())))
+    Output
+      <error/rlang_error>
       Error in `vec_rbind()`:
       ! Can't zap outer names when `.names_to` is supplied.
-
----
-
     Code
-      vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap(), .call = call(
-        "foo"))
-    Condition
+      (expect_error(vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap(),
+      .call = call("foo"))))
+    Output
+      <error/rlang_error>
       Error in `foo()`:
       ! Can't zap outer names when `.names_to` is supplied.
 

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -1,11 +1,26 @@
-# type of column is common type of individual columns
+# incompatible columns throws common type error
 
     Code
-      (expect_error(vec_rbind(x_int, x_chr), class = "vctrs_error_incompatible_type"))
-    Output
-      <error/vctrs_error_incompatible_type>
+      vec_rbind(x_int, x_chr)
+    Condition
       Error in `vec_rbind()`:
       ! Can't combine `..1$x` <integer> and `..2$x` <character>.
+
+---
+
+    Code
+      vec_rbind(x_int, x_chr, .call = call("foo"))
+    Condition
+      Error in `foo()`:
+      ! Can't combine `..1$x` <integer> and `..2$x` <character>.
+
+---
+
+    Code
+      vec_rbind(x_int, x_chr, .ptype = x_chr, .call = call("foo"))
+    Condition
+      Error in `foo()`:
+      ! Can't convert `..1$x` <integer> to match type of `x` <character>.
 
 # names are supplied if needed
 
@@ -44,10 +59,17 @@
 # vec_rbind() fails with arrays of dimensionality > 3
 
     Code
-      (expect_error(vec_rbind(array(NA, c(1, 1, 1))), "Can't bind arrays"))
-    Output
-      <error/rlang_error>
+      vec_rbind(array(NA, c(1, 1, 1)))
+    Condition
       Error in `vec_rbind()`:
+      ! Can't bind arrays.
+
+---
+
+    Code
+      vec_rbind(array(NA, c(1, 1, 1)), .call = call("foo"))
+    Condition
+      Error in `foo()`:
       ! Can't bind arrays.
 
 # can assign row names in vec_rbind()
@@ -114,6 +136,30 @@
       ! Names must be unique.
       x These names are duplicated:
         * "a" at locations 1 and 2.
+
+# can supply `.names_to` to `vec_rbind()` (#229)
+
+    Code
+      vec_rbind(.names_to = letters)
+    Condition
+      Error in `vec_rbind()`:
+      ! `.names_to` must be `NULL`, a string, or an `rlang::zap()` object.
+
+---
+
+    Code
+      vec_rbind(.names_to = 10)
+    Condition
+      Error in `vec_rbind()`:
+      ! `.names_to` must be `NULL`, a string, or an `rlang::zap()` object.
+
+---
+
+    Code
+      vec_rbind(.names_to = letters, .call = call("foo"))
+    Condition
+      Error in `foo()`:
+      ! `.names_to` must be `NULL`, a string, or an `rlang::zap()` object.
 
 # vec_rbind() name repair messages are useful
 

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -83,16 +83,33 @@
 # vec_cbind() reports error context
 
     Code
-      (expect_error(vec_cbind(foobar(list()))))
-    Output
-      <error/vctrs_error_scalar_type>
+      vec_cbind(foobar(list()))
+    Condition
       Error in `vec_cbind()`:
       ! `..1` must be a vector, not a <vctrs_foobar> object.
+
+---
+
     Code
-      (expect_error(vec_cbind(a = 1:2, b = int())))
-    Output
-      <error/vctrs_error_incompatible_size>
+      vec_cbind(foobar(list()), .call = call("foo"))
+    Condition
+      Error in `foo()`:
+      ! `..1` must be a vector, not a <vctrs_foobar> object.
+
+---
+
+    Code
+      vec_cbind(a = 1:2, b = int())
+    Condition
       Error in `vec_cbind()`:
+      ! Can't recycle `a` (size 2) to match `b` (size 0).
+
+---
+
+    Code
+      vec_cbind(a = 1:2, b = int(), .call = call("foo"))
+    Condition
+      Error in `foo()`:
       ! Can't recycle `a` (size 2) to match `b` (size 0).
 
 # duplicate names are de-deduplicated
@@ -160,6 +177,30 @@
     Condition
       Error in `foo()`:
       ! `.names_to` must be `NULL`, a string, or an `rlang::zap()` object.
+
+# vec_cbind() fails with arrays of dimensionality > 3
+
+    Code
+      vec_cbind(a)
+    Condition
+      Error in `vec_cbind()`:
+      ! Can't bind arrays.
+
+---
+
+    Code
+      vec_cbind(a, .call = call("foo"))
+    Condition
+      Error in `foo()`:
+      ! Can't bind arrays.
+
+---
+
+    Code
+      vec_cbind(x = a)
+    Condition
+      Error in `vec_cbind()`:
+      ! Can't bind arrays.
 
 # vec_rbind() name repair messages are useful
 
@@ -311,6 +352,26 @@
         ...1 ...2
       1    1    2
 
+# rbind repairs names of data frames (#704)
+
+    Code
+      vec_rbind(df, df, .name_repair = "check_unique")
+    Condition
+      Error in `vec_rbind()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "x" at locations 1 and 2.
+
+---
+
+    Code
+      vec_rbind(df, df, .name_repair = "check_unique", .call = call("foo"))
+    Condition
+      Error in `foo()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "x" at locations 1 and 2.
+
 # vec_rbind() fails with complex foreign S3 classes
 
     Code
@@ -341,11 +402,18 @@
 # can't zap names when `.names_to` is supplied
 
     Code
-      (expect_error(vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap()),
-      "Can't zap outer names when `.names_to` is supplied.", fixed = TRUE))
-    Output
-      <error/rlang_error>
+      vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap())
+    Condition
       Error in `vec_rbind()`:
+      ! Can't zap outer names when `.names_to` is supplied.
+
+---
+
+    Code
+      vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap(), .call = call(
+        "foo"))
+    Condition
+      Error in `foo()`:
       ! Can't zap outer names when `.names_to` is supplied.
 
 # row-binding performs expected allocations

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -33,14 +33,19 @@ test_that("incompatible columns throws common type error", {
   x_int <- data_frame(x = 1L)
   x_chr <- data_frame(x = "a")
 
-  expect_snapshot(error = TRUE, {
-    vec_rbind(x_int, x_chr)
-  })
-  expect_snapshot(error = TRUE, {
-    vec_rbind(x_int, x_chr, .call = call("foo"))
-  })
-  expect_snapshot(error = TRUE, {
-    vec_rbind(x_int, x_chr, .ptype = x_chr, .call = call("foo"))
+  expect_snapshot({
+    (expect_error(
+      vec_rbind(x_int, x_chr),
+      class = "vctrs_error_incompatible_type"
+    ))
+    (expect_error(
+      vec_rbind(x_int, x_chr, .call = call("foo")),
+      class = "vctrs_error_incompatible_type"
+    ))
+    (expect_error(
+      vec_rbind(x_int, x_chr, .ptype = x_chr, .call = call("foo")),
+      class = "vctrs_error_incompatible_type"
+    ))
   })
 })
 
@@ -214,11 +219,9 @@ test_that("can construct an id column", {
 })
 
 test_that("vec_rbind() fails with arrays of dimensionality > 3", {
-  expect_snapshot(error = TRUE, {
-    vec_rbind(array(NA, c(1, 1, 1)))
-  })
-  expect_snapshot(error = TRUE, {
-    vec_rbind(array(NA, c(1, 1, 1)), .call = call("foo"))
+  expect_snapshot({
+    (expect_error(vec_rbind(array(NA, c(1, 1, 1)))))
+    (expect_error(vec_rbind(array(NA, c(1, 1, 1)), .call = call("foo"))))
   })
 })
 
@@ -391,18 +394,12 @@ test_that("performance: Row binding with df-cols doesn't duplicate on every assi
 # cols --------------------------------------------------------------------
 
 test_that("vec_cbind() reports error context", {
-  expect_snapshot(error = TRUE, {
-    vec_cbind(foobar(list()))
-  })
-  expect_snapshot(error = TRUE, {
-    vec_cbind(foobar(list()), .call = call("foo"))
-  })
+  expect_snapshot({
+    (expect_error(vec_cbind(foobar(list()))))
+    (expect_error(vec_cbind(foobar(list()), .call = call("foo"))))
 
-  expect_snapshot(error = TRUE, {
-    vec_cbind(a = 1:2, b = int())
-  })
-  expect_snapshot(error = TRUE, {
-    vec_cbind(a = 1:2, b = int(), .call = call("foo"))
+    (expect_error(vec_cbind(a = 1:2, b = int())))
+    (expect_error(vec_cbind(a = 1:2, b = int(), .call = call("foo"))))
   })
 })
 
@@ -497,14 +494,10 @@ test_that("can repair names in `vec_cbind()` (#227)", {
 })
 
 test_that("can supply `.names_to` to `vec_rbind()` (#229)", {
-  expect_snapshot(error = TRUE, {
-    vec_rbind(.names_to = letters)
-  })
-  expect_snapshot(error = TRUE, {
-    vec_rbind(.names_to = 10)
-  })
-  expect_snapshot(error = TRUE, {
-    vec_rbind(.names_to = letters, .call = call("foo"))
+  expect_snapshot({
+    (expect_error(vec_rbind(.names_to = letters)))
+    (expect_error(vec_rbind(.names_to = 10)))
+    (expect_error(vec_rbind(.names_to = letters, .call = call("foo"))))
   })
 
   x <- data_frame(foo = 1:2, bar = 3:4)
@@ -602,14 +595,10 @@ test_that("names are not repaired if packed", {
 test_that("vec_cbind() fails with arrays of dimensionality > 3", {
   a <- array(NA, c(1, 1, 1))
 
-  expect_snapshot(error = TRUE, {
-    vec_cbind(a)
-  })
-  expect_snapshot(error = TRUE, {
-    vec_cbind(a, .call = call("foo"))
-  })
-  expect_snapshot(error = TRUE, {
-    vec_cbind(x = a)
+  expect_snapshot({
+    (expect_error(vec_cbind(a)))
+    (expect_error(vec_cbind(a, .call = call("foo"))))
+    (expect_error(vec_cbind(x = a)))
   })
 })
 
@@ -757,16 +746,15 @@ test_that("rbind repairs names of data frames (#704)", {
   expect_identical(vec_rbind(df), df_repaired)
   expect_identical(vec_rbind(df, df), vec_rbind(df_repaired, df_repaired))
 
-  expect_error(
-    vec_rbind(df, df, .name_repair = "check_unique"),
-    class = "vctrs_error_names_must_be_unique"
-  )
-
-  expect_snapshot(error = TRUE, {
-    vec_rbind(df, df, .name_repair = "check_unique")
-  })
-  expect_snapshot(error = TRUE, {
-    vec_rbind(df, df, .name_repair = "check_unique", .call = call("foo"))
+  expect_snapshot({
+    (expect_error(
+      vec_rbind(df, df, .name_repair = "check_unique"),
+      class = "vctrs_error_names_must_be_unique"
+    ))
+    (expect_error(
+      vec_rbind(df, df, .name_repair = "check_unique", .call = call("foo")),
+      class = "vctrs_error_names_must_be_unique"
+    ))
   })
 })
 
@@ -1002,11 +990,13 @@ test_that("can't zap names when `.names_to` is supplied", {
     data.frame(x = 1)
   )
 
-  expect_snapshot(error = TRUE, {
-    vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap())
-  })
-  expect_snapshot(error = TRUE, {
-    vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap(), .call = call("foo"))
+  expect_snapshot({
+    (expect_error(
+      vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap())
+    ))
+    (expect_error(
+      vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap(), .call = call("foo"))
+    ))
   })
 })
 

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -24,13 +24,23 @@ test_that("vec_rbind() output is tibble if any input is tibble", {
 test_that("type of column is common type of individual columns", {
   x_int <- data_frame(x = 1L)
   x_dbl <- data_frame(x = 2.5)
-  x_chr <- data_frame(x = "a")
 
   expect_equal(vec_rbind(x_int, x_int), data_frame(x = c(1L, 1L)))
   expect_equal(vec_rbind(x_int, x_dbl), data_frame(x = c(1, 2.5)))
+})
 
-  expect_snapshot({
-    (expect_error(vec_rbind(x_int, x_chr), class = "vctrs_error_incompatible_type"))
+test_that("incompatible columns throws common type error", {
+  x_int <- data_frame(x = 1L)
+  x_chr <- data_frame(x = "a")
+
+  expect_snapshot(error = TRUE, {
+    vec_rbind(x_int, x_chr)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_rbind(x_int, x_chr, .call = call("foo"))
+  })
+  expect_snapshot(error = TRUE, {
+    vec_rbind(x_int, x_chr, .ptype = x_chr, .call = call("foo"))
   })
 })
 
@@ -204,8 +214,11 @@ test_that("can construct an id column", {
 })
 
 test_that("vec_rbind() fails with arrays of dimensionality > 3", {
-  expect_snapshot({
-    (expect_error(vec_rbind(array(NA, c(1, 1, 1))), "Can't bind arrays"))
+  expect_snapshot(error = TRUE, {
+    vec_rbind(array(NA, c(1, 1, 1)))
+  })
+  expect_snapshot(error = TRUE, {
+    vec_rbind(array(NA, c(1, 1, 1)), .call = call("foo"))
   })
 })
 
@@ -475,8 +488,15 @@ test_that("can repair names in `vec_cbind()` (#227)", {
 })
 
 test_that("can supply `.names_to` to `vec_rbind()` (#229)", {
-  expect_error(vec_rbind(.names_to = letters), "must be")
-  expect_error(vec_rbind(.names_to = 10), "must be")
+  expect_snapshot(error = TRUE, {
+    vec_rbind(.names_to = letters)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_rbind(.names_to = 10)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_rbind(.names_to = letters, .call = call("foo"))
+  })
 
   x <- data_frame(foo = 1:2, bar = 3:4)
   y <- data_frame(foo = 5L, bar = 6L)

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -391,9 +391,18 @@ test_that("performance: Row binding with df-cols doesn't duplicate on every assi
 # cols --------------------------------------------------------------------
 
 test_that("vec_cbind() reports error context", {
-  expect_snapshot({
-    (expect_error(vec_cbind(foobar(list()))))
-    (expect_error(vec_cbind(a = 1:2, b = int())))
+  expect_snapshot(error = TRUE, {
+    vec_cbind(foobar(list()))
+  })
+  expect_snapshot(error = TRUE, {
+    vec_cbind(foobar(list()), .call = call("foo"))
+  })
+
+  expect_snapshot(error = TRUE, {
+    vec_cbind(a = 1:2, b = int())
+  })
+  expect_snapshot(error = TRUE, {
+    vec_cbind(a = 1:2, b = int(), .call = call("foo"))
   })
 })
 
@@ -592,8 +601,16 @@ test_that("names are not repaired if packed", {
 
 test_that("vec_cbind() fails with arrays of dimensionality > 3", {
   a <- array(NA, c(1, 1, 1))
-  expect_error(vec_cbind(a), "Can't bind arrays")
-  expect_error(vec_cbind(x = a), "Can't bind arrays")
+
+  expect_snapshot(error = TRUE, {
+    vec_cbind(a)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_cbind(a, .call = call("foo"))
+  })
+  expect_snapshot(error = TRUE, {
+    vec_cbind(x = a)
+  })
 })
 
 test_that("monitoring: name repair while cbinding doesn't modify in place", {
@@ -744,6 +761,13 @@ test_that("rbind repairs names of data frames (#704)", {
     vec_rbind(df, df, .name_repair = "check_unique"),
     class = "vctrs_error_names_must_be_unique"
   )
+
+  expect_snapshot(error = TRUE, {
+    vec_rbind(df, df, .name_repair = "check_unique")
+  })
+  expect_snapshot(error = TRUE, {
+    vec_rbind(df, df, .name_repair = "check_unique", .call = call("foo"))
+  })
 })
 
 test_that("vec_rbind() works with simple homogeneous foreign S3 classes", {
@@ -977,12 +1001,12 @@ test_that("can't zap names when `.names_to` is supplied", {
     vec_rbind(foo = c(x = 1), .names_to = zap(), .name_spec = zap()),
     data.frame(x = 1)
   )
-  expect_snapshot({
-    (expect_error(
-      vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap()),
-      "Can't zap outer names when `.names_to` is supplied.",
-      fixed = TRUE
-    ))
+
+  expect_snapshot(error = TRUE, {
+    vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap())
+  })
+  expect_snapshot(error = TRUE, {
+    vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap(), .call = call("foo"))
   })
 })
 


### PR DESCRIPTION
Closes #1597 

Fairly straightforward because we already passed a call through, it just wasn't a user supplied one.

For the tests, I extended a few existing tests where it seemed important that the call was being passed through (like common type or size tests). I also updated some to `expect_snapshot(error = TRUE` style