### PR TITLE
Proxy and restore recursively in concatenation operations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # vctrs (development version)
 
+* `vec_c()`, `vec_unchop()`, and `vec_rbind()` now proxy and restore
+  recursively (#1107). This prevents `vec_restore()` from being called
+  with partially filled vectors and improves performance (#1217,
+  #1496).
+
 * New `vec_any_missing()` for quickly determining if a vector has any missing
   values (#1672).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* `vec_rbind()` now applies `base::c()` fallback recursively within
+  packed df-cols (#1331, #1462, #1640).
+
 * `vec_c()`, `vec_unchop()`, and `vec_rbind()` now proxy and restore
   recursively (#1107). This prevents `vec_restore()` from being called
   with partially filled vectors and improves performance (#1217,

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -144,11 +144,6 @@ vec_proxy.default <- function(x, ...) {
   x
 }
 
-vec_proxy_recurse <- function(x, ...) {
-  check_dots_empty0(...)
-  .Call(ffi_vec_proxy_recurse, x)
-}
-
 #' @rdname vec_proxy
 #' @param to The original vector to restore to.
 #' @export
@@ -166,6 +161,15 @@ vec_restore.default <- function(x, to, ...) {
 }
 vec_restore_default <- function(x, to, ...) {
   .Call(ffi_vec_restore_default, x, to)
+}
+
+vec_proxy_recurse <- function(x, ...) {
+  check_dots_empty0(...)
+  .Call(ffi_vec_proxy_recurse, x)
+}
+vec_restore_recurse <- function(x, to, ...) {
+  check_dots_empty0(...)
+  .Call(ffi_vec_restore_recurse, x, to)
 }
 
 #' Extract underlying data

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -136,12 +136,17 @@
 #' @export
 vec_proxy <- function(x, ...) {
   check_dots_empty0(...)
-  return(.Call(vctrs_proxy, x))
+  return(.Call(ffi_vec_proxy, x))
   UseMethod("vec_proxy")
 }
 #' @export
 vec_proxy.default <- function(x, ...) {
   x
+}
+
+vec_proxy_recurse <- function(x, ...) {
+  check_dots_empty0(...)
+  .Call(ffi_vec_proxy_recurse, x)
 }
 
 #' @rdname vec_proxy

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -135,8 +135,8 @@
 #' @keywords internal
 #' @export
 vec_proxy <- function(x, ...) {
-  recurse <- match_recurse(...)
-  return(.Call(ffi_vec_proxy, x, recurse))
+  check_dots_empty0(...)
+  return(.Call(ffi_vec_proxy, x))
   UseMethod("vec_proxy")
 }
 #' @export
@@ -148,8 +148,8 @@ vec_proxy.default <- function(x, ...) {
 #' @param to The original vector to restore to.
 #' @export
 vec_restore <- function(x, to, ...) {
-  recurse <- match_recurse(...)
-  return(.Call(ffi_vec_restore, x, to, recurse))
+  check_dots_empty0(...)
+  return(.Call(ffi_vec_restore, x, to))
   UseMethod("vec_restore", to)
 }
 vec_restore_dispatch <- function(x, to, ...) {
@@ -163,16 +163,11 @@ vec_restore_default <- function(x, to, ...) {
   .Call(ffi_vec_restore_default, x, to)
 }
 
-match_recurse <- function(..., recurse = FALSE) {
-  check_dots_empty0(..., call = caller_env())
-  recurse
-}
-
 vec_proxy_recurse <- function(x, ...) {
-  vec_proxy(x, ..., recurse = TRUE)
+  .Call(ffi_vec_proxy_recurse, x)
 }
 vec_restore_recurse <- function(x, to, ...) {
-  vec_restore(x, to, ..., recurse = TRUE)
+  .Call(ffi_vec_restore_recurse, x, to)
 }
 
 #' Extract underlying data

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -135,8 +135,8 @@
 #' @keywords internal
 #' @export
 vec_proxy <- function(x, ...) {
-  check_dots_empty0(...)
-  return(.Call(ffi_vec_proxy, x))
+  recurse <- match_recurse(...)
+  return(.Call(ffi_vec_proxy, x, recurse))
   UseMethod("vec_proxy")
 }
 #' @export
@@ -148,8 +148,8 @@ vec_proxy.default <- function(x, ...) {
 #' @param to The original vector to restore to.
 #' @export
 vec_restore <- function(x, to, ...) {
-  check_dots_empty0(...)
-  return(.Call(ffi_vec_restore, x, to))
+  recurse <- match_recurse(...)
+  return(.Call(ffi_vec_restore, x, to, recurse))
   UseMethod("vec_restore", to)
 }
 vec_restore_dispatch <- function(x, to, ...) {
@@ -163,13 +163,16 @@ vec_restore_default <- function(x, to, ...) {
   .Call(ffi_vec_restore_default, x, to)
 }
 
+match_recurse <- function(..., recurse = FALSE) {
+  check_dots_empty0(..., call = caller_env())
+  recurse
+}
+
 vec_proxy_recurse <- function(x, ...) {
-  check_dots_empty0(...)
-  .Call(ffi_vec_proxy_recurse, x)
+  vec_proxy(x, ..., recurse = TRUE)
 }
 vec_restore_recurse <- function(x, to, ...) {
-  check_dots_empty0(...)
-  .Call(ffi_vec_restore_recurse, x, to)
+  vec_restore(x, to, ..., recurse = TRUE)
 }
 
 #' Extract underlying data

--- a/R/utils.R
+++ b/R/utils.R
@@ -328,3 +328,8 @@ browser <- function(...,
   # contexts.
   on.exit(base::browser(..., skipCalls = skipCalls + 1))
 }
+
+vec_paste0 <- function(...) {
+  args <- vec_recycle_common(...)
+  exec(paste0, !!!args)
+}

--- a/src/bind.c
+++ b/src/bind.c
@@ -248,9 +248,7 @@ r_obj* vec_rbind(r_obj* xs,
   }
 
   // Not optimal. Happens after the fallback columns have been
-  // assigned already, ideally they should be ignored. Also this is
-  // currently not recursive. Should we deal with this during
-  // restoration?
+  // assigned already, ideally they should be ignored.
   df_c_fallback(out, ptype, xs, n_rows, name_spec, name_repair);
 
   out = vec_restore_recurse(out, ptype, VCTRS_OWNED_true);

--- a/src/bind.c
+++ b/src/bind.c
@@ -277,7 +277,7 @@ void df_c_fallback(r_obj* out,
     r_obj* ptype_col = r_list_get(ptype, i);
 
     // Recurse into df-cols
-    if (is_data_frame(ptype_col)) {
+    if (is_data_frame(ptype_col) && df_needs_fallback(ptype_col)) {
       r_obj* xs_col = KEEP(list_pluck(xs, i));
       r_obj* out_col = r_list_get(out, i);
       df_c_fallback(out_col, ptype_col, xs_col, n_rows, name_spec, name_repair);
@@ -300,6 +300,25 @@ void df_c_fallback(r_obj* out,
       FREE(1);
     }
   }
+}
+
+static
+bool df_needs_fallback(r_obj* x) {
+  r_ssize n_cols = r_length(x);
+  r_obj* const * v_x = r_list_cbegin(x);
+
+  for (r_ssize i = 0; i < n_cols; ++i) {
+    r_obj* col = v_x[i];
+
+    if (vec_is_common_class_fallback(col)) {
+      return true;
+    }
+    if (is_data_frame(col) && df_needs_fallback(col)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -295,7 +295,7 @@ void df_c_fallback(r_obj* out,
 
       // Remove fallback vector from the ptype so it doesn't get in
       // the way of restoration later on
-      r_list_poke(ptype, i, vec_slice(out_col, r_null));
+      r_list_poke(ptype, i, vec_ptype_final(out_col));
 
       FREE(1);
     }

--- a/src/bind.c
+++ b/src/bind.c
@@ -275,15 +275,15 @@ void df_c_fallback(r_obj* out,
 
   for (r_ssize i = 0; i < n_cols; ++i) {
     r_obj* ptype_col = r_list_get(ptype, i);
-    r_obj* xs_col = KEEP(list_pluck(xs, i));
 
     // Recurse into df-cols
     if (is_data_frame(ptype_col)) {
+      r_obj* xs_col = KEEP(list_pluck(xs, i));
       r_obj* out_col = r_list_get(out, i);
       df_c_fallback(out_col, ptype_col, xs_col, n_rows, name_spec, name_repair);
-    }
-
-    if (vec_is_common_class_fallback(ptype_col)) {
+      FREE(1);
+    } else if (vec_is_common_class_fallback(ptype_col)) {
+      r_obj* xs_col = KEEP(list_pluck(xs, i));
       r_obj* out_col = vec_c_fallback(ptype_col, xs_col, name_spec, name_repair);
       r_list_poke(out, i, out_col);
 
@@ -296,9 +296,9 @@ void df_c_fallback(r_obj* out,
       // Remove fallback vector from the ptype so it doesn't get in
       // the way of restoration later on
       r_list_poke(ptype, i, vec_slice(out_col, r_null));
-    }
 
-    FREE(1);
+      FREE(1);
+    }
   }
 }
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -251,22 +251,59 @@ r_obj* vec_rbind(r_obj* xs,
   // assigned already, ideally they should be ignored. Also this is
   // currently not recursive. Should we deal with this during
   // restoration?
-  for (r_ssize i = 0; i < n_cols; ++i) {
-    r_obj* col = r_list_get(ptype, i);
-
-    if (vec_is_common_class_fallback(col)) {
-      r_obj* col_xs = KEEP(list_pluck(xs, i));
-      r_obj* col_out = vec_c_fallback(col, col_xs, name_spec, name_repair);
-      r_list_poke(out, i, col_out);
-      FREE(1);
-    }
-  }
+  df_c_fallback(out, ptype, xs, n_rows, name_spec, name_repair);
 
   out = vec_restore_recurse(out, ptype, VCTRS_OWNED_true);
 
   FREE(n_prot);
   return out;
 }
+
+// `ptype` contains fallback information
+static
+void df_c_fallback(r_obj* out,
+                   r_obj* ptype,
+                   r_obj* xs,
+                   r_ssize n_rows,
+                   r_obj* name_spec,
+                   struct name_repair_opts* name_repair) {
+  r_ssize n_cols = r_length(out);
+
+  if (r_length(ptype) != n_cols ||
+      r_typeof(out) != R_TYPE_list ||
+      r_typeof(ptype) != R_TYPE_list) {
+    r_stop_internal("`ptype` and `out` must be lists of the same length.");
+  }
+
+  for (r_ssize i = 0; i < n_cols; ++i) {
+    r_obj* ptype_col = r_list_get(ptype, i);
+    r_obj* xs_col = KEEP(list_pluck(xs, i));
+
+    // Recurse into df-cols
+    if (is_data_frame(ptype_col)) {
+      r_obj* out_col = r_list_get(out, i);
+      df_c_fallback(out_col, ptype_col, xs_col, n_rows, name_spec, name_repair);
+    }
+
+    if (vec_is_common_class_fallback(ptype_col)) {
+      r_obj* out_col = vec_c_fallback(ptype_col, xs_col, name_spec, name_repair);
+      r_list_poke(out, i, out_col);
+
+      if (vec_size(out_col) != n_rows) {
+        r_stop_internal("`c()` method returned a vector of unexpected size %d instead of %d.",
+                        vec_size(out_col),
+                        n_rows);
+      }
+
+      // Remove fallback vector from the ptype so it doesn't get in
+      // the way of restoration later on
+      r_list_poke(ptype, i, vec_slice(out_col, r_null));
+    }
+
+    FREE(1);
+  }
+}
+
 
 static
 r_obj* as_df_row(r_obj* x,

--- a/src/bind.c
+++ b/src/bind.c
@@ -137,7 +137,7 @@ r_obj* vec_rbind(r_obj* xs,
     ns[i] = size;
   }
 
-  r_obj* proxy = KEEP_N(vec_proxy(ptype), &n_prot);
+  r_obj* proxy = KEEP_N(vec_proxy_recurse(ptype), &n_prot);
   if (!is_data_frame(proxy)) {
     r_abort_lazy_call(error_call, "Can't fill a data frame that doesn't have a data frame proxy.");
   }
@@ -190,6 +190,7 @@ r_obj* vec_rbind(r_obj* xs,
   r_ssize counter = 0;
 
   const struct vec_assign_opts bind_assign_opts = {
+    .recursive = true,
     .assign_names = assign_names,
     // Unlike in `vec_c()` we don't need to ignore outer names because
     // `df_assign()` doesn't deal with those
@@ -261,7 +262,7 @@ r_obj* vec_rbind(r_obj* xs,
     }
   }
 
-  out = vec_restore(out, ptype, VCTRS_OWNED_true);
+  out = vec_restore_recurse(out, ptype, VCTRS_OWNED_true);
 
   FREE(n_prot);
   return out;

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -86,7 +86,7 @@ r_obj* list_unchop(r_obj* xs,
 
   r_obj* locs = KEEP(vec_as_indices(indices, out_size, r_null));
 
-  r_obj* proxy = vec_proxy(ptype);
+  r_obj* proxy = vec_proxy_recurse(ptype);
   r_keep_loc proxy_pi;
   KEEP_HERE(proxy, &proxy_pi);
 
@@ -98,6 +98,7 @@ r_obj* list_unchop(r_obj* xs,
   KEEP_HERE(out_names, &out_names_pi);
 
   const struct vec_assign_opts unchop_assign_opts = {
+    .recursive = true,
     .assign_names = assign_names,
     .ignore_outer_names = true
   };
@@ -136,7 +137,7 @@ r_obj* list_unchop(r_obj* xs,
     KEEP_AT(proxy, proxy_pi);
   }
 
-  r_obj* out = KEEP(vec_restore(proxy, ptype, VCTRS_OWNED_true));
+  r_obj* out = KEEP(vec_restore_recurse(proxy, ptype, VCTRS_OWNED_true));
 
   if (out_names != r_null) {
     out_names = KEEP(vec_as_names(out_names, name_repair));

--- a/src/c.c
+++ b/src/c.c
@@ -77,7 +77,7 @@ r_obj* vec_c_opts(r_obj* xs,
   r_keep_loc out_pi;
   KEEP_HERE(out, &out_pi);
 
-  out = vec_proxy(out);
+  out = vec_proxy_recurse(out);
   KEEP_AT(out, out_pi);
 
   r_obj* loc = KEEP(compact_seq(0, 0, true));
@@ -95,6 +95,7 @@ r_obj* vec_c_opts(r_obj* xs,
   r_ssize counter = 0;
 
   const struct vec_assign_opts c_assign_opts = {
+    .recursive = true,
     .assign_names = assign_names,
     .ignore_outer_names = true
   };
@@ -143,7 +144,7 @@ r_obj* vec_c_opts(r_obj* xs,
     FREE(1);
   }
 
-  out = KEEP(vec_restore(out, ptype, VCTRS_OWNED_true));
+  out = KEEP(vec_restore_recurse(out, ptype, VCTRS_OWNED_true));
 
   if (out_names != r_null) {
     out_names = KEEP(vec_as_names(out_names, name_repair));

--- a/src/decl/bind-decl.h
+++ b/src/decl/bind-decl.h
@@ -49,3 +49,11 @@ r_obj* shaped_as_df_col(r_obj* x, r_obj* outer);
 
 static
 r_obj* vec_as_df_col(r_obj* x, r_obj* outer);
+
+static
+void df_c_fallback(r_obj* out,
+                   r_obj* ptype,
+                   r_obj* xs,
+                   r_ssize n_rows,
+                   r_obj* name_spec,
+                   struct name_repair_opts* name_repair);

--- a/src/decl/bind-decl.h
+++ b/src/decl/bind-decl.h
@@ -57,3 +57,6 @@ void df_c_fallback(r_obj* out,
                    r_ssize n_rows,
                    r_obj* name_spec,
                    struct name_repair_opts* name_repair);
+
+static
+bool df_needs_fallback(r_obj* x);

--- a/src/decl/proxy-decl.h
+++ b/src/decl/proxy-decl.h
@@ -10,6 +10,9 @@ r_obj* fns_vec_proxy_equal_array;
 r_obj* fns_vec_proxy_compare_array;
 r_obj* fns_vec_proxy_order_array;
 
+static
+r_obj* vec_proxy_2(r_obj* x, bool recurse);
+
 static inline
 r_obj* vec_proxy_equal_impl(r_obj* x);
 static inline
@@ -37,3 +40,6 @@ r_obj* vec_proxy_order_invoke(r_obj* x, r_obj* method);
 
 static inline
 r_obj* df_proxy(r_obj* x, enum vctrs_proxy_kind kind);
+
+static inline
+r_obj* df_proxy_recurse(r_obj* x);

--- a/src/decl/proxy-decl.h
+++ b/src/decl/proxy-decl.h
@@ -11,7 +11,7 @@ r_obj* fns_vec_proxy_compare_array;
 r_obj* fns_vec_proxy_order_array;
 
 static
-r_obj* vec_proxy_2(r_obj* x, bool recurse);
+r_obj* vec_proxy_2(r_obj* x, enum vctrs_recurse recurse);
 
 static inline
 r_obj* vec_proxy_equal_impl(r_obj* x);

--- a/src/decl/proxy-restore-decl.h
+++ b/src/decl/proxy-restore-decl.h
@@ -2,4 +2,10 @@ static r_obj* syms_vec_restore_dispatch;
 static r_obj* fns_vec_restore_dispatch;
 
 static
+r_obj* vec_restore_4(r_obj* x,
+                     r_obj* to,
+                     const enum vctrs_owned owned,
+                     bool recurse);
+
+static
 r_obj* vec_restore_dispatch(r_obj* x, r_obj* to);

--- a/src/decl/proxy-restore-decl.h
+++ b/src/decl/proxy-restore-decl.h
@@ -8,4 +8,4 @@ r_obj* vec_restore_4(r_obj* x,
                      bool recurse);
 
 static
-r_obj* vec_restore_dispatch(r_obj* x, r_obj* to, bool recurse);
+r_obj* vec_restore_dispatch(r_obj* x, r_obj* to);

--- a/src/decl/proxy-restore-decl.h
+++ b/src/decl/proxy-restore-decl.h
@@ -4,8 +4,8 @@ static r_obj* fns_vec_restore_dispatch;
 static
 r_obj* vec_restore_4(r_obj* x,
                      r_obj* to,
-                     const enum vctrs_owned owned,
-                     bool recurse);
+                     enum vctrs_owned owned,
+                     enum vctrs_recurse recurse);
 
 static
 r_obj* vec_restore_dispatch(r_obj* x, r_obj* to);

--- a/src/decl/proxy-restore-decl.h
+++ b/src/decl/proxy-restore-decl.h
@@ -8,4 +8,4 @@ r_obj* vec_restore_4(r_obj* x,
                      bool recurse);
 
 static
-r_obj* vec_restore_dispatch(r_obj* x, r_obj* to);
+r_obj* vec_restore_dispatch(r_obj* x, r_obj* to, bool recurse);

--- a/src/decl/ptype-decl.h
+++ b/src/decl/ptype-decl.h
@@ -32,3 +32,9 @@ r_obj* vec_ptype_finalise_unspecified(r_obj* x);
 
 static
 r_obj* vec_ptype_finalise_dispatch(r_obj* x);
+
+static
+r_obj* vec_ptype_final_call;
+
+static
+struct r_lazy vec_ptype_final_lazy_call;

--- a/src/decl/type-info-decl.h
+++ b/src/decl/type-info-decl.h
@@ -6,7 +6,3 @@ r_obj* fns_vec_is_vector_dispatch;
 
 static
 enum vctrs_type vec_base_typeof(r_obj* x, bool proxied);
-
-// From proxy.c
-r_obj* vec_proxy_method(r_obj* x);
-r_obj* vec_proxy_invoke(r_obj* x, r_obj* method);

--- a/src/globals.c
+++ b/src/globals.c
@@ -54,6 +54,7 @@ void vctrs_init_globals(r_obj* ns) {
   syms.dot_error_call = r_sym(".error_call");
   syms.haystack_arg = r_sym("haystack_arg");
   syms.needles_arg = r_sym("needles_arg");
+  syms.recurse = r_sym("recurse");
   syms.repair_arg = r_sym("repair_arg");
   syms.times_arg = r_sym("times_arg");
   syms.to_arg = r_sym("to_arg");

--- a/src/globals.h
+++ b/src/globals.h
@@ -11,6 +11,7 @@ struct syms {
   r_obj* dot_error_call;
   r_obj* haystack_arg;
   r_obj* needles_arg;
+  r_obj* recurse;
   r_obj* repair_arg;
   r_obj* times_arg;
   r_obj* to_arg;

--- a/src/init.c
+++ b/src/init.c
@@ -55,7 +55,8 @@ extern r_obj* ffi_slice_seq(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_slice_rep(r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_vec_restore(r_obj*, r_obj*);
 extern r_obj* ffi_vec_restore_default(r_obj*, r_obj*);
-extern SEXP vec_proxy(SEXP);
+extern r_obj* vec_proxy(r_obj*);
+extern r_obj* vec_proxy_recurse(r_obj*);
 extern SEXP vec_proxy_equal(SEXP);
 extern SEXP vec_proxy_compare(SEXP);
 extern SEXP vec_proxy_order(SEXP);
@@ -224,7 +225,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"ffi_slice_rep",                         (DL_FUNC) &ffi_slice_rep, 3},
   {"ffi_vec_restore",                       (DL_FUNC) &ffi_vec_restore, 2},
   {"ffi_vec_restore_default",               (DL_FUNC) &ffi_vec_restore_default, 2},
-  {"vctrs_proxy",                           (DL_FUNC) &vec_proxy, 1},
+  {"ffi_vec_proxy",                         (DL_FUNC) &vec_proxy, 1},
+  {"ffi_vec_proxy_recurse",                 (DL_FUNC) &vec_proxy_recurse, 1},
   {"vctrs_proxy_equal",                     (DL_FUNC) &vec_proxy_equal, 1},
   {"vctrs_proxy_compare",                   (DL_FUNC) &vec_proxy_compare, 1},
   {"vctrs_proxy_order",                     (DL_FUNC) &vec_proxy_order, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -53,9 +53,9 @@ extern r_obj* ffi_list_unchop(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_chop_seq(SEXP, SEXP, SEXP, SEXP);
 extern r_obj* ffi_slice_seq(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_slice_rep(r_obj*, r_obj*, r_obj*);
-extern r_obj* ffi_vec_restore(r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_vec_restore(r_obj*, r_obj*);
+extern r_obj* ffi_vec_restore_recurse(r_obj*, r_obj*);
 extern r_obj* ffi_vec_restore_default(r_obj*, r_obj*);
-extern r_obj* ffi_vec_proxy(r_obj*, r_obj*);
 extern SEXP vec_proxy_equal(SEXP);
 extern SEXP vec_proxy_compare(SEXP);
 extern SEXP vec_proxy_order(SEXP);
@@ -222,9 +222,11 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_chop_seq",                        (DL_FUNC) &vctrs_chop_seq, 4},
   {"ffi_slice_seq",                         (DL_FUNC) &ffi_slice_seq, 4},
   {"ffi_slice_rep",                         (DL_FUNC) &ffi_slice_rep, 3},
-  {"ffi_vec_restore",                       (DL_FUNC) &ffi_vec_restore, 3},
+  {"ffi_vec_restore",                       (DL_FUNC) &ffi_vec_restore, 2},
+  {"ffi_vec_restore_recurse",               (DL_FUNC) &ffi_vec_restore_recurse, 2},
   {"ffi_vec_restore_default",               (DL_FUNC) &ffi_vec_restore_default, 2},
-  {"ffi_vec_proxy",                         (DL_FUNC) &ffi_vec_proxy, 2},
+  {"ffi_vec_proxy",                         (DL_FUNC) &vec_proxy, 1},
+  {"ffi_vec_proxy_recurse",                 (DL_FUNC) &vec_proxy_recurse, 1},
   {"vctrs_proxy_equal",                     (DL_FUNC) &vec_proxy_equal, 1},
   {"vctrs_proxy_compare",                   (DL_FUNC) &vec_proxy_compare, 1},
   {"vctrs_proxy_order",                     (DL_FUNC) &vec_proxy_order, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -53,11 +53,9 @@ extern r_obj* ffi_list_unchop(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_chop_seq(SEXP, SEXP, SEXP, SEXP);
 extern r_obj* ffi_slice_seq(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_slice_rep(r_obj*, r_obj*, r_obj*);
-extern r_obj* ffi_vec_restore(r_obj*, r_obj*);
+extern r_obj* ffi_vec_restore(r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_vec_restore_default(r_obj*, r_obj*);
-extern r_obj* ffi_vec_restore_recurse(r_obj*, r_obj*);
-extern r_obj* vec_proxy(r_obj*);
-extern r_obj* vec_proxy_recurse(r_obj*);
+extern r_obj* ffi_vec_proxy(r_obj*, r_obj*);
 extern SEXP vec_proxy_equal(SEXP);
 extern SEXP vec_proxy_compare(SEXP);
 extern SEXP vec_proxy_order(SEXP);
@@ -224,11 +222,9 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_chop_seq",                        (DL_FUNC) &vctrs_chop_seq, 4},
   {"ffi_slice_seq",                         (DL_FUNC) &ffi_slice_seq, 4},
   {"ffi_slice_rep",                         (DL_FUNC) &ffi_slice_rep, 3},
-  {"ffi_vec_restore",                       (DL_FUNC) &ffi_vec_restore, 2},
+  {"ffi_vec_restore",                       (DL_FUNC) &ffi_vec_restore, 3},
   {"ffi_vec_restore_default",               (DL_FUNC) &ffi_vec_restore_default, 2},
-  {"ffi_vec_restore_recurse",               (DL_FUNC) &ffi_vec_restore_recurse, 2},
-  {"ffi_vec_proxy",                         (DL_FUNC) &vec_proxy, 1},
-  {"ffi_vec_proxy_recurse",                 (DL_FUNC) &vec_proxy_recurse, 1},
+  {"ffi_vec_proxy",                         (DL_FUNC) &ffi_vec_proxy, 2},
   {"vctrs_proxy_equal",                     (DL_FUNC) &vec_proxy_equal, 1},
   {"vctrs_proxy_compare",                   (DL_FUNC) &vec_proxy_compare, 1},
   {"vctrs_proxy_order",                     (DL_FUNC) &vec_proxy_order, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -55,6 +55,7 @@ extern r_obj* ffi_slice_seq(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_slice_rep(r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_vec_restore(r_obj*, r_obj*);
 extern r_obj* ffi_vec_restore_default(r_obj*, r_obj*);
+extern r_obj* ffi_vec_restore_recurse(r_obj*, r_obj*);
 extern r_obj* vec_proxy(r_obj*);
 extern r_obj* vec_proxy_recurse(r_obj*);
 extern SEXP vec_proxy_equal(SEXP);
@@ -225,6 +226,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"ffi_slice_rep",                         (DL_FUNC) &ffi_slice_rep, 3},
   {"ffi_vec_restore",                       (DL_FUNC) &ffi_vec_restore, 2},
   {"ffi_vec_restore_default",               (DL_FUNC) &ffi_vec_restore_default, 2},
+  {"ffi_vec_restore_recurse",               (DL_FUNC) &ffi_vec_restore_recurse, 2},
   {"ffi_vec_proxy",                         (DL_FUNC) &vec_proxy, 1},
   {"ffi_vec_proxy_recurse",                 (DL_FUNC) &vec_proxy_recurse, 1},
   {"vctrs_proxy_equal",                     (DL_FUNC) &vec_proxy_equal, 1},

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -30,10 +30,6 @@ r_obj* vec_restore_4(r_obj* x,
                      enum vctrs_recurse recurse) {
   enum vctrs_class_type to_type = class_type(to);
 
-  if (recurse && !class_type_is_data_frame(to_type) && is_data_frame(x)) {
-    return vec_df_restore(x, to, owned, recurse);
-  }
-
   switch (to_type) {
   case VCTRS_CLASS_bare_factor:
   case VCTRS_CLASS_bare_ordered:
@@ -44,7 +40,12 @@ r_obj* vec_restore_4(r_obj* x,
   case VCTRS_CLASS_bare_data_frame:
   case VCTRS_CLASS_bare_tibble: return vec_bare_df_restore(x, to, owned, recurse);
   case VCTRS_CLASS_data_frame: return vec_df_restore(x, to, owned, recurse);
-  default: return vec_restore_dispatch(x, to);
+  default:
+    if (recurse && is_data_frame(x)) {
+      return vec_df_restore(x, to, owned, recurse);
+    } else {
+      return vec_restore_dispatch(x, to);
+    }
   }
 }
 

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -10,17 +10,17 @@
 // call `vec_clone_referenced()`, which won't attempt to clone if we know we
 // own the object. See #1151.
 r_obj* vec_restore(r_obj* x, r_obj* to, const enum vctrs_owned owned) {
-  return vec_restore_4(x, to, owned, false);
+  return vec_restore_4(x, to, owned, VCTRS_RECURSE_false);
 }
 r_obj* vec_restore_recurse(r_obj* x, r_obj* to, const enum vctrs_owned owned) {
-  return vec_restore_4(x, to, owned, true);
+  return vec_restore_4(x, to, owned, VCTRS_RECURSE_true);
 }
 
 r_obj* ffi_vec_restore(r_obj* x, r_obj* to) {
-  return vec_restore_4(x, to, vec_owned(x), false);
+  return vec_restore_4(x, to, vec_owned(x), VCTRS_RECURSE_false);
 }
 r_obj* ffi_vec_restore_recurse(r_obj* x, r_obj* to) {
-  return vec_restore_4(x, to, vec_owned(x), true);
+  return vec_restore_4(x, to, vec_owned(x), VCTRS_RECURSE_true);
 }
 
 static
@@ -162,8 +162,8 @@ r_obj* ffi_vec_restore_default(r_obj* x, r_obj* to) {
 
 r_obj* vec_df_restore(r_obj* x,
                       r_obj* to,
-                      const enum vctrs_owned owned,
-                      bool recurse) {
+                      enum vctrs_owned owned,
+                      enum vctrs_recurse recurse) {
   r_obj* out = KEEP(vec_bare_df_restore(x, to, owned, recurse));
   out = vec_restore_dispatch(out, to);
   FREE(1);
@@ -173,7 +173,7 @@ r_obj* vec_df_restore(r_obj* x,
 r_obj* vec_bare_df_restore(r_obj* x,
                            r_obj* to,
                            const enum vctrs_owned owned,
-                           bool recurse) {
+                           enum vctrs_recurse recurse) {
   if (r_typeof(x) != R_TYPE_list) {
     r_stop_internal("Attempt to restore data frame from a %s.",
                     r_type_as_c_string(r_typeof(x)));

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -37,11 +37,7 @@ r_obj* vec_restore_4(r_obj* x,
 }
 
 r_obj* ffi_vec_restore(r_obj* x, r_obj* to, r_obj* recurse) {
-  if (r_lgl_get(recurse, 0)) {
-    return vec_restore_recurse(x, to, vec_owned(x));
-  } else {
-    return vec_restore(x, to, vec_owned(x));
-  }
+  return vec_restore_4(x, to, vec_owned(x), r_as_bool(recurse));
 }
 r_obj* ffi_vec_restore_recurse(r_obj* x, r_obj* to) {
   return vec_restore_recurse(x, to, vec_owned(x));

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -9,25 +9,25 @@
 // causing duplication to occur. Passing `owned` through here allows us to
 // call `vec_clone_referenced()`, which won't attempt to clone if we know we
 // own the object. See #1151.
-r_obj* vec_restore(r_obj* x, r_obj* to, const enum vctrs_owned owned) {
+r_obj* vec_restore(r_obj* x, r_obj* to, enum vctrs_owned owned) {
   return vec_restore_4(x, to, owned, VCTRS_RECURSE_false);
 }
-r_obj* vec_restore_recurse(r_obj* x, r_obj* to, const enum vctrs_owned owned) {
+r_obj* vec_restore_recurse(r_obj* x, r_obj* to, enum vctrs_owned owned) {
   return vec_restore_4(x, to, owned, VCTRS_RECURSE_true);
 }
 
 r_obj* ffi_vec_restore(r_obj* x, r_obj* to) {
-  return vec_restore_4(x, to, vec_owned(x), VCTRS_RECURSE_false);
+  return vec_restore(x, to, vec_owned(x));
 }
 r_obj* ffi_vec_restore_recurse(r_obj* x, r_obj* to) {
-  return vec_restore_4(x, to, vec_owned(x), VCTRS_RECURSE_true);
+  return vec_restore_recurse(x, to, vec_owned(x));
 }
 
 static
 r_obj* vec_restore_4(r_obj* x,
                      r_obj* to,
-                     const enum vctrs_owned owned,
-                     bool recurse) {
+                     enum vctrs_owned owned,
+                     enum vctrs_recurse recurse) {
   enum vctrs_class_type to_type = class_type(to);
 
   if (recurse && !class_type_is_data_frame(to_type) && is_data_frame(x)) {
@@ -58,7 +58,7 @@ r_obj* vec_restore_dispatch(r_obj* x, r_obj* to) {
 
 
 // Copy attributes except names and dim. This duplicates `x` if needed.
-r_obj* vec_restore_default(r_obj* x, r_obj* to, const enum vctrs_owned owned) {
+r_obj* vec_restore_default(r_obj* x, r_obj* to, enum vctrs_owned owned) {
   r_obj* attrib = r_attrib(to);
 
   const bool is_s4 = IS_S4_OBJECT(to);
@@ -172,7 +172,7 @@ r_obj* vec_df_restore(r_obj* x,
 
 r_obj* vec_bare_df_restore(r_obj* x,
                            r_obj* to,
-                           const enum vctrs_owned owned,
+                           enum vctrs_owned owned,
                            enum vctrs_recurse recurse) {
   if (r_typeof(x) != R_TYPE_list) {
     r_stop_internal("Attempt to restore data frame from a %s.",
@@ -228,7 +228,10 @@ r_obj* vec_bare_df_restore(r_obj* x,
 }
 
 r_obj* ffi_vec_bare_df_restore(r_obj* x, r_obj* to) {
-  return vec_bare_df_restore(x, to, vec_owned(x), false);
+  return vec_bare_df_restore(x,
+                             to,
+                             vec_owned(x),
+                             VCTRS_RECURSE_false);
 }
 
 

--- a/src/proxy-restore.c
+++ b/src/proxy-restore.c
@@ -186,10 +186,11 @@ r_obj* vec_bare_df_restore(r_obj* x,
       r_stop_internal("Shape of `x` doesn't match `to` in recursive df restoration.");
     };
 
+    r_obj* const * v_x = r_list_cbegin(x);
+    r_obj* const * v_to = r_list_cbegin(to);
+
     for (r_ssize i = 0; i < n_cols; ++i) {
-      r_obj* x_col = r_list_get(x, i);
-      r_obj* to_col = r_list_get(to, i);
-      r_obj* x_restored = vec_restore_recurse(x_col, to_col, owned);
+      r_obj* x_restored = vec_restore_recurse(v_x[i], v_to[i], owned);
       r_list_poke(x, i, x_restored);
     }
   }

--- a/src/proxy-restore.h
+++ b/src/proxy-restore.h
@@ -7,8 +7,17 @@
 r_obj* vec_restore(r_obj* x, r_obj* to, const enum vctrs_owned owned);
 r_obj* vec_restore_default(r_obj* x, r_obj* to, const enum vctrs_owned owned);
 
-r_obj* vec_bare_df_restore(r_obj* x, r_obj* to, const enum vctrs_owned owned);
-r_obj* vec_df_restore(r_obj* x, r_obj* to, const enum vctrs_owned owned);
+r_obj* vec_restore_recurse(r_obj* x, r_obj* to, const enum vctrs_owned owned);
+
+r_obj* vec_df_restore(r_obj* x,
+                      r_obj* to,
+                      const enum vctrs_owned owned,
+                      bool recurse);
+
+r_obj* vec_bare_df_restore(r_obj* x,
+                           r_obj* to,
+                           const enum vctrs_owned owned,
+                           bool recurse);
 
 
 #endif

--- a/src/proxy-restore.h
+++ b/src/proxy-restore.h
@@ -4,20 +4,20 @@
 #include "vctrs-core.h"
 
 
-r_obj* vec_restore(r_obj* x, r_obj* to, const enum vctrs_owned owned);
-r_obj* vec_restore_default(r_obj* x, r_obj* to, const enum vctrs_owned owned);
+r_obj* vec_restore(r_obj* x, r_obj* to, enum vctrs_owned owned);
+r_obj* vec_restore_default(r_obj* x, r_obj* to, enum vctrs_owned owned);
 
-r_obj* vec_restore_recurse(r_obj* x, r_obj* to, const enum vctrs_owned owned);
+r_obj* vec_restore_recurse(r_obj* x, r_obj* to, enum vctrs_owned owned);
 
 r_obj* vec_df_restore(r_obj* x,
                       r_obj* to,
-                      const enum vctrs_owned owned,
-                      bool recurse);
+                      enum vctrs_owned owned,
+                      enum vctrs_recurse recurse);
 
 r_obj* vec_bare_df_restore(r_obj* x,
                            r_obj* to,
-                           const enum vctrs_owned owned,
-                           bool recurse);
+                           enum vctrs_owned owned,
+                           enum vctrs_recurse recurse);
 
 
 #endif

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -11,11 +11,7 @@ r_obj* vec_proxy_recurse(r_obj* x) {
 }
 
 r_obj* ffi_vec_proxy(r_obj* x, r_obj* recurse) {
-  if (r_as_bool(recurse)) {
-    return vec_proxy_2(x, true);
-  } else {
-    return vec_proxy_2(x, false);
-  }
+  return vec_proxy_2(x, r_as_bool(recurse));
 }
 
 static

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -4,10 +4,10 @@
 
 
 r_obj* vec_proxy(r_obj* x) {
-  return vec_proxy_2(x, false);
+  return vec_proxy_2(x, VCTRS_RECURSE_false);
 }
 r_obj* vec_proxy_recurse(r_obj* x) {
-  return vec_proxy_2(x, true);
+  return vec_proxy_2(x, VCTRS_RECURSE_true);
 }
 
 static

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -26,15 +26,8 @@ r_obj* vec_proxy_2(r_obj* x, bool recurse) {
   }
 
   case VCTRS_TYPE_s3: {
-    r_obj* out = KEEP(vec_proxy_invoke(x, info.proxy_method));
-    if (!is_data_frame(out)) {
-      FREE(2);
-      return out;
-    }
-
-    out = KEEP(recurse ? df_proxy_recurse(out) : out);
-
-    FREE(3);
+    r_obj* out = vec_proxy_invoke(x, info.proxy_method);
+    FREE(1);
     return out;
   }
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -47,9 +47,11 @@ static
 r_obj* df_proxy_recurse(r_obj* x) {
   r_obj* out = KEEP(r_clone(x));
 
-  for (r_ssize i = 0, n = r_length(out); i < n; ++i) {
-    r_obj* col = r_list_get(out, i);
-    r_list_poke(out, i, vec_proxy_recurse(col));
+  r_ssize n = r_length(out);
+  r_obj* const * v_out = r_list_cbegin(out);
+
+  for (r_ssize i = 0; i < n; ++i) {
+    r_list_poke(out, i, vec_proxy_recurse(v_out[i]));
   }
 
   FREE(1);

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -47,7 +47,7 @@ r_obj* vec_proxy_2(r_obj* x, bool recurse) {
 // Recurse into data frames
 static
 r_obj* df_proxy_recurse(r_obj* x) {
-  r_obj* out = KEEP(vec_clone_referenced(x, VCTRS_OWNED_false));
+  r_obj* out = KEEP(r_clone(x));
 
   for (r_ssize i = 0, n = r_length(out); i < n; ++i) {
     r_obj* col = r_list_get(out, i);

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -11,7 +11,7 @@ r_obj* vec_proxy_recurse(r_obj* x) {
 }
 
 static
-r_obj* vec_proxy_2(r_obj* x, bool recurse) {
+r_obj* vec_proxy_2(r_obj* x, enum vctrs_recurse recurse) {
   struct vctrs_type_info info = vec_type_info(x);
   KEEP(info.shelter);
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -3,14 +3,19 @@
 #include "decl/proxy-decl.h"
 
 
-// [[ register() ]]
 r_obj* vec_proxy(r_obj* x) {
   return vec_proxy_2(x, false);
 }
-
-// [[ register() ]]
 r_obj* vec_proxy_recurse(r_obj* x) {
   return vec_proxy_2(x, true);
+}
+
+r_obj* ffi_vec_proxy(r_obj* x, r_obj* recurse) {
+  if (r_as_bool(recurse)) {
+    return vec_proxy_2(x, true);
+  } else {
+    return vec_proxy_2(x, false);
+  }
 }
 
 static
@@ -26,7 +31,7 @@ r_obj* vec_proxy_2(r_obj* x, bool recurse) {
   }
 
   case VCTRS_TYPE_s3: {
-    r_obj* out = vec_proxy_invoke(x, info.proxy_method);
+    r_obj* out = vec_proxy_invoke(x, info.proxy_method, recurse);
     FREE(1);
     return out;
   }
@@ -127,11 +132,13 @@ r_obj* vec_proxy_method(r_obj* x) {
 // This should be faster than normal dispatch but also means that
 // proxy methods can't call `NextMethod()`. This could be changed if
 // it turns out a problem.
-r_obj* vec_proxy_invoke(r_obj* x, r_obj* method) {
+r_obj* vec_proxy_invoke(r_obj* x, r_obj* method, bool recurse) {
   if (method == r_null) {
     return x;
   } else {
-    return vctrs_dispatch1(syms_vec_proxy, method, syms_x, x);
+    return vctrs_dispatch2(syms_vec_proxy, method,
+                           syms_x, x,
+                           syms.recurse, r_lgl(recurse));
   }
 }
 

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -10,7 +10,7 @@ r_obj* vec_proxy_order(r_obj* x);
 r_obj* vec_proxy_recurse(r_obj* x);
 
 r_obj* vec_proxy_method(r_obj* x);
-r_obj* vec_proxy_invoke(r_obj* x, r_obj* method, bool recurse);
+r_obj* vec_proxy_invoke(r_obj* x, r_obj* method);
 r_obj* vec_proxy_unwrap(r_obj* x);
 
 #endif

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -10,7 +10,7 @@ r_obj* vec_proxy_order(r_obj* x);
 r_obj* vec_proxy_recurse(r_obj* x);
 
 r_obj* vec_proxy_method(r_obj* x);
-r_obj* vec_proxy_invoke(r_obj* x, r_obj* method);
+r_obj* vec_proxy_invoke(r_obj* x, r_obj* method, bool recurse);
 r_obj* vec_proxy_unwrap(r_obj* x);
 
 #endif

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -7,6 +7,7 @@ r_obj* vec_proxy(r_obj* x);
 r_obj* vec_proxy_equal(r_obj* x);
 r_obj* vec_proxy_compare(r_obj* x);
 r_obj* vec_proxy_order(r_obj* x);
+r_obj* vec_proxy_recurse(r_obj* x);
 
 r_obj* vec_proxy_method(r_obj* x);
 r_obj* vec_proxy_invoke(r_obj* x, r_obj* method);

--- a/src/ptype.c
+++ b/src/ptype.c
@@ -195,18 +195,29 @@ r_obj* vec_ptype_finalise_dispatch(r_obj* x) {
   );
 }
 
+r_obj* vec_ptype_final(r_obj* x) {
+  r_obj* out = KEEP(vec_ptype(x, vec_args.x, vec_ptype_final_lazy_call));
+  out = vec_ptype_finalise(out);
+
+  FREE(1);
+  return out;
+}
+
+
 void vctrs_init_ptype(r_obj* ns) {
   syms_vec_ptype = r_sym("vec_ptype");
 
   syms_vec_ptype_finalise_dispatch = r_sym("vec_ptype_finalise_dispatch");
   fns_vec_ptype_finalise_dispatch = r_eval(syms_vec_ptype_finalise_dispatch, ns);
+
+  vec_ptype_final_call = r_parse("vec_ptype_final()");
+  r_preserve_global(vec_ptype_final_call);
+
+  vec_ptype_final_lazy_call = (struct r_lazy) { .x = vec_ptype_final_call, .env = r_null };
 }
 
-static
-r_obj* syms_vec_ptype = NULL;
-
-static
-r_obj* syms_vec_ptype_finalise_dispatch = NULL;
-
-static
-r_obj* fns_vec_ptype_finalise_dispatch = NULL;
+static r_obj* syms_vec_ptype = NULL;
+static r_obj* syms_vec_ptype_finalise_dispatch = NULL;
+static r_obj* fns_vec_ptype_finalise_dispatch = NULL;
+static r_obj* vec_ptype_final_call = NULL;
+static struct r_lazy vec_ptype_final_lazy_call = { 0 };

--- a/src/ptype.h
+++ b/src/ptype.h
@@ -4,5 +4,6 @@
 #include "vctrs-core.h"
 
 r_obj* vec_ptype(r_obj* x, struct vctrs_arg* x_arg, struct r_lazy call);
+r_obj* vec_ptype_final(r_obj* x);
 
 #endif

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -357,16 +357,11 @@ r_obj* df_assign(r_obj* x,
 
     // No need to cast or recycle because those operations are
     // recursive and have already been performed. However, proxy and
-    // restore are not necessarily recursive and we wight need to
+    // restore are not necessarily recursive and we might need to
     // proxy each element we recurse into.
     //
     // NOTE: `vec_proxy_assign()` proxies `value_elt`.
-    r_obj* proxy_elt = r_null;
-    if (opts->recursive) {
-      proxy_elt = KEEP(out_elt);
-    } else {
-      proxy_elt = KEEP(vec_proxy(out_elt));
-    }
+    r_obj* proxy_elt = KEEP(opts->recursive ? out_elt : vec_proxy(out_elt));
 
     r_obj* assigned = KEEP(vec_proxy_assign_opts(proxy_elt, index, value_elt, owned, opts));
 

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -143,6 +143,12 @@ r_obj* vec_proxy_assign_opts(r_obj* proxy,
                              const struct vec_assign_opts* opts) {
   int n_protect = 0;
 
+  // Ignore vectors marked as fallback because the caller will apply
+  // a fallback method instead
+  if (vec_is_common_class_fallback(proxy)) {
+    return proxy;
+  }
+
   struct vec_assign_opts mut_opts = *opts;
   bool ignore_outer_names = mut_opts.ignore_outer_names;
   mut_opts.ignore_outer_names = false;

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -347,12 +347,22 @@ r_obj* df_assign(r_obj* x,
 
     // No need to cast or recycle because those operations are
     // recursive and have already been performed. However, proxy and
-    // restore are not recursive so need to be done for each element
-    // we recurse into. `vec_proxy_assign()` will proxy the `value_elt`.
-    r_obj* proxy_elt = KEEP(vec_proxy(out_elt));
+    // restore are not necessarily recursive and we wight need to
+    // proxy each element we recurse into.
+    //
+    // NOTE: `vec_proxy_assign()` proxies `value_elt`.
+    r_obj* proxy_elt = r_null;
+    if (opts->recursive) {
+      proxy_elt = KEEP(out_elt);
+    } else {
+      proxy_elt = KEEP(vec_proxy(out_elt));
+    }
 
     r_obj* assigned = KEEP(vec_proxy_assign_opts(proxy_elt, index, value_elt, owned, opts));
-    assigned = vec_restore(assigned, out_elt, owned);
+
+    if (!opts->recursive) {
+      assigned = vec_restore(assigned, out_elt, owned);
+    }
 
     r_list_poke(out, i, assigned);
     FREE(2);

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -262,7 +262,9 @@ r_obj* raw_assign(r_obj* x, r_obj* index, r_obj* value, const enum vctrs_owned o
   int* index_data = r_int_begin(index);                                 \
                                                                         \
   if (n != r_length(value)) {                                           \
-    r_stop_internal("`value` should have been recycled to fit `x`.");   \
+    r_stop_internal("`value` (size %d) doesn't match `x` (size %d).",   \
+                    r_length(value),                                    \
+                    n);                                                 \
   }                                                                     \
                                                                         \
   r_obj* out = KEEP(vec_clone_referenced(x, owned));                    \
@@ -284,7 +286,9 @@ r_obj* raw_assign(r_obj* x, r_obj* index, r_obj* value, const enum vctrs_owned o
   r_ssize step = index_data[2];                                         \
                                                                         \
   if (n != r_length(value)) {                                           \
-    r_stop_internal("`value` should have been recycled to fit `x`.");   \
+    r_stop_internal("`value` (size %d) doesn't match `x` (size %d).",   \
+                    r_length(value),                                    \
+                    n);                                                 \
   }                                                                     \
                                                                         \
   r_obj* out = KEEP(vec_clone_referenced(x, owned));                    \

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -7,6 +7,7 @@
 struct vec_assign_opts {
   bool assign_names;
   bool ignore_outer_names;
+  bool recursive;
   struct vctrs_arg* x_arg;
   struct vctrs_arg* value_arg;
   struct r_lazy call;

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -1,17 +1,12 @@
+#include "utils-dispatch.h"
 #include "vctrs.h"
 #include "type-data-frame.h"
 #include "decl/type-data-frame-decl.h"
 
 bool is_data_frame(r_obj* x) {
-  if (r_typeof(x) != R_TYPE_list) {
-    return false;
-  }
-
-  enum vctrs_class_type type = class_type(x);
   return
-    type == VCTRS_CLASS_bare_data_frame ||
-    type == VCTRS_CLASS_bare_tibble ||
-    type == VCTRS_CLASS_data_frame;
+    r_typeof(x) == R_TYPE_list &&
+    class_type_is_data_frame(class_type(x));
 }
 
 bool is_native_df(r_obj* x) {

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -27,7 +27,7 @@ struct vctrs_proxy_info vec_proxy_info(r_obj* x) {
     info.type = vec_base_typeof(x, false);
     info.proxy = x;
   } else {
-    r_obj* proxy = KEEP(vec_proxy_invoke(x, info.proxy_method, false));
+    r_obj* proxy = KEEP(vec_proxy_invoke(x, info.proxy_method));
     info.type = vec_base_typeof(proxy, true);
     info.proxy = proxy;
     FREE(1);

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -27,7 +27,7 @@ struct vctrs_proxy_info vec_proxy_info(r_obj* x) {
     info.type = vec_base_typeof(x, false);
     info.proxy = x;
   } else {
-    r_obj* proxy = KEEP(vec_proxy_invoke(x, info.proxy_method));
+    r_obj* proxy = KEEP(vec_proxy_invoke(x, info.proxy_method, false));
     info.type = vec_base_typeof(proxy, true);
     info.proxy = proxy;
     FREE(1);

--- a/src/utils-dispatch.c
+++ b/src/utils-dispatch.c
@@ -91,17 +91,6 @@ enum vctrs_class_type class_type_impl(r_obj* class) {
   return VCTRS_CLASS_unknown;
 }
 
-bool class_type_is_data_frame(enum vctrs_class_type type) {
-  switch (type) {
-  case VCTRS_CLASS_data_frame:
-  case VCTRS_CLASS_bare_data_frame:
-  case VCTRS_CLASS_bare_tibble:
-    return true;
-  default:
-    return false;
-  }
-}
-
 static
 const char* class_type_as_str(enum vctrs_class_type type) {
   switch (type) {

--- a/src/utils-dispatch.c
+++ b/src/utils-dispatch.c
@@ -91,6 +91,17 @@ enum vctrs_class_type class_type_impl(r_obj* class) {
   return VCTRS_CLASS_unknown;
 }
 
+bool class_type_is_data_frame(enum vctrs_class_type type) {
+  switch (type) {
+  case VCTRS_CLASS_data_frame:
+  case VCTRS_CLASS_bare_data_frame:
+  case VCTRS_CLASS_bare_tibble:
+    return true;
+  default:
+    return false;
+  }
+}
+
 static
 const char* class_type_as_str(enum vctrs_class_type type) {
   switch (type) {

--- a/src/utils-dispatch.h
+++ b/src/utils-dispatch.h
@@ -20,7 +20,17 @@ enum vctrs_class_type {
 
 enum vctrs_class_type class_type(r_obj* x);
 
-bool class_type_is_data_frame(enum vctrs_class_type type);
+static inline
+bool class_type_is_data_frame(enum vctrs_class_type type) {
+  switch (type) {
+  case VCTRS_CLASS_data_frame:
+  case VCTRS_CLASS_bare_data_frame:
+  case VCTRS_CLASS_bare_tibble:
+    return true;
+  default:
+    return false;
+  }
+}
 
 bool vec_is_partial(r_obj* x);
 

--- a/src/utils-dispatch.h
+++ b/src/utils-dispatch.h
@@ -20,6 +20,8 @@ enum vctrs_class_type {
 
 enum vctrs_class_type class_type(r_obj* x);
 
+bool class_type_is_data_frame(enum vctrs_class_type type);
+
 bool vec_is_partial(r_obj* x);
 
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -793,16 +793,18 @@ bool list_has_inner_vec_names(SEXP x, R_len_t size) {
  * @return A list of the same length as `xs`.
  */
 // [[ include("utils.h") ]]
-SEXP list_pluck(SEXP xs, R_len_t i) {
-  R_len_t n = Rf_length(xs);
-  SEXP out = PROTECT(r_new_list(n));
+r_obj* list_pluck(r_obj* xs, r_ssize i) {
+  r_ssize n = r_length(xs);
+  r_obj* out = KEEP(r_new_list(n));
 
-  for (R_len_t j = 0; j < n; ++j) {
-    SEXP x = r_list_get(xs, j);
-    r_list_poke(out, j, r_list_get(x, i));
+  for (r_ssize j = 0; j < n; ++j) {
+    r_obj* x = r_list_get(xs, j);
+    if (x != r_null) {
+      r_list_poke(out, j, r_list_get(x, i));
+    }
   }
 
-  UNPROTECT(1);
+  FREE(1);
   return out;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,3 +1,4 @@
+#include "vctrs-core.h"
 #include "vctrs.h"
 #include "type-data-frame.h"
 #include <R_ext/Rdynload.h>
@@ -353,7 +354,10 @@ SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
 
   // Total ownership because `map()` generates a fresh list
-  out = vec_bare_df_restore(out, df, VCTRS_OWNED_true, false);
+  out = vec_bare_df_restore(out,
+                            df,
+                            VCTRS_OWNED_true,
+                            VCTRS_RECURSE_false);
 
   UNPROTECT(1);
   return out;
@@ -364,7 +368,10 @@ SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
 
   // Total ownership because `map()` generates a fresh list
-  out = vec_df_restore(out, df, VCTRS_OWNED_true, false);
+  out = vec_df_restore(out,
+                       df,
+                       VCTRS_OWNED_true,
+                       VCTRS_RECURSE_false);
 
   UNPROTECT(1);
   return out;

--- a/src/utils.c
+++ b/src/utils.c
@@ -353,7 +353,7 @@ SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
 
   // Total ownership because `map()` generates a fresh list
-  out = vec_bare_df_restore(out, df, VCTRS_OWNED_true);
+  out = vec_bare_df_restore(out, df, VCTRS_OWNED_true, false);
 
   UNPROTECT(1);
   return out;
@@ -364,7 +364,7 @@ SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
 
   // Total ownership because `map()` generates a fresh list
-  out = vec_df_restore(out, df, VCTRS_OWNED_true);
+  out = vec_df_restore(out, df, VCTRS_OWNED_true, false);
 
   UNPROTECT(1);
   return out;

--- a/src/utils.c
+++ b/src/utils.c
@@ -795,10 +795,12 @@ bool list_has_inner_vec_names(SEXP x, R_len_t size) {
 // [[ include("utils.h") ]]
 r_obj* list_pluck(r_obj* xs, r_ssize i) {
   r_ssize n = r_length(xs);
+  r_obj* const * v_xs = r_list_cbegin(xs);
+
   r_obj* out = KEEP(r_new_list(n));
 
   for (r_ssize j = 0; j < n; ++j) {
-    r_obj* x = r_list_get(xs, j);
+    r_obj* x = v_xs[j];
     if (x != r_null) {
       r_list_poke(out, j, r_list_get(x, i));
     }

--- a/src/utils.h
+++ b/src/utils.h
@@ -174,7 +174,7 @@ SEXP new_empty_factor(SEXP levels);
 SEXP new_empty_ordered(SEXP levels);
 
 bool list_has_inner_vec_names(SEXP x, R_len_t size);
-SEXP list_pluck(SEXP xs, R_len_t i);
+r_obj* list_pluck(r_obj* xs, r_ssize i);
 
 void init_compact_seq(int* p, R_len_t start, R_len_t size, bool increasing);
 SEXP compact_seq(R_len_t start, R_len_t size, bool increasing);

--- a/src/vctrs-core.h
+++ b/src/vctrs-core.h
@@ -27,6 +27,11 @@ enum vctrs_owned {
   VCTRS_OWNED_true
 };
 
+enum vctrs_recurse {
+  VCTRS_RECURSE_false = 0,
+  VCTRS_RECURSE_true
+};
+
 
 /**
  * Structure for argument tags

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -413,11 +413,11 @@
       # Integers as rows
       suppressMessages(with_memory_prof(vec_rbind_list(ints)))
     Output
-      [1] 3.62KB
+      [1] 2.79KB
     Code
       suppressMessages(with_memory_prof(vec_rbind_list(named_ints)))
     Output
-      [1] 6.15KB
+      [1] 3.66KB
     Code
       # Data frame with named columns
       df <- data_frame(x = set_names(as.list(1:2), c("a", "b")), y = set_names(1:2, c(
@@ -425,7 +425,7 @@
       dfs <- rep(list(df), 100)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 13.8KB
+      [1] 11.3KB
     Code
       # Data frame with rownames (non-repaired, non-recursive case)
       df <- data_frame(x = 1:2)
@@ -433,13 +433,13 @@
       dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 8.51KB
+      [1] 7.68KB
     Code
       # Data frame with rownames (repaired, non-recursive case)
       dfs <- map(dfs, set_rownames_recursively)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 14.7KB
+      [1] 13.8KB
     Code
       # Data frame with rownames (non-repaired, recursive case) (#1217)
       df <- data_frame(x = 1:2, y = data_frame(x = 1:2))
@@ -447,11 +447,11 @@
       dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 15.5KB
+      [1] 13.8KB
     Code
       # Data frame with rownames (repaired, recursive case) (#1217)
       dfs <- map(dfs, set_rownames_recursively)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 27.8KB
+      [1] 26.2KB
 

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -441,17 +441,17 @@
     Output
       [1] 13.8KB
     Code
-      # FIXME (#1217): Data frame with rownames (non-repaired, recursive case)
+      # Data frame with rownames (non-repaired, recursive case) (#1217)
       df <- data_frame(x = 1:2, y = data_frame(x = 1:2))
       dfs <- rep(list(df), 100)
       dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 909KB
+      [1] 13KB
     Code
-      # FIXME (#1217): Data frame with rownames (repaired, recursive case)
+      # Data frame with rownames (repaired, recursive case) (#1217)
       dfs <- map(dfs, set_rownames_recursively)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 922KB
+      [1] 25.3KB
 

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -413,11 +413,11 @@
       # Integers as rows
       suppressMessages(with_memory_prof(vec_rbind_list(ints)))
     Output
-      [1] 2.79KB
+      [1] 3.62KB
     Code
       suppressMessages(with_memory_prof(vec_rbind_list(named_ints)))
     Output
-      [1] 3.66KB
+      [1] 6.15KB
     Code
       # Data frame with named columns
       df <- data_frame(x = set_names(as.list(1:2), c("a", "b")), y = set_names(1:2, c(
@@ -425,7 +425,7 @@
       dfs <- rep(list(df), 100)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 10.4KB
+      [1] 13.8KB
     Code
       # Data frame with rownames (non-repaired, non-recursive case)
       df <- data_frame(x = 1:2)
@@ -433,13 +433,13 @@
       dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 7.68KB
+      [1] 8.51KB
     Code
       # Data frame with rownames (repaired, non-recursive case)
       dfs <- map(dfs, set_rownames_recursively)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 13.8KB
+      [1] 14.7KB
     Code
       # Data frame with rownames (non-repaired, recursive case) (#1217)
       df <- data_frame(x = 1:2, y = data_frame(x = 1:2))
@@ -447,11 +447,11 @@
       dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 13KB
+      [1] 15.5KB
     Code
       # Data frame with rownames (repaired, recursive case) (#1217)
       dfs <- map(dfs, set_rownames_recursively)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 25.3KB
+      [1] 27.8KB
 

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -425,7 +425,7 @@
       dfs <- rep(list(df), 100)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 11.3KB
+      [1] 10.4KB
     Code
       # Data frame with rownames (non-repaired, non-recursive case)
       df <- data_frame(x = 1:2)
@@ -447,11 +447,11 @@
       dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 13.8KB
+      [1] 13KB
     Code
       # Data frame with rownames (repaired, recursive case) (#1217)
       dfs <- map(dfs, set_rownames_recursively)
       with_memory_prof(vec_rbind_list(dfs))
     Output
-      [1] 26.2KB
+      [1] 25.3KB
 

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -183,13 +183,13 @@
       })
       with_memory_prof(list_unchop(make_list_of(1000)))
     Output
-      [1] 104KB
+      [1] 112KB
     Code
       with_memory_prof(list_unchop(make_list_of(2000)))
     Output
-      [1] 206KB
+      [1] 222KB
     Code
       with_memory_prof(list_unchop(make_list_of(4000)))
     Output
-      [1] 409KB
+      [1] 440KB
 

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -168,11 +168,11 @@
       dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
       with_memory_prof(list_unchop(dfs))
     Output
-      [1] 908KB
+      [1] 11.6KB
     Code
       # FIXME (#1217): Data frame with rownames (repaired, recursive case)
       dfs <- map(dfs, set_rownames_recursively)
       with_memory_prof(list_unchop(dfs))
     Output
-      [1] 920KB
+      [1] 23.9KB
 

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -162,7 +162,7 @@
     Output
       [1] 12.4KB
     Code
-      # FIXME (#1217): Data frame with rownames (non-repaired, recursive case)
+      # Data frame with rownames (non-repaired, recursive case) (#1217)
       df <- data_frame(x = 1:2, y = data_frame(x = 1:2))
       dfs <- rep(list(df), 100)
       dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
@@ -170,7 +170,7 @@
     Output
       [1] 11.6KB
     Code
-      # FIXME (#1217): Data frame with rownames (repaired, recursive case)
+      # Data frame with rownames (repaired, recursive case) (#1217)
       dfs <- map(dfs, set_rownames_recursively)
       with_memory_prof(list_unchop(dfs))
     Output

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -175,4 +175,21 @@
       with_memory_prof(list_unchop(dfs))
     Output
       [1] 23.9KB
+    Code
+      # list-ofs (#1496)
+      make_list_of <- (function(n) {
+        df <- tibble::tibble(x = new_list_of(vec_chop(1:n), ptype = integer()))
+        vec_chop(df)
+      })
+      with_memory_prof(list_unchop(make_list_of(1000)))
+    Output
+      [1] 112KB
+    Code
+      with_memory_prof(list_unchop(make_list_of(2000)))
+    Output
+      [1] 222KB
+    Code
+      with_memory_prof(list_unchop(make_list_of(4000)))
+    Output
+      [1] 440KB
 

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -183,13 +183,13 @@
       })
       with_memory_prof(list_unchop(make_list_of(1000)))
     Output
-      [1] 112KB
+      [1] 104KB
     Code
       with_memory_prof(list_unchop(make_list_of(2000)))
     Output
-      [1] 222KB
+      [1] 206KB
     Code
       with_memory_prof(list_unchop(make_list_of(4000)))
     Output
-      [1] 440KB
+      [1] 409KB
 

--- a/tests/testthat/helper-s3.R
+++ b/tests/testthat/helper-s3.R
@@ -55,7 +55,7 @@ local_proxy <- function(frame = caller_env()) {
 new_proxy <- function(x) {
   structure(list(env(x = x)), class = "vctrs_proxy")
 }
-proxy_deref <- function(x) {
+proxy_deref <- function(x, ...) {
   x[[1]]$x
 }
 local_env_proxy <- function(frame = caller_env()) {
@@ -78,7 +78,7 @@ tibble <- function(...) {
 }
 
 local_foobar_proxy <- function(frame = caller_env()) {
-  local_methods(.frame = frame, vec_proxy.vctrs_foobar = identity)
+  local_methods(.frame = frame, vec_proxy.vctrs_foobar = function(x, ...) x)
 }
 
 subclass <- function(x) {

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -160,7 +160,7 @@ test_that("data frames are always classified as such even when dispatch is off",
 
 test_that("assertion is not applied on proxy", {
   local_methods(
-    vec_proxy.vctrs_foobar = unclass,
+    vec_proxy.vctrs_foobar = function(x, ...) unclass(x),
     vec_restore.vctrs_foobar = function(x, ...) foobar(x),
     `[.vctrs_foobar` = function(x, i) vec_slice(x, i)
   )

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -508,6 +508,17 @@ test_that("concatenation performs expected allocations", {
     "Data frame with rownames (repaired, recursive case) (#1217)"
     dfs <- map(dfs, set_rownames_recursively)
     with_memory_prof(list_unchop(dfs))
+
+    "list-ofs (#1496)"
+    make_list_of <- function(n) {
+      df <- tibble::tibble(
+        x = new_list_of(vec_chop(1:n), ptype = integer())
+      )
+      vec_chop(df)
+    }
+    with_memory_prof(list_unchop(make_list_of(1e3)))
+    with_memory_prof(list_unchop(make_list_of(2e3)))
+    with_memory_prof(list_unchop(make_list_of(4e3)))
   })
 })
 

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -496,10 +496,7 @@ test_that("concatenation performs expected allocations", {
     dfs <- map(dfs, set_rownames_recursively)
     with_memory_prof(list_unchop(dfs))
 
-    # FIXME: The following recursive cases duplicate rownames
-    # excessively because df-cols are restored at each chunk
-    # assignment, causing a premature name-repair
-    "FIXME (#1217): Data frame with rownames (non-repaired, recursive case)"
+    "Data frame with rownames (non-repaired, recursive case) (#1217)"
     df <- data_frame(
       x = 1:2,
       y = data_frame(x = 1:2)
@@ -508,7 +505,7 @@ test_that("concatenation performs expected allocations", {
     dfs <- map2(dfs, seq_along(dfs), set_rownames_recursively)
     with_memory_prof(list_unchop(dfs))
 
-    "FIXME (#1217): Data frame with rownames (repaired, recursive case)"
+    "Data frame with rownames (repaired, recursive case) (#1217)"
     dfs <- map(dfs, set_rownames_recursively)
     with_memory_prof(list_unchop(dfs))
   })

--- a/tests/testthat/test-proxy-restore.R
+++ b/tests/testthat/test-proxy-restore.R
@@ -75,7 +75,7 @@ test_that("arguments are not inlined in the dispatch call (#300)", {
     vec_proxy.vctrs_foobar = unclass
   )
   call <- vec_restore(foobar(list(1)), foobar(list(1)))
-  expect_equal(call, quote(vec_restore.vctrs_foobar(x = x, to = to)))
+  expect_equal(call, quote(vec_restore.vctrs_foobar(x = x, to = to, recurse = recurse)))
 })
 
 test_that("restoring to non-bare data frames calls `vec_bare_df_restore()` before dispatching", {
@@ -128,4 +128,44 @@ test_that("names<- is not called with partial data (#1108)", {
 
   vec_c(x, x)
   expect_equal(values, list(c("a", "b", "a", "b")))
+})
+
+test_that("proxy and restore pass `recurse` through `...`", {
+  new_recursive_rcrd <- function(x) {
+    new_rcrd(
+      list(field = x),
+      class = "my_recursive_rcrd"
+    )
+  }
+
+  internal <- new_rcrd(list(internal_field = 1:2))
+  x <- new_recursive_rcrd(data_frame(col = internal))
+
+  local_methods(
+    vec_proxy.my_recursive_rcrd = function(x, ...) {
+      vec_proxy(field(x, "field"), ...)
+    },
+    vec_restore.my_recursive_rcrd = function(x, to, ...) {
+      out <- vec_restore(x, field(to, "field"), ...)
+      new_recursive_rcrd(out)
+    }
+  )
+
+  proxy <- vec_proxy(x, recurse = TRUE)
+  exp <- data_frame(col = data_frame(internal_field = 1:2))
+  expect_equal(proxy, exp)
+
+  out <- vec_restore(proxy, x, recurse = TRUE)
+  expect_equal(out, x)
+
+  x_exp <- new_recursive_rcrd(data_frame(col = vec_rep(internal, 2)))
+  expect_equal(
+    list_unchop(list(x, x)),
+    x_exp
+  )
+
+  df <- data_frame(x = x)
+  df_exp <- data_frame(x = x_exp)
+  expect_equal(vec_rbind(df, df), df_exp)
+  expect_equal(vec_c(df, df), df_exp)
 })

--- a/tests/testthat/test-proxy-restore.R
+++ b/tests/testthat/test-proxy-restore.R
@@ -146,6 +146,12 @@ test_that("recursive proxy and restore work with recursive records", {
   expect_equal(proxy, exp)
   expect_equal(vec_restore_recurse(proxy, x), x)
 
+  # Non-recursive case doesn't proxy `internal`
+  proxy <- vec_proxy(x)
+  exp <- data_frame(field = data_frame(col = internal))
+  expect_equal(proxy, exp)
+  expect_equal(vec_restore(proxy, x), x)
+
   x_exp <- new_recursive_rcrd(data_frame(col = vec_rep(internal, 2)))
   expect_equal(
     list_unchop(list(x, x)),

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -170,7 +170,7 @@ test_that("vec_chop() falls back to `[` for shaped objects with no proxy when in
 
 test_that("vec_chop() with data frame proxies always uses the proxy's length info", {
   local_methods(
-    vec_proxy.vctrs_proxy = function(x) {
+    vec_proxy.vctrs_proxy = function(x, ...) {
       x <- proxy_deref(x)
       new_data_frame(list(x = x$x, y = x$y))
     },

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -205,7 +205,7 @@ test_that("can `vec_slice()` records", {
 
 test_that("vec_restore() is called after proxied slicing", {
   local_methods(
-    vec_proxy.vctrs_foobar = identity,
+    vec_proxy.vctrs_foobar = function(x, ...) x,
     vec_restore.vctrs_foobar = function(x, to, ...) "dispatch"
   )
   expect_identical(vec_slice(foobar(1:3), 2), "dispatch")
@@ -236,7 +236,7 @@ test_that("dimensions are preserved by vec_slice()", {
   attrib <- NULL
 
   local_methods(
-    vec_proxy.vctrs_foobar = identity,
+    vec_proxy.vctrs_foobar = function(x, ...) x,
     vec_restore.vctrs_foobar = function(x, to, ...) attrib <<- attributes(x)
   )
 
@@ -260,7 +260,7 @@ test_that("can slice shaped objects by name", {
 test_that("vec_slice() unclasses input before calling `vec_restore()`", {
   oo <- NULL
   local_methods(
-    vec_proxy.vctrs_foobar = identity,
+    vec_proxy.vctrs_foobar = function(x, ...) x,
     vec_restore.vctrs_foobar = function(x, ...) oo <<- is.object(x)
   )
 
@@ -302,7 +302,7 @@ test_that("vec_slice() falls back to `[` with S3 objects", {
 
   expect_error(vec_slice(foobar(list(NA)), 1), class = "vctrs_error_scalar_type")
   local_methods(
-    vec_proxy.vctrs_foobar = identity
+    vec_proxy.vctrs_foobar = function(x, ...) x
   )
   expect_identical(vec_slice(foobar(list(NA)), 1), foobar(list(NA)))
 })

--- a/tests/testthat/test-type-sf.R
+++ b/tests/testthat/test-type-sf.R
@@ -256,6 +256,21 @@ test_that("`vec_locate_matches()` works with `sfc` vectors", {
   expect_identical(out$haystack, c(2L, 4L, 5L, NA, 1L))
 })
 
+test_that("`vec_rbind()` doesn't leak common type fallbacks (#1331)", {
+	sf = st_sf(id = 1:2, geo = st_sfc(st_point(c(1, 1)), st_point(c(2, 2))))
+
+	expect_equal(
+		vec_rbind(sf, sf),
+		data_frame(id = rep(1:2, 2), geo = rep(sf$geo, 2))
+	)
+
+	expect_equal(
+		vec_rbind(sf, sf, .names_to = "id"),
+		data_frame(id = rep(1:2, each = 2), geo = rep(sf$geo, 2))
+	)
+})
+
+
 # Local Variables:
 # indent-tabs-mode: t
 # ess-indent-offset: 4


### PR DESCRIPTION
### Recursive proxying and restoration across df-cols

- Prevents partially filled proxies from being restored prematurely.
- Fixes performance issues (closes #1217, closes #1496).

Closes #1107.
Progress towards #1098.

### Recursive application of `base::c()` fallback

This is in the same PR because recursive proxying and restoration causes regressions without this fix.

Closes #1331.
Closes #1462.
Closes #1640.