### PR TITLE
Normalize integer storage difftimes to double storage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # vctrs (development version)
 
+* The `difftime` to `difftime` `vec_cast()` method now standardizes the internal
+  storage type to double, catching potentially corrupt integer storage
+  `difftime` vectors (#1602).
+
 * `vec_as_location2()` and `vec_as_subscript2()` more correctly utilize their
   `call` arguments (#1605).
 

--- a/R/type-date-time.R
+++ b/R/type-date-time.R
@@ -306,6 +306,10 @@ vec_cast.difftime <- function(x, to, ...) {
 #' @method vec_cast.difftime difftime
 vec_cast.difftime.difftime <- function(x, to, ...) {
   if (identical(units(x), units(to))) {
+    if (typeof(x) == "integer") {
+      # Catch corrupt difftime objects (#1602)
+      storage.mode(x) <- "double"
+    }
     x
   } else {
     # Hack: I can't see any obvious way of changing the units

--- a/tests/testthat/test-type-date-time.R
+++ b/tests/testthat/test-type-date-time.R
@@ -173,6 +173,11 @@ test_that("vec_ptype2(<difftime>, NA) is symmetric (#687)", {
   )
 })
 
+test_that("vec_ptype2() standardizes duration storage type to double", {
+  x <- structure(1L, units = "secs", class = "difftime")
+  expect <- new_duration(double(), units = "secs")
+  expect_identical(vec_ptype2(x, x), expect)
+})
 
 # cast: dates ---------------------------------------------------------------
 
@@ -344,6 +349,17 @@ test_that("invalid casts generate error", {
 test_that("can cast NA and unspecified to duration", {
   expect_identical(vec_cast(NA, new_duration()), new_duration(na_dbl))
   expect_identical(vec_cast(unspecified(2), new_duration()), new_duration(dbl(NA, NA)))
+})
+
+test_that("casting coerces corrupt integer storage durations to double (#1602)", {
+  x <- structure(1L, units = "secs", class = "difftime")
+  expect <- new_duration(1, units = "secs")
+
+  expect_identical(vec_cast(x, x), expect)
+
+  # Names are retained through the coercion
+  names(x) <- "a"
+  expect_named(vec_cast(x, x), "a")
 })
 
 # proxy/restore: dates ---------------------------------------------------


### PR DESCRIPTION
Closes #1602

I strongly believe that difftime objects should always have double storage internally. Our `new_duration()` constructor already enforces this, which means that our `vec_ptype2()` method handled this already. But our `vec_cast.difftime.difftime()` method had a path that could allow integer storage difftimes to slip through without being corrected. This causes issues later in functions like `vec_c()` and `vec_rbind()`.

This PR tweaks the `vec_cast()` method to coerce integer difftimes to double in a way that doesn't drop attributes.

I've also reached out to the r-devel mailing list about this https://stat.ethz.ch/pipermail/r-devel/2022-August/081933.html