### PR TITLE
Add `call` argument to `vec_locate_matches()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `vec_locate_matches()` has gained a `call` argument (#1611).
+
 * `"select"` and `"relocate"` have been added as valid subscript actions to
   support tidyselect and dplyr (#1596).
 

--- a/R/match.R
+++ b/R/match.R
@@ -374,11 +374,12 @@ cnd_body.vctrs_error_matches_remaining <- function(cnd, ...) {
 
 # ------------------------------------------------------------------------------
 
-stop_matches_incomplete <- function(i, needles_arg) {
+stop_matches_incomplete <- function(i, needles_arg, call) {
   stop_matches(
     class = "vctrs_error_matches_incomplete",
     i = i,
-    needles_arg = needles_arg
+    needles_arg = needles_arg,
+    call = call
   )
 }
 

--- a/R/match.R
+++ b/R/match.R
@@ -403,12 +403,13 @@ cnd_body.vctrs_error_matches_incomplete <- function(cnd, ...) {
 
 # ------------------------------------------------------------------------------
 
-stop_matches_multiple <- function(i, needles_arg, haystack_arg) {
+stop_matches_multiple <- function(i, needles_arg, haystack_arg, call) {
   stop_matches(
     class = "vctrs_error_matches_multiple",
     i = i,
     needles_arg = needles_arg,
-    haystack_arg = haystack_arg
+    haystack_arg = haystack_arg,
+    call = call
   )
 }
 

--- a/R/match.R
+++ b/R/match.R
@@ -302,12 +302,13 @@ warn_matches <- function(message, class = NULL, ...) {
 
 # ------------------------------------------------------------------------------
 
-stop_matches_nothing <- function(i, needles_arg, haystack_arg) {
+stop_matches_nothing <- function(i, needles_arg, haystack_arg, call) {
   stop_matches(
     class = "vctrs_error_matches_nothing",
     i = i,
     needles_arg = needles_arg,
-    haystack_arg = haystack_arg
+    haystack_arg = haystack_arg,
+    call = call
   )
 }
 

--- a/R/match.R
+++ b/R/match.R
@@ -34,6 +34,7 @@
 #' * [vec_detect_complete()]
 #'
 #' @inheritParams rlang::args_dots_empty
+#' @inheritParams rlang::args_error_context
 #' @inheritParams order-radix
 #'
 #' @param needles,haystack Vectors used for matching.
@@ -241,8 +242,10 @@ vec_locate_matches <- function(needles,
                                nan_distinct = FALSE,
                                chr_proxy_collate = NULL,
                                needles_arg = "",
-                               haystack_arg = "") {
+                               haystack_arg = "",
+                               call = current_env()) {
   check_dots_empty0(...)
+  frame <- environment()
 
   .Call(
     ffi_locate_matches,
@@ -257,7 +260,8 @@ vec_locate_matches <- function(needles,
     nan_distinct,
     chr_proxy_collate,
     needles_arg,
-    haystack_arg
+    haystack_arg,
+    frame
   )
 }
 

--- a/R/match.R
+++ b/R/match.R
@@ -285,18 +285,20 @@ compute_nesting_container_info <- function(x, condition) {
 
 # ------------------------------------------------------------------------------
 
-stop_matches <- function(class = NULL, ...) {
+stop_matches <- function(class = NULL, ..., call = caller_env()) {
   stop_vctrs(
     class = c(class, "vctrs_error_matches"),
-    ...
+    ...,
+    call = call
   )
 }
 
-warn_matches <- function(message, class = NULL, ...) {
+warn_matches <- function(message, class = NULL, ..., call = caller_env()) {
   warn_vctrs(
     message = message,
     class = c(class, "vctrs_warning_matches"),
-    ...
+    ...,
+    call = call
   )
 }
 

--- a/R/match.R
+++ b/R/match.R
@@ -338,12 +338,13 @@ cnd_body.vctrs_error_matches_nothing <- function(cnd, ...) {
 
 # ------------------------------------------------------------------------------
 
-stop_matches_remaining <- function(i, needles_arg, haystack_arg) {
+stop_matches_remaining <- function(i, needles_arg, haystack_arg, call) {
   stop_matches(
     class = "vctrs_error_matches_remaining",
     i = i,
     needles_arg = needles_arg,
-    haystack_arg = haystack_arg
+    haystack_arg = haystack_arg,
+    call = call
   )
 }
 

--- a/R/match.R
+++ b/R/match.R
@@ -445,7 +445,7 @@ cnd_matches_multiple_body <- function(i) {
 
 # ------------------------------------------------------------------------------
 
-warn_matches_multiple <- function(i, needles_arg, haystack_arg) {
+warn_matches_multiple <- function(i, needles_arg, haystack_arg, call) {
   message <- paste(
     cnd_matches_multiple_header(needles_arg, haystack_arg),
     cnd_matches_multiple_body(i),
@@ -457,6 +457,7 @@ warn_matches_multiple <- function(i, needles_arg, haystack_arg) {
     class = "vctrs_warning_matches_multiple",
     i = i,
     needles_arg = needles_arg,
-    haystack_arg = haystack_arg
+    haystack_arg = haystack_arg,
+    call = call
   )
 }

--- a/man/vec_locate_matches.Rd
+++ b/man/vec_locate_matches.Rd
@@ -17,7 +17,8 @@ vec_locate_matches(
   nan_distinct = FALSE,
   chr_proxy_collate = NULL,
   needles_arg = "",
-  haystack_arg = ""
+  haystack_arg = "",
+  call = current_env()
 )
 }
 \arguments{
@@ -136,6 +137,11 @@ ordering and \code{stringi::stri_sort_key()} for locale-aware ordering.}
 
 \item{needles_arg, haystack_arg}{Argument tags for \code{needles} and \code{haystack}
 used in error messages.}
+
+\item{call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 }
 \value{
 A two column data frame containing the locations of the matches.

--- a/src/cast.h
+++ b/src/cast.h
@@ -42,6 +42,7 @@ r_obj* vec_cast_params(r_obj* x,
                        r_obj* to,
                        struct vctrs_arg* p_x_arg,
                        struct vctrs_arg* p_to_arg,
+                       struct r_lazy call,
                        enum df_fallback df_fallback,
                        enum s3_fallback s3_fallback) {
   const struct cast_opts opts = {
@@ -49,6 +50,7 @@ r_obj* vec_cast_params(r_obj* x,
     .to = to,
     .p_x_arg = p_x_arg,
     .p_to_arg = p_to_arg,
+    .call = call,
     .fallback = {
       .df = df_fallback,
       .s3 = s3_fallback

--- a/src/decl/match-decl.h
+++ b/src/decl/match-decl.h
@@ -21,7 +21,8 @@ r_obj* vec_locate_matches(r_obj* needles,
                           bool nan_distinct,
                           r_obj* chr_proxy_collate,
                           struct vctrs_arg* needles_arg,
-                          struct vctrs_arg* haystack_arg);
+                          struct vctrs_arg* haystack_arg,
+                          struct r_lazy call);
 
 static
 r_obj* df_locate_matches(r_obj* needles,

--- a/src/decl/match-decl.h
+++ b/src/decl/match-decl.h
@@ -225,7 +225,8 @@ void stop_matches_incomplete(r_ssize i,
 static inline
 void stop_matches_multiple(r_ssize i,
                            struct vctrs_arg* needles_arg,
-                           struct vctrs_arg* haystack_arg);
+                           struct vctrs_arg* haystack_arg,
+                           struct r_lazy call);
 
 static inline
 void warn_matches_multiple(r_ssize i,

--- a/src/decl/match-decl.h
+++ b/src/decl/match-decl.h
@@ -231,4 +231,5 @@ void stop_matches_multiple(r_ssize i,
 static inline
 void warn_matches_multiple(r_ssize i,
                            struct vctrs_arg* needles_arg,
-                           struct vctrs_arg* haystack_arg);
+                           struct vctrs_arg* haystack_arg,
+                           struct r_lazy call);

--- a/src/decl/match-decl.h
+++ b/src/decl/match-decl.h
@@ -39,7 +39,8 @@ r_obj* df_locate_matches(r_obj* needles,
                          const enum vctrs_filter* v_filters,
                          const enum vctrs_ops* v_ops,
                          struct vctrs_arg* needles_arg,
-                         struct vctrs_arg* haystack_arg);
+                         struct vctrs_arg* haystack_arg,
+                         struct r_lazy call);
 
 static
 void df_locate_matches_recurse(r_ssize col,
@@ -161,13 +162,13 @@ r_obj* expand_compact_indices(const int* v_o_haystack,
                               const int* v_loc_filter_match_o_haystack,
                               const struct poly_df_data* p_haystack,
                               struct vctrs_arg* needles_arg,
-                              struct vctrs_arg* haystack_arg);
+                              struct vctrs_arg* haystack_arg,
+                              struct r_lazy call);
 
 static
 r_obj* compute_nesting_container_info(r_obj* haystack,
                                       r_ssize size_haystack,
-                                      const enum vctrs_ops* v_ops,
-                                      struct vctrs_arg* haystack_arg);
+                                      const enum vctrs_ops* v_ops);
 
 static
 r_obj* compute_nesting_container_ids(r_obj* x,
@@ -207,7 +208,8 @@ void stop_matches_overflow(double size);
 static inline
 void stop_matches_nothing(r_ssize i,
                           struct vctrs_arg* needles_arg,
-                          struct vctrs_arg* haystack_arg);
+                          struct vctrs_arg* haystack_arg,
+                          struct r_lazy call);
 
 static inline
 void stop_matches_remaining(r_ssize i,

--- a/src/decl/match-decl.h
+++ b/src/decl/match-decl.h
@@ -133,7 +133,8 @@ struct vctrs_no_match parse_no_match(r_obj* no_match,
                                      struct r_lazy call);
 
 static inline
-struct vctrs_remaining parse_remaining(r_obj* remaining);
+struct vctrs_remaining parse_remaining(r_obj* remaining,
+                                       struct r_lazy call);
 
 static inline
 struct vctrs_incomplete parse_incomplete(r_obj* incomplete,

--- a/src/decl/match-decl.h
+++ b/src/decl/match-decl.h
@@ -135,7 +135,8 @@ static inline
 struct vctrs_remaining parse_remaining(r_obj* remaining);
 
 static inline
-struct vctrs_incomplete parse_incomplete(r_obj* incomplete);
+struct vctrs_incomplete parse_incomplete(r_obj* incomplete,
+                                         struct r_lazy call);
 
 static inline
 enum vctrs_multiple parse_multiple(r_obj* multiple);

--- a/src/decl/match-decl.h
+++ b/src/decl/match-decl.h
@@ -218,7 +218,9 @@ void stop_matches_remaining(r_ssize i,
                             struct r_lazy call);
 
 static inline
-void stop_matches_incomplete(r_ssize i, struct vctrs_arg* needles_arg);
+void stop_matches_incomplete(r_ssize i,
+                             struct vctrs_arg* needles_arg,
+                             struct r_lazy call);
 
 static inline
 void stop_matches_multiple(r_ssize i,

--- a/src/decl/match-decl.h
+++ b/src/decl/match-decl.h
@@ -214,7 +214,8 @@ void stop_matches_nothing(r_ssize i,
 static inline
 void stop_matches_remaining(r_ssize i,
                             struct vctrs_arg* needles_arg,
-                            struct vctrs_arg* haystack_arg);
+                            struct vctrs_arg* haystack_arg,
+                            struct r_lazy call);
 
 static inline
 void stop_matches_incomplete(r_ssize i, struct vctrs_arg* needles_arg);

--- a/src/decl/match-decl.h
+++ b/src/decl/match-decl.h
@@ -129,7 +129,8 @@ static inline
 void parse_condition(r_obj* condition, r_ssize n_cols, enum vctrs_ops* v_ops);
 
 static inline
-struct vctrs_no_match parse_no_match(r_obj* no_match);
+struct vctrs_no_match parse_no_match(r_obj* no_match,
+                                     struct r_lazy call);
 
 static inline
 struct vctrs_remaining parse_remaining(r_obj* remaining);

--- a/src/decl/match-decl.h
+++ b/src/decl/match-decl.h
@@ -141,7 +141,8 @@ struct vctrs_incomplete parse_incomplete(r_obj* incomplete,
                                          struct r_lazy call);
 
 static inline
-enum vctrs_multiple parse_multiple(r_obj* multiple);
+enum vctrs_multiple parse_multiple(r_obj* multiple,
+                                   struct r_lazy call);
 
 static inline
 void parse_filter(r_obj* filter, r_ssize n_cols, enum vctrs_filter* v_filters);

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -330,6 +330,8 @@ SEXP vctrs_id(SEXP x) {
 // [[ register() ]]
 SEXP vctrs_match(SEXP needles, SEXP haystack, SEXP na_equal,
                  SEXP frame) {
+  struct r_lazy call = { .x = frame, .env = r_null };
+
   struct r_lazy needles_arg_ = { .x = syms.needles_arg, .env = frame };
   struct vctrs_arg needles_arg = new_lazy_arg(&needles_arg_);
 
@@ -340,7 +342,8 @@ SEXP vctrs_match(SEXP needles, SEXP haystack, SEXP na_equal,
                           haystack,
                           r_bool_as_int(na_equal),
                           &needles_arg,
-                          &haystack_arg);
+                          &haystack_arg,
+                          call);
 }
 
 static inline void vec_match_loop(int* p_out,
@@ -356,23 +359,27 @@ SEXP vec_match_params(SEXP needles,
                       SEXP haystack,
                       bool na_equal,
                       struct vctrs_arg* needles_arg,
-                      struct vctrs_arg* haystack_arg) {
+                      struct vctrs_arg* haystack_arg,
+                      struct r_lazy call) {
   int nprot = 0;
   int _;
   SEXP type = vec_ptype2_params(needles, haystack,
                                 needles_arg, haystack_arg,
+                                call,
                                 DF_FALLBACK_quiet,
                                 &_);
   PROTECT_N(type, &nprot);
 
   needles = vec_cast_params(needles, type,
                             needles_arg, vec_args.empty,
+                            call,
                             DF_FALLBACK_quiet,
                             S3_FALLBACK_false);
   PROTECT_N(needles, &nprot);
 
   haystack = vec_cast_params(haystack, type,
                              haystack_arg, vec_args.empty,
+                             call,
                              DF_FALLBACK_quiet,
                              S3_FALLBACK_false);
   PROTECT_N(haystack, &nprot);
@@ -453,6 +460,8 @@ static inline void vec_match_loop_propagate(int* p_out,
 
 // [[ register() ]]
 SEXP vctrs_in(SEXP needles, SEXP haystack, SEXP na_equal_, SEXP frame) {
+  struct r_lazy call = { .x = frame, .env = r_null };
+
   int nprot = 0;
   bool na_equal = r_bool_as_int(na_equal_);
 
@@ -466,18 +475,21 @@ SEXP vctrs_in(SEXP needles, SEXP haystack, SEXP na_equal_, SEXP frame) {
 
   SEXP type = vec_ptype2_params(needles, haystack,
                                 &needles_arg, &haystack_arg,
+                                call,
                                 DF_FALLBACK_quiet,
                                 &_);
   PROTECT_N(type, &nprot);
 
   needles = vec_cast_params(needles, type,
                             &needles_arg, vec_args.empty,
+                            call,
                             DF_FALLBACK_quiet,
                             S3_FALLBACK_false);
   PROTECT_N(needles, &nprot);
 
   haystack = vec_cast_params(haystack, type,
                              &haystack_arg, vec_args.empty,
+                             call,
                              DF_FALLBACK_quiet,
                              S3_FALLBACK_false);
   PROTECT_N(haystack, &nprot);

--- a/src/init.c
+++ b/src/init.c
@@ -140,7 +140,7 @@ extern r_obj* vctrs_list_drop_empty(r_obj*);
 extern r_obj* vctrs_is_altrep(r_obj* x);
 extern r_obj* ffi_interleave_indices(r_obj*, r_obj*);
 extern r_obj* ffi_compute_nesting_container_info(r_obj*, r_obj*);
-extern r_obj* ffi_locate_matches(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_locate_matches(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_interval_groups(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_interval_locate_groups(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_interval_complement(r_obj*, r_obj*, r_obj*, r_obj*);
@@ -310,7 +310,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_is_altrep",                       (DL_FUNC) &vctrs_is_altrep, 1},
   {"ffi_interleave_indices",                (DL_FUNC) &ffi_interleave_indices, 2},
   {"ffi_compute_nesting_container_info",    (DL_FUNC) &ffi_compute_nesting_container_info, 2},
-  {"ffi_locate_matches",                    (DL_FUNC) &ffi_locate_matches, 12},
+  {"ffi_locate_matches",                    (DL_FUNC) &ffi_locate_matches, 13},
   {"ffi_interval_groups",                   (DL_FUNC) &ffi_interval_groups, 4},
   {"ffi_interval_locate_groups",            (DL_FUNC) &ffi_interval_locate_groups, 4},
   {"ffi_interval_complement",               (DL_FUNC) &ffi_interval_complement, 4},

--- a/src/interval.c
+++ b/src/interval.c
@@ -80,6 +80,7 @@ r_obj* vec_interval_group_info(r_obj* start,
     end,
     args_start,
     args_end,
+    r_lazy_null,
     DF_FALLBACK_quiet,
     &_
   );
@@ -90,6 +91,7 @@ r_obj* vec_interval_group_info(r_obj* start,
     ptype,
     args_start,
     vec_args.empty,
+    r_lazy_null,
     DF_FALLBACK_quiet,
     S3_FALLBACK_false
   );
@@ -100,6 +102,7 @@ r_obj* vec_interval_group_info(r_obj* start,
     ptype,
     args_end,
     vec_args.empty,
+    r_lazy_null,
     DF_FALLBACK_quiet,
     S3_FALLBACK_false
   );
@@ -316,6 +319,7 @@ r_obj* vec_interval_complement(r_obj* start,
     end,
     args_start,
     args_end,
+    r_lazy_null,
     DF_FALLBACK_quiet,
     &_
   );
@@ -326,6 +330,7 @@ r_obj* vec_interval_complement(r_obj* start,
     ptype,
     args_start,
     vec_args.empty,
+    r_lazy_null,
     DF_FALLBACK_quiet,
     S3_FALLBACK_false
   );
@@ -336,6 +341,7 @@ r_obj* vec_interval_complement(r_obj* start,
     ptype,
     args_end,
     vec_args.empty,
+    r_lazy_null,
     DF_FALLBACK_quiet,
     S3_FALLBACK_false
   );
@@ -376,6 +382,7 @@ r_obj* vec_interval_complement(r_obj* start,
       ptype,
       args_lower,
       vec_args.empty,
+      r_lazy_null,
       DF_FALLBACK_quiet,
       S3_FALLBACK_false
     );
@@ -405,6 +412,7 @@ r_obj* vec_interval_complement(r_obj* start,
       ptype,
       args_upper,
       vec_args.empty,
+      r_lazy_null,
       DF_FALLBACK_quiet,
       S3_FALLBACK_false
     );

--- a/src/match.c
+++ b/src/match.c
@@ -1632,7 +1632,7 @@ r_obj* expand_compact_indices(const int* v_o_haystack,
         continue;
       }
       case VCTRS_INCOMPLETE_ACTION_error: {
-        stop_matches_incomplete(loc_needles, needles_arg);
+        stop_matches_incomplete(loc_needles, needles_arg, call);
       }
       case VCTRS_INCOMPLETE_ACTION_compare:
       case VCTRS_INCOMPLETE_ACTION_match: {
@@ -2421,20 +2421,24 @@ void stop_matches_remaining(r_ssize i,
 }
 
 static inline
-void stop_matches_incomplete(r_ssize i, struct vctrs_arg* needles_arg) {
-  r_obj* syms[3] = {
+void stop_matches_incomplete(r_ssize i,
+                             struct vctrs_arg* needles_arg,
+                             struct r_lazy call) {
+  r_obj* syms[4] = {
     syms_i,
     syms_needles_arg,
+    syms_call,
     NULL
   };
-  r_obj* args[3] = {
+  r_obj* args[4] = {
     KEEP(r_int((int)i + 1)),
     KEEP(vctrs_arg(needles_arg)),
+    KEEP(r_lazy_eval_protect(call)),
     NULL
   };
 
-  r_obj* call = KEEP(r_call_n(syms_stop_matches_incomplete, syms, args));
-  Rf_eval(call, vctrs_ns_env);
+  r_obj* ffi_call = KEEP(r_call_n(syms_stop_matches_incomplete, syms, args));
+  Rf_eval(ffi_call, vctrs_ns_env);
 
   never_reached("stop_matches_incomplete");
 }

--- a/src/match.c
+++ b/src/match.c
@@ -91,7 +91,7 @@ r_obj* ffi_locate_matches(r_obj* needles,
   const struct vctrs_incomplete c_incomplete = parse_incomplete(incomplete, internal_call);
   const struct vctrs_no_match c_no_match = parse_no_match(no_match, internal_call);
   const struct vctrs_remaining c_remaining = parse_remaining(remaining, internal_call);
-  const enum vctrs_multiple c_multiple = parse_multiple(multiple);
+  const enum vctrs_multiple c_multiple = parse_multiple(multiple, internal_call);
   const bool c_nan_distinct = r_arg_as_bool(nan_distinct, "nan_distinct");
 
   struct vctrs_arg c_needles_arg = vec_as_arg(needles_arg);
@@ -1357,9 +1357,9 @@ struct vctrs_incomplete parse_incomplete(r_obj* incomplete,
 // -----------------------------------------------------------------------------
 
 static inline
-enum vctrs_multiple parse_multiple(r_obj* multiple) {
+enum vctrs_multiple parse_multiple(r_obj* multiple, struct r_lazy call) {
   if (!r_is_string(multiple)) {
-    r_abort("`multiple` must be a string.");
+    r_abort_lazy_call(call, "`multiple` must be a string.");
   }
 
   const char* c_multiple = r_chr_get_c_string(multiple, 0);
@@ -1371,7 +1371,10 @@ enum vctrs_multiple parse_multiple(r_obj* multiple) {
   if (!strcmp(c_multiple, "warning")) return VCTRS_MULTIPLE_warning;
   if (!strcmp(c_multiple, "error")) return VCTRS_MULTIPLE_error;
 
-  r_abort("`multiple` must be one of \"all\", \"any\", \"first\", \"last\", \"warning\", or \"error\".");
+  r_abort_lazy_call(
+    call,
+    "`multiple` must be one of \"all\", \"any\", \"first\", \"last\", \"warning\", or \"error\"."
+  );
 }
 
 // -----------------------------------------------------------------------------

--- a/src/match.c
+++ b/src/match.c
@@ -89,7 +89,7 @@ r_obj* ffi_locate_matches(r_obj* needles,
   struct r_lazy internal_call = { .x = frame, .env = r_null };
 
   const struct vctrs_incomplete c_incomplete = parse_incomplete(incomplete, internal_call);
-  const struct vctrs_no_match c_no_match = parse_no_match(no_match);
+  const struct vctrs_no_match c_no_match = parse_no_match(no_match, internal_call);
   const struct vctrs_remaining c_remaining = parse_remaining(remaining);
   const enum vctrs_multiple c_multiple = parse_multiple(multiple);
   const bool c_nan_distinct = r_arg_as_bool(nan_distinct, "nan_distinct");
@@ -1423,9 +1423,14 @@ void parse_filter(r_obj* filter, r_ssize n_cols, enum vctrs_filter* v_filters) {
 // -----------------------------------------------------------------------------
 
 static inline
-struct vctrs_no_match parse_no_match(r_obj* no_match) {
+struct vctrs_no_match parse_no_match(r_obj* no_match,
+                                     struct r_lazy call) {
   if (r_length(no_match) != 1) {
-    r_abort("`no_match` must be length 1, not length %i.", r_length(no_match));
+    r_abort_lazy_call(
+      call,
+      "`no_match` must be length 1, not length %i.",
+      r_length(no_match)
+    );
   }
 
   if (r_is_string(no_match)) {
@@ -1445,10 +1450,19 @@ struct vctrs_no_match parse_no_match(r_obj* no_match) {
       };
     }
 
-    r_abort("`no_match` must be either \"drop\" or \"error\".");
+    r_abort_lazy_call(
+      call,
+      "`no_match` must be either \"drop\" or \"error\"."
+    );
   }
 
-  no_match = vec_cast(no_match, vctrs_shared_empty_int, args_no_match, vec_args.empty, r_lazy_null);
+  no_match = vec_cast(
+    no_match,
+    vctrs_shared_empty_int,
+    args_no_match,
+    vec_args.empty,
+    call
+  );
   int c_no_match = r_int_get(no_match, 0);
 
   return (struct vctrs_no_match) {

--- a/src/match.c
+++ b/src/match.c
@@ -2360,11 +2360,9 @@ r_ssize midpoint(r_ssize lhs, r_ssize rhs) {
 
 static inline
 void stop_matches_overflow(double size) {
-  r_abort(
+  r_stop_internal(
     "Match procedure results in an allocation larger than 2^31-1 elements. "
-    "Attempted allocation size was %.0lf. "
-    "Please report this to the vctrs maintainers at "
-    "<https://github.com/r-lib/vctrs/issues>.",
+    "Attempted allocation size was %.0lf.",
     size
   );
 }

--- a/src/match.c
+++ b/src/match.c
@@ -83,7 +83,10 @@ r_obj* ffi_locate_matches(r_obj* needles,
                           r_obj* nan_distinct,
                           r_obj* chr_proxy_collate,
                           r_obj* needles_arg,
-                          r_obj* haystack_arg) {
+                          r_obj* haystack_arg,
+                          r_obj* frame) {
+  struct r_lazy call = { .x = syms_call, .env = frame };
+
   const struct vctrs_incomplete c_incomplete = parse_incomplete(incomplete);
   const struct vctrs_no_match c_no_match = parse_no_match(no_match);
   const struct vctrs_remaining c_remaining = parse_remaining(remaining);
@@ -105,7 +108,8 @@ r_obj* ffi_locate_matches(r_obj* needles,
     c_nan_distinct,
     chr_proxy_collate,
     &c_needles_arg,
-    &c_haystack_arg
+    &c_haystack_arg,
+    call
   );
 }
 
@@ -121,7 +125,8 @@ r_obj* vec_locate_matches(r_obj* needles,
                           bool nan_distinct,
                           r_obj* chr_proxy_collate,
                           struct vctrs_arg* needles_arg,
-                          struct vctrs_arg* haystack_arg) {
+                          struct vctrs_arg* haystack_arg,
+                          struct r_lazy call) {
   int n_prot = 0;
 
   int _;

--- a/src/match.c
+++ b/src/match.c
@@ -90,7 +90,7 @@ r_obj* ffi_locate_matches(r_obj* needles,
 
   const struct vctrs_incomplete c_incomplete = parse_incomplete(incomplete, internal_call);
   const struct vctrs_no_match c_no_match = parse_no_match(no_match, internal_call);
-  const struct vctrs_remaining c_remaining = parse_remaining(remaining);
+  const struct vctrs_remaining c_remaining = parse_remaining(remaining, internal_call);
   const enum vctrs_multiple c_multiple = parse_multiple(multiple);
   const bool c_nan_distinct = r_arg_as_bool(nan_distinct, "nan_distinct");
 
@@ -1474,9 +1474,14 @@ struct vctrs_no_match parse_no_match(r_obj* no_match,
 // -----------------------------------------------------------------------------
 
 static inline
-struct vctrs_remaining parse_remaining(r_obj* remaining) {
+struct vctrs_remaining parse_remaining(r_obj* remaining,
+                                       struct r_lazy call) {
   if (r_length(remaining) != 1) {
-    r_abort("`remaining` must be length 1, not length %i.", r_length(remaining));
+    r_abort_lazy_call(
+      call,
+      "`remaining` must be length 1, not length %i.",
+      r_length(remaining)
+    );
   }
 
   if (r_is_string(remaining)) {
@@ -1496,10 +1501,19 @@ struct vctrs_remaining parse_remaining(r_obj* remaining) {
       };
     }
 
-    r_abort("`remaining` must be either \"drop\" or \"error\".");
+    r_abort_lazy_call(
+      call,
+      "`remaining` must be either \"drop\" or \"error\"."
+    );
   }
 
-  remaining = vec_cast(remaining, vctrs_shared_empty_int, args_remaining, vec_args.empty, r_lazy_null);
+  remaining = vec_cast(
+    remaining,
+    vctrs_shared_empty_int,
+    args_remaining,
+    vec_args.empty,
+    call
+  );
   int c_remaining = r_int_get(remaining, 0);
 
   return (struct vctrs_remaining) {

--- a/src/match.c
+++ b/src/match.c
@@ -135,6 +135,7 @@ r_obj* vec_locate_matches(r_obj* needles,
     haystack,
     needles_arg,
     haystack_arg,
+    call,
     DF_FALLBACK_quiet,
     &_
   ), &n_prot);
@@ -144,6 +145,7 @@ r_obj* vec_locate_matches(r_obj* needles,
     ptype,
     needles_arg,
     vec_args.empty,
+    call,
     DF_FALLBACK_quiet,
     S3_FALLBACK_false
   ), &n_prot);
@@ -153,6 +155,7 @@ r_obj* vec_locate_matches(r_obj* needles,
     ptype,
     haystack_arg,
     vec_args.empty,
+    call,
     DF_FALLBACK_quiet,
     S3_FALLBACK_false
   ), &n_prot);
@@ -191,7 +194,7 @@ r_obj* vec_locate_matches(r_obj* needles,
 
   if (n_cols == 0) {
     // If there are no columns, this operation isn't well defined.
-    r_abort("Must have at least 1 column to match on.");
+    r_abort_lazy_call(call, "Must have at least 1 column to match on.");
   }
 
   // Compute the locations of incomplete values per column since computing

--- a/src/match.c
+++ b/src/match.c
@@ -1714,7 +1714,7 @@ r_obj* expand_compact_indices(const int* v_o_haystack,
 
       if (any_multiple) {
         if (multiple == VCTRS_MULTIPLE_error) {
-          stop_matches_multiple(loc_needles, needles_arg, haystack_arg);
+          stop_matches_multiple(loc_needles, needles_arg, haystack_arg, call);
         } else if (multiple == VCTRS_MULTIPLE_warning) {
           warn_matches_multiple(loc_needles, needles_arg, haystack_arg);
         }
@@ -2446,22 +2446,25 @@ void stop_matches_incomplete(r_ssize i,
 static inline
 void stop_matches_multiple(r_ssize i,
                            struct vctrs_arg* needles_arg,
-                           struct vctrs_arg* haystack_arg) {
-  r_obj* syms[4] = {
+                           struct vctrs_arg* haystack_arg,
+                           struct r_lazy call) {
+  r_obj* syms[5] = {
     syms_i,
     syms_needles_arg,
     syms_haystack_arg,
+    syms_call,
     NULL
   };
-  r_obj* args[4] = {
+  r_obj* args[5] = {
     KEEP(r_int((int)i + 1)),
     KEEP(vctrs_arg(needles_arg)),
     KEEP(vctrs_arg(haystack_arg)),
+    KEEP(r_lazy_eval_protect(call)),
     NULL
   };
 
-  r_obj* call = KEEP(r_call_n(syms_stop_matches_multiple, syms, args));
-  Rf_eval(call, vctrs_ns_env);
+  r_obj* ffi_call = KEEP(r_call_n(syms_stop_matches_multiple, syms, args));
+  Rf_eval(ffi_call, vctrs_ns_env);
 
   never_reached("stop_matches_multiple");
 }

--- a/src/match.c
+++ b/src/match.c
@@ -1877,7 +1877,7 @@ r_obj* expand_compact_indices(const int* v_o_haystack,
       }
 
       if (remaining->action == VCTRS_REMAINING_ACTION_error) {
-        stop_matches_remaining(i, needles_arg, haystack_arg);
+        stop_matches_remaining(i, needles_arg, haystack_arg, call);
       }
 
       // Overwrite with location, this moves all "remaining" locations to the
@@ -2397,22 +2397,25 @@ void stop_matches_nothing(r_ssize i,
 static inline
 void stop_matches_remaining(r_ssize i,
                             struct vctrs_arg* needles_arg,
-                            struct vctrs_arg* haystack_arg) {
-  r_obj* syms[4] = {
+                            struct vctrs_arg* haystack_arg,
+                            struct r_lazy call) {
+  r_obj* syms[5] = {
     syms_i,
     syms_needles_arg,
     syms_haystack_arg,
+    syms_call,
     NULL
   };
-  r_obj* args[4] = {
+  r_obj* args[5] = {
     KEEP(r_int((int)i + 1)),
     KEEP(vctrs_arg(needles_arg)),
     KEEP(vctrs_arg(haystack_arg)),
+    KEEP(r_lazy_eval_protect(call)),
     NULL
   };
 
-  r_obj* call = KEEP(r_call_n(syms_stop_matches_remaining, syms, args));
-  Rf_eval(call, vctrs_ns_env);
+  r_obj* ffi_call = KEEP(r_call_n(syms_stop_matches_remaining, syms, args));
+  Rf_eval(ffi_call, vctrs_ns_env);
 
   never_reached("stop_matches_remaining");
 }

--- a/src/match.c
+++ b/src/match.c
@@ -1716,7 +1716,7 @@ r_obj* expand_compact_indices(const int* v_o_haystack,
         if (multiple == VCTRS_MULTIPLE_error) {
           stop_matches_multiple(loc_needles, needles_arg, haystack_arg, call);
         } else if (multiple == VCTRS_MULTIPLE_warning) {
-          warn_matches_multiple(loc_needles, needles_arg, haystack_arg);
+          warn_matches_multiple(loc_needles, needles_arg, haystack_arg, call);
         }
 
         // We know there are multiple and don't need to continue checking
@@ -2472,23 +2472,26 @@ void stop_matches_multiple(r_ssize i,
 static inline
 void warn_matches_multiple(r_ssize i,
                            struct vctrs_arg* needles_arg,
-                           struct vctrs_arg* haystack_arg) {
-  r_obj* syms[4] = {
+                           struct vctrs_arg* haystack_arg,
+                           struct r_lazy call) {
+  r_obj* syms[5] = {
     syms_i,
     syms_needles_arg,
     syms_haystack_arg,
+    syms_call,
     NULL
   };
-  r_obj* args[4] = {
+  r_obj* args[5] = {
     KEEP(r_int((int)i + 1)),
     KEEP(vctrs_arg(needles_arg)),
     KEEP(vctrs_arg(haystack_arg)),
+    KEEP(r_lazy_eval_protect(call)),
     NULL
   };
 
-  r_obj* call = KEEP(r_call_n(syms_warn_matches_multiple, syms, args));
-  Rf_eval(call, vctrs_ns_env);
-  FREE(4);
+  r_obj* ffi_call = KEEP(r_call_n(syms_warn_matches_multiple, syms, args));
+  Rf_eval(ffi_call, vctrs_ns_env);
+  FREE(5);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/ptype2.h
+++ b/src/ptype2.h
@@ -45,6 +45,7 @@ r_obj* vec_ptype2_params(r_obj* x,
                          r_obj* y,
                          struct vctrs_arg* p_x_arg,
                          struct vctrs_arg* p_y_arg,
+                         struct r_lazy call,
                          enum df_fallback df_fallback,
                          int* left) {
   const struct ptype2_opts opts = {
@@ -52,6 +53,7 @@ r_obj* vec_ptype2_params(r_obj* x,
     .y = y,
     .p_x_arg = p_x_arg,
     .p_y_arg = p_y_arg,
+    .call = call,
     .fallback = {
       .df = df_fallback
     }

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -320,12 +320,16 @@ SEXP vec_names(SEXP x);
 SEXP vec_proxy_names(SEXP x);
 SEXP vec_group_loc(SEXP x);
 SEXP vec_identify_runs(SEXP x);
-SEXP vec_match_params(SEXP needles, SEXP haystack, bool na_equal,
-                      struct vctrs_arg* needles_arg, struct vctrs_arg* haystack_arg);
+SEXP vec_match_params(SEXP needles,
+                      SEXP haystack,
+                      bool na_equal,
+                      struct vctrs_arg* needles_arg,
+                      struct vctrs_arg* haystack_arg,
+                      struct r_lazy call);
 
 static inline
 SEXP vec_match(SEXP needles, SEXP haystack) {
-  return vec_match_params(needles, haystack, true, NULL, NULL);
+  return vec_match_params(needles, haystack, true, NULL, NULL, r_lazy_null);
 }
 
 

--- a/tests/testthat/_snaps/dictionary.md
+++ b/tests/testthat/_snaps/dictionary.md
@@ -6,26 +6,26 @@
       (expect_error(vec_match(df1, df2), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error:
+      Error in `vec_match()`:
       ! Can't combine `x$foo` <double> and `x$foo` <character>.
     Code
       (expect_error(vec_match(df1, df2, needles_arg = "n", haystack_arg = "h"),
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error:
+      Error in `vec_match()`:
       ! Can't combine `n$x$foo` <double> and `h$x$foo` <character>.
     Code
       (expect_error(vec_in(df1, df2), class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
-      Error:
+      Error in `vec_in()`:
       ! Can't combine `x$foo` <double> and `x$foo` <character>.
     Code
       (expect_error(vec_in(df1, df2, needles_arg = "n", haystack_arg = "h"), class = "vctrs_error_incompatible_type")
       )
     Output
       <error/vctrs_error_incompatible_type>
-      Error:
+      Error in `vec_in()`:
       ! Can't combine `n$x$foo` <double> and `h$x$foo` <character>.
 

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -265,7 +265,7 @@
       (expect_error(vec_locate_matches(1, 2, remaining = 1.5)))
     Output
       <error/vctrs_error_cast_lossy>
-      Error:
+      Error in `vec_locate_matches()`:
       ! Can't convert from `remaining` <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
@@ -280,6 +280,12 @@
       <error/rlang_error>
       Error in `vec_locate_matches()`:
       ! `remaining` must be either "drop" or "error".
+    Code
+      (expect_error(vec_locate_matches(1, 2, remaining = "x", call = call("fn"))))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_matches()`:
+      ! `remaining` must be either "drop" or "error".
 
 # potential overflow on large output size is caught informatively
 
