### PR TITLE
Correctly error on `"ignore"`d oob negative values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # vctrs (development version)
 
+* `num_as_location()` now throws the right error when there are out-of-bounds
+  negative values and `oob = "extend"` and `negative = "ignore"` are set
+  (#1614, #1630).
+
 * `num_as_location()` now works correctly when a combination of `zero = "error"`
   and `negative = "invert"` are used (#1612).
 

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -481,11 +481,16 @@ cnd_body.vctrs_error_subscript_oob <- function(cnd, ...) {
 cnd_body_vctrs_error_subscript_oob_location <- function(cnd, ...) {
   i <- cnd$i
 
-  # In case of negative indexing
-  i <- abs(i)
-
   # In case of missing locations
   i <- i[!is.na(i)]
+
+  if (cnd_subscript_action(cnd) == "negate") {
+    # Only report negative indices
+    i <- i[i < 0L]
+  }
+
+  # In case of negative indexing
+  i <- abs(i)
 
   oob <- i[i > cnd$size]
   oob_enum <- vctrs_cli_vec(oob)

--- a/src/decl/subscript-loc-decl.h
+++ b/src/decl/subscript-loc-decl.h
@@ -43,6 +43,10 @@ void stop_subscript_oob_location(r_obj* i,
                                  r_ssize size,
                                  const struct location_opts* opts);
 static
+void stop_subscript_negative_oob_location(r_obj* i,
+                                          r_ssize size,
+                                          const struct location_opts* opts);
+static
 void stop_subscript_oob_name(r_obj* i,
                              r_obj* names,
                              const struct location_opts* opts);

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -511,7 +511,7 @@
       i Input has size 3.
       x Subscript `c(1:5, 7, 1, 10)` contains non-consecutive locations 4, 7, and 10.
 
-# num_as_location() errors when inverting oob negatives unless `oob = 'remove'`
+# num_as_location() errors when inverting oob negatives unless `oob = 'remove'` (#1630)
 
     Code
       num_as_location(-4, 3, oob = "error", negative = "invert")
@@ -524,7 +524,7 @@
 ---
 
     Code
-      num_as_location(-4, 3, oob = "extend", negative = "invert")
+      num_as_location(c(-4, 4, 5), 3, oob = "extend", negative = "invert")
     Condition
       Error:
       ! Can't negate elements past the end.
@@ -550,6 +550,46 @@
       ! Must subset elements with a valid subscript vector.
       x Subscript `c(-1, 0)` can't contain `0` values.
       i It has a `0` value at location 2.
+
+# num_as_location() with `oob = 'extend'` doesn't allow ignored oob negative values (#1614)
+
+    Code
+      num_as_location(-6L, 5L, oob = "extend", negative = "ignore")
+    Condition
+      Error:
+      ! Can't negate elements past the end.
+      i Location 6 doesn't exist.
+      i There are only 5 elements.
+
+---
+
+    Code
+      num_as_location(c(-7L, 6L), 5L, oob = "extend", negative = "ignore")
+    Condition
+      Error:
+      ! Can't negate elements past the end.
+      i Location 7 doesn't exist.
+      i There are only 5 elements.
+
+---
+
+    Code
+      num_as_location(c(-7L, NA), 5L, oob = "extend", negative = "ignore")
+    Condition
+      Error:
+      ! Can't negate elements past the end.
+      i Location 7 doesn't exist.
+      i There are only 5 elements.
+
+# num_as_location() with `oob = 'error'` reports negative and positive oob values
+
+    Code
+      num_as_location(c(-6L, 7L), n = 5L, oob = "error", negative = "ignore")
+    Condition
+      Error:
+      ! Can't subset elements past the end.
+      i Locations 6 and 7 don't exist.
+      i There are only 5 elements.
 
 # missing values are supported in error formatters
 

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -287,12 +287,12 @@ test_that("num_as_location() can optionally remove oob values (#1595)", {
   expect_identical(num_as_location(c(-4, 5, 2, -1), 3, oob = "remove", negative = "ignore"), c(2L, -1L))
 })
 
-test_that("num_as_location() errors when inverting oob negatives unless `oob = 'remove'`", {
+test_that("num_as_location() errors when inverting oob negatives unless `oob = 'remove'` (#1630)", {
   expect_snapshot(error = TRUE, {
     num_as_location(-4, 3, oob = "error", negative = "invert")
   })
   expect_snapshot(error = TRUE, {
-    num_as_location(-4, 3, oob = "extend", negative = "invert")
+    num_as_location(c(-4, 4, 5), 3, oob = "extend", negative = "invert")
   })
   expect_identical(num_as_location(-4, 3, oob = "remove", negative = "invert"), c(1L, 2L, 3L))
   expect_identical(num_as_location(c(-4, -2), 3, oob = "remove", negative = "invert"), c(1L, 3L))
@@ -330,6 +330,29 @@ test_that("num_as_location() with `oob = 'remove'` doesn't remove missings if th
 test_that("num_as_location() with `oob = 'remove'` doesn't remove zeros if they are being ignored", {
   expect_identical(num_as_location(0, 1, oob = "remove", zero = "ignore"), 0L)
   expect_identical(num_as_location(0, 0, oob = "remove", zero = "ignore"), 0L)
+})
+
+test_that("num_as_location() with `oob = 'extend'` doesn't allow ignored oob negative values (#1614)", {
+  # This is fine (ignored negative that is in bounds)
+  expect_identical(num_as_location(c(-5L, 6L), 5L, oob = "extend", negative = "ignore"), c(-5L, 6L))
+
+  expect_snapshot(error = TRUE, {
+    # Ignored negatives aren't allowed to extend the vector
+    num_as_location(-6L, 5L, oob = "extend", negative = "ignore")
+  })
+  expect_snapshot(error = TRUE, {
+    # Ensure error only reports negative indices
+    num_as_location(c(-7L, 6L), 5L, oob = "extend", negative = "ignore")
+  })
+  expect_snapshot(error = TRUE, {
+    num_as_location(c(-7L, NA), 5L, oob = "extend", negative = "ignore")
+  })
+})
+
+test_that("num_as_location() with `oob = 'error'` reports negative and positive oob values", {
+  expect_snapshot(error = TRUE, {
+    num_as_location(c(-6L, 7L), n = 5L, oob = "error", negative = "ignore")
+  })
 })
 
 test_that("missing values are supported in error formatters", {


### PR DESCRIPTION
Closes #1614 
Closes #1630 

Slightly more invasive change than the other `num_as_location()` changes so far. I've restructured the for-loop to be one series of flat `if/else` statements. The main change that comes from this (beyond looking a little nicer IMO) is that the OOB behavior for negative values becomes more explicit because it gets its own `switch()` statement under `LOC_NEGATIVE_IGNORE`. This makes sense to me because it has slightly different behavior from the normal OOB behavior.