### PR TITLE
Add `<list-of>` self-self cast optimization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 
 * `vec_c()` has gained an `.error_call` argument (#1641).
 
-* Improved the performance of list-of common type methods (#1686).
+* Improved the performance of list-of common type methods (#1686, #875).
 
 * The list-of method for `as_list_of()` now places the optional `.ptype`
   argument after the `...` (#1686).

--- a/R/type-list-of.R
+++ b/R/type-list-of.R
@@ -204,12 +204,18 @@ vec_cast.vctrs_list_of <- function(x, to, ...) {
 #' @export
 #' @method vec_cast.vctrs_list_of vctrs_list_of
 vec_cast.vctrs_list_of.vctrs_list_of <- function(x, to, ...) {
-  # Casting list to list_of will warn/err if the cast is lossy,
-  # but the locations refer to the inner vectors,
-  # and the cast fails if all (vector) elements in a single (list) element
-  x <- unclass(x)
-  ptype <- attr(to, "ptype")
-  list_as_list_of(x, ptype = ptype)
+  x_ptype <- attr(x, "ptype", exact = TRUE)
+  to_ptype <- attr(to, "ptype", exact = TRUE)
+
+  if (identical(x_ptype, to_ptype)) {
+    # FIXME: Suboptimal check for "same type", but should be good enough for the
+    # common case of unchopping a list of identically generated list-ofs (#875).
+    # Would be fixed by https://github.com/r-lib/vctrs/issues/1688.
+    x
+  } else {
+    x <- unclass(x)
+    list_as_list_of(x, ptype = to_ptype)
+  }
 }
 
 # Helpers -----------------------------------------------------------------

--- a/tests/testthat/test-type-list-of.R
+++ b/tests/testthat/test-type-list-of.R
@@ -146,6 +146,23 @@ test_that("max<list_of<a>, list_of<b>> is list_of<max<a, b>>", {
   expect_equal(vec_ptype_common(r_int, r_dbl), r_int)
 })
 
+test_that("can cast to self type", {
+  x <- list_of(1)
+  expect_identical(vec_cast(x, x), x)
+})
+
+test_that("can cast between different list_of types", {
+  x <- list_of(1, 2)
+  to <- list_of(.ptype = integer())
+  expect_identical(vec_cast(x, to), list_of(1L, 2L))
+})
+
+test_that("list_of casting retains outer names", {
+  x <- list_of(x = 1, 2, z = 3)
+  to <- list_of(.ptype = integer())
+  expect_named(vec_cast(x, to), c("x", "", "z"))
+})
+
 test_that("safe casts work as expected", {
   x <- list_of(1)
   expect_equal(vec_cast(NULL, x), NULL)


### PR DESCRIPTION
Closes #875 

We now apply an optimization by just returning `x` if the ptype attributes are identical. This is suboptimal for a "same type" check at the moment, but would be improved by #1688.

The main beneficiary of this optimization is the case in #875 (which is common) where you have a long `list_of<type>` and you are casting it to another `list_of<type>` (i.e. no change in the inner element type).

The main branch was already faster than the reprex given in #875, but this additional optimization really helps here because we no longer re-cast the inner data.

``` r
library(vctrs)

create_list_of <- function(n) {
  x <- as.list(rep(letters, 10^n))
  new_list_of(x, ptype = character())
}

# Create 1 list-of with size 10^n. Each list-of element is size 1.
x3 <- create_list_of(3)
x4 <- create_list_of(4)
x5 <- create_list_of(5)

# Cast those list-ofs to the same type
bench::mark(
  cast3 = vec_cast(x3, list_of(.ptype = character())),
  cast4 = vec_cast(x4, list_of(.ptype = character())),
  cast5 = vec_cast(x5, list_of(.ptype = character())),
  check = FALSE
)

# main (each element of `x` is recast to the same type)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 cast3        1.91ms   2.19ms    392.      1.31MB    13.5 
#> 2 cast4       27.58ms  29.69ms     31.2     11.9MB     9.74
#> 3 cast5      343.42ms 398.76ms      2.51  119.02MB     5.02

# This PR (no work is done, early exit)
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 cast3        36.1µs   49.8µs    19279.     129KB     2.05
#> 2 cast4        35.7µs   42.4µs    21462.        0B     4.29
#> 3 cast5        35.2µs   39.3µs    23453.        0B     4.69
```

That said, it also helps with the example from https://github.com/r-lib/vctrs/pull/1686 where we have a large amount of size 1 list-ofs that we want to combine together with `list_unchop()` (i.e. a simplify operation). It seems to be about 2-3x faster to avoid the inner cast - and that is when the inner type is one we natively support.

``` r
library(vctrs)

make_list_of <- function(n) {
  vec_chop(new_list_of(vec_chop(1:n), ptype = integer()))
}

list1 <- make_list_of(1e3)
list2 <- make_list_of(2e3)
list4 <- make_list_of(4e3)
list8 <- make_list_of(8e3)

ptype <- vec_ptype(list1[[1]])

bench::mark(
  list1 = list_unchop(list1, ptype = ptype),
  list2 = list_unchop(list2, ptype = ptype),
  list4 = list_unchop(list4, ptype = ptype),
  list8 = list_unchop(list8, ptype = ptype),
  min_iterations = 200,
  check = FALSE
)

# main
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 4 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 list1        18.6ms     25ms     39.8       58KB     21.3
#> 2 list2        39.8ms   44.6ms     22.0     70.5KB     23.6
#> 3 list4        81.7ms   89.9ms     11.0    140.9KB     23.5
#> 4 list8       168.8ms  178.8ms      5.51   281.5KB     23.6

# This PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 4 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 list1        8.72ms    9.7ms      97.7    54.9KB     27.4
#> 2 list2       13.96ms   18.6ms      52.9    70.5KB     29.4
#> 3 list4       32.06ms   36.6ms      26.8   140.9KB     29.8
#> 4 list8       63.23ms   73.9ms      13.4   281.5KB     29.7
```

I also tried with the "worst case" scenario to see if this optimization made it much worse. This is when the type you are casting to is _different_ from the original type, meaning the `identical()` check is a waste and we have to go through `list_as_list_of()` anyways. I think that `list_as_list_of()` dominates the computation enough that we don't need to worry about the `identical()` check at all.

``` r
library(vctrs)

to <- list_of(.ptype = integer())

# 100,000 empty list_of<dbl>s to cast to list_of<int>
# (in theory this would be the most damaging because list_as_list_of() is "cheap" here, but we don't see much impact)
x <- rep(list(list_of(.ptype = double())), 1e5)
bench::mark(vec_cast_common(!!!x, .to = to))

# main
#> # A tibble: 1 × 6
#>   expression                           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast_common(!!!x, .to = to)     2.2s     2.2s     0.455    1.54MB     12.3

# This PR
#> # A tibble: 1 × 6
#>   expression                           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast_common(!!!x, .to = to)    2.27s    2.27s     0.441    1.56MB     11.9


# 100,000 list_of<dbl>s with 1 element of size 10,000 to cast to list_of<int>
# (in this case, casting of the actual data dominates the time)
x <- rep(list(list_of(1:10000 + 0)), 1e5)
bench::mark(vec_cast_common(!!!x, .to = to))

# main
#> # A tibble: 1 × 6
#>   expression                           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast_common(!!!x, .to = to)    5.96s    5.96s     0.168    3.73GB     3.36

# This PR
#> # A tibble: 1 × 6
#>   expression                           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_cast_common(!!!x, .to = to)    5.92s    5.92s     0.169    3.73GB     2.36
```

<sup>Created on 2022-09-28 with [reprex v2.0.2.9000](https://reprex.tidyverse.org)</sup>