### PR TITLE
Early exit for `vec_in()` and `vec_matches()` when one input is empty

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -369,6 +369,19 @@ SEXP vec_match_params(SEXP needles,
                                 DF_FALLBACK_quiet,
                                 &_);
   PROTECT_N(type, &nprot);
+  // can exit early here. Following operations cannot fail:
+  // * `vec_cast()` must work
+  // * `vec_proxy_equal()`
+  // * `vec_normalize_encoding()`
+  if (vec_size(needles) == 0) {
+    UNPROTECT(nprot);
+    return vctrs_shared_empty_int;
+  }
+
+  if (vec_size(haystack) == 0) {
+    UNPROTECT(nprot);
+    return vec_recycle(vctrs_shared_na_int, vec_size(needles));
+  }
 
   needles = vec_cast_params(needles, type,
                             needles_arg, vec_args.empty,
@@ -479,6 +492,19 @@ SEXP vctrs_in(SEXP needles, SEXP haystack, SEXP na_equal_, SEXP frame) {
                                 DF_FALLBACK_quiet,
                                 &_);
   PROTECT_N(type, &nprot);
+  // can exit early here. Following operations cannot fail:
+  // * `vec_cast()` must work
+  // * `vec_proxy_equal()`
+  // * `vec_normalize_encoding()`
+  if (vec_size(needles) == 0) {
+    UNPROTECT(nprot);
+    return vctrs_shared_empty_lgl;
+  }
+
+  if (vec_size(haystack) == 0) {
+    UNPROTECT(nprot);
+    return vec_recycle(vctrs_shared_false, vec_size(needles));
+  }
 
   needles = vec_cast_params(needles, type,
                             &needles_arg, vec_args.empty,

--- a/src/utils.c
+++ b/src/utils.c
@@ -1503,6 +1503,7 @@ SEXP vctrs_shared_false = NULL;
 
 Rcomplex vctrs_shared_na_cpl;
 SEXP vctrs_shared_na_lgl = NULL;
+SEXP vctrs_shared_na_int = NULL;
 SEXP vctrs_shared_na_list = NULL;
 
 SEXP vctrs_shared_zero_int = NULL;
@@ -1828,6 +1829,9 @@ void vctrs_init_utils(SEXP ns) {
 
   vctrs_shared_na_lgl = r_new_shared_vector(LGLSXP, 1);
   LOGICAL(vctrs_shared_na_lgl)[0] = NA_LOGICAL;
+
+  vctrs_shared_na_int = r_new_shared_vector(INTSXP, 1);
+  INTEGER(vctrs_shared_na_int)[0] = NA_INTEGER;
 
   vctrs_shared_na_list = r_new_shared_vector(VECSXP, 1);
   SET_VECTOR_ELT(vctrs_shared_na_list, 0, R_NilValue);

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -243,6 +243,7 @@ extern SEXP vctrs_shared_false;
 
 extern Rcomplex vctrs_shared_na_cpl;
 extern SEXP vctrs_shared_na_lgl;
+extern SEXP vctrs_shared_na_int;
 extern SEXP vctrs_shared_na_list;
 
 SEXP vec_unspecified(R_len_t n);

--- a/tests/testthat/_snaps/dictionary.md
+++ b/tests/testthat/_snaps/dictionary.md
@@ -29,3 +29,34 @@
       Error in `vec_in()`:
       ! Can't combine `n$x$foo` <double> and `h$x$foo` <character>.
 
+# vec_match() and vec_in() work for empty vectors
+
+    Code
+      (expect_error(vctrs::vec_in(1:2, character()), class = "vctrs_error_incompatible_type")
+      )
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `vctrs::vec_in()`:
+      ! Can't combine <integer> and <character>.
+    Code
+      (expect_error(vctrs::vec_in(character(), 1:2), class = "vctrs_error_incompatible_type")
+      )
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `vctrs::vec_in()`:
+      ! Can't combine <character> and <integer>.
+    Code
+      (expect_error(vctrs::vec_match(1:2, character()), class = "vctrs_error_incompatible_type")
+      )
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `vctrs::vec_match()`:
+      ! Can't combine <integer> and <character>.
+    Code
+      (expect_error(vctrs::vec_match(character(), 1:2), class = "vctrs_error_incompatible_type")
+      )
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `vctrs::vec_match()`:
+      ! Can't combine <character> and <integer>.
+

--- a/tests/testthat/test-dictionary.R
+++ b/tests/testthat/test-dictionary.R
@@ -252,6 +252,21 @@ test_that("vec_match works with empty data frame", {
   expect_equal(out, vec_init(integer(), 3))
 })
 
+test_that("vec_match() and vec_in() work for empty vectors", {
+  expect_equal(vctrs::vec_in(1:2, integer()), c(FALSE, FALSE))
+  expect_equal(vctrs::vec_in(integer(), 1:2), logical())
+
+  expect_equal(vctrs::vec_match(1:2, integer()), c(NA_integer_, NA_integer_))
+  expect_equal(vctrs::vec_match(integer(), 1:2), integer())
+
+  expect_snapshot({
+    (expect_error(vctrs::vec_in(1:2, character()), class = "vctrs_error_incompatible_type"))
+    (expect_error(vctrs::vec_in(character(), 1:2), class = "vctrs_error_incompatible_type"))
+    (expect_error(vctrs::vec_match(1:2, character()), class = "vctrs_error_incompatible_type"))
+    (expect_error(vctrs::vec_match(character(), 1:2), class = "vctrs_error_incompatible_type"))
+  })
+})
+
 test_that("matching functions take the equality proxy (#375)", {
   local_comparable_tuple()
   x <- tuple(c(1, 2, 1), 1:3)


### PR DESCRIPTION
Closes #579.

I think this early exit is less problematic than the one in #1591.

``` r
x <- 1:10e3 + 0L

bench::mark(
  one_x = vctrs::vec_in(1L, x),
  empty_x = vctrs::vec_in(integer(), x),
  x_one = vctrs::vec_in(x, 1L),
  x_empty = vctrs::vec_in(x, integer()),
  check = FALSE
)

# Before
#> # A tibble: 4 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one_x          82µs  104.4µs     8941.    2.05MB     15.1
#> 2 empty_x      81.8µs   91.6µs     9809.  103.17KB     16.3
#> 3 x_one        38.1µs   43.8µs    20656.   78.23KB     32.5
#> 4 x_empty      31.6µs   36.4µs    24931.   78.23KB     34.5

# After
#> # A tibble: 4 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one_x       79.59µs 103.57µs     7803.    2.05MB     14.2
#> 2 empty_x      1.98µs   2.23µs   342233.        0B      0  
#> 3 x_one       38.63µs  45.63µs    18206.   78.23KB     24.9
#> 4 x_empty      4.76µs   7.63µs    90908.   39.11KB     63.7

bench::mark(
  one_x = vctrs::vec_match(1L, x),
  empty_x = vctrs::vec_match(integer(), x),
  x_one = vctrs::vec_match(x, 1L),
  x_empty = vctrs::vec_match(x, integer()),
  check = FALSE
)

# Before
#> # A tibble: 4 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one_x          81µs   89.1µs    10280.   106.8KB     21.9
#> 2 empty_x      81.2µs   88.8µs    10510.   103.2KB     18.4
#> 3 x_one        34.8µs   39.8µs    23007.    78.2KB     36.2
#> 4 x_empty      29.4µs   34.4µs    26560.    78.2KB     38.6

# After
#> # A tibble: 4 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one_x       81.26µs  90.84µs     9594.   106.8KB     21.1
#> 2 empty_x      2.02µs   2.27µs   310860.        0B      0  
#> 3 x_one       34.77µs  40.86µs    19220.    78.2KB     26.5
#> 4 x_empty      4.88µs   7.65µs    87792.    39.1KB     70.3
```

<sup>Created on 2022-08-31 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
