### PR TITLE
Ensure `vec_rep_each(times = 0)` early exit works properly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* `vec_rep_each(times = 0)` now works correctly with logical vectors that are
+  considered unspecified and with named vectors (#1673).
+
 * `list_of()` was relaxed to make it easier to combine. It is now
   coercible with `list()` (#1161). When incompatible `list_of()` types
   are combined, the result is now a bare `list()`.

--- a/src/rep.c
+++ b/src/rep.c
@@ -96,7 +96,7 @@ r_obj* vec_rep_each(r_obj* x,
     if (times_ == 1) {
       out = x;
     } else if (times_ == 0) {
-      out = vec_ptype(x, p_x_arg, error_call);
+      out = vec_slice_unsafe(x, r_globals.empty_int);
     } else {
       out = vec_rep_each_uniform(x, times_, error_call, p_times_arg);
     }

--- a/tests/testthat/test-rep.R
+++ b/tests/testthat/test-rep.R
@@ -58,6 +58,15 @@ test_that("`vec_rep_each()` can repeat 0 `times`", {
   expect_identical(vec_rep_each(1:2, 0), integer())
 })
 
+test_that("`vec_rep_each()` finalizes type when repeating 0 times (#1673)", {
+  expect_identical(vec_rep_each(NA, 0), logical())
+})
+
+test_that("`vec_rep_each()` retains names when repeating 0 times (#1673)", {
+  x <- c(a = 1, b = 2)
+  expect_identical(vec_rep_each(x, 0), named(numeric()))
+})
+
 test_that("`vec_rep_each()` can repeat 1 `time`", {
   expect_identical(vec_rep_each(1:2, 1), 1:2)
 })


### PR DESCRIPTION
Closes https://github.com/r-lib/vctrs/issues/1673