### PR TITLE
Clean up slice fallback and remove bit64 slice hacks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     lifecycle (>= 1.0.2),
     rlang (>= 1.0.6)
 Suggests: 
-    bit64,
+    bit64 (>= 4.0.5),
     covr,
     crayon,
     dplyr (>= 0.8.5),

--- a/R/slice.R
+++ b/R/slice.R
@@ -117,49 +117,6 @@ bracket_shaped_dispatch <- function(x, i) {
   x
 }
 
-vec_slice_fallback_integer64 <- function(x, i) {
-  d <- vec_dim_n(x)
-
-  if (d == 2) {
-    out <- x[i, , drop = FALSE]
-  } else {
-    miss_args <- rep(list(missing_arg()), d - 1)
-    out <- eval_bare(expr(x[i, !!!miss_args, drop = FALSE]))
-  }
-
-  is_na <- is.na(i)
-
-  if (!any(is_na)) {
-    return(out)
-  }
-
-  if (d == 2) {
-    out[is_na,] <- bit64::NA_integer64_
-  } else {
-    eval_bare(expr(out[is_na, !!!miss_args] <- bit64::NA_integer64_))
-  }
-
-  out
-}
-
-# bit64::integer64() objects do not have support for `NA_integer_`
-# slicing. This manually replaces the garbage values that are created
-# any time a slice with `NA_integer_` is made.
-vec_slice_dispatch_integer64 <- function(x, i) {
-  out <- x[i]
-
-  is_na <- is.na(i)
-
-  if (!any(is_na)) {
-    return(out)
-  }
-
-  out[is_na] <- bit64::NA_integer64_
-
-  out
-}
-
-
 #' @rdname vec_slice
 #' @export
 `vec_slice<-` <- function(x, i, value) {

--- a/R/slice.R
+++ b/R/slice.R
@@ -110,19 +110,11 @@ vec_slice <- function(x, i) {
 }
 
 # Called when `x` has dimensions
-vec_slice_fallback <- function(x, i) {
-  out <- unclass(vec_proxy(x))
-  vec_assert(out)
-
-  d <- vec_dim_n(out)
-  if (d == 2) {
-    out <- out[i, , drop = FALSE]
-  } else {
-    miss_args <- rep(list(missing_arg()), d - 1)
-    out <- eval_bare(expr(out[i, !!!miss_args, drop = FALSE]))
-  }
-
-  vec_restore(out, x)
+bracket_shaped_dispatch <- function(x, i) {
+  d <- vec_dim_n(x)
+  miss_args <- rep(list(missing_arg()), d - 1)
+  x <- eval_bare(expr(x[i, !!!miss_args, drop = FALSE]))
+  x
 }
 
 vec_slice_fallback_integer64 <- function(x, i) {

--- a/src/globals.h
+++ b/src/globals.h
@@ -17,8 +17,6 @@ struct syms {
   r_obj* to_arg;
   r_obj* value_arg;
   r_obj* vec_default_cast;
-  r_obj* vec_slice_dispatch_integer64;
-  r_obj* vec_slice_fallback_integer64;
   r_obj* bracket_shaped_dispatch;
   r_obj* x_arg;
   r_obj* y_arg;
@@ -36,8 +34,6 @@ struct chrs {
 };
 
 struct fns {
-  r_obj* vec_slice_dispatch_integer64;
-  r_obj* vec_slice_fallback_integer64;
   r_obj* bracket_shaped_dispatch;
 };
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -18,8 +18,8 @@ struct syms {
   r_obj* value_arg;
   r_obj* vec_default_cast;
   r_obj* vec_slice_dispatch_integer64;
-  r_obj* vec_slice_fallback;
   r_obj* vec_slice_fallback_integer64;
+  r_obj* bracket_shaped_dispatch;
   r_obj* x_arg;
   r_obj* y_arg;
 };
@@ -37,8 +37,8 @@ struct chrs {
 
 struct fns {
   r_obj* vec_slice_dispatch_integer64;
-  r_obj* vec_slice_fallback;
   r_obj* vec_slice_fallback_integer64;
+  r_obj* bracket_shaped_dispatch;
 };
 
 struct vec_args {

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -296,6 +296,10 @@ static SEXP chop_shaped(SEXP x, SEXP indices, struct vctrs_chop_info info) {
 }
 
 static SEXP chop_fallback(SEXP x, SEXP indices, struct vctrs_chop_info info) {
+  // TODO: Do we really care about micro performance that much here? Can we just
+  // merge with `chop_shaped_fallback()` now that `vec_slice_fallback()`
+  // handles shaped an unshaped vectors?
+
   // Evaluate in a child of the global environment to allow dispatch
   // to custom functions. We define `[` to point to its base
   // definition to ensure consistent look-up. This is the same logic
@@ -329,6 +333,7 @@ static SEXP chop_fallback(SEXP x, SEXP indices, struct vctrs_chop_info info) {
 
     SEXP elt = PROTECT(Rf_eval(call, env));
 
+    // Same logic as `vec_slice_fallback()`
     if (!vec_is_restored(elt, x)) {
       elt = vec_restore(elt, x, vec_owned(elt));
     }
@@ -349,7 +354,6 @@ static r_obj* chop_fallback_shaped(r_obj* x, r_obj* indices, struct vctrs_chop_i
       ++(*info.p_index);
     }
 
-    // `vec_slice_fallback()` will also `vec_restore()` for us
     r_obj* elt = PROTECT(vec_slice_fallback(x, info.index));
 
     SET_VECTOR_ELT(info.out, i, elt);

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -310,16 +310,8 @@ static SEXP chop_fallback(SEXP x, SEXP indices, struct vctrs_chop_info info) {
   Rf_defineVar(syms_i, info.index, env);
 
   // Construct call with symbols, not values, for performance.
-  // TODO - Remove once bit64 is updated on CRAN. Special casing integer64
-  // objects to ensure correct slicing with `NA_integer_`.
-  SEXP call;
-  if (is_integer64(x)) {
-    call = PROTECT(Rf_lang3(syms.vec_slice_dispatch_integer64, syms_x, syms_i));
-    Rf_defineVar(syms.vec_slice_dispatch_integer64, fns.vec_slice_dispatch_integer64, env);
-  } else {
-    call = PROTECT(Rf_lang3(syms_bracket, syms_x, syms_i));
-    Rf_defineVar(syms_bracket, fns_bracket, env);
-  }
+  SEXP call = PROTECT(Rf_lang3(syms_bracket, syms_x, syms_i));
+  Rf_defineVar(syms_bracket, fns_bracket, env);
 
   for (R_len_t i = 0; i < info.out_size; ++i) {
     if (info.has_indices) {

--- a/src/slice.c
+++ b/src/slice.c
@@ -209,13 +209,6 @@ r_obj* df_slice(r_obj* x, r_obj* subscript) {
 
 static
 r_obj* bracket_dispatch(r_obj* x, r_obj* subscript) {
-  // TODO - Remove once bit64 is updated on CRAN. Special casing integer64
-  // objects to ensure correct slicing with `NA_integer_`.
-  if (is_integer64(x)) {
-    return vctrs_dispatch2(syms.vec_slice_dispatch_integer64, fns.vec_slice_dispatch_integer64,
-                           syms_x, x,
-                           syms_i, subscript);
-
   return vctrs_dispatch2(
     syms_bracket, fns_bracket,
     syms_x, x,
@@ -232,14 +225,6 @@ r_obj* bracket_shaped_dispatch(r_obj* x, r_obj* subscript) {
 }
 
 r_obj* vec_slice_fallback(r_obj* x, r_obj* subscript) {
-  // TODO - Remove once bit64 is updated on CRAN. Special casing integer64
-  // objects to ensure correct slicing with `NA_integer_`.
-  if (is_integer64(x)) {
-    return vctrs_dispatch2(syms.vec_slice_fallback_integer64, fns.vec_slice_fallback_integer64,
-                           syms_x, x,
-                           syms_i, subscript);
-  }
-
   r_obj* out = r_null;
 
   if (has_dim(x)) {
@@ -495,11 +480,6 @@ r_obj* ffi_slice_rep(r_obj* x, r_obj* ffi_i, r_obj* ffi_n) {
 
 
 void vctrs_init_slice(r_obj* ns) {
-  syms.vec_slice_dispatch_integer64 = r_sym("vec_slice_dispatch_integer64");
-  syms.vec_slice_fallback_integer64 = r_sym("vec_slice_fallback_integer64");
-
-  fns.vec_slice_dispatch_integer64 = r_eval(syms.vec_slice_dispatch_integer64, ns);
-  fns.vec_slice_fallback_integer64 = r_eval(syms.vec_slice_fallback_integer64, ns);
   syms.bracket_shaped_dispatch = r_sym("bracket_shaped_dispatch");
   fns.bracket_shaped_dispatch = r_eval(syms.bracket_shaped_dispatch, ns);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -966,11 +966,6 @@ r_obj* colnames2(r_obj* x) {
 }
 
 // [[ include("utils.h") ]]
-bool is_integer64(SEXP x) {
-  return TYPEOF(x) == REALSXP && Rf_inherits(x, "integer64");
-}
-
-// [[ include("utils.h") ]]
 bool lgl_any_na(SEXP x) {
   R_xlen_t size = Rf_xlength(x);
   const int* p_x = LOGICAL_RO(x);

--- a/src/utils.h
+++ b/src/utils.h
@@ -188,8 +188,6 @@ bool is_compact(SEXP x);
 SEXP compact_materialize(SEXP x);
 R_len_t vec_subscript_size(SEXP x);
 
-bool is_integer64(SEXP x);
-
 bool lgl_any_na(SEXP x);
 
 SEXP colnames(SEXP x);

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -272,6 +272,18 @@ test_that("vec_slice() unclasses input before calling `vec_restore()`", {
 })
 
 test_that("can call `vec_slice()` from `[` methods with shaped objects without infloop", {
+  skip("Until infloop is talked about")
+  # TODO: I don't think it is our job to prevent this.
+  # You can already make this infloop today with non-shaped objects, i.e
+  # `[.vctrs_foobar` = function(x, i, ...) vec_slice(x, i)
+  # x <- structure(1:4, class = "vctrs_foobar")
+  # x[1]
+  # So we shouldn't be special casing shaped objects.
+  # I believe that if your `[` method is going to call `vec_slice()` (i.e. you
+  # are requesting native vctrs slicing), then you need to declare a
+  # `vec_proxy()` method as well to tell vctrs what it needs to be natively
+  # slicing.
+
   local_methods(
     `[.vctrs_foobar` = function(x, i, ...) vec_slice(x, i)
   )
@@ -351,6 +363,7 @@ test_that("vec_restore() is called after slicing data frames", {
 
 test_that("additional subscripts are forwarded to `[`", {
   local_methods(
+    vec_proxy.vctrs_foobar = function(x, ...) x,
     `[.vctrs_foobar` = function(x, i, ...) vec_index(x, i, ...)
   )
 


### PR DESCRIPTION
I originally intended to just remove the old bit64 hacks around slicing with `NA_integer_`, but trying to do so exposed some strange bugs with the way our fallback slicing was working. I'll add some inline comments below.

The first commit cleans up the fallback slicing approach. The second commit removes the bit64 hacks.