### PR TITLE
Add `"select"` and `"relocate"` subscript actions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* `"select"` and `"relocate"` have been added as valid subscript actions to
+  support tidyselect and dplyr (#1596).
+
 * `num_as_location()` has a new `oob = "remove"` argument to remove
   out-of-bounds locations (#1595).
 

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -457,7 +457,7 @@ cnd_header.vctrs_error_subscript_oob <- function(cnd, ...) {
   action <- cnd_subscript_action(cnd)
   type <- cnd_subscript_type(cnd)
 
-  if (action == "rename" || type == "character") {
+  if (action %in% c("rename", "relocate") || type == "character") {
     glue::glue("Can't {action} {elt[[2]]} that don't exist.")
   } else {
     glue::glue("Can't {action} {elt[[2]]} past the end.")

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -346,7 +346,9 @@ cnd_subscript_element_cli <- function(n, cnd, capital = FALSE) {
 }
 
 subscript_actions <- c(
-  "subset", "extract", "assign", "rename", "remove", "negate"
+  "select", "subset", "extract",
+  "assign", "rename", "relocate",
+  "remove", "negate"
 )
 cnd_subscript_action <- function(cnd, assign_to = TRUE) {
   action <- cnd$subscript_action
@@ -360,10 +362,14 @@ cnd_subscript_action <- function(cnd, assign_to = TRUE) {
   }
 
   if (!is_string(action, subscript_actions)) {
-    abort(paste0(
-      "Internal error: `cnd$subscript_action` must be one of ",
-      "`subset`, `extract`, `assign`, `rename`, `remove`, or `negate`."
-    ))
+    subscript_actions <- glue::backtick(subscript_actions)
+    subscript_actions <- glue::glue_collapse(
+      subscript_actions,
+      sep = ", ",
+      last = ", or "
+    )
+    message <- glue::glue("`cnd$subscript_action` must be one of {subscript_actions}.")
+    abort(message, .internal = TRUE)
   }
 
   if (assign_to && action == "assign") {

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -362,14 +362,10 @@ cnd_subscript_action <- function(cnd, assign_to = TRUE) {
   }
 
   if (!is_string(action, subscript_actions)) {
-    subscript_actions <- glue::backtick(subscript_actions)
-    subscript_actions <- glue::glue_collapse(
-      subscript_actions,
-      sep = ", ",
-      last = ", or "
+    cli::cli_abort(
+      "`cnd$subscript_action` must be one of {.or {.arg {subscript_actions}}}.",
+      .internal = TRUE
     )
-    message <- glue::glue("`cnd$subscript_action` must be one of {subscript_actions}.")
-    abort(message, .internal = TRUE)
   }
 
   if (assign_to && action == "assign") {

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -875,6 +875,60 @@
       ! Can't remove rows past the end.
       i Locations 27, 28, 29, and 30 don't exist.
       i There are only 26 rows.
+    Code
+      # With tidyselect select
+      (expect_error(with_tidyselect_select(vec_slice(set_names(letters), c("foo",
+        "bar"))), class = "vctrs_error_subscript_oob"))
+    Output
+      <error/vctrs_error_subscript_oob>
+      Error in `vec_slice()`:
+      ! Can't select columns that don't exist.
+      x Columns `foo` and `bar` don't exist.
+    Code
+      (expect_error(with_tidyselect_select(vec_slice(set_names(letters), 30)), class = "vctrs_error_subscript_oob")
+      )
+    Output
+      <error/vctrs_error_subscript_oob>
+      Error in `vec_slice()`:
+      ! Can't select columns past the end.
+      i Location 30 doesn't exist.
+      i There are only 26 columns.
+    Code
+      (expect_error(with_tidyselect_select(vec_slice(set_names(letters), -(1:30))),
+      class = "vctrs_error_subscript_oob"))
+    Output
+      <error/vctrs_error_subscript_oob>
+      Error in `vec_slice()`:
+      ! Can't select columns past the end.
+      i Locations 27, 28, 29, and 30 don't exist.
+      i There are only 26 columns.
+    Code
+      # With tidyselect relocate
+      (expect_error(with_tidyselect_relocate(vec_slice(set_names(letters), c("foo",
+        "bar"))), class = "vctrs_error_subscript_oob"))
+    Output
+      <error/vctrs_error_subscript_oob>
+      Error in `vec_slice()`:
+      ! Can't relocate columns that don't exist.
+      x Columns `foo` and `bar` don't exist.
+    Code
+      (expect_error(with_tidyselect_relocate(vec_slice(set_names(letters), 30)),
+      class = "vctrs_error_subscript_oob"))
+    Output
+      <error/vctrs_error_subscript_oob>
+      Error in `vec_slice()`:
+      ! Can't relocate columns that don't exist.
+      i Location 30 doesn't exist.
+      i There are only 26 columns.
+    Code
+      (expect_error(with_tidyselect_relocate(vec_slice(set_names(letters), -(1:30))),
+      class = "vctrs_error_subscript_oob"))
+    Output
+      <error/vctrs_error_subscript_oob>
+      Error in `vec_slice()`:
+      ! Can't relocate columns that don't exist.
+      i Locations 27, 28, 29, and 30 don't exist.
+      i There are only 26 columns.
 
 # vec_as_location() checks dimensionality
 

--- a/tests/testthat/helper-conditions.R
+++ b/tests/testthat/helper-conditions.R
@@ -39,3 +39,19 @@ with_dm_tables <- function(expr) {
     subscript_action = "extract"
   )
 }
+with_tidyselect_select <- function(expr) {
+  with_subscript_data(
+    expr,
+    subscript_arg = quote(foo(bar)),
+    subscript_elt = "column",
+    subscript_action = "select"
+  )
+}
+with_tidyselect_relocate <- function(expr) {
+  with_subscript_data(
+    expr,
+    subscript_arg = quote(foo(bar)),
+    subscript_elt = "column",
+    subscript_action = "relocate"
+  )
+}

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -485,6 +485,34 @@ test_that("can customise OOB errors", {
       with_tibble_rows(vec_slice(set_names(letters), -(1:30))),
       class = "vctrs_error_subscript_oob"
     ))
+
+    "With tidyselect select"
+    (expect_error(
+      with_tidyselect_select(vec_slice(set_names(letters), c("foo", "bar"))),
+      class = "vctrs_error_subscript_oob"
+    ))
+    (expect_error(
+      with_tidyselect_select(vec_slice(set_names(letters), 30)),
+      class = "vctrs_error_subscript_oob"
+    ))
+    (expect_error(
+      with_tidyselect_select(vec_slice(set_names(letters), -(1:30))),
+      class = "vctrs_error_subscript_oob"
+    ))
+
+    "With tidyselect relocate"
+    (expect_error(
+      with_tidyselect_relocate(vec_slice(set_names(letters), c("foo", "bar"))),
+      class = "vctrs_error_subscript_oob"
+    ))
+    (expect_error(
+      with_tidyselect_relocate(vec_slice(set_names(letters), 30)),
+      class = "vctrs_error_subscript_oob"
+    ))
+    (expect_error(
+      with_tidyselect_relocate(vec_slice(set_names(letters), -(1:30))),
+      class = "vctrs_error_subscript_oob"
+    ))
   })
 })
 


### PR DESCRIPTION
Closes #1596

Note that `"relocate"` does the same thing as `"rename"` in that it never uses the `"past the end"` terminology. I don't think that ever makes sense for relocating.