@@ -289,6 +295,6 @@
       <error/rlang_error>
       Error in `vec_locate_matches()`:
       ! Match procedure results in an allocation larger than 2^31-1 elements. Attempted allocation size was 50000005000000.
-      i In file 'match.c' at line 2397.
+      i In file 'match.c' at line 2411.
       i This is an internal error in the vctrs package, please report it to the package authors.
 

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -84,7 +84,7 @@
       (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error")))
     Output
       <error/vctrs_error_matches_multiple>
-      Error in `stop_matches()`:
+      Error in `vec_locate_matches()`:
       ! Each element can match at most 1 observation.
       x The element at location 1 has multiple matches.
     Code
@@ -92,7 +92,15 @@
       needles_arg = "foo")))
     Output
       <error/vctrs_error_matches_multiple>
-      Error in `stop_matches()`:
+      Error in `vec_locate_matches()`:
+      ! Each element of `foo` can match at most 1 observation.
+      x The element at location 1 has multiple matches.
+    Code
+      (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error",
+      needles_arg = "foo", call = call("fn"))))
+    Output
+      <error/vctrs_error_matches_multiple>
+      Error in `fn()`:
       ! Each element of `foo` can match at most 1 observation.
       x The element at location 1 has multiple matches.
     Code
@@ -100,7 +108,7 @@
       needles_arg = "foo", haystack_arg = "bar")))
     Output
       <error/vctrs_error_matches_multiple>
