### PR TITLE
Implement `missing = "remove"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # vctrs (development version)
 
+* `vec_as_location()` and `num_as_location()` have gained a `missing = "remove"`
+  option (#1595).
+
+* `vec_as_location()` no longer matches `NA_character_` and `""` indices if
+  those invalid names appear in `names` (#1489).
+
 * `vec_unchop()` has been renamed to `list_unchop()` to better indicate that it
   requires list input. `vec_unchop()` will stick around for a few minor
   versions, but has been formally soft-deprecated (#1209).

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -415,6 +415,31 @@ cnd_bullets_subscript_missing <- function(cnd, ...) {
   ))
 }
 
+stop_subscript_empty <- function(i, ..., call = caller_env()) {
+  cnd_signal(new_error_subscript_type(
+    i = i,
+    body = cnd_bullets_subscript_empty,
+    ...,
+    call = call
+  ))
+}
+cnd_bullets_subscript_empty <- function(cnd, ...) {
+  cnd$subscript_arg <- append_arg("Subscript", cnd$subscript_arg)
+
+  loc <- which(cnd$i == "")
+  if (length(loc) == 1) {
+    line <- glue::glue("It has an empty string at location {loc}.")
+  } else {
+    enum <- ensure_full_stop(enumerate(loc))
+    line <- glue::glue("It has an empty string at locations {enum}")
+  }
+
+  format_error_bullets(c(
+    x = glue::glue_data(cnd, "{subscript_arg} can't contain the empty string."),
+    x = line
+  ))
+}
+
 stop_indicator_size <- function(i, n, ..., call = caller_env()) {
   cnd_signal(new_error_subscript_size(
     i,

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -25,8 +25,8 @@
 #'   vector that `i` will be matched against to construct the index. Otherwise,
 #'   not used. The default value of `NULL` will result in an error
 #'   if `i` is a character vector.
-#' @param missing Whether to throw an `"error"` when `i` is a missing
-#'   value, or `"propagate"` it (return it as is). By default, vector
+#' @param missing Whether to throw an `"error"` when `i` is a missing value,
+#'   `"propagate"` it (return it as is), or `"remove"` it. By default, vector
 #'   subscripts can contain missing values and scalar subscripts can't.
 #'   Propagated missing values can't be combined with negative indices.
 #' @param arg The argument name to be displayed in error messages when
@@ -60,7 +60,7 @@ vec_as_location <- function(i,
                             n,
                             names = NULL,
                             ...,
-                            missing = c("propagate", "error"),
+                            missing = c("propagate", "remove", "error"),
                             arg = caller_arg(i),
                             call = caller_env()) {
   check_dots_empty0(...)
@@ -91,7 +91,7 @@ vec_as_location <- function(i,
 num_as_location <- function(i,
                             n,
                             ...,
-                            missing = c("propagate", "error"),
+                            missing = c("propagate", "remove", "error"),
                             negative = c("invert", "error", "ignore"),
                             oob = c("error", "remove", "extend"),
                             zero = c("remove", "error", "ignore"),

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -28,6 +28,7 @@
 #' @param missing Whether to throw an `"error"` when `i` is a missing
 #'   value, or `"propagate"` it (return it as is). By default, vector
 #'   subscripts can contain missing values and scalar subscripts can't.
+#'   Propagated missing values can't be combined with negative indices.
 #' @param arg The argument name to be displayed in error messages when
 #'   `vec_as_location()` and `vec_as_location2()` are used to check the
 #'   type of a function input.

--- a/man/vec_as_location.Rd
+++ b/man/vec_as_location.Rd
@@ -67,7 +67,8 @@ if \code{i} is a character vector.}
 
 \item{missing}{Whether to throw an \code{"error"} when \code{i} is a missing
 value, or \code{"propagate"} it (return it as is). By default, vector
-subscripts can contain missing values and scalar subscripts can't.}
+subscripts can contain missing values and scalar subscripts can't.
+Propagated missing values can't be combined with negative indices.}
 
 \item{arg}{The argument name to be displayed in error messages when
 \code{vec_as_location()} and \code{vec_as_location2()} are used to check the

--- a/man/vec_as_location.Rd
+++ b/man/vec_as_location.Rd
@@ -12,7 +12,7 @@ vec_as_location(
   n,
   names = NULL,
   ...,
-  missing = c("propagate", "error"),
+  missing = c("propagate", "remove", "error"),
   arg = caller_arg(i),
   call = caller_env()
 )
@@ -21,7 +21,7 @@ num_as_location(
   i,
   n,
   ...,
-  missing = c("propagate", "error"),
+  missing = c("propagate", "remove", "error"),
   negative = c("invert", "error", "ignore"),
   oob = c("error", "remove", "extend"),
   zero = c("remove", "error", "ignore"),
@@ -65,8 +65,8 @@ if \code{i} is a character vector.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{missing}{Whether to throw an \code{"error"} when \code{i} is a missing
-value, or \code{"propagate"} it (return it as is). By default, vector
+\item{missing}{Whether to throw an \code{"error"} when \code{i} is a missing value,
+\code{"propagate"} it (return it as is), or \code{"remove"} it. By default, vector
 subscripts can contain missing values and scalar subscripts can't.
 Propagated missing values can't be combined with negative indices.}
 

--- a/src/decl/subscript-loc-decl.h
+++ b/src/decl/subscript-loc-decl.h
@@ -39,6 +39,9 @@ r_obj* chr_as_location(r_obj* subscript,
 static
 void stop_subscript_missing(r_obj* i,
                             const struct location_opts* opts);
+static
+void stop_subscript_empty(r_obj* i,
+                          const struct location_opts* opts);
 
 static
 void stop_subscript_oob_location(r_obj* i,

--- a/src/decl/subscript-loc-decl.h
+++ b/src/decl/subscript-loc-decl.h
@@ -14,6 +14,8 @@ r_obj* int_invert_location(r_obj* subscript,
                            const struct location_opts* opts);
 static
 r_obj* int_filter_zero(r_obj* subscript, r_ssize n_zero);
+static
+r_obj* int_filter_missing(r_obj* subscript, r_ssize n_missing);
 
 static
 r_obj* int_filter_oob(r_obj* subscript, r_ssize n, r_ssize n_oob);

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -581,7 +581,7 @@ enum num_loc_zero parse_loc_zero(r_obj* x,
 
 static
 void stop_subscript_arg_missing(struct r_lazy call) {
-  r_abort_call(call.env, "`missing` must be one of \"propagate\" or \"error\".");
+  r_abort_call(call.env, "`missing` must be one of \"propagate\", \"remove\", or \"error\".");
 }
 static
 void stop_bad_negative(struct r_lazy call) {

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -255,6 +255,8 @@ r_obj* int_invert_location(r_obj* subscript,
     int j = *data;
 
     if (j == r_globals.na_int) {
+      // Following base R by erroring on `missing = "propagate"`, e.g. `1[c(NA, -1)]`.
+      // Doesn't make sense to invert an `NA`, so we can't meaningfully propagate.
       switch (opts->missing) {
       case SUBSCRIPT_MISSING_PROPAGATE: stop_location_negative_missing(subscript, opts);
       case SUBSCRIPT_MISSING_REMOVE: continue;

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -76,16 +76,7 @@ r_obj* lgl_as_location(r_obj* subscript,
     }
     }
 
-    r_obj* out = KEEP(r_lgl_which(subscript, na_propagate));
-
-    r_obj* nms = KEEP(r_names(subscript));
-    if (nms != R_NilValue) {
-      nms = vec_slice(nms, out);
-      r_attrib_poke_names(out, nms);
-    }
-
-    FREE(2);
-    return out;
+    return r_lgl_which(subscript, na_propagate);
   }
 
   /* A single `TRUE` or `FALSE` index is recycled to the full vector

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -63,16 +63,15 @@ r_obj* lgl_as_location(r_obj* subscript,
   r_ssize subscript_n = r_length(subscript);
 
   if (subscript_n == n) {
-    bool na_propagate;
+    bool na_propagate = false;
 
     switch (opts->missing) {
     case SUBSCRIPT_MISSING_PROPAGATE: na_propagate = true; break;
-    case SUBSCRIPT_MISSING_REMOVE: na_propagate = false; break;
+    case SUBSCRIPT_MISSING_REMOVE: break;
     case SUBSCRIPT_MISSING_ERROR: {
       if (lgl_any_na(subscript)) {
         stop_subscript_missing(subscript, opts);
       }
-      na_propagate = false;
       break;
     }
     }

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -307,6 +307,17 @@ r_obj* int_filter(r_obj* subscript, r_ssize n_filter, int value) {
 
   r_obj* out = KEEP(r_alloc_integer(size - n_filter));
   int* v_out = r_int_begin(out);
+
+  r_obj* names = r_names(subscript);
+  const bool has_names = names != r_null;
+  r_obj* const* v_names = NULL;
+  r_obj* out_names = r_null;
+  if (has_names) {
+    v_names = r_chr_cbegin(names);
+    out_names = r_alloc_character(size - n_filter);
+    r_attrib_poke_names(out, out_names);
+  }
+
   r_ssize j = 0;
 
   for (r_ssize i = 0; i < size; ++i) {
@@ -314,6 +325,11 @@ r_obj* int_filter(r_obj* subscript, r_ssize n_filter, int value) {
 
     if (elt != value) {
       v_out[j] = elt;
+
+      if (has_names) {
+        r_chr_poke(out_names, j, v_names[i]);
+      }
+
       ++j;
     }
   }
@@ -335,18 +351,34 @@ r_obj* int_filter_oob(r_obj* subscript, r_ssize n, r_ssize n_oob) {
   const r_ssize n_subscript = r_length(subscript);
   const r_ssize n_out = n_subscript - n_oob;
 
+  const int* v_subscript = r_int_cbegin(subscript);
+
   r_obj* out = KEEP(r_alloc_integer(n_out));
   int* v_out = r_int_begin(out);
-  r_ssize i_out = 0;
 
-  const int* v_subscript = r_int_cbegin(subscript);
+  r_obj* names = r_names(subscript);
+  const bool has_names = names != r_null;
+  r_obj* const* v_names = NULL;
+  r_obj* out_names = r_null;
+  if (has_names) {
+    v_names = r_chr_cbegin(names);
+    out_names = r_alloc_character(n_out);
+    r_attrib_poke_names(out, out_names);
+  }
+
+  r_ssize j = 0;
 
   for (r_ssize i = 0; i < n_subscript; ++i) {
     const int elt = v_subscript[i];
 
     if (abs(elt) <= n || elt == r_globals.na_int) {
-      v_out[i_out] = elt;
-      ++i_out;
+      v_out[j] = elt;
+
+      if (has_names) {
+        r_chr_poke(out_names, j, v_names[i]);
+      }
+
+      ++j;
     }
   }
 

--- a/src/subscript-loc.c
+++ b/src/subscript-loc.c
@@ -115,7 +115,8 @@ r_obj* lgl_as_location(r_obj* subscript,
         break;
       }
       case SUBSCRIPT_MISSING_REMOVE: {
-        out = r_globals.empty_int;
+        out = r_copy(r_globals.empty_int);
+        KEEP_AT(out, out_shelter);
         recycle_size = 0;
         break;
       }
@@ -128,7 +129,8 @@ r_obj* lgl_as_location(r_obj* subscript,
       KEEP_AT(out, out_shelter);
       r_int_fill_seq(out, 1, n);
     } else {
-      out = r_globals.empty_int;
+      out = r_copy(r_globals.empty_int);
+      KEEP_AT(out, out_shelter);
       recycle_size = 0;
     }
 

--- a/src/subscript-loc.h
+++ b/src/subscript-loc.h
@@ -8,6 +8,7 @@
 
 enum subscript_missing {
   SUBSCRIPT_MISSING_PROPAGATE = 0,
+  SUBSCRIPT_MISSING_REMOVE,
   SUBSCRIPT_MISSING_ERROR
 };
 enum num_loc_negative {

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -198,7 +198,7 @@
     Output
       <error/rlang_error>
       Error in `vctrs::num_as_location()`:
-      ! `missing` must be one of "propagate" or "error".
+      ! `missing` must be one of "propagate", "remove", or "error".
 
 ---
 

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -687,7 +687,7 @@
 ---
 
     Code
-      vec_as_location(NA, n = 2L, missing = "error")
+      vec_as_location(x, n = 2L, missing = "error")
     Condition
       Error:
       ! Must subset elements with a valid subscript vector.

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -674,6 +674,26 @@
       x Subscript `foo(bar)` can't contain missing values.
       x It has a missing value at location 1.
 
+# can alter logical missing value handling (#1595)
+
+    Code
+      vec_as_location(x, n = 4L, missing = "error")
+    Condition
+      Error:
+      ! Must subset elements with a valid subscript vector.
+      x Subscript can't contain missing values.
+      x It has missing values at locations 2 and 4.
+
+---
+
+    Code
+      vec_as_location(NA, n = 2L, missing = "error")
+    Condition
+      Error:
+      ! Must subset elements with a valid subscript vector.
+      x Subscript can't contain missing values.
+      x It has a missing value at location 1.
+
 # can customise subscript type errors
 
     Code

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -694,6 +694,36 @@
       x Subscript can't contain missing values.
       x It has a missing value at location 1.
 
+# can alter integer missing value handling (#1595)
+
+    Code
+      vec_as_location(x, n = 4L, missing = "error")
+    Condition
+      Error:
+      ! Must subset elements with a valid subscript vector.
+      x Subscript can't contain missing values.
+      x It has missing values at locations 1 and 3.
+
+# can alter negative integer missing value handling (#1595)
+
+    Code
+      num_as_location(x, n = 4L, missing = "propagate", negative = "invert")
+    Condition
+      Error:
+      ! Must subset elements with a valid subscript vector.
+      x Negative locations can't have missing values.
+      i Subscript `x` has 2 missing values at locations 2 and 3.
+
+---
+
+    Code
+      num_as_location(x, n = 4L, missing = "error", negative = "invert")
+    Condition
+      Error:
+      ! Must subset elements with a valid subscript vector.
+      x Negative locations can't have missing values.
+      i Subscript `x` has 2 missing values at locations 2 and 3.
+
 # can customise subscript type errors
 
     Code

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -694,6 +694,16 @@
       x Subscript can't contain missing values.
       x It has a missing value at location 1.
 
+# can alter character missing value handling (#1595)
+
+    Code
+      vec_as_location(x, n = 2L, names = names, missing = "error")
+    Condition
+      Error:
+      ! Must subset elements with a valid subscript vector.
+      x Subscript can't contain missing values.
+      x It has missing values at locations 1 and 3.
+
 # can alter integer missing value handling (#1595)
 
     Code
@@ -723,6 +733,26 @@
       ! Must subset elements with a valid subscript vector.
       x Negative locations can't have missing values.
       i Subscript `x` has 2 missing values at locations 2 and 3.
+
+# empty string character indices never match empty string names (#1489)
+
+    Code
+      vec_as_location("", n = 2L, names = names)
+    Condition
+      Error:
+      ! Must subset elements with a valid subscript vector.
+      x Subscript can't contain the empty string.
+      x It has an empty string at location 1.
+
+---
+
+    Code
+      vec_as_location(c("", "y", ""), n = 2L, names = names)
+    Condition
+      Error:
+      ! Must subset elements with a valid subscript vector.
+      x Subscript can't contain the empty string.
+      x It has an empty string at locations 1 and 3.
 
 # can customise subscript type errors
 

--- a/tests/testthat/_snaps/subscript-loc.md
+++ b/tests/testthat/_snaps/subscript-loc.md
@@ -1069,7 +1069,7 @@
       vec_as_location(1, 1L, missing = "bogus")
     Condition
       Error in `vec_as_location()`:
-      ! `missing` must be one of "propagate" or "error".
+      ! `missing` must be one of "propagate", "remove", or "error".
 
 # num_as_location() UI
 
@@ -1077,7 +1077,7 @@
       num_as_location(1, 1L, missing = "bogus")
     Condition
       Error in `num_as_location()`:
-      ! `missing` must be one of "propagate" or "error".
+      ! `missing` must be one of "propagate", "remove", or "error".
 
 ---
 

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -486,6 +486,25 @@ test_that("empty string character indices never match empty string names (#1489)
   })
 })
 
+test_that("scalar logical `FALSE` and `NA` cases don't modify a shared object (#1633)", {
+  x <- vec_as_location(FALSE, n = 2)
+  expect_identical(x, integer())
+
+  y <- vec_as_location(c(a = FALSE), n = 2)
+  expect_identical(y, named(integer()))
+  # Still unnamed
+  expect_identical(x, integer())
+
+
+  x <- vec_as_location(NA, n = 2, missing = "remove")
+  expect_identical(x, integer())
+
+  y <- vec_as_location(c(a = FALSE), n = 2, missing = "remove")
+  expect_identical(y, named(integer()))
+  # Still unnamed
+  expect_identical(x, integer())
+})
+
 test_that("can customise subscript type errors", {
   expect_snapshot({
     "With custom `arg`"

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -401,6 +401,23 @@ test_that("can disallow missing values", {
   })
 })
 
+test_that("can alter logical missing value handling (#1595)", {
+  x <- c(TRUE, NA, FALSE, NA)
+
+  expect_identical(vec_as_location(x, n = 4L, missing = "propagate"), c(1L, NA, NA))
+  expect_identical(vec_as_location(x, n = 4L, missing = "remove"), 1L)
+  expect_snapshot(error = TRUE, {
+    vec_as_location(x, n = 4L, missing = "error")
+  })
+
+  # Specifically test size 1 case, which has its own special path
+  expect_identical(vec_as_location(NA, n = 2L, missing = "propagate"), c(NA_integer_, NA_integer_))
+  expect_identical(vec_as_location(NA, n = 2L, missing = "remove"), integer())
+  expect_snapshot(error = TRUE, {
+    vec_as_location(NA, n = 2L, missing = "error")
+  })
+})
+
 test_that("can customise subscript type errors", {
   expect_snapshot({
     "With custom `arg`"

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -418,6 +418,24 @@ test_that("can alter logical missing value handling (#1595)", {
   })
 })
 
+test_that("can alter character missing value handling (#1595)", {
+  x <- c(NA, "z", NA)
+  names(x) <- c("a", "b", "c")
+  names <- c("x", "z")
+
+  expect_identical(
+    vec_as_location(x, n = 2L, names = names, missing = "propagate"),
+    set_names(c(NA, 2L, NA), names(x))
+  )
+  expect_identical(
+    vec_as_location(x, n = 2L, names = names, missing = "remove"),
+    set_names(2L, "b")
+  )
+  expect_snapshot(error = TRUE, {
+    vec_as_location(x, n = 2L, names = names, missing = "error")
+  })
+})
+
 test_that("can alter integer missing value handling (#1595)", {
   x <- c(NA, 1L, NA, 3L)
 
@@ -446,6 +464,25 @@ test_that("can alter negative integer missing value handling (#1595)", {
   )
   expect_snapshot(error = TRUE, {
     num_as_location(x, n = 4L, missing = "error", negative = "invert")
+  })
+})
+
+test_that("missing value character indices never match missing value names (#1489)", {
+  x <- NA_character_
+  names <- NA_character_
+
+  expect_identical(vec_as_location(x, n = 1L, names = names, missing = "propagate"), NA_integer_)
+  expect_identical(vec_as_location(x, n = 1L, names = names, missing = "remove"), integer())
+})
+
+test_that("empty string character indices never match empty string names (#1489)", {
+  names <- c("", "y")
+
+  expect_snapshot(error = TRUE, {
+    vec_as_location("", n = 2L, names = names)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_as_location(c("", "y", ""), n = 2L, names = names)
   })
 })
 

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -141,7 +141,6 @@ test_that("vec_as_location() preserves names if possible", {
   expect_identical(vec_as_location(c(a = 1, b = 3), 3L), c(a = 1L, b = 3L))
   expect_identical(vec_as_location(c(a = "z", b = "y"), 26L, letters), c(a = 26L, b = 25L))
 
-  skip("Until https://github.com/r-lib/rlang/pull/1471 is merged and `rlang:::use_rlang_c_library()` is rerun.")
   expect_identical(vec_as_location(c(foo = TRUE, bar = FALSE, baz = TRUE), 3L), c(foo = 1L, baz = 3L))
   expect_identical(vec_as_location(c(foo = TRUE), 3L), c(foo = 1L, foo = 2L, foo = 3L))
   expect_identical(vec_as_location(c(foo = NA), 3L), c(foo = na_int, foo = na_int, foo = na_int))
@@ -424,7 +423,6 @@ test_that("can disallow missing values", {
 })
 
 test_that("can alter logical missing value handling (#1595)", {
-  skip("Until https://github.com/r-lib/rlang/pull/1471 is merged and `rlang:::use_rlang_c_library()` is rerun.")
   x <- c(a = TRUE, b = NA, c = FALSE, d = NA)
 
   expect_identical(

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -355,6 +355,27 @@ test_that("num_as_location() with `oob = 'error'` reports negative and positive 
   })
 })
 
+test_that("num_as_location() with `missing = 'remove'` retains names (#1633)", {
+  x <- c(a = 1, b = NA, c = 2, d = NA)
+  expect_named(num_as_location(x, n = 2, missing = "remove"), c("a", "c"))
+})
+
+test_that("num_as_location() with `zero = 'remove'` retains names (#1633)", {
+  x <- c(a = 1, b = 0, c = 2, d = 0)
+  expect_named(num_as_location(x, n = 2, zero = "remove"), c("a", "c"))
+})
+
+test_that("num_as_location() with `oob = 'remove'` retains names (#1633)", {
+  x <- c(a = 1, b = 3, c = 2, d = 4)
+  expect_named(num_as_location(x, n = 2, oob = "remove"), c("a", "c"))
+})
+
+test_that("num_as_location() with `negative = 'invert'` drops names (#1633)", {
+  # The inputs don't map 1:1 to outputs
+  x <- c(a = -1, b = -3)
+  expect_named(num_as_location(x, n = 5), NULL)
+})
+
 test_that("missing values are supported in error formatters", {
   expect_snapshot({
     (expect_error(
@@ -438,6 +459,7 @@ test_that("can alter character missing value handling (#1595)", {
 
 test_that("can alter integer missing value handling (#1595)", {
   x <- c(NA, 1L, NA, 3L)
+  names(x) <- c("a", "b", "c", "d")
 
   expect_identical(
     vec_as_location(x, n = 4L, missing = "propagate"),
@@ -445,7 +467,7 @@ test_that("can alter integer missing value handling (#1595)", {
   )
   expect_identical(
     vec_as_location(x, n = 4L, missing = "remove"),
-    c(1L, 3L)
+    c(b = 1L, d = 3L)
   )
   expect_snapshot(error = TRUE, {
     vec_as_location(x, n = 4L, missing = "error")

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -418,6 +418,37 @@ test_that("can alter logical missing value handling (#1595)", {
   })
 })
 
+test_that("can alter integer missing value handling (#1595)", {
+  x <- c(NA, 1L, NA, 3L)
+
+  expect_identical(
+    vec_as_location(x, n = 4L, missing = "propagate"),
+    x
+  )
+  expect_identical(
+    vec_as_location(x, n = 4L, missing = "remove"),
+    c(1L, 3L)
+  )
+  expect_snapshot(error = TRUE, {
+    vec_as_location(x, n = 4L, missing = "error")
+  })
+})
+
+test_that("can alter negative integer missing value handling (#1595)", {
+  x <- c(-1L, NA, NA, -3L)
+
+  expect_snapshot(error = TRUE, {
+    num_as_location(x, n = 4L, missing = "propagate", negative = "invert")
+  })
+  expect_identical(
+    num_as_location(x, n = 4L, missing = "remove", negative = "invert"),
+    c(2L, 4L)
+  )
+  expect_snapshot(error = TRUE, {
+    num_as_location(x, n = 4L, missing = "error", negative = "invert")
+  })
+})
+
 test_that("can customise subscript type errors", {
   expect_snapshot({
     "With custom `arg`"

--- a/tests/testthat/test-subscript-loc.R
+++ b/tests/testthat/test-subscript-loc.R
@@ -141,6 +141,7 @@ test_that("vec_as_location() preserves names if possible", {
   expect_identical(vec_as_location(c(a = 1, b = 3), 3L), c(a = 1L, b = 3L))
   expect_identical(vec_as_location(c(a = "z", b = "y"), 26L, letters), c(a = 26L, b = 25L))
 
+  skip("Until https://github.com/r-lib/rlang/pull/1471 is merged and `rlang:::use_rlang_c_library()` is rerun.")
   expect_identical(vec_as_location(c(foo = TRUE, bar = FALSE, baz = TRUE), 3L), c(foo = 1L, baz = 3L))
   expect_identical(vec_as_location(c(foo = TRUE), 3L), c(foo = 1L, foo = 2L, foo = 3L))
   expect_identical(vec_as_location(c(foo = NA), 3L), c(foo = na_int, foo = na_int, foo = na_int))
@@ -423,19 +424,34 @@ test_that("can disallow missing values", {
 })
 
 test_that("can alter logical missing value handling (#1595)", {
-  x <- c(TRUE, NA, FALSE, NA)
+  skip("Until https://github.com/r-lib/rlang/pull/1471 is merged and `rlang:::use_rlang_c_library()` is rerun.")
+  x <- c(a = TRUE, b = NA, c = FALSE, d = NA)
 
-  expect_identical(vec_as_location(x, n = 4L, missing = "propagate"), c(1L, NA, NA))
-  expect_identical(vec_as_location(x, n = 4L, missing = "remove"), 1L)
+  expect_identical(
+    vec_as_location(x, n = 4L, missing = "propagate"),
+    c(a = 1L, b = NA, d = NA)
+  )
+  expect_identical(
+    vec_as_location(x, n = 4L, missing = "remove"),
+    c(a = 1L)
+  )
   expect_snapshot(error = TRUE, {
     vec_as_location(x, n = 4L, missing = "error")
   })
 
   # Specifically test size 1 case, which has its own special path
-  expect_identical(vec_as_location(NA, n = 2L, missing = "propagate"), c(NA_integer_, NA_integer_))
-  expect_identical(vec_as_location(NA, n = 2L, missing = "remove"), integer())
+  x <- c(a = NA)
+
+  expect_identical(
+    vec_as_location(x, n = 2L, missing = "propagate"),
+    c(a = NA_integer_, a = NA_integer_)
+  )
+  expect_identical(
+    vec_as_location(x, n = 2L, missing = "remove"),
+    named(integer())
+  )
   expect_snapshot(error = TRUE, {
-    vec_as_location(NA, n = 2L, missing = "error")
+    vec_as_location(x, n = 2L, missing = "error")
   })
 })
 


### PR DESCRIPTION
Closes #1595 
Closes #1489

Another fairly complex PR unfortunately, but I've tried to keep each commit self contained again

- I tackled #1489 while I was here, because it was staring me in the face as I modified `chr_as_location()`

- `num_as_location2()` and `vec_as_location2()` did not gain this argument. They have to select exactly 1 element so it doesn't make sense there

I'll mark some other important things inline