### PR TITLE
Transition from `call` to `error_call`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,7 +76,7 @@
 
 * `data_frame()` and `df_list()` have gained `.error_call` arguments (#1610).
 
-* `vec_locate_matches()` has gained a `call` argument (#1611).
+* `vec_locate_matches()` has gained an `error_call` argument (#1611).
 
 * `"select"` and `"relocate"` have been added as valid subscript actions to
   support tidyselect and dplyr (#1596).

--- a/NEWS.md
+++ b/NEWS.md
@@ -84,7 +84,7 @@
 * `num_as_location()` has a new `oob = "remove"` argument to remove
   out-of-bounds locations (#1595).
 
-* `vec_rbind()` and `vec_cbind()` now have `.call` arguments (#1597).
+* `vec_rbind()` and `vec_cbind()` now have `.error_call` arguments (#1597).
 
 * `df_list()` has gained a new `.unpack` argument to optionally disable data
   frame unpacking (#1616).

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,7 +28,7 @@
 * `vec_compare()` now throws a more informative error when attempting to compare
   complex vectors (#1655).
 
-* `vec_rep()` and friends gain `call`, `x_arg`, and `times_arg`
+* `vec_rep()` and friends gain `error_call`, `x_arg`, and `times_arg`
   arguments so they can be embedded in frontends (#1303).
 
 * Record vectors now fail as expected when indexed along dimensions

--- a/NEWS.md
+++ b/NEWS.md
@@ -74,7 +74,7 @@
 * `num_as_location()` now works correctly when a combination of `zero = "error"`
   and `negative = "invert"` are used (#1612).
 
-* `data_frame()` and `df_list()` have gained `.call` arguments (#1610).
+* `data_frame()` and `df_list()` have gained `.error_call` arguments (#1610).
 
 * `vec_locate_matches()` has gained a `call` argument (#1611).
 

--- a/R/bind.R
+++ b/R/bind.R
@@ -195,7 +195,7 @@ vec_cbind <- function(...,
                       .ptype = NULL,
                       .size = NULL,
                       .name_repair = c("unique", "universal", "check_unique", "minimal"),
-                      .call = current_env()) {
+                      .error_call = current_env()) {
   .External2(ffi_cbind, .ptype, .size, .name_repair)
 }
 vec_cbind <- fn_inline_formals(vec_cbind, ".name_repair")

--- a/R/bind.R
+++ b/R/bind.R
@@ -178,7 +178,7 @@ vec_rbind <- function(...,
                       .names_to = rlang::zap(),
                       .name_repair = c("unique", "universal", "check_unique"),
                       .name_spec = NULL,
-                      .call = current_env()) {
+                      .error_call = current_env()) {
   .External2(ffi_rbind, .ptype, .names_to, .name_repair, .name_spec)
 }
 vec_rbind <- fn_inline_formals(vec_rbind, ".name_repair")

--- a/R/match.R
+++ b/R/match.R
@@ -243,7 +243,7 @@ vec_locate_matches <- function(needles,
                                chr_proxy_collate = NULL,
                                needles_arg = "",
                                haystack_arg = "",
-                               call = current_env()) {
+                               error_call = current_env()) {
   check_dots_empty0(...)
   frame <- environment()
 

--- a/R/rep.R
+++ b/R/rep.R
@@ -89,7 +89,7 @@ NULL
 vec_rep <- function(x,
                     times,
                     ...,
-                    call = current_env(),
+                    error_call = current_env(),
                     x_arg = "x",
                     times_arg = "times") {
   check_dots_empty0(...)
@@ -101,7 +101,7 @@ vec_rep <- function(x,
 vec_rep_each <- function(x,
                          times,
                          ...,
-                         call = current_env(),
+                         error_call = current_env(),
                          x_arg = "x",
                          times_arg = "times") {
   check_dots_empty0(...)

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -90,7 +90,7 @@ df_list <- function(...,
                     .size = NULL,
                     .unpack = TRUE,
                     .name_repair = c("check_unique", "unique", "universal", "minimal"),
-                    .call = current_env()) {
+                    .error_call = current_env()) {
   .Call(ffi_df_list, list2(...), .size, .unpack, .name_repair, environment())
 }
 df_list <- fn_inline_formals(df_list, ".name_repair")

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -164,7 +164,7 @@ df_list <- fn_inline_formals(df_list, ".name_repair")
 data_frame <- function(...,
                        .size = NULL,
                        .name_repair = c("check_unique", "unique", "universal", "minimal"),
-                       .call = current_env()) {
+                       .error_call = current_env()) {
   .Call(ffi_data_frame, list2(...), .size, .name_repair, environment())
 }
 data_frame <- fn_inline_formals(data_frame, ".name_repair")

--- a/man/data_frame.Rd
+++ b/man/data_frame.Rd
@@ -8,7 +8,7 @@ data_frame(
   ...,
   .size = NULL,
   .name_repair = c("check_unique", "unique", "universal", "minimal"),
-  .call = current_env()
+  .error_call = current_env()
 )
 }
 \arguments{
@@ -21,7 +21,7 @@ be computed as the common size of the inputs.}
 \item{.name_repair}{One of \code{"check_unique"}, \code{"unique"}, \code{"universal"} or
 \code{"minimal"}. See \code{\link[=vec_as_names]{vec_as_names()}} for the meaning of these options.}
 
-\item{.call}{The execution environment of a currently
+\item{.error_call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be
 mentioned in error messages as the source of the error. See the
 \code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}

--- a/man/df_list.Rd
+++ b/man/df_list.Rd
@@ -9,7 +9,7 @@ df_list(
   .size = NULL,
   .unpack = TRUE,
   .name_repair = c("check_unique", "unique", "universal", "minimal"),
-  .call = current_env()
+  .error_call = current_env()
 )
 }
 \arguments{
@@ -25,7 +25,7 @@ will be computed as the common size of the inputs.}
 \item{.name_repair}{One of \code{"check_unique"}, \code{"unique"}, \code{"universal"} or
 \code{"minimal"}. See \code{\link[=vec_as_names]{vec_as_names()}} for the meaning of these options.}
 
-\item{.call}{The execution environment of a currently
+\item{.error_call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be
 mentioned in error messages as the source of the error. See the
 \code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}

--- a/man/vec-rep.Rd
+++ b/man/vec-rep.Rd
@@ -7,13 +7,20 @@
 \alias{vec_unrep}
 \title{Repeat a vector}
 \usage{
-vec_rep(x, times, ..., call = current_env(), x_arg = "x", times_arg = "times")
+vec_rep(
+  x,
+  times,
+  ...,
+  error_call = current_env(),
+  x_arg = "x",
+  times_arg = "times"
+)
 
 vec_rep_each(
   x,
   times,
   ...,
-  call = current_env(),
+  error_call = current_env(),
   x_arg = "x",
   times_arg = "times"
 )
@@ -32,7 +39,7 @@ the size of \code{x}.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{call}{The execution environment of a currently
+\item{error_call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be
 mentioned in error messages as the source of the error. See the
 \code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -12,7 +12,7 @@ vec_rbind(
   .names_to = rlang::zap(),
   .name_repair = c("unique", "universal", "check_unique"),
   .name_spec = NULL,
-  .call = current_env()
+  .error_call = current_env()
 )
 
 vec_cbind(
@@ -73,7 +73,7 @@ names of the inputs. This only has an effect when \code{.names_to} is
 set to \code{NULL}, which causes the input names to be assigned as row
 names.}
 
-\item{.call}{The execution environment of a currently
+\item{.error_call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be
 mentioned in error messages as the source of the error. See the
 \code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
@@ -83,6 +83,11 @@ mentioned in error messages as the source of the error. See the
 
 Alternatively, specify the desired number of rows, and any inputs of length
 1 will be recycled appropriately.}
+
+\item{.call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 }
 \value{
 A data frame, or subclass of data frame.

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -20,7 +20,7 @@ vec_cbind(
   .ptype = NULL,
   .size = NULL,
   .name_repair = c("unique", "universal", "check_unique", "minimal"),
-  .call = current_env()
+  .error_call = current_env()
 )
 }
 \arguments{
@@ -83,11 +83,6 @@ mentioned in error messages as the source of the error. See the
 
 Alternatively, specify the desired number of rows, and any inputs of length
 1 will be recycled appropriately.}
-
-\item{.call}{The execution environment of a currently
-running function, e.g. \code{caller_env()}. The function will be
-mentioned in error messages as the source of the error. See the
-\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 }
 \value{
 A data frame, or subclass of data frame.

--- a/man/vec_locate_matches.Rd
+++ b/man/vec_locate_matches.Rd
@@ -18,7 +18,7 @@ vec_locate_matches(
   chr_proxy_collate = NULL,
   needles_arg = "",
   haystack_arg = "",
-  call = current_env()
+  error_call = current_env()
 )
 }
 \arguments{
@@ -138,7 +138,7 @@ ordering and \code{stringi::stri_sort_key()} for locale-aware ordering.}
 \item{needles_arg, haystack_arg}{Argument tags for \code{needles} and \code{haystack}
 used in error messages.}
 
-\item{call}{The execution environment of a currently
+\item{error_call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be
 mentioned in error messages as the source of the error. See the
 \code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}

--- a/src/decl/bind-decl.h
+++ b/src/decl/bind-decl.h
@@ -24,19 +24,19 @@ r_obj* vec_cbind(r_obj* xs,
                  r_obj* ptype,
                  r_obj* size,
                  struct name_repair_opts* name_repair,
-                 struct r_lazy call);
+                 struct r_lazy error_call);
 
 static
 r_obj* cbind_names_to(bool has_names,
                       r_obj* names_to,
                       r_obj* ptype,
-                      struct r_lazy call);
+                      struct r_lazy error_call);
 
 static
 r_obj* as_df_col(r_obj* x,
                  r_obj* outer,
                  bool* allow_pack,
-                 struct r_lazy call);
+                 struct r_lazy error_call);
 
 static
 r_obj* cbind_container_type(r_obj* x, void* data);

--- a/src/decl/bind-decl.h
+++ b/src/decl/bind-decl.h
@@ -4,17 +4,17 @@ r_obj* vec_rbind(r_obj* xs,
                  r_obj* id,
                  struct name_repair_opts* name_repair,
                  r_obj* name_spec,
-                 struct r_lazy call);
+                 struct r_lazy error_call);
 
 static
 r_obj* as_df_row(r_obj* x,
                  struct name_repair_opts* name_repair,
-                 struct r_lazy call);
+                 struct r_lazy error_call);
 
 static
 r_obj* as_df_row_impl(r_obj* x,
                       struct name_repair_opts* name_repair,
-                      struct r_lazy call);
+                      struct r_lazy error_call);
 
 static
 struct name_repair_opts validate_bind_name_repair(r_obj* name_repair, bool allow_minimal);

--- a/src/decl/match-decl.h
+++ b/src/decl/match-decl.h
@@ -22,7 +22,7 @@ r_obj* vec_locate_matches(r_obj* needles,
                           r_obj* chr_proxy_collate,
                           struct vctrs_arg* needles_arg,
                           struct vctrs_arg* haystack_arg,
-                          struct r_lazy call);
+                          struct r_lazy error_call);
 
 static
 r_obj* df_locate_matches(r_obj* needles,
@@ -40,7 +40,7 @@ r_obj* df_locate_matches(r_obj* needles,
                          const enum vctrs_ops* v_ops,
                          struct vctrs_arg* needles_arg,
                          struct vctrs_arg* haystack_arg,
-                         struct r_lazy call);
+                         struct r_lazy error_call);
 
 static
 void df_locate_matches_recurse(r_ssize col,
@@ -167,7 +167,7 @@ r_obj* expand_compact_indices(const int* v_o_haystack,
                               const struct poly_df_data* p_haystack,
                               struct vctrs_arg* needles_arg,
                               struct vctrs_arg* haystack_arg,
-                              struct r_lazy call);
+                              struct r_lazy error_call);
 
 static
 r_obj* compute_nesting_container_info(r_obj* haystack,

--- a/src/decl/rep-decl.h
+++ b/src/decl/rep-decl.h
@@ -25,14 +25,14 @@ void stop_rep_size_oob(struct r_lazy call);
 static
 r_obj* vec_rep_each_uniform(r_obj* x,
                             int times,
-                            struct r_lazy call,
+                            struct r_lazy error_call,
                             struct vctrs_arg* p_times_arg);
 
 static
 r_obj* vec_rep_each_impl(r_obj* x,
                          r_obj* times,
                          const r_ssize times_size,
-                         struct r_lazy call,
+                         struct r_lazy error_call,
                          struct vctrs_arg* p_times_arg);
 
 static inline

--- a/src/decl/type-data-frame-decl.h
+++ b/src/decl/type-data-frame-decl.h
@@ -17,14 +17,14 @@ static
 r_obj* data_frame(r_obj* x,
                   r_ssize size,
                   const struct name_repair_opts* p_name_repair_opts,
-                  struct r_lazy call);
+                  struct r_lazy error_call);
 
 static
 r_obj* df_list(r_obj* x,
                r_ssize size,
                bool unpack,
                const struct name_repair_opts* p_name_repair_opts,
-               struct r_lazy call);
+               struct r_lazy error_call);
 
 static
 r_obj* df_list_drop_null(r_obj* x);

--- a/src/globals.c
+++ b/src/globals.c
@@ -51,6 +51,7 @@ void vctrs_init_globals(r_obj* ns) {
   syms.arg = r_sym("arg");
   syms.dot_arg = r_sym(".arg");
   syms.dot_call = r_sym(".call");
+  syms.dot_error_call = r_sym(".error_call");
   syms.haystack_arg = r_sym("haystack_arg");
   syms.needles_arg = r_sym("needles_arg");
   syms.repair_arg = r_sym("repair_arg");

--- a/src/globals.h
+++ b/src/globals.h
@@ -8,6 +8,7 @@ struct syms {
   r_obj* arg;
   r_obj* dot_arg;
   r_obj* dot_call;
+  r_obj* dot_error_call;
   r_obj* haystack_arg;
   r_obj* needles_arg;
   r_obj* repair_arg;

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -175,22 +175,22 @@ r_obj* ffi_data_frame(r_obj* x,
                       r_obj* size,
                       r_obj* name_repair,
                       r_obj* frame) {
-  struct r_lazy call = { .x = syms_dot_call, .env = frame };
+  struct r_lazy error_call = { .x = syms.dot_error_call, .env = frame };
 
   struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair,
                                                                   lazy_args.dot_name_repair,
                                                                   false,
-                                                                  call);
+                                                                  error_call);
   KEEP(name_repair_opts.shelter);
 
   r_ssize c_size = 0;
   if (size == r_null) {
-    c_size = vec_check_size_common(x, 0, vec_args.empty, call);
+    c_size = vec_check_size_common(x, 0, vec_args.empty, error_call);
   } else {
-    c_size = vec_as_short_length(size, vec_args.dot_size, call);
+    c_size = vec_as_short_length(size, vec_args.dot_size, error_call);
   }
 
-  r_obj* out = data_frame(x, c_size, &name_repair_opts, call);
+  r_obj* out = data_frame(x, c_size, &name_repair_opts, error_call);
 
   FREE(1);
   return out;
@@ -200,9 +200,9 @@ static
 r_obj* data_frame(r_obj* x,
                   r_ssize size,
                   const struct name_repair_opts* p_name_repair_opts,
-                  struct r_lazy call) {
+                  struct r_lazy error_call) {
   const bool unpack = true;
-  r_obj* out = KEEP(df_list(x, size, unpack, p_name_repair_opts, call));
+  r_obj* out = KEEP(df_list(x, size, unpack, p_name_repair_opts, error_call));
   out = new_data_frame(out, size);
   FREE(1);
   return out;

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -215,24 +215,24 @@ r_obj* ffi_df_list(r_obj* x,
                    r_obj* unpack,
                    r_obj* name_repair,
                    r_obj* frame) {
-  struct r_lazy call = { .x = syms_dot_call, .env = frame };
+  struct r_lazy error_call = { .x = syms.dot_error_call, .env = frame };
 
   struct name_repair_opts name_repair_opts = new_name_repair_opts(name_repair,
                                                                   lazy_args.dot_name_repair,
                                                                   false,
-                                                                  call);
+                                                                  error_call);
   KEEP(name_repair_opts.shelter);
 
   r_ssize c_size = 0;
   if (size == r_null) {
-    c_size = vec_check_size_common(x, 0, vec_args.empty, call);
+    c_size = vec_check_size_common(x, 0, vec_args.empty, error_call);
   } else {
-    c_size = vec_as_short_length(size, vec_args.dot_size, call);
+    c_size = vec_as_short_length(size, vec_args.dot_size, error_call);
   }
 
   const bool c_unpack = r_arg_as_bool(unpack, ".unpack");
 
-  r_obj* out = df_list(x, c_size, c_unpack, &name_repair_opts, call);
+  r_obj* out = df_list(x, c_size, c_unpack, &name_repair_opts, error_call);
 
   FREE(1);
   return out;
@@ -243,12 +243,12 @@ r_obj* df_list(r_obj* x,
                r_ssize size,
                bool unpack,
                const struct name_repair_opts* p_name_repair_opts,
-               struct r_lazy call) {
+               struct r_lazy error_call) {
   if (r_typeof(x) != R_TYPE_list) {
     r_stop_internal("`x` must be a list.");
   }
 
-  x = KEEP(vec_check_recycle_common(x, size, vec_args.empty, call));
+  x = KEEP(vec_check_recycle_common(x, size, vec_args.empty, error_call));
 
   r_ssize n_cols = r_length(x);
 

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -89,7 +89,7 @@
       Error in `vec_cbind()`:
       ! `..1` must be a vector, not a <vctrs_foobar> object.
     Code
-      (expect_error(vec_cbind(foobar(list()), .call = call("foo"))))
+      (expect_error(vec_cbind(foobar(list()), .error_call = call("foo"))))
     Output
       <error/vctrs_error_scalar_type>
       Error in `foo()`:
@@ -101,7 +101,7 @@
       Error in `vec_cbind()`:
       ! Can't recycle `a` (size 2) to match `b` (size 0).
     Code
-      (expect_error(vec_cbind(a = 1:2, b = int(), .call = call("foo"))))
+      (expect_error(vec_cbind(a = 1:2, b = int(), .error_call = call("foo"))))
     Output
       <error/vctrs_error_incompatible_size>
       Error in `foo()`:
@@ -179,7 +179,7 @@
       Error in `vec_cbind()`:
       ! Can't bind arrays.
     Code
-      (expect_error(vec_cbind(a, .call = call("foo"))))
+      (expect_error(vec_cbind(a, .error_call = call("foo"))))
     Output
       <error/rlang_error>
       Error in `foo()`:

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -7,14 +7,14 @@
       Error in `vec_rbind()`:
       ! Can't combine `..1$x` <integer> and `..2$x` <character>.
     Code
-      (expect_error(vec_rbind(x_int, x_chr, .call = call("foo")), class = "vctrs_error_incompatible_type")
+      (expect_error(vec_rbind(x_int, x_chr, .error_call = call("foo")), class = "vctrs_error_incompatible_type")
       )
     Output
       <error/vctrs_error_incompatible_type>
       Error in `foo()`:
       ! Can't combine `..1$x` <integer> and `..2$x` <character>.
     Code
-      (expect_error(vec_rbind(x_int, x_chr, .ptype = x_chr, .call = call("foo")),
+      (expect_error(vec_rbind(x_int, x_chr, .ptype = x_chr, .error_call = call("foo")),
       class = "vctrs_error_incompatible_type"))
     Output
       <error/vctrs_error_incompatible_type>
@@ -64,7 +64,7 @@
       Error in `vec_rbind()`:
       ! Can't bind arrays.
     Code
-      (expect_error(vec_rbind(array(NA, c(1, 1, 1)), .call = call("foo"))))
+      (expect_error(vec_rbind(array(NA, c(1, 1, 1)), .error_call = call("foo"))))
     Output
       <error/rlang_error>
       Error in `foo()`:
@@ -164,7 +164,7 @@
       Error in `vec_rbind()`:
       ! `.names_to` must be `NULL`, a string, or an `rlang::zap()` object.
     Code
-      (expect_error(vec_rbind(.names_to = letters, .call = call("foo"))))
+      (expect_error(vec_rbind(.names_to = letters, .error_call = call("foo"))))
     Output
       <error/rlang_error>
       Error in `foo()`:
@@ -353,7 +353,7 @@
       x These names are duplicated:
         * "x" at locations 1 and 2.
     Code
-      (expect_error(vec_rbind(df, df, .name_repair = "check_unique", .call = call(
+      (expect_error(vec_rbind(df, df, .name_repair = "check_unique", .error_call = call(
         "foo")), class = "vctrs_error_names_must_be_unique"))
     Output
       <error/vctrs_error_names_must_be_unique>
@@ -399,7 +399,7 @@
       ! Can't zap outer names when `.names_to` is supplied.
     Code
       (expect_error(vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap(),
-      .call = call("foo"))))
+      .error_call = call("foo"))))
     Output
       <error/rlang_error>
       Error in `foo()`:

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -9,7 +9,7 @@
 ---
 
     Code
-      vec_locate_matches(data_frame(), data_frame(), call = call("foo"))
+      vec_locate_matches(data_frame(), data_frame(), error_call = call("foo"))
     Condition
       Error in `foo()`:
       ! Must have at least 1 column to match on.
@@ -25,7 +25,7 @@
 ---
 
     Code
-      vec_locate_matches(x, y, needles_arg = "x", call = call("foo"))
+      vec_locate_matches(x, y, needles_arg = "x", error_call = call("foo"))
     Condition
       Error in `foo()`:
       ! Can't combine `x` <double> and <character>.
@@ -49,7 +49,7 @@
       x The element at location 1 contains missing values.
     Code
       (expect_error(vec_locate_matches(NA, 1, incomplete = "error", needles_arg = "foo",
-        call = call("fn"))))
+        error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_incomplete>
       Error in `fn()`:
@@ -78,7 +78,8 @@
       Error in `vec_locate_matches()`:
       ! `incomplete` must be one of: "compare", "match", "drop", or "error".
     Code
-      (expect_error(vec_locate_matches(1, 2, incomplete = "x", call = call("fn"))))
+      (expect_error(vec_locate_matches(1, 2, incomplete = "x", error_call = call("fn")))
+      )
     Output
       <error/rlang_error>
       Error in `vec_locate_matches()`:
@@ -103,7 +104,7 @@
       x The element at location 1 has multiple matches.
     Code
       (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error",
-      needles_arg = "foo", call = call("fn"))))
+      needles_arg = "foo", error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_multiple>
       Error in `fn()`:
@@ -137,7 +138,7 @@
       x The element at location 1 has multiple matches.
     Code
       (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning",
-      needles_arg = "foo", call = call("fn"))))
+      needles_arg = "foo", error_call = call("fn"))))
     Output
       <warning/vctrs_warning_matches_multiple>
       Warning in `fn()`:
@@ -173,7 +174,8 @@
       Error in `vec_locate_matches()`:
       ! `multiple` must be one of "all", "any", "first", "last", "warning", or "error".
     Code
-      (expect_error(vec_locate_matches(1, 2, multiple = "x", call = call("fn"))))
+      (expect_error(vec_locate_matches(1, 2, multiple = "x", error_call = call("fn")))
+      )
     Output
       <error/rlang_error>
       Error in `vec_locate_matches()`:
@@ -198,7 +200,7 @@
       x The element at location 1 does not have a match.
     Code
       (expect_error(vec_locate_matches(1, 2, no_match = "error", needles_arg = "foo",
-        call = call("fn"))))
+        error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_nothing>
       Error in `fn()`:
@@ -246,7 +248,8 @@
       Error in `vec_locate_matches()`:
       ! `no_match` must be either "drop" or "error".
     Code
-      (expect_error(vec_locate_matches(1, 2, no_match = "x", call = call("fn"))))
+      (expect_error(vec_locate_matches(1, 2, no_match = "x", error_call = call("fn")))
+      )
     Output
       <error/rlang_error>
       Error in `vec_locate_matches()`:
@@ -271,7 +274,7 @@
       x The value at location 1 was not matched.
     Code
       (expect_error(vec_locate_matches(1, 2, remaining = "error", needles_arg = "foo",
-        call = call("fn"))))
+        error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_remaining>
       Error in `fn()`:
@@ -308,7 +311,8 @@
       Error in `vec_locate_matches()`:
       ! `remaining` must be either "drop" or "error".
     Code
-      (expect_error(vec_locate_matches(1, 2, remaining = "x", call = call("fn"))))
+      (expect_error(vec_locate_matches(1, 2, remaining = "x", error_call = call("fn")))
+      )
     Output
       <error/rlang_error>
       Error in `vec_locate_matches()`:

--- a/tests/testthat/_snaps/type-data-frame.md
+++ b/tests/testthat/_snaps/type-data-frame.md
@@ -194,7 +194,7 @@
         * "a" at locations 1 and 2.
       i Use argument `.name_repair` to specify repair strategy.
     Code
-      (expect_error(df_list(a = 1, a = 1, .call = call("foo"))))
+      (expect_error(df_list(a = 1, a = 1, .error_call = call("foo"))))
     Output
       <error/vctrs_error_names_must_be_unique>
       Error in `foo()`:
@@ -209,7 +209,7 @@
       Error in `df_list()`:
       ! Can't recycle `a` (size 2) to match `b` (size 0).
     Code
-      (expect_error(df_list(a = 1:2, b = int(), .call = call("foo"))))
+      (expect_error(df_list(a = 1:2, b = int(), .error_call = call("foo"))))
     Output
       <error/vctrs_error_incompatible_size>
       Error in `foo()`:

--- a/tests/testthat/_snaps/type-data-frame.md
+++ b/tests/testthat/_snaps/type-data-frame.md
@@ -164,7 +164,7 @@
         * "a" at locations 1 and 2.
       i Use argument `.name_repair` to specify repair strategy.
     Code
-      (expect_error(data_frame(a = 1, a = 1, .call = call("foo"))))
+      (expect_error(data_frame(a = 1, a = 1, .error_call = call("foo"))))
     Output
       <error/vctrs_error_names_must_be_unique>
       Error in `foo()`:
@@ -179,7 +179,7 @@
       Error in `data_frame()`:
       ! Can't recycle `a` (size 2) to match `b` (size 0).
     Code
-      (expect_error(data_frame(a = 1:2, b = int(), .call = call("foo"))))
+      (expect_error(data_frame(a = 1:2, b = int(), .error_call = call("foo"))))
     Output
       <error/vctrs_error_incompatible_size>
       Error in `foo()`:

--- a/tests/testthat/helper-conditions.R
+++ b/tests/testthat/helper-conditions.R
@@ -60,7 +60,7 @@ my_vec_rep <- function(my_x, my_times) {
   vec_rep(
     my_x,
     my_times,
-    call = current_env(),
+    error_call = current_env(),
     x_arg = "my_x",
     times_arg = "my_times"
   )
@@ -70,7 +70,7 @@ my_vec_rep_each <- function(my_x, my_times) {
   vec_rep_each(
     my_x,
     my_times,
-    call = current_env(),
+    error_call = current_env(),
     x_arg = "my_x",
     times_arg = "my_times"
   )

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -39,11 +39,11 @@ test_that("incompatible columns throws common type error", {
       class = "vctrs_error_incompatible_type"
     ))
     (expect_error(
-      vec_rbind(x_int, x_chr, .call = call("foo")),
+      vec_rbind(x_int, x_chr, .error_call = call("foo")),
       class = "vctrs_error_incompatible_type"
     ))
     (expect_error(
-      vec_rbind(x_int, x_chr, .ptype = x_chr, .call = call("foo")),
+      vec_rbind(x_int, x_chr, .ptype = x_chr, .error_call = call("foo")),
       class = "vctrs_error_incompatible_type"
     ))
   })
@@ -221,7 +221,7 @@ test_that("can construct an id column", {
 test_that("vec_rbind() fails with arrays of dimensionality > 3", {
   expect_snapshot({
     (expect_error(vec_rbind(array(NA, c(1, 1, 1)))))
-    (expect_error(vec_rbind(array(NA, c(1, 1, 1)), .call = call("foo"))))
+    (expect_error(vec_rbind(array(NA, c(1, 1, 1)), .error_call = call("foo"))))
   })
 })
 
@@ -497,7 +497,7 @@ test_that("can supply `.names_to` to `vec_rbind()` (#229)", {
   expect_snapshot({
     (expect_error(vec_rbind(.names_to = letters)))
     (expect_error(vec_rbind(.names_to = 10)))
-    (expect_error(vec_rbind(.names_to = letters, .call = call("foo"))))
+    (expect_error(vec_rbind(.names_to = letters, .error_call = call("foo"))))
   })
 
   x <- data_frame(foo = 1:2, bar = 3:4)
@@ -752,7 +752,7 @@ test_that("rbind repairs names of data frames (#704)", {
       class = "vctrs_error_names_must_be_unique"
     ))
     (expect_error(
-      vec_rbind(df, df, .name_repair = "check_unique", .call = call("foo")),
+      vec_rbind(df, df, .name_repair = "check_unique", .error_call = call("foo")),
       class = "vctrs_error_names_must_be_unique"
     ))
   })
@@ -995,7 +995,7 @@ test_that("can't zap names when `.names_to` is supplied", {
       vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap())
     ))
     (expect_error(
-      vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap(), .call = call("foo"))
+      vec_rbind(foo = c(x = 1), .names_to = "id", .name_spec = zap(), .error_call = call("foo"))
     ))
   })
 })

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -396,10 +396,10 @@ test_that("performance: Row binding with df-cols doesn't duplicate on every assi
 test_that("vec_cbind() reports error context", {
   expect_snapshot({
     (expect_error(vec_cbind(foobar(list()))))
-    (expect_error(vec_cbind(foobar(list()), .call = call("foo"))))
+    (expect_error(vec_cbind(foobar(list()), .error_call = call("foo"))))
 
     (expect_error(vec_cbind(a = 1:2, b = int())))
-    (expect_error(vec_cbind(a = 1:2, b = int(), .call = call("foo"))))
+    (expect_error(vec_cbind(a = 1:2, b = int(), .error_call = call("foo"))))
   })
 })
 
@@ -597,7 +597,7 @@ test_that("vec_cbind() fails with arrays of dimensionality > 3", {
 
   expect_snapshot({
     (expect_error(vec_cbind(a)))
-    (expect_error(vec_cbind(a, .call = call("foo"))))
+    (expect_error(vec_cbind(a, .error_call = call("foo"))))
     (expect_error(vec_cbind(x = a)))
   })
 })

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -395,7 +395,7 @@ test_that("must have at least 1 column to match", {
     vec_locate_matches(data_frame(), data_frame())
   })
   expect_snapshot(error = TRUE, {
-    vec_locate_matches(data_frame(), data_frame(), call = call("foo"))
+    vec_locate_matches(data_frame(), data_frame(), error_call = call("foo"))
   })
 })
 
@@ -544,7 +544,7 @@ test_that("common type of `needles` and `haystack` is taken", {
     vec_locate_matches(x, y)
   })
   expect_snapshot(error = TRUE, {
-    vec_locate_matches(x, y, needles_arg = "x", call = call("foo"))
+    vec_locate_matches(x, y, needles_arg = "x", error_call = call("foo"))
   })
 })
 
@@ -817,7 +817,7 @@ test_that("`incomplete` can error informatively", {
   expect_snapshot({
     (expect_error(vec_locate_matches(NA, 1, incomplete = "error")))
     (expect_error(vec_locate_matches(NA, 1, incomplete = "error", needles_arg = "foo")))
-    (expect_error(vec_locate_matches(NA, 1, incomplete = "error", needles_arg = "foo", call = call("fn"))))
+    (expect_error(vec_locate_matches(NA, 1, incomplete = "error", needles_arg = "foo", error_call = call("fn"))))
   })
 })
 
@@ -831,7 +831,7 @@ test_that("`incomplete` is validated", {
     (expect_error(vec_locate_matches(1, 2, incomplete = c("match", "drop"))))
     (expect_error(vec_locate_matches(1, 2, incomplete = "x")))
     # Uses internal call
-    (expect_error(vec_locate_matches(1, 2, incomplete = "x", call = call("fn"))))
+    (expect_error(vec_locate_matches(1, 2, incomplete = "x", error_call = call("fn"))))
   })
 })
 
@@ -909,7 +909,7 @@ test_that("`multiple` can error informatively", {
   expect_snapshot({
     (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error")))
     (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error", needles_arg = "foo")))
-    (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error", needles_arg = "foo", call = call("fn"))))
+    (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error", needles_arg = "foo", error_call = call("fn"))))
     (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error", needles_arg = "foo", haystack_arg = "bar")))
   })
 })
@@ -918,7 +918,7 @@ test_that("`multiple` can warn informatively", {
   expect_snapshot({
     (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning")))
     (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning", needles_arg = "foo")))
-    (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning", needles_arg = "foo", call = call("fn"))))
+    (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning", needles_arg = "foo", error_call = call("fn"))))
     (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning", needles_arg = "foo", haystack_arg = "bar")))
   })
 })
@@ -1034,7 +1034,7 @@ test_that("`multiple` is validated", {
     (expect_error(vec_locate_matches(1, 2, multiple = c("first", "last"))))
     (expect_error(vec_locate_matches(1, 2, multiple = "x")))
     # Uses internal error
-    (expect_error(vec_locate_matches(1, 2, multiple = "x", call = call("fn"))))
+    (expect_error(vec_locate_matches(1, 2, multiple = "x", error_call = call("fn"))))
   })
 })
 
@@ -1080,7 +1080,7 @@ test_that("`no_match` can error informatively", {
   expect_snapshot({
     (expect_error(vec_locate_matches(1, 2, no_match = "error")))
     (expect_error(vec_locate_matches(1, 2, no_match = "error", needles_arg = "foo")))
-    (expect_error(vec_locate_matches(1, 2, no_match = "error", needles_arg = "foo", call = call("fn"))))
+    (expect_error(vec_locate_matches(1, 2, no_match = "error", needles_arg = "foo", error_call = call("fn"))))
     (expect_error(vec_locate_matches(1, 2, no_match = "error", needles_arg = "foo", haystack_arg = "bar")))
   })
 })
@@ -1115,7 +1115,7 @@ test_that("`no_match` is validated", {
     (expect_error(vec_locate_matches(1, 2, no_match = c(1L, 2L))))
     (expect_error(vec_locate_matches(1, 2, no_match = "x")))
     # Uses internal call
-    (expect_error(vec_locate_matches(1, 2, no_match = "x", call = call("fn"))))
+    (expect_error(vec_locate_matches(1, 2, no_match = "x", error_call = call("fn"))))
   })
 })
 
@@ -1204,7 +1204,7 @@ test_that("`remaining` can error informatively", {
   expect_snapshot({
     (expect_error(vec_locate_matches(1, 2, remaining = "error")))
     (expect_error(vec_locate_matches(1, 2, remaining = "error", needles_arg = "foo")))
-    (expect_error(vec_locate_matches(1, 2, remaining = "error", needles_arg = "foo", call = call("fn"))))
+    (expect_error(vec_locate_matches(1, 2, remaining = "error", needles_arg = "foo", error_call = call("fn"))))
     (expect_error(vec_locate_matches(1, 2, remaining = "error", needles_arg = "foo", haystack_arg = "bar")))
   })
 })
@@ -1215,7 +1215,7 @@ test_that("`remaining` is validated", {
     (expect_error(vec_locate_matches(1, 2, remaining = c(1L, 2L))))
     (expect_error(vec_locate_matches(1, 2, remaining = "x")))
     # Uses internal call
-    (expect_error(vec_locate_matches(1, 2, remaining = "x", call = call("fn"))))
+    (expect_error(vec_locate_matches(1, 2, remaining = "x", error_call = call("fn"))))
   })
 })
 

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -453,9 +453,9 @@ test_that("data_frame() and df_list() report error context", {
     (expect_error(data_frame(a = 1:2, b = int(), .error_call = call("foo"))))
 
     (expect_error(df_list(a = 1, a = 1)))
-    (expect_error(df_list(a = 1, a = 1, .call = call("foo"))))
+    (expect_error(df_list(a = 1, a = 1, .error_call = call("foo"))))
     (expect_error(df_list(a = 1:2, b = int())))
-    (expect_error(df_list(a = 1:2, b = int(), .call = call("foo"))))
+    (expect_error(df_list(a = 1:2, b = int(), .error_call = call("foo"))))
   })
 })
 

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -448,9 +448,9 @@ test_that("new_data_frame() zaps existing attributes", {
 test_that("data_frame() and df_list() report error context", {
   expect_snapshot({
     (expect_error(data_frame(a = 1, a = 1)))
-    (expect_error(data_frame(a = 1, a = 1, .call = call("foo"))))
+    (expect_error(data_frame(a = 1, a = 1, .error_call = call("foo"))))
     (expect_error(data_frame(a = 1:2, b = int())))
-    (expect_error(data_frame(a = 1:2, b = int(), .call = call("foo"))))
+    (expect_error(data_frame(a = 1:2, b = int(), .error_call = call("foo"))))
 
     (expect_error(df_list(a = 1, a = 1)))
     (expect_error(df_list(a = 1, a = 1, .call = call("foo"))))


### PR DESCRIPTION
Closes #1671 

Any C level helper function that was named like `stop_*()` or `check_*()` retained `struct r_lazy* call`, but otherwise I transitioned most signatures to `struct r_lazy* error_call` if the R level function also used `error_call`

`vec_c()` is handled in #1660 and then `list_unchop()` will be handled in a follow up to that.

@lionel- I don't think you need to do an in depth review, just a quick scan to confirm that is what we wanted