### PR TITLE
Improve performance of list-of implementation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* Improved the performance of list-of common type methods (#1686).
+
 * `vec_rbind()` now applies `base::c()` fallback recursively within
   packed df-cols (#1331, #1462, #1640).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * Improved the performance of list-of common type methods (#1686).
 
+* The list-of method for `as_list_of()` now places the optional `.ptype`
+  argument after the `...` (#1686).
+
 * `vec_rbind()` now applies `base::c()` fallback recursively within
   packed df-cols (#1331, #1462, #1640).
 

--- a/R/type-list-of.R
+++ b/R/type-list-of.R
@@ -65,13 +65,7 @@ new_list_of <- function(x = list(), ptype = logical(), ..., class = character())
 }
 
 new_list_of0 <- function(x, ptype, ..., class = character()) {
-  if (length(class) == 0L) {
-    class <- "vctrs_list_of"
-  } else {
-    class <- c(class, "vctrs_list_of")
-  }
-
-  new_vctr(x, ..., ptype = ptype, class = class)
+  new_vctr(x, ..., ptype = ptype, class = c(class, "vctrs_list_of"))
 }
 
 #' @export

--- a/R/type-list-of.R
+++ b/R/type-list-of.R
@@ -20,15 +20,7 @@
 #' vec_c(list_of(1, 2), list_of(FALSE, TRUE))
 list_of <- function(..., .ptype = NULL) {
   args <- list2(...)
-
-  ptype <- vec_ptype_common(!!!args, .ptype = .ptype)
-  if (is.null(ptype)) {
-    abort("Could not find common type for elements of `x`.")
-  }
-
-  args <- vec_cast_common(!!!args, .to = ptype)
-
-  new_list_of(args, ptype)
+  list_as_list_of(args, ptype = .ptype)
 }
 
 #' @export
@@ -38,9 +30,10 @@ as_list_of <- function(x, ...) {
 }
 
 #' @export
-as_list_of.vctrs_list_of <- function(x, .ptype = NULL, ...) {
+as_list_of.vctrs_list_of <- function(x, ..., .ptype = NULL) {
   if (!is.null(.ptype)) {
-    list_of(!!!x, .ptype = .ptype)
+    x <- unclass(x)
+    list_as_list_of(x, ptype = .ptype)
   } else {
     x
   }
@@ -48,7 +41,7 @@ as_list_of.vctrs_list_of <- function(x, .ptype = NULL, ...) {
 
 #' @export
 as_list_of.list <- function(x, ..., .ptype = NULL) {
-  list_of(!!!x, .ptype = .ptype)
+  list_as_list_of(x, ptype = .ptype)
 }
 
 #' Create list_of subclass
@@ -68,7 +61,17 @@ new_list_of <- function(x = list(), ptype = logical(), ..., class = character())
     abort("`ptype` must have size 0.")
   }
 
-  new_vctr(x, ..., ptype = ptype, class = c(class, "vctrs_list_of"))
+  new_list_of0(x = x, ptype = ptype, ..., class = class)
+}
+
+new_list_of0 <- function(x, ptype, ..., class = character()) {
+  if (length(class) == 0L) {
+    class <- "vctrs_list_of"
+  } else {
+    class <- c(class, "vctrs_list_of")
+  }
+
+  new_vctr(x, ..., ptype = ptype, class = class)
 }
 
 #' @export
@@ -157,7 +160,7 @@ as.character.vctrs_list_of <- function(x, ...) {
 `[<-.vctrs_list_of` <- function(x, i, value) {
   wrapped_type <- attr(x, "ptype")
   value <- map(value, vec_cast, to = wrapped_type)
-  value <- new_list_of(value, ptype = attr(x, "ptype"))
+  value <- new_list_of0(value, ptype = wrapped_type)
   NextMethod()
 }
 #' @export
@@ -192,8 +195,8 @@ vec_ptype2.vctrs_list_of <- function(x, y, ..., x_arg = "", y_arg = "") {
 #' @method vec_ptype2.vctrs_list_of vctrs_list_of
 #' @export
 vec_ptype2.vctrs_list_of.vctrs_list_of <- function(x, y, ...) {
-  type <- vec_ptype2(attr(x, "ptype"), attr(y, "ptype"))
-  new_list_of(list(), type)
+  ptype <- vec_ptype2(attr(x, "ptype"), attr(y, "ptype"))
+  new_list_of0(x = list(), ptype = ptype)
 }
 
 #' @rdname list_of
@@ -206,9 +209,25 @@ vec_cast.vctrs_list_of <- function(x, to, ...) {
 
 #' @export
 #' @method vec_cast.vctrs_list_of vctrs_list_of
-vec_cast.vctrs_list_of.vctrs_list_of <-function(x, to, ...) {
+vec_cast.vctrs_list_of.vctrs_list_of <- function(x, to, ...) {
   # Casting list to list_of will warn/err if the cast is lossy,
   # but the locations refer to the inner vectors,
   # and the cast fails if all (vector) elements in a single (list) element
-  as_list_of(x, .ptype = attr(to, "ptype"))
+  x <- unclass(x)
+  ptype <- attr(to, "ptype")
+  list_as_list_of(x, ptype = ptype)
+}
+
+# Helpers -----------------------------------------------------------------
+
+list_as_list_of <- function(x, ptype = NULL, error_call = caller_env()) {
+  ptype <- vec_ptype_common(!!!x, .ptype = ptype, .call = error_call)
+
+  if (is.null(ptype)) {
+    abort("Can't find common type for elements of `x`.", call = error_call)
+  }
+
+  x <- vec_cast_common(!!!x, .to = ptype, .call = error_call)
+
+  new_list_of0(x = x, ptype = ptype)
 }


### PR DESCRIPTION
A few improvements to the list-of implementation including:
- Avoiding calling `!!!` on a list-of. This has to go through `rlang:::rlang_as_list()` to unstructure the list, which can be expensive if called from the cast method repeatedly
- Faster internal `new_list_of0()` that avoids a few checks that don't need when passing lists around internally
- Avoiding dispatch of `as_list_of()` in the self-self cast method

A benchmark using a simplified version of the example from #1496 (this only focuses on the list-of part, not the list-col-in-a-tibble part)

``` r
library(vctrs)

make_list_of <- function(n) {
  vec_chop(new_list_of(vec_chop(1:n), ptype = integer()))
}

list1 <- make_list_of(1e3)
list2 <- make_list_of(2e3)
list4 <- make_list_of(4e3)
list8 <- make_list_of(8e3)

ptype <- vec_ptype(list1[[1]])

bench::mark(
  list1 = list_unchop(list1, ptype = ptype),
  list2 = list_unchop(list2, ptype = ptype),
  list4 = list_unchop(list4, ptype = ptype),
  list8 = list_unchop(list8, ptype = ptype),
  min_iterations = 200,
  check = FALSE
)

# Main
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 4 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 list1        39.2ms   44.6ms     22.1     94.6KB     16.7
#> 2 list2        64.6ms   83.1ms     12.1     70.5KB     18.3
#> 3 list4       131.8ms    146ms      6.58   140.9KB     20.0
#> 4 list8       277.7ms  350.7ms      2.86   281.5KB     17.4

# This PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 4 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 list1        24.2ms   28.9ms     34.0     75.3KB     17.9
#> 2 list2        49.4ms   53.4ms     18.4     70.5KB     19.4
#> 3 list4       100.1ms  105.8ms      9.27   140.9KB     19.4
#> 4 list8       202.6ms    214ms      4.62   281.5KB     19.4
```