-      Error in `stop_matches()`:
+      Error in `vec_locate_matches()`:
       ! Each element of `foo` can match at most 1 observation from `bar`.
       x The element at location 1 has multiple matches.
 

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -62,7 +62,7 @@
       (expect_error(vec_locate_matches(1, 2, incomplete = 1.5)))
     Output
       <error/vctrs_error_cast_lossy>
-      Error:
+      Error in `vec_locate_matches()`:
       ! Can't convert from `incomplete` <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
@@ -73,6 +73,12 @@
       ! `incomplete` must be length 1, not length 2.
     Code
       (expect_error(vec_locate_matches(1, 2, incomplete = "x")))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_matches()`:
+      ! `incomplete` must be one of: "compare", "match", "drop", or "error".
+    Code
+      (expect_error(vec_locate_matches(1, 2, incomplete = "x", call = call("fn"))))
     Output
       <error/rlang_error>
       Error in `vec_locate_matches()`:
@@ -277,6 +283,6 @@
       <error/rlang_error>
       Error in `vec_locate_matches()`:
       ! Match procedure results in an allocation larger than 2^31-1 elements. Attempted allocation size was 50000005000000.
-      i In file 'match.c' at line 2368.
+      i In file 'match.c' at line 2383.
       i This is an internal error in the vctrs package, please report it to the package authors.
 

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -128,7 +128,7 @@
       (expect_error(vec_locate_matches(1, 2, no_match = "error")))
     Output
       <error/vctrs_error_matches_nothing>
-      Error in `stop_matches()`:
+      Error in `vec_locate_matches()`:
       ! Each element must have a match.
       x The element at location 1 does not have a match.
     Code
@@ -136,7 +136,15 @@
       )
     Output
       <error/vctrs_error_matches_nothing>
-      Error in `stop_matches()`:
+      Error in `vec_locate_matches()`:
+      ! Each element of `foo` must have a match.
+      x The element at location 1 does not have a match.
+    Code
+      (expect_error(vec_locate_matches(1, 2, no_match = "error", needles_arg = "foo",
+        call = call("fn"))))
+    Output
+      <error/vctrs_error_matches_nothing>
+      Error in `fn()`:
       ! Each element of `foo` must have a match.
       x The element at location 1 does not have a match.
     Code
@@ -144,7 +152,7 @@
         haystack_arg = "bar")))
     Output
       <error/vctrs_error_matches_nothing>
-      Error in `stop_matches()`:
+      Error in `vec_locate_matches()`:
       ! Each element of `foo` must have a match in `bar`.
       x The element at location 1 does not have a match.
 
@@ -155,7 +163,7 @@
       )
     Output
       <error/vctrs_error_matches_nothing>
-      Error in `stop_matches()`:
+      Error in `vec_locate_matches()`:
       ! Each element must have a match.
       x The element at location 2 does not have a match.
 

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -36,7 +36,7 @@
       (expect_error(vec_locate_matches(NA, 1, incomplete = "error")))
     Output
       <error/vctrs_error_matches_incomplete>
-      Error in `stop_matches()`:
+      Error in `vec_locate_matches()`:
       ! No element can contain missing values.
       x The element at location 1 contains missing values.
     Code
@@ -44,7 +44,15 @@
       )
     Output
       <error/vctrs_error_matches_incomplete>
-      Error in `stop_matches()`:
+      Error in `vec_locate_matches()`:
+      ! No element of `foo` can contain missing values.
+      x The element at location 1 contains missing values.
+    Code
+      (expect_error(vec_locate_matches(NA, 1, incomplete = "error", needles_arg = "foo",
+        call = call("fn"))))
+    Output
+      <error/vctrs_error_matches_incomplete>
+      Error in `fn()`:
       ! No element of `foo` can contain missing values.
       x The element at location 1 contains missing values.
 

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -118,7 +118,7 @@
       (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning")))
     Output
       <warning/vctrs_warning_matches_multiple>
-      Warning in `warn_matches()`:
+      Warning in `vec_locate_matches()`:
       Each element can match at most 1 observation.
       x The element at location 1 has multiple matches.
     Code
@@ -126,7 +126,15 @@
       needles_arg = "foo")))
     Output
       <warning/vctrs_warning_matches_multiple>
-      Warning in `warn_matches()`:
+      Warning in `vec_locate_matches()`:
+      Each element of `foo` can match at most 1 observation.
+      x The element at location 1 has multiple matches.
+    Code
+      (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning",
+      needles_arg = "foo", call = call("fn"))))
+    Output
+      <warning/vctrs_warning_matches_multiple>
+      Warning in `fn()`:
       Each element of `foo` can match at most 1 observation.
       x The element at location 1 has multiple matches.
     Code
@@ -134,7 +142,7 @@
       needles_arg = "foo", haystack_arg = "bar")))
     Output
       <warning/vctrs_warning_matches_multiple>
-      Warning in `warn_matches()`:
+      Warning in `vec_locate_matches()`:
       Each element of `foo` can match at most 1 observation from `bar`.
       x The element at location 1 has multiple matches.
 

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -236,5 +236,7 @@
     Output
       <error/rlang_error>
       Error in `vec_locate_matches()`:
-      ! Match procedure results in an allocation larger than 2^31-1 elements. Attempted allocation size was 50000005000000. Please report this to the vctrs maintainers at <https://github.com/r-lib/vctrs/issues>.
+      ! Match procedure results in an allocation larger than 2^31-1 elements. Attempted allocation size was 50000005000000.
+      i In file 'match.c' at line 2368.
+      i This is an internal error in the vctrs package, please report it to the package authors.
 

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -203,7 +203,7 @@
       (expect_error(vec_locate_matches(1, 2, no_match = 1.5)))
     Output
       <error/vctrs_error_cast_lossy>
-      Error:
+      Error in `vec_locate_matches()`:
       ! Can't convert from `no_match` <double> to <integer> due to loss of precision.
       * Locations: 1
     Code
@@ -214,6 +214,12 @@
       ! `no_match` must be length 1, not length 2.
     Code
       (expect_error(vec_locate_matches(1, 2, no_match = "x")))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_matches()`:
