### PR TITLE
Remove old dplyr backwards compatibility patch

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -58,23 +58,13 @@
 #' df <- new_data_frame(list(x = x))
 #' vec_sort(df)
 vec_proxy_compare <- function(x, ...) {
-  if (!missing(...)) {
-    # For backward compatibility with older dplyr versions
-    if (match_relax(...)) {
-      return(vec_proxy_order(x))
-    }
-    check_dots_empty0(...)
-  }
+  check_dots_empty0(...)
   return(.Call(vctrs_proxy_compare, x))
   UseMethod("vec_proxy_compare")
 }
 #' @export
 vec_proxy_compare.default <- function(x, ...) {
   stop_native_implementation("vec_proxy_compare.default")
-}
-
-match_relax <- function(..., relax = FALSE) {
-  relax
 }
 
 #' @rdname vec_proxy_compare


### PR DESCRIPTION
Reverts this commit https://github.com/r-lib/vctrs/commit/a672f8c43e2503f639746de06e8ae577c1290acd, which was over two years ago now. I think that is plenty of time to have updated dplyr