### PR TITLE
Prevent `$<-` assignment with `NULL` from shortening list-ofs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* The list-of method for `$<-` no longer shortens lists when assigning `NULL`
+  (#1704).
+
 * `validate_list_of()` has been removed. It hasn't proven to be practically
   useful, and isn't used by any packages on CRAN (#1697).
 

--- a/R/type-list-of.R
+++ b/R/type-list-of.R
@@ -155,6 +155,13 @@ as.character.vctrs_list_of <- function(x, ...) {
 
 #' @export
 `$<-.vctrs_list_of` <- function(x, i, value) {
+  if (is.null(value)) {
+    # Setting to NULL via `$<-` shortens the list! Example:
+    # `$<-`(list(a = 1), "a", NULL)
+    x[i] <- list(value)
+    return(x)
+  }
+
   value <- vec_cast(value, attr(x, "ptype"))
   NextMethod()
 }

--- a/tests/testthat/test-type-list-of.R
+++ b/tests/testthat/test-type-list-of.R
@@ -97,13 +97,19 @@ test_that("[<-, [[<- and $<- coerce their input", {
   x[[2]] <- NULL
   expect_equal(x, list_of(x = 0, y = NULL, z = 1, w = 0))
 
+  # #1704
+  x$z <- NULL
+  expect_equal(x, list_of(x = 0, y = NULL, z = NULL, w = 0))
+
   expect_error(x[[2]] <- list(20), class = "vctrs_error_incompatible_type")
   expect_error(x$y <- list(20), class = "vctrs_error_incompatible_type")
 
-  x[3:4] <- list(NULL)
-  expect_equal(x, list_of(x = 0, y = NULL, z = NULL, w = NULL))
+  x[["a"]] <- 1
 
-  expect_equal(is.na(x), c(FALSE, TRUE, TRUE, TRUE))
+  x[4:5] <- list(NULL)
+  expect_equal(x, list_of(x = 0, y = NULL, z = NULL, w = NULL, a = NULL))
+
+  expect_equal(is.na(x), c(FALSE, TRUE, TRUE, TRUE, TRUE))
 })
 
 test_that("assingment can increase size of vector", {


### PR DESCRIPTION
Closes #1704 