### PR TITLE
Ensure `zero = "error"` errors when inverting negatives

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* `num_as_location()` now works correctly when a combination of `zero = "error"`
+  and `negative = "invert"` are used (#1612).
+
 * `data_frame()` and `df_list()` have gained `.call` arguments (#1610).
 
 * `vec_locate_matches()` has gained a `call` argument (#1611).

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -216,7 +216,11 @@ r_obj* int_invert_location(r_obj* subscript,
     }
     if (j >= 0) {
       if (j == 0) {
-        continue;
+        switch (opts->loc_zero) {
+        case LOC_ZERO_REMOVE: continue;
+        case LOC_ZERO_IGNORE: continue;
+        case LOC_ZERO_ERROR: stop_location_zero(subscript, opts);
+        }
       } else {
         stop_location_negative_positive(subscript, opts);
       }

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -531,6 +531,26 @@
       i Location 4 doesn't exist.
       i There are only 3 elements.
 
+# num_as_location() errors on disallowed zeros when inverting negatives (#1612)
+
+    Code
+      num_as_location(c(0, -1), n = 2L, negative = "invert", zero = "error")
+    Condition
+      Error:
+      ! Must subset elements with a valid subscript vector.
+      x Subscript `c(0, -1)` can't contain `0` values.
+      i It has a `0` value at location 1.
+
+---
+
+    Code
+      num_as_location(c(-1, 0), n = 2L, negative = "invert", zero = "error")
+    Condition
+      Error:
+      ! Must subset elements with a valid subscript vector.
+      x Subscript `c(-1, 0)` can't contain `0` values.
+      i It has a `0` value at location 2.
+
 # missing values are supported in error formatters
 
     Code

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -298,6 +298,31 @@ test_that("num_as_location() errors when inverting oob negatives unless `oob = '
   expect_identical(num_as_location(c(-4, -2), 3, oob = "remove", negative = "invert"), c(1L, 3L))
 })
 
+test_that("num_as_location() generally drops zeros when inverting negatives (#1612)", {
+  expect_identical(
+    num_as_location(c(-3, 0, -1), n = 5L, negative = "invert", zero = "remove"),
+    c(2L, 4L, 5L)
+  )
+
+  # Trying to "ignore" and retain the zeroes in the output doesn't make sense,
+  # where would they be placed? Instead, think of the ignored zeros as being
+  # inverted as well, they just don't correspond to any location after the
+  # inversion so they aren't in the output.
+  expect_identical(
+    num_as_location(c(-3, 0, -1, 0), n = 5L, negative = "invert", zero = "ignore"),
+    c(2L, 4L, 5L)
+  )
+})
+
+test_that("num_as_location() errors on disallowed zeros when inverting negatives (#1612)", {
+  expect_snapshot(error = TRUE, {
+    num_as_location(c(0, -1), n = 2L, negative = "invert", zero = "error")
+  })
+  expect_snapshot(error = TRUE, {
+    num_as_location(c(-1, 0), n = 2L, negative = "invert", zero = "error")
+  })
+})
+
 test_that("num_as_location() with `oob = 'remove'` doesn't remove missings if they are being propagated", {
   expect_identical(num_as_location(NA_integer_, 1, oob = "remove"), NA_integer_)
 })


### PR DESCRIPTION
Closes #1612 

Also added a test for `zero = "ignore", negative = "invert"` which is a little hand wavy, but I think what we have makes sense.