### PR TITLE
Remove experimental `n` argument of `vec_restore()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # vctrs (development version)
 
+* The experimental `n` argument of `vec_restore()` has been
+  removed. It was only used to inform on the size of data frames in
+  case a bare list is restored. It is now expected that bare lists be
+  initialised to data frame so that the size is carried through row
+  attributes. This makes the generic simpler and fixes some
+  performance issues (#650).
+
 * The `anyNA()` method for `vctrs_vctr` (and thus `vctrs_list_of`) now
   supports the `recursive` argument (#1278).
 

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -146,28 +146,21 @@ vec_proxy.default <- function(x, ...) {
 
 #' @rdname vec_proxy
 #' @param to The original vector to restore to.
-#' @param n `r lifecycle::badge("experimental")`
-#'   The total size to restore to. This is currently passed by
-#'   `vec_slice()` to solve edge cases arising in data frame
-#'   restoration. In most cases you don't need this information and
-#'   can safely ignore that argument. This parameter should be
-#'   considered internal and experimental, it might change in the
-#'   future.
 #' @export
-vec_restore <- function(x, to, ..., n = NULL) {
+vec_restore <- function(x, to, ...) {
   check_dots_empty0(...)
-  return(.Call(ffi_restore, x, to, n))
+  return(.Call(ffi_vec_restore, x, to))
   UseMethod("vec_restore", to)
 }
-vec_restore_dispatch <- function(x, to, ..., n = NULL) {
+vec_restore_dispatch <- function(x, to, ...) {
   UseMethod("vec_restore", to)
 }
 #' @export
-vec_restore.default <- function(x, to, ..., n = NULL) {
-  .Call(ffi_restore_default, x, to)
+vec_restore.default <- function(x, to, ...) {
+  .Call(ffi_vec_restore_default, x, to)
 }
 vec_restore_default <- function(x, to, ...) {
-  .Call(ffi_restore_default, x, to)
+  .Call(ffi_vec_restore_default, x, to)
 }
 
 #' Extract underlying data

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -484,8 +484,8 @@ vec_cast.data.frame.data.frame <- function(x, to, ..., x_arg = "", to_arg = "") 
 }
 
 #' @export
-vec_restore.data.frame <- function(x, to, ..., n = NULL) {
-  .Call(ffi_bare_df_restore, x, to, n)
+vec_restore.data.frame <- function(x, to, ...) {
+  .Call(ffi_vec_bare_df_restore, x, to)
 }
 
 # Helpers -----------------------------------------------------------------

--- a/man/vec_proxy.Rd
+++ b/man/vec_proxy.Rd
@@ -7,7 +7,7 @@
 \usage{
 vec_proxy(x, ...)
 
-vec_restore(x, to, ..., n = NULL)
+vec_restore(x, to, ...)
 }
 \arguments{
 \item{x}{A vector.}
@@ -15,14 +15,6 @@ vec_restore(x, to, ..., n = NULL)
 \item{...}{These dots are for future extensions and must be empty.}
 
 \item{to}{The original vector to restore to.}
-
-\item{n}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-The total size to restore to. This is currently passed by
-\code{vec_slice()} to solve edge cases arising in data frame
-restoration. In most cases you don't need this information and
-can safely ignore that argument. This parameter should be
-considered internal and experimental, it might change in the
-future.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/src/bind.c
+++ b/src/bind.c
@@ -261,8 +261,7 @@ r_obj* vec_rbind(r_obj* xs,
     }
   }
 
-  r_obj* r_n_rows = KEEP_N(r_int(n_rows), &n_prot);
-  out = vec_restore(out, ptype, r_n_rows, VCTRS_OWNED_true);
+  out = vec_restore(out, ptype, VCTRS_OWNED_true);
 
   FREE(n_prot);
   return out;
@@ -515,7 +514,7 @@ r_obj* vec_cbind(r_obj* xs,
     r_attrib_poke(out, r_syms.row_names, rownames);
   }
 
-  out = vec_restore(out, type, r_null, VCTRS_OWNED_true);
+  out = vec_restore(out, type, VCTRS_OWNED_true);
 
   FREE(9);
   return out;

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -136,9 +136,7 @@ r_obj* list_unchop(r_obj* xs,
     KEEP_AT(proxy, proxy_pi);
   }
 
-  r_obj* out_size_sexp = KEEP(r_int(out_size));
-
-  r_obj* out = KEEP(vec_restore(proxy, ptype, out_size_sexp, VCTRS_OWNED_true));
+  r_obj* out = KEEP(vec_restore(proxy, ptype, VCTRS_OWNED_true));
 
   if (out_names != r_null) {
     out_names = KEEP(vec_as_names(out_names, name_repair));
@@ -151,7 +149,7 @@ r_obj* list_unchop(r_obj* xs,
     out = vec_set_names(out, r_null);
   }
 
-  FREE(8);
+  FREE(7);
   return out;
 }
 

--- a/src/c.c
+++ b/src/c.c
@@ -143,7 +143,7 @@ r_obj* vec_c_opts(r_obj* xs,
     FREE(1);
   }
 
-  out = KEEP(vec_restore(out, ptype, r_null, VCTRS_OWNED_true));
+  out = KEEP(vec_restore(out, ptype, VCTRS_OWNED_true));
 
   if (out_names != r_null) {
     out_names = KEEP(vec_as_names(out_names, name_repair));

--- a/src/decl/proxy-restore-decl.h
+++ b/src/decl/proxy-restore-decl.h
@@ -2,4 +2,4 @@ static r_obj* syms_vec_restore_dispatch;
 static r_obj* fns_vec_restore_dispatch;
 
 static
-r_obj* vec_restore_dispatch(r_obj* x, r_obj* to, r_obj* n);
+r_obj* vec_restore_dispatch(r_obj* x, r_obj* to);

--- a/src/init.c
+++ b/src/init.c
@@ -53,8 +53,8 @@ extern r_obj* ffi_list_unchop(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_chop_seq(SEXP, SEXP, SEXP, SEXP);
 extern r_obj* ffi_slice_seq(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_slice_rep(r_obj*, r_obj*, r_obj*);
-extern r_obj* ffi_restore(r_obj*, r_obj*, r_obj*);
-extern r_obj* ffi_restore_default(r_obj*, r_obj*);
+extern r_obj* ffi_vec_restore(r_obj*, r_obj*);
+extern r_obj* ffi_vec_restore_default(r_obj*, r_obj*);
 extern SEXP vec_proxy(SEXP);
 extern SEXP vec_proxy_equal(SEXP);
 extern SEXP vec_proxy_compare(SEXP);
@@ -75,7 +75,7 @@ extern r_obj* ffi_df_ptype2_opts(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_type_info(r_obj*);
 extern SEXP ffi_proxy_info(SEXP);
 extern r_obj* ffi_class_type(r_obj*);
-extern r_obj* ffi_bare_df_restore(r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_vec_bare_df_restore(r_obj*, r_obj*);
 extern r_obj* ffi_recycle(r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_assign(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_assign_seq(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
@@ -222,8 +222,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_chop_seq",                        (DL_FUNC) &vctrs_chop_seq, 4},
   {"ffi_slice_seq",                         (DL_FUNC) &ffi_slice_seq, 4},
   {"ffi_slice_rep",                         (DL_FUNC) &ffi_slice_rep, 3},
-  {"ffi_restore",                           (DL_FUNC) &ffi_restore, 3},
-  {"ffi_restore_default",                   (DL_FUNC) &ffi_restore_default, 2},
+  {"ffi_vec_restore",                       (DL_FUNC) &ffi_vec_restore, 2},
+  {"ffi_vec_restore_default",               (DL_FUNC) &ffi_vec_restore_default, 2},
   {"vctrs_proxy",                           (DL_FUNC) &vec_proxy, 1},
   {"vctrs_proxy_equal",                     (DL_FUNC) &vec_proxy_equal, 1},
   {"vctrs_proxy_compare",                   (DL_FUNC) &vec_proxy_compare, 1},
@@ -244,7 +244,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"ffi_type_info",                         (DL_FUNC) &ffi_type_info, 1},
   {"ffi_proxy_info",                        (DL_FUNC) &ffi_proxy_info, 1},
   {"ffi_class_type",                        (DL_FUNC) &ffi_class_type, 1},
-  {"ffi_bare_df_restore",                   (DL_FUNC) &ffi_bare_df_restore, 3},
+  {"ffi_vec_bare_df_restore",               (DL_FUNC) &ffi_vec_bare_df_restore, 2},
   {"ffi_recycle",                           (DL_FUNC) &ffi_recycle, 3},
   {"ffi_assign",                            (DL_FUNC) &ffi_assign, 4},
   {"ffi_assign_seq",                        (DL_FUNC) &ffi_assign_seq, 5},

--- a/src/proxy-restore.h
+++ b/src/proxy-restore.h
@@ -4,11 +4,11 @@
 #include "vctrs-core.h"
 
 
-r_obj* vec_restore(r_obj* x, r_obj* to, r_obj* n, const enum vctrs_owned owned);
+r_obj* vec_restore(r_obj* x, r_obj* to, const enum vctrs_owned owned);
 r_obj* vec_restore_default(r_obj* x, r_obj* to, const enum vctrs_owned owned);
 
-r_obj* vec_bare_df_restore(r_obj* x, r_obj* to, r_obj* n, const enum vctrs_owned owned);
-r_obj* vec_df_restore(r_obj* x, r_obj* to, r_obj* n, const enum vctrs_owned owned);
+r_obj* vec_bare_df_restore(r_obj* x, r_obj* to, const enum vctrs_owned owned);
+r_obj* vec_df_restore(r_obj* x, r_obj* to, const enum vctrs_owned owned);
 
 
 #endif

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -35,7 +35,7 @@ r_obj* vec_assign_opts(r_obj* x,
   const enum vctrs_owned owned = vec_owned(proxy);
   proxy = KEEP(vec_proxy_assign_opts(proxy, index, value, owned, &opts));
 
-  r_obj* out = vec_restore(proxy, x, r_null, owned);
+  r_obj* out = vec_restore(proxy, x, owned);
 
   FREE(6);
   return out;
@@ -352,7 +352,7 @@ r_obj* df_assign(r_obj* x,
     r_obj* proxy_elt = KEEP(vec_proxy(out_elt));
 
     r_obj* assigned = KEEP(vec_proxy_assign_opts(proxy_elt, index, value_elt, owned, opts));
-    assigned = vec_restore(assigned, out_elt, r_null, owned);
+    assigned = vec_restore(assigned, out_elt, owned);
 
     r_list_poke(out, i, assigned);
     FREE(2);
@@ -421,7 +421,7 @@ r_obj* ffi_assign_seq(r_obj* x,
   const enum vctrs_owned owned = vec_owned(proxy);
   proxy = KEEP(vec_proxy_check_assign(proxy, index, value, vec_args.x, vec_args.value, call));
 
-  r_obj* out = vec_restore(proxy, x, r_null, owned);
+  r_obj* out = vec_restore(proxy, x, owned);
 
   FREE(5);
   return out;

--- a/src/slice.c
+++ b/src/slice.c
@@ -195,6 +195,8 @@ r_obj* df_slice(r_obj* x, r_obj* subscript) {
     r_list_poke(out, i, sliced);
   }
 
+  init_data_frame(out, vec_subscript_size(subscript));
+
   r_obj* row_nms = KEEP(df_rownames(x));
   if (r_typeof(row_nms) == R_TYPE_character) {
     row_nms = slice_rownames(row_nms, subscript);
@@ -355,8 +357,7 @@ r_obj* vec_slice_unsafe(r_obj* x, r_obj* subscript) {
 
   case VCTRS_TYPE_dataframe: {
     r_obj* out = KEEP_N(df_slice(data, subscript), &nprot);
-    r_obj* restore_size = KEEP_N(r_int(vec_subscript_size(subscript)), &nprot);
-    out = vec_restore(out, x, restore_size, vec_owned(out));
+    out = vec_restore(out, x, r_null, vec_owned(out));
     FREE(nprot);
     return out;
   }

--- a/src/slice.c
+++ b/src/slice.c
@@ -310,7 +310,7 @@ r_obj* vec_slice_unsafe(r_obj* x, r_obj* subscript) {
 
     // Take over attribute restoration only if there is no `[` method
     if (!vec_is_restored(out, x)) {
-      out = vec_restore(out, x, r_null, vec_owned(out));
+      out = vec_restore(out, x, vec_owned(out));
     }
 
     FREE(nprot);
@@ -349,7 +349,7 @@ r_obj* vec_slice_unsafe(r_obj* x, r_obj* subscript) {
       r_attrib_poke_names(out, names);
     }
 
-    out = vec_restore(out, x, r_null, vec_owned(out));
+    out = vec_restore(out, x, vec_owned(out));
 
     FREE(nprot);
     return out;
@@ -357,7 +357,7 @@ r_obj* vec_slice_unsafe(r_obj* x, r_obj* subscript) {
 
   case VCTRS_TYPE_dataframe: {
     r_obj* out = KEEP_N(df_slice(data, subscript), &nprot);
-    out = vec_restore(out, x, r_null, vec_owned(out));
+    out = vec_restore(out, x, vec_owned(out));
     FREE(nprot);
     return out;
   }

--- a/src/slice.c
+++ b/src/slice.c
@@ -282,8 +282,6 @@ r_obj* slice_rownames(r_obj* names, r_obj* subscript) {
 r_obj* vec_slice_unsafe(r_obj* x, r_obj* subscript) {
   int nprot = 0;
 
-  r_obj* restore_size = KEEP_N(r_int(vec_subscript_size(subscript)), &nprot);
-
   struct vctrs_proxy_info info = vec_proxy_info(x);
   KEEP_N(info.shelter, &nprot);
 
@@ -310,7 +308,7 @@ r_obj* vec_slice_unsafe(r_obj* x, r_obj* subscript) {
 
     // Take over attribute restoration only if there is no `[` method
     if (!vec_is_restored(out, x)) {
-      out = vec_restore(out, x, restore_size, vec_owned(out));
+      out = vec_restore(out, x, r_null, vec_owned(out));
     }
 
     FREE(nprot);
@@ -349,7 +347,7 @@ r_obj* vec_slice_unsafe(r_obj* x, r_obj* subscript) {
       r_attrib_poke_names(out, names);
     }
 
-    out = vec_restore(out, x, restore_size, vec_owned(out));
+    out = vec_restore(out, x, r_null, vec_owned(out));
 
     FREE(nprot);
     return out;
@@ -357,6 +355,7 @@ r_obj* vec_slice_unsafe(r_obj* x, r_obj* subscript) {
 
   case VCTRS_TYPE_dataframe: {
     r_obj* out = KEEP_N(df_slice(data, subscript), &nprot);
+    r_obj* restore_size = KEEP_N(r_int(vec_subscript_size(subscript)), &nprot);
     out = vec_restore(out, x, restore_size, vec_owned(out));
     FREE(nprot);
     return out;

--- a/src/utils.c
+++ b/src/utils.c
@@ -357,7 +357,7 @@ SEXP bare_df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
 
   // Total ownership because `map()` generates a fresh list
-  out = vec_bare_df_restore(out, df, vctrs_shared_zero_int, VCTRS_OWNED_true);
+  out = vec_bare_df_restore(out, df, VCTRS_OWNED_true);
 
   UNPROTECT(1);
   return out;
@@ -368,7 +368,7 @@ SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
   SEXP out = PROTECT(map(df, fn));
 
   // Total ownership because `map()` generates a fresh list
-  out = vec_df_restore(out, df, vctrs_shared_zero_int, VCTRS_OWNED_true);
+  out = vec_df_restore(out, df, VCTRS_OWNED_true);
 
   UNPROTECT(1);
   return out;

--- a/tests/testthat/test-proxy-restore.R
+++ b/tests/testthat/test-proxy-restore.R
@@ -44,14 +44,6 @@ test_that("can use vctrs primitives from vec_restore() without inflooping", {
   expect_identical(vec_slice(foobar, 2), "woot")
 })
 
-test_that("vec_restore() passes `n` argument to methods", {
-  local_methods(
-    vec_proxy.vctrs_foobar = identity,
-    vec_restore.vctrs_foobar = function(x, to, ..., n) n
-  )
-  expect_identical(vec_slice(foobar(1:3), 2), 1L)
-})
-
 test_that("dimensions are preserved by default restore method", {
   x <- foobar(1:4)
   dim(x) <- c(2, 2)

--- a/tests/testthat/test-proxy-restore.R
+++ b/tests/testthat/test-proxy-restore.R
@@ -71,11 +71,11 @@ test_that("names attribute isn't set when restoring 1D arrays using 2D+ objects"
 
 test_that("arguments are not inlined in the dispatch call (#300)", {
   local_methods(
-    vec_restore.vctrs_foobar = function(x, to, ..., n) sys.call(),
+    vec_restore.vctrs_foobar = function(x, to, ...) sys.call(),
     vec_proxy.vctrs_foobar = unclass
   )
   call <- vec_restore(foobar(list(1)), foobar(list(1)))
-  expect_equal(call, quote(vec_restore.vctrs_foobar(x = x, to = to, n = n)))
+  expect_equal(call, quote(vec_restore.vctrs_foobar(x = x, to = to)))
 })
 
 test_that("restoring to non-bare data frames calls `vec_bare_df_restore()` before dispatching", {


### PR DESCRIPTION
It was only used to restore data frames from bare lists, which was kind of an abstraction leak. Instead, we now initialise bare lists to data frame before calling `vec_restore()`.

Closes #650
cc @hadley