### PR TITLE
Use `vec_any_missing()` internally

### DIFF
--- a/R/slice-interleave.R
+++ b/R/slice-interleave.R
@@ -41,10 +41,9 @@ vec_interleave <- function(...,
                            .name_repair = c("minimal", "unique", "check_unique", "universal")) {
   args <- list2(...)
 
-  # TODO: Use `vec_drop_missing()`
   # `NULL`s must be dropped up front to generate appropriate indices
-  missing <- vec_detect_missing(args)
-  if (any(missing)) {
+  if (vec_any_missing(args)) {
+    missing <- vec_detect_missing(args)
     args <- vec_slice(args, !missing)
   }
 

--- a/R/type-bare.R
+++ b/R/type-bare.R
@@ -414,8 +414,12 @@ vec_proxy_order.list <- function(x, ...) {
   # This allows list elements to be grouped in `vec_order()`.
   # Have to separately ensure missing values are propagated.
   out <- vec_duplicate_id(x)
-  na <- vec_detect_missing(x)
-  out <- vec_assign(out, na, NA_integer_)
+
+  if (vec_any_missing(x)) {
+    missing <- vec_detect_missing(x)
+    out <- vec_assign(out, missing, NA_integer_)
+  }
+
   out
 }
 

--- a/R/type-vctr.R
+++ b/R/type-vctr.R
@@ -103,12 +103,11 @@ names_repair_missing <- function(x) {
     return(x)
   }
 
-  missing <- vec_detect_missing(x)
-
-  if (any(missing)) {
+  if (vec_any_missing(x)) {
     # We never want to allow `NA_character_` names to slip through, but
     # erroring on them has caused issues. Instead, we repair them to the
     # empty string (#784).
+    missing <- vec_detect_missing(x)
     x <- vec_assign(x, missing, "")
   }
 
@@ -410,9 +409,7 @@ is.na.vctrs_vctr <- function(x) {
 #' @importFrom stats na.fail
 #' @export
 na.fail.vctrs_vctr <- function(object, ...) {
-  missing <- vec_detect_missing(object)
-
-  if (any(missing)) {
+  if (vec_any_missing(object)) {
     # Return the same error as `na.fail.default()`
     abort("missing values in object")
   }
@@ -436,13 +433,12 @@ na_remove <- function(x, type) {
   # The only difference between `na.omit()` and `na.exclude()` is the class
   # of the `na.action` attribute
 
-  missing <- vec_detect_missing(x)
-
-  if (!any(missing)) {
+  if (!vec_any_missing(x)) {
     return(x)
   }
 
   # `na.omit/exclude()` attach the locations of the omitted values to the result
+  missing <- vec_detect_missing(x)
   loc <- which(missing)
 
   names <- vec_names(x)


### PR DESCRIPTION
I had marked a few places to use `vec_any_missing()` where it made sense from a code cleanliness or performance perspective 