### PR TITLE
Use positional errors in `vec_c()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* Directed calls to `vec_c()`, like `vec_c(.ptype = <type>)`, now mention the
+  position of the problematic argument when there are cast errors (#1690).
+
 * `list_unchop()` no longer drops names in some cases when `indices` were
   supplied (#1689).
 

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -12,7 +12,29 @@
       vec_c("x", .ptype = integer(), .error_call = call("foo"))
     Condition
       Error in `foo()`:
-      ! Can't convert <character> to <integer>.
+      ! Can't convert `..1` <character> to <integer>.
+
+# common type failure uses positional errors
+
+    Code
+      (expect_error(vec_c(1, a = "x", 2)))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `vec_c()`:
+      ! Can't combine `..1` <double> and `a` <character>.
+    Code
+      (expect_error(vec_c(1, a = "x", 2, .ptype = double())))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `vec_c()`:
+      ! Can't convert `a` <character> to <double>.
+    Code
+      (expect_error(vec_c(1, a = 2.5, .ptype = integer())))
+    Output
+      <error/vctrs_error_cast_lossy>
+      Error in `vec_c()`:
+      ! Can't convert from `a` <double> to <integer> due to loss of precision.
+      * Locations: 1
 
 # vec_c() includes index in argument tag
 
@@ -103,7 +125,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error in `vec_c()`:
-      ! Can't convert <vctrs_foobar> to <character>.
+      ! Can't convert `..1` <vctrs_foobar> to <character>.
     Code
       (expect_error(with_c_foobar(vec_c(foobar(1), foobar(2), .error_call = call(
         "foo"), .name_spec = "{outer}_{inner}"))))

--- a/tests/testthat/_snaps/slice-chop.md
+++ b/tests/testthat/_snaps/slice-chop.md
@@ -77,6 +77,49 @@
       Error in `foo()`:
       ! Can't combine `..1` <double> and `..2` <character>.
 
+# common type failure uses positional errors
+
+    Code
+      (expect_error(list_unchop(list(1, a = "x", 2))))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `list_unchop()`:
+      ! Can't combine `..1` <double> and `a` <character>.
+    Code
+      (expect_error(list_unchop(list(1, a = "x", 2), indices = list(2, 1, 3))))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `list_unchop()`:
+      ! Can't combine `..1` <double> and `a` <character>.
+    Code
+      (expect_error(list_unchop(list(1, a = "x", 2), ptype = double())))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `list_unchop()`:
+      ! Can't convert `a` <character> to <double>.
+    Code
+      (expect_error(list_unchop(list(1, a = "x", 2), indices = list(2, 1, 3), ptype = double()))
+      )
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `list_unchop()`:
+      ! Can't convert `a` <character> to <double>.
+    Code
+      (expect_error(list_unchop(list(1, a = 2.5), ptype = integer())))
+    Output
+      <error/vctrs_error_cast_lossy>
+      Error in `list_unchop()`:
+      ! Can't convert from `a` <double> to <integer> due to loss of precision.
+      * Locations: 1
+    Code
+      (expect_error(list_unchop(list(1, a = 2.5), indices = list(2, 1), ptype = integer()))
+      )
+    Output
+      <error/vctrs_error_cast_lossy>
+      Error in `list_unchop()`:
+      ! Can't convert from `a` <double> to <integer> due to loss of precision.
+      * Locations: 1
+
 # can specify a ptype to override common type
 
     Code
@@ -202,7 +245,7 @@
     Output
       <error/vctrs_error_incompatible_type>
       Error in `list_unchop()`:
-      ! Can't convert <vctrs_foobar> to <character>.
+      ! Can't convert `..1` <vctrs_foobar> to <character>.
 
 # list_unchop() does not support non-numeric S3 indices
 

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -49,6 +49,19 @@ test_that("common type failure uses error call (#1641)", {
   })
 })
 
+test_that("common type failure uses positional errors", {
+  expect_snapshot({
+    # Looking for `..1` and `a`
+    (expect_error(vec_c(1, a = "x", 2)))
+
+    # Directed cast should also produce directional errors (#1690)
+    (expect_error(vec_c(1, a = "x", 2, .ptype = double())))
+
+    # Lossy cast
+    (expect_error(vec_c(1, a = 2.5, .ptype = integer())))
+  })
+})
+
 test_that("combines outer an inner names", {
   expect_equal(vec_c(x = 1), c(x = 1))
   expect_equal(vec_c(c(x = 1)), c(x = 1))
@@ -102,6 +115,11 @@ test_that("vec_c() handles record classes", {
 test_that("can mix named and unnamed vectors (#271)", {
   expect_identical(vec_c(c(a = 1), 2), c(a = 1, 2))
   expect_identical(vec_c(0, c(a = 1), 2, b = 3), c(0, a = 1, 2, b =3))
+})
+
+test_that("preserves names when inputs are cast to a common type (#1690)", {
+  expect_named(vec_c(c(a = 1), .ptype = integer()), "a")
+  expect_named(vec_c(foo = c(a = 1), .ptype = integer(), .name_spec = "{outer}_{inner}"), "foo_a", )
 })
 
 test_that("vec_c() repairs names", {

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -430,6 +430,22 @@ test_that("unchopping takes the common type", {
   expect_type(list_unchop(x, indices), "double")
 })
 
+test_that("common type failure uses positional errors", {
+  expect_snapshot({
+    # Looking for `..1` and `a`
+    (expect_error(list_unchop(list(1, a = "x", 2))))
+    (expect_error(list_unchop(list(1, a = "x", 2), indices = list(2, 1, 3))))
+
+    # Directed cast should also produce directional errors (#1690)
+    (expect_error(list_unchop(list(1, a = "x", 2), ptype = double())))
+    (expect_error(list_unchop(list(1, a = "x", 2), indices = list(2, 1, 3), ptype = double())))
+
+    # Lossy cast
+    (expect_error(list_unchop(list(1, a = 2.5), ptype = integer())))
+    (expect_error(list_unchop(list(1, a = 2.5), indices = list(2, 1), ptype = integer())))
+  })
+})
+
 test_that("can specify a ptype to override common type", {
   indices <- list(1, 2)
 


### PR DESCRIPTION
Closes #1690 
Supersedes #1694 as this seems like a cleaner and more memory efficient approach
Synced with #1699 

As mentioned in #1699, it seems cleanest to keep casting in the loop, and use `new_subscript_arg()` to get nice positional error messages.

I renamed `n` to `xs_size` to match `list_unchop()` a little more