### PR TITLE
Implement `num_as_location(oob = "remove")`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* `num_as_location()` has a new `oob = "remove"` argument to remove
+  out-of-bounds locations (#1595).
+
 * `vec_rbind()` and `vec_cbind()` now have `.call` arguments (#1597).
 
 * `df_list()` has gained a new `.unpack` argument to optionally disable data

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -81,7 +81,7 @@ vec_as_location <- function(i,
 #'   locations, throw an informative `"error"`, or `"ignore"` them.
 #' @param oob If `"error"`, throws an informative `"error"` if some elements are
 #'   out-of-bounds. If `"remove"`, removes both positive and negative
-#'   out-of-bound locations. If `"extend"`, out-of-bounds locations are allowed
+#'   out-of-bounds locations. If `"extend"`, out-of-bounds locations are allowed
 #'   if they are consecutive after the end. This can be used to implement
 #'   extendable vectors like `letters[1:30]`.
 #' @param zero Whether to `"remove"` zero values, throw an informative

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -79,10 +79,11 @@ vec_as_location <- function(i,
 #' @rdname vec_as_location
 #' @param negative Whether to `"invert"` negative values to positive
 #'   locations, throw an informative `"error"`, or `"ignore"` them.
-#' @param oob If `"error"`, throws an informative `"error"` if some
-#'   elements are out-of-bounds. If `"extend"`, out-of-bounds
-#'   locations are allowed if they are consecutive after the end. This
-#'   can be used to implement extendable vectors like `letters[1:30]`.
+#' @param oob If `"error"`, throws an informative `"error"` if some elements are
+#'   out-of-bounds. If `"remove"`, removes both positive and negative
+#'   out-of-bound locations. If `"extend"`, out-of-bounds locations are allowed
+#'   if they are consecutive after the end. This can be used to implement
+#'   extendable vectors like `letters[1:30]`.
 #' @param zero Whether to `"remove"` zero values, throw an informative
 #'   `"error"`, or `"ignore"` them.
 #' @export
@@ -91,7 +92,7 @@ num_as_location <- function(i,
                             ...,
                             missing = c("propagate", "error"),
                             negative = c("invert", "error", "ignore"),
-                            oob = c("error", "extend"),
+                            oob = c("error", "remove", "extend"),
                             zero = c("remove", "error", "ignore"),
                             arg = caller_arg(i),
                             call = caller_env()) {

--- a/man/vec_as_location.Rd
+++ b/man/vec_as_location.Rd
@@ -83,7 +83,7 @@ negative location value, or \code{"ignore"} it.}
 
 \item{oob}{If \code{"error"}, throws an informative \code{"error"} if some elements are
 out-of-bounds. If \code{"remove"}, removes both positive and negative
-out-of-bound locations. If \code{"extend"}, out-of-bounds locations are allowed
+out-of-bounds locations. If \code{"extend"}, out-of-bounds locations are allowed
 if they are consecutive after the end. This can be used to implement
 extendable vectors like \code{letters[1:30]}.}
 

--- a/man/vec_as_location.Rd
+++ b/man/vec_as_location.Rd
@@ -23,7 +23,7 @@ num_as_location(
   ...,
   missing = c("propagate", "error"),
   negative = c("invert", "error", "ignore"),
-  oob = c("error", "extend"),
+  oob = c("error", "remove", "extend"),
   zero = c("remove", "error", "ignore"),
   arg = caller_arg(i),
   call = caller_env()
@@ -81,10 +81,11 @@ mentioned in error messages as the source of the error. See the
 \item{negative}{Whether to throw an \code{"error"} when \code{i} is a
 negative location value, or \code{"ignore"} it.}
 
-\item{oob}{If \code{"error"}, throws an informative \code{"error"} if some
-elements are out-of-bounds. If \code{"extend"}, out-of-bounds
-locations are allowed if they are consecutive after the end. This
-can be used to implement extendable vectors like \code{letters[1:30]}.}
+\item{oob}{If \code{"error"}, throws an informative \code{"error"} if some elements are
+out-of-bounds. If \code{"remove"}, removes both positive and negative
+out-of-bound locations. If \code{"extend"}, out-of-bounds locations are allowed
+if they are consecutive after the end. This can be used to implement
+extendable vectors like \code{letters[1:30]}.}
 
 \item{zero}{Whether to \code{"remove"} zero values, throw an informative
 \code{"error"}, or \code{"ignore"} them.}

--- a/src/decl/subscript-loc-decl.h
+++ b/src/decl/subscript-loc-decl.h
@@ -16,6 +16,9 @@ static
 r_obj* int_filter_zero(r_obj* subscript, r_ssize n_zero);
 
 static
+r_obj* int_filter_oob(r_obj* subscript, r_ssize n, r_ssize n_oob);
+
+static
 void int_check_consecutive(r_obj* subscript,
                            r_ssize n,
                            r_ssize n_extend,

--- a/src/subscript-loc.h
+++ b/src/subscript-loc.h
@@ -17,6 +17,7 @@ enum num_loc_negative {
 };
 enum num_loc_oob {
   LOC_OOB_ERROR = 0,
+  LOC_OOB_REMOVE,
   LOC_OOB_EXTEND
 };
 enum num_loc_zero {

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -511,6 +511,26 @@
       i Input has size 3.
       x Subscript `c(1:5, 7, 1, 10)` contains non-consecutive locations 4, 7, and 10.
 
+# num_as_location() errors when inverting oob negatives unless `oob = 'remove'`
+
+    Code
+      num_as_location(-4, 3, oob = "error", negative = "invert")
+    Condition
+      Error:
+      ! Can't negate elements past the end.
+      i Location 4 doesn't exist.
+      i There are only 3 elements.
+
+---
+
+    Code
+      num_as_location(-4, 3, oob = "extend", negative = "invert")
+    Condition
+      Error:
+      ! Can't negate elements past the end.
+      i Location 4 doesn't exist.
+      i There are only 3 elements.
+
 # missing values are supported in error formatters
 
     Code

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -282,6 +282,31 @@ test_that("can extend beyond the end consecutively but non-monotonically (#1166)
   expect_identical(num_as_location(c(1, NA, 4, 3), 2, oob = "extend"), c(1L, NA, 4L, 3L))
 })
 
+test_that("num_as_location() can optionally remove oob values (#1595)", {
+  expect_identical(num_as_location(c(5, 3, 2, 4), 3, oob = "remove"), c(3L, 2L))
+  expect_identical(num_as_location(c(-4, 5, 2, -1), 3, oob = "remove", negative = "ignore"), c(2L, -1L))
+})
+
+test_that("num_as_location() errors when inverting oob negatives unless `oob = 'remove'`", {
+  expect_snapshot(error = TRUE, {
+    num_as_location(-4, 3, oob = "error", negative = "invert")
+  })
+  expect_snapshot(error = TRUE, {
+    num_as_location(-4, 3, oob = "extend", negative = "invert")
+  })
+  expect_identical(num_as_location(-4, 3, oob = "remove", negative = "invert"), c(1L, 2L, 3L))
+  expect_identical(num_as_location(c(-4, -2), 3, oob = "remove", negative = "invert"), c(1L, 3L))
+})
+
+test_that("num_as_location() with `oob = 'remove'` doesn't remove missings if they are being propagated", {
+  expect_identical(num_as_location(NA_integer_, 1, oob = "remove"), NA_integer_)
+})
+
+test_that("num_as_location() with `oob = 'remove'` doesn't remove zeros if they are being ignored", {
+  expect_identical(num_as_location(0, 1, oob = "remove", zero = "ignore"), 0L)
+  expect_identical(num_as_location(0, 0, oob = "remove", zero = "ignore"), 0L)
+})
+
 test_that("missing values are supported in error formatters", {
   expect_snapshot({
     (expect_error(


### PR DESCRIPTION
Part of #1595 

We also need `missing = "remove"`, but I will do that in another PR because these code paths are already highly complex due to the number of options