### PR TITLE
Implement internal `vec_interval_locate_containers()` for ivs

### DIFF
--- a/src/decl/interval-decl.h
+++ b/src/decl/interval-decl.h
@@ -23,8 +23,15 @@ r_obj* vec_interval_complement(r_obj* start,
                                r_obj* lower,
                                r_obj* upper);
 
+static
+r_obj* vec_interval_locate_containers(r_obj* start, r_obj* end);
+
 static inline
-r_obj* interval_order(r_obj* start, r_obj* end, r_ssize size);
+r_obj* interval_order(r_obj* start,
+                      r_obj* end,
+                      r_obj* direction,
+                      r_obj* na_value,
+                      r_ssize size);
 
 static inline
 enum vctrs_interval_missing parse_missing(r_obj* missing);

--- a/src/init.c
+++ b/src/init.c
@@ -144,6 +144,7 @@ extern r_obj* ffi_locate_matches(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*,
 extern r_obj* ffi_interval_groups(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_interval_locate_groups(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_interval_complement(r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_interval_locate_containers(r_obj*, r_obj*);
 extern r_obj* ffi_check_list(r_obj*, r_obj*);
 extern r_obj* ffi_list_all_vectors(r_obj*, r_obj*);
 extern r_obj* ffi_list_check_all_vectors(r_obj*, r_obj*);
@@ -314,6 +315,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"ffi_interval_groups",                   (DL_FUNC) &ffi_interval_groups, 4},
   {"ffi_interval_locate_groups",            (DL_FUNC) &ffi_interval_locate_groups, 4},
   {"ffi_interval_complement",               (DL_FUNC) &ffi_interval_complement, 4},
+  {"ffi_interval_locate_containers",        (DL_FUNC) &ffi_interval_locate_containers, 2},
   {"ffi_check_list",                        (DL_FUNC) &ffi_check_list, 2},
   {"ffi_list_all_vectors",                  (DL_FUNC) &ffi_list_all_vectors, 2},
   {"ffi_list_check_all_vectors",            (DL_FUNC) &ffi_list_check_all_vectors, 2},

--- a/tests/testthat/_snaps/interval.md
+++ b/tests/testthat/_snaps/interval.md
@@ -25,6 +25,15 @@
       Error:
       ! Can't combine `start` <double> and `end` <character>.
 
+---
+
+    Code
+      (expect_error(vec_interval_locate_containers(1, "x")))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error:
+      ! Can't combine `start` <double> and `end` <character>.
+
 # `lower` and `upper` can't contain missing values
 
     Code


### PR DESCRIPTION
Another internal vctrs function specifically for ivs. It has been very nice to be able to experiment with the C tooling of vctrs and provide internal functions that ivs can call. Once ivs is mature we can generalize the internal C level vctrs tooling so ivs can call it directly, but for now this is very useful.

To support https://github.com/DavisVaughan/ivs/pull/22