+      ! `no_match` must be either "drop" or "error".
+    Code
+      (expect_error(vec_locate_matches(1, 2, no_match = "x", call = call("fn"))))
     Output
       <error/rlang_error>
       Error in `vec_locate_matches()`:
@@ -283,6 +289,6 @@
       <error/rlang_error>
       Error in `vec_locate_matches()`:
       ! Match procedure results in an allocation larger than 2^31-1 elements. Attempted allocation size was 50000005000000.
-      i In file 'match.c' at line 2383.
+      i In file 'match.c' at line 2397.
       i This is an internal error in the vctrs package, please report it to the package authors.
 

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -1,3 +1,35 @@
+# must have at least 1 column to match
+
+    Code
+      vec_locate_matches(data_frame(), data_frame())
+    Condition
+      Error in `vec_locate_matches()`:
+      ! Must have at least 1 column to match on.
+
+---
+
+    Code
+      vec_locate_matches(data_frame(), data_frame(), call = call("foo"))
+    Condition
+      Error in `foo()`:
+      ! Must have at least 1 column to match on.
+
+# common type of `needles` and `haystack` is taken
+
+    Code
+      vec_locate_matches(x, y)
+    Condition
+      Error in `vec_locate_matches()`:
+      ! Can't combine <double> and <character>.
+
+---
+
+    Code
+      vec_locate_matches(x, y, needles_arg = "x", call = call("foo"))
+    Condition
+      Error in `foo()`:
+      ! Can't combine `x` <double> and <character>.
+
 # `incomplete` can error informatively
 
     Code

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -152,6 +152,33 @@
       Each element of `foo` can match at most 1 observation from `bar`.
       x The element at location 1 has multiple matches.
 
+# `multiple` is validated
+
+    Code
+      (expect_error(vec_locate_matches(1, 2, multiple = 1.5)))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_matches()`:
+      ! `multiple` must be a string.
+    Code
+      (expect_error(vec_locate_matches(1, 2, multiple = c("first", "last"))))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_matches()`:
+      ! `multiple` must be a string.
+    Code
+      (expect_error(vec_locate_matches(1, 2, multiple = "x")))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_matches()`:
+      ! `multiple` must be one of "all", "any", "first", "last", "warning", or "error".
+    Code
+      (expect_error(vec_locate_matches(1, 2, multiple = "x", call = call("fn"))))
+    Output
+      <error/rlang_error>
+      Error in `vec_locate_matches()`:
+      ! `multiple` must be one of "all", "any", "first", "last", "warning", or "error".
+
 # `no_match` can error informatively
 
     Code
@@ -295,6 +322,6 @@
       <error/rlang_error>
       Error in `vec_locate_matches()`:
       ! Match procedure results in an allocation larger than 2^31-1 elements. Attempted allocation size was 50000005000000.
-      i In file 'match.c' at line 2411.
+      i In file 'match.c' at line 2414.
       i This is an internal error in the vctrs package, please report it to the package authors.
 

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -322,6 +322,6 @@
       <error/rlang_error>
       Error in `vec_locate_matches()`:
       ! Match procedure results in an allocation larger than 2^31-1 elements. Attempted allocation size was 50000005000000.
-      i In file 'match.c' at line 2414.
+      i In file 'match.c' at line <scrubbed>.
       i This is an internal error in the vctrs package, please report it to the package authors.
 

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -195,7 +195,7 @@
       (expect_error(vec_locate_matches(1, 2, remaining = "error")))
     Output
       <error/vctrs_error_matches_remaining>
-      Error in `stop_matches()`:
+      Error in `vec_locate_matches()`:
       ! Each haystack value must be matched.
       x The value at location 1 was not matched.
     Code
@@ -203,7 +203,15 @@
       )
     Output
       <error/vctrs_error_matches_remaining>
-      Error in `stop_matches()`:
+      Error in `vec_locate_matches()`:
+      ! Each haystack value must be matched by `foo`.
+      x The value at location 1 was not matched.
+    Code
+      (expect_error(vec_locate_matches(1, 2, remaining = "error", needles_arg = "foo",
+        call = call("fn"))))
+    Output
+      <error/vctrs_error_matches_remaining>
+      Error in `fn()`:
       ! Each haystack value must be matched by `foo`.
       x The value at location 1 was not matched.
     Code
@@ -211,7 +219,7 @@
         haystack_arg = "bar")))
     Output
       <error/vctrs_error_matches_remaining>
-      Error in `stop_matches()`:
+      Error in `vec_locate_matches()`:
       ! Each haystack value of `bar` must be matched by `foo`.
       x The value at location 1 was not matched.
 

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -101,3 +101,8 @@ expect_df_fallback_warning_maybe <- function(expr) {
     expr
   }
 }
+
+scrub_internal_error_line_number <- function(x) {
+  # Because it varies by OS
+  sub(pattern = "at line [[:digit:]]+", replacement = "at line <scrubbed>", x = x)
+}

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -916,6 +916,7 @@ test_that("`multiple` can warn informatively", {
   expect_snapshot({
     (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning")))
     (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning", needles_arg = "foo")))
+    (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning", needles_arg = "foo", call = call("fn"))))
     (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning", needles_arg = "foo", haystack_arg = "bar")))
   })
 })

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -907,6 +907,7 @@ test_that("`multiple` can error informatively", {
   expect_snapshot({
     (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error")))
     (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error", needles_arg = "foo")))
+    (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error", needles_arg = "foo", call = call("fn"))))
     (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error", needles_arg = "foo", haystack_arg = "bar")))
   })
 })

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -1110,6 +1110,8 @@ test_that("`no_match` is validated", {
     (expect_error(vec_locate_matches(1, 2, no_match = 1.5)))
     (expect_error(vec_locate_matches(1, 2, no_match = c(1L, 2L))))
     (expect_error(vec_locate_matches(1, 2, no_match = "x")))
+    # Uses internal call
+    (expect_error(vec_locate_matches(1, 2, no_match = "x", call = call("fn"))))
   })
 })
 

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -1071,6 +1071,7 @@ test_that("`no_match` can error informatively", {
   expect_snapshot({
     (expect_error(vec_locate_matches(1, 2, no_match = "error")))
     (expect_error(vec_locate_matches(1, 2, no_match = "error", needles_arg = "foo")))
+    (expect_error(vec_locate_matches(1, 2, no_match = "error", needles_arg = "foo", call = call("fn"))))
     (expect_error(vec_locate_matches(1, 2, no_match = "error", needles_arg = "foo", haystack_arg = "bar")))
   })
 })

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -390,6 +390,15 @@ test_that("df-cols aren't flattened, so `condition` is applied jointly on the df
   expect_identical(res$haystack, 1L)
 })
 
+test_that("must have at least 1 column to match", {
+  expect_snapshot(error = TRUE, {
+    vec_locate_matches(data_frame(), data_frame())
+  })
+  expect_snapshot(error = TRUE, {
+    vec_locate_matches(data_frame(), data_frame(), call = call("foo"))
+  })
+})
+
 # ------------------------------------------------------------------------------
 # vec_locate_matches() - rcrd
 
@@ -522,6 +531,21 @@ test_that("AsIs types are combined before order proxies are taken (#1557)", {
   res <- vec_locate_matches(x, y)
   expect_identical(res$needles, c(1L, 1L, 2L))
   expect_identical(res$haystack, c(2L, 3L, NA))
+})
+
+# ------------------------------------------------------------------------------
+# vec_locate_matches() - ptype2 / casting
+
+test_that("common type of `needles` and `haystack` is taken", {
+  x <- 1
+  y <- "a"
+
+  expect_snapshot(error = TRUE, {
+    vec_locate_matches(x, y)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_locate_matches(x, y, needles_arg = "x", call = call("foo"))
+  })
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -1029,9 +1029,13 @@ test_that("`multiple = 'error'` doesn't error errneously on the last observation
 })
 
 test_that("`multiple` is validated", {
-  expect_error(vec_locate_matches(1, 2, multiple = 1.5), "`multiple` must be a string")
-  expect_error(vec_locate_matches(1, 2, multiple = c("first", "last")), "`multiple` must be a string")
-  expect_error(vec_locate_matches(1, 2, multiple = "x"), '`multiple` must be one of "all", "any", "first", "last", "warning", or "error"')
+  expect_snapshot({
+    (expect_error(vec_locate_matches(1, 2, multiple = 1.5)))
+    (expect_error(vec_locate_matches(1, 2, multiple = c("first", "last"))))
+    (expect_error(vec_locate_matches(1, 2, multiple = "x")))
+    # Uses internal error
+    (expect_error(vec_locate_matches(1, 2, multiple = "x", call = call("fn"))))
+  })
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -1437,7 +1437,7 @@ test_that("potential overflow on large output size is caught informatively", {
   # intermediate `r_ssize` will be too large
   skip_if(.Machine$sizeof.pointer < 8L, message = "No long vector support")
 
-  expect_snapshot({
+  expect_snapshot(transform = scrub_internal_error_line_number, {
     (expect_error(vec_locate_matches(1:1e7, 1:1e7, condition = ">=")))
   })
 })

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -1193,6 +1193,7 @@ test_that("`remaining` can error informatively", {
   expect_snapshot({
     (expect_error(vec_locate_matches(1, 2, remaining = "error")))
     (expect_error(vec_locate_matches(1, 2, remaining = "error", needles_arg = "foo")))
+    (expect_error(vec_locate_matches(1, 2, remaining = "error", needles_arg = "foo", call = call("fn"))))
     (expect_error(vec_locate_matches(1, 2, remaining = "error", needles_arg = "foo", haystack_arg = "bar")))
   })
 })

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -830,6 +830,8 @@ test_that("`incomplete` is validated", {
     (expect_error(vec_locate_matches(1, 2, incomplete = 1.5)))
     (expect_error(vec_locate_matches(1, 2, incomplete = c("match", "drop"))))
     (expect_error(vec_locate_matches(1, 2, incomplete = "x")))
+    # Uses internal call
+    (expect_error(vec_locate_matches(1, 2, incomplete = "x", call = call("fn"))))
   })
 })
 

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -817,6 +817,7 @@ test_that("`incomplete` can error informatively", {
   expect_snapshot({
     (expect_error(vec_locate_matches(NA, 1, incomplete = "error")))
     (expect_error(vec_locate_matches(NA, 1, incomplete = "error", needles_arg = "foo")))
+    (expect_error(vec_locate_matches(NA, 1, incomplete = "error", needles_arg = "foo", call = call("fn"))))
   })
 })
 

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -1210,6 +1210,8 @@ test_that("`remaining` is validated", {
     (expect_error(vec_locate_matches(1, 2, remaining = 1.5)))
     (expect_error(vec_locate_matches(1, 2, remaining = c(1L, 2L))))
     (expect_error(vec_locate_matches(1, 2, remaining = "x")))
+    # Uses internal call
+    (expect_error(vec_locate_matches(1, 2, remaining = "x", call = call("fn"))))
   })
 })
 


### PR DESCRIPTION
Closes #1611 

- I ended up going with `call = current_env()` as the default. I do think that this function could be used by advanced users at the top level, in the same way that `match()` is used.

- `vec_ptype2_params()` and `vec_cast_params()` were missing a `call` argument, so I added that in

Other than that, this was a straightforward if tedious PR. Each commit is pretty self-contained