### PR TITLE
More work re `"*_quiet"` name repair strings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,11 @@
   like specifying `repair = "unique", quiet = TRUE`. When the `"*_quiet"`
   options are used, any setting of `quiet` is silently overridden (@jennybc,
   #1629).
+  
+  `"unique_quiet"` and `"universal_quiet"` are also newly accepted for the name
+  repair argument of several other functions that do not expose a `quiet`
+  argument: `data_frame()`, `df_list()`, `vec_c()`, `list_unchop()`,
+  `vec_interleave()`, `vec_rbind()`, and `vec_cbind()` (@jennybc, #1716).
 
 * `list_unchop()` has gained `error_call` and `error_arg` arguments (#1641,
   #1692).

--- a/R/bind.R
+++ b/R/bind.R
@@ -54,9 +54,9 @@
 #'     not named, an integer column is used instead.
 #'
 #'   * If `NULL`, the input names are used as row names.
-#' @param .name_repair One of `"unique"`, `"universal"`, or
-#'   `"check_unique"`. See [vec_as_names()] for the meaning of these
-#'   options.
+#' @param .name_repair One of `"unique"`, `"universal"`, `"check_unique"`,
+#'   `"unique_quiet"`, or  `"universal_quiet"`. See [vec_as_names()] for the
+#'   meaning of these options.
 #'
 #'   With `vec_rbind()`, the repair function is applied to all inputs
 #'   separately. This is because `vec_rbind()` needs to align their
@@ -176,7 +176,7 @@ NULL
 vec_rbind <- function(...,
                       .ptype = NULL,
                       .names_to = rlang::zap(),
-                      .name_repair = c("unique", "universal", "check_unique"),
+                      .name_repair = c("unique", "universal", "check_unique", "unique_quiet", "universal_quiet"),
                       .name_spec = NULL,
                       .error_call = current_env()) {
   .External2(ffi_rbind, .ptype, .names_to, .name_repair, .name_spec)
@@ -194,7 +194,7 @@ vec_rbind <- fn_inline_formals(vec_rbind, ".name_repair")
 vec_cbind <- function(...,
                       .ptype = NULL,
                       .size = NULL,
-                      .name_repair = c("unique", "universal", "check_unique", "minimal"),
+                      .name_repair = c("unique", "universal", "check_unique", "minimal", "unique_quiet", "universal_quiet"),
                       .error_call = current_env()) {
   .External2(ffi_cbind, .ptype, .size, .name_repair)
 }

--- a/R/c.R
+++ b/R/c.R
@@ -68,7 +68,7 @@
 vec_c <- function(...,
                   .ptype = NULL,
                   .name_spec = NULL,
-                  .name_repair = c("minimal", "unique", "check_unique", "universal"),
+                  .name_repair = c("minimal", "unique", "check_unique", "universal", "unique_quiet", "universal_quiet"),
                   .error_arg = "",
                   .error_call = current_env()) {
   .External2(ffi_vec_c, .ptype, .name_spec, .name_repair)

--- a/R/slice-chop.R
+++ b/R/slice-chop.R
@@ -97,7 +97,7 @@ list_unchop <- function(x,
                         indices = NULL,
                         ptype = NULL,
                         name_spec = NULL,
-                        name_repair = c("minimal", "unique", "check_unique", "universal"),
+                        name_repair = c("minimal", "unique", "check_unique", "universal", "unique_quiet", "universal_quiet"),
                         error_arg = "x",
                         error_call = current_env()) {
   .Call(ffi_list_unchop, x, indices, ptype, name_spec, name_repair, environment())

--- a/R/slice-interleave.R
+++ b/R/slice-interleave.R
@@ -38,7 +38,7 @@
 vec_interleave <- function(...,
                            .ptype = NULL,
                            .name_spec = NULL,
-                           .name_repair = c("minimal", "unique", "check_unique", "universal")) {
+                           .name_repair = c("minimal", "unique", "check_unique", "universal", "unique_quiet", "universal_quiet")) {
   args <- list2(...)
 
   # `NULL`s must be dropped up front to generate appropriate indices

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -67,8 +67,9 @@ new_data_frame <- fn_inline_formals(new_data_frame, "x")
 #'   will be computed as the common size of the inputs.
 #' @param .unpack Should unnamed data frame inputs be unpacked? Defaults to
 #'   `TRUE`.
-#' @param .name_repair One of `"check_unique"`, `"unique"`, `"universal"` or
-#'   `"minimal"`. See [vec_as_names()] for the meaning of these options.
+#' @param .name_repair One of `"check_unique"`, `"unique"`, `"universal"`,
+#'   `"minimal"`, `"unique_quiet"`, or `"universal_quiet"`. See [vec_as_names()]
+#'   for the meaning of these options.
 #'
 #' @export
 #' @examples
@@ -89,7 +90,7 @@ new_data_frame <- fn_inline_formals(new_data_frame, "x")
 df_list <- function(...,
                     .size = NULL,
                     .unpack = TRUE,
-                    .name_repair = c("check_unique", "unique", "universal", "minimal"),
+                    .name_repair = c("check_unique", "unique", "universal", "minimal", "unique_quiet", "universal_quiet"),
                     .error_call = current_env()) {
   .Call(ffi_df_list, list2(...), .size, .unpack, .name_repair, environment())
 }
@@ -103,10 +104,10 @@ df_list <- fn_inline_formals(df_list, ".name_repair")
 #' more in line with vctrs principles. The Properties section outlines these.
 #'
 #' @details
-#' If no column names are supplied, `""` will be used as a default for all
-#' columns. This is applied before name repair occurs, so the default
-#' name repair of `"check_unique"` will error if any unnamed inputs
-#' are supplied and `"unique"` will repair the empty string column names
+#' If no column names are supplied, `""` will be used as a default name for all
+#' columns. This is applied before name repair occurs, so the default name
+#' repair of `"check_unique"` will error if any unnamed inputs are supplied and
+#' `"unique"` (or `"unique_quiet"`) will repair the empty string column names
 #' appropriately. If the column names don't matter, use a `"minimal"` name
 #' repair for convenience and performance.
 #'
@@ -125,8 +126,9 @@ df_list <- fn_inline_formals(df_list, ".name_repair")
 #'   named, those names are used for column names.
 #' @param .size The number of rows in the data frame. If `NULL`, this will
 #'   be computed as the common size of the inputs.
-#' @param .name_repair One of `"check_unique"`, `"unique"`, `"universal"` or
-#'   `"minimal"`. See [vec_as_names()] for the meaning of these options.
+#' @param .name_repair One of `"check_unique"`, `"unique"`, `"universal"`,
+#'   `"minimal"`, `"unique_quiet"`, or `"universal_quiet"`. See [vec_as_names()]
+#'   for the meaning of these options.
 #'
 #' @export
 #' @examples
@@ -163,7 +165,7 @@ df_list <- fn_inline_formals(df_list, ".name_repair")
 #' data_frame(x = 1, data_frame(y = 1:2, z = "a"))
 data_frame <- function(...,
                        .size = NULL,
-                       .name_repair = c("check_unique", "unique", "universal", "minimal"),
+                       .name_repair = c("check_unique", "unique", "universal", "minimal", "unique_quiet", "universal_quiet"),
                        .error_call = current_env()) {
   .Call(ffi_data_frame, list2(...), .size, .name_repair, environment())
 }

--- a/man/data_frame.Rd
+++ b/man/data_frame.Rd
@@ -7,7 +7,8 @@
 data_frame(
   ...,
   .size = NULL,
-  .name_repair = c("check_unique", "unique", "universal", "minimal"),
+  .name_repair = c("check_unique", "unique", "universal", "minimal", "unique_quiet",
+    "universal_quiet"),
   .error_call = current_env()
 )
 }
@@ -18,8 +19,9 @@ named, those names are used for column names.}
 \item{.size}{The number of rows in the data frame. If \code{NULL}, this will
 be computed as the common size of the inputs.}
 
-\item{.name_repair}{One of \code{"check_unique"}, \code{"unique"}, \code{"universal"} or
-\code{"minimal"}. See \code{\link[=vec_as_names]{vec_as_names()}} for the meaning of these options.}
+\item{.name_repair}{One of \code{"check_unique"}, \code{"unique"}, \code{"universal"},
+\code{"minimal"}, \code{"unique_quiet"}, or \code{"universal_quiet"}. See \code{\link[=vec_as_names]{vec_as_names()}}
+for the meaning of these options.}
 
 \item{.error_call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be
@@ -32,10 +34,10 @@ mentioned in error messages as the source of the error. See the
 more in line with vctrs principles. The Properties section outlines these.
 }
 \details{
-If no column names are supplied, \code{""} will be used as a default for all
-columns. This is applied before name repair occurs, so the default
-name repair of \code{"check_unique"} will error if any unnamed inputs
-are supplied and \code{"unique"} will repair the empty string column names
+If no column names are supplied, \code{""} will be used as a default name for all
+columns. This is applied before name repair occurs, so the default name
+repair of \code{"check_unique"} will error if any unnamed inputs are supplied and
+\code{"unique"} (or \code{"unique_quiet"}) will repair the empty string column names
 appropriately. If the column names don't matter, use a \code{"minimal"} name
 repair for convenience and performance.
 }

--- a/man/df_list.Rd
+++ b/man/df_list.Rd
@@ -8,7 +8,8 @@ df_list(
   ...,
   .size = NULL,
   .unpack = TRUE,
-  .name_repair = c("check_unique", "unique", "universal", "minimal"),
+  .name_repair = c("check_unique", "unique", "universal", "minimal", "unique_quiet",
+    "universal_quiet"),
   .error_call = current_env()
 )
 }
@@ -22,8 +23,9 @@ will be computed as the common size of the inputs.}
 \item{.unpack}{Should unnamed data frame inputs be unpacked? Defaults to
 \code{TRUE}.}
 
-\item{.name_repair}{One of \code{"check_unique"}, \code{"unique"}, \code{"universal"} or
-\code{"minimal"}. See \code{\link[=vec_as_names]{vec_as_names()}} for the meaning of these options.}
+\item{.name_repair}{One of \code{"check_unique"}, \code{"unique"}, \code{"universal"},
+\code{"minimal"}, \code{"unique_quiet"}, or \code{"universal_quiet"}. See \code{\link[=vec_as_names]{vec_as_names()}}
+for the meaning of these options.}
 
 \item{.error_call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be

--- a/man/vec_bind.Rd
+++ b/man/vec_bind.Rd
@@ -10,7 +10,8 @@ vec_rbind(
   ...,
   .ptype = NULL,
   .names_to = rlang::zap(),
-  .name_repair = c("unique", "universal", "check_unique"),
+  .name_repair = c("unique", "universal", "check_unique", "unique_quiet",
+    "universal_quiet"),
   .name_spec = NULL,
   .error_call = current_env()
 )
@@ -19,7 +20,8 @@ vec_cbind(
   ...,
   .ptype = NULL,
   .size = NULL,
-  .name_repair = c("unique", "universal", "check_unique", "minimal"),
+  .name_repair = c("unique", "universal", "check_unique", "minimal", "unique_quiet",
+    "universal_quiet"),
   .error_call = current_env()
 )
 }
@@ -55,9 +57,9 @@ not named, an integer column is used instead.
 \item If \code{NULL}, the input names are used as row names.
 }}
 
-\item{.name_repair}{One of \code{"unique"}, \code{"universal"}, or
-\code{"check_unique"}. See \code{\link[=vec_as_names]{vec_as_names()}} for the meaning of these
-options.
+\item{.name_repair}{One of \code{"unique"}, \code{"universal"}, \code{"check_unique"},
+\code{"unique_quiet"}, or  \code{"universal_quiet"}. See \code{\link[=vec_as_names]{vec_as_names()}} for the
+meaning of these options.
 
 With \code{vec_rbind()}, the repair function is applied to all inputs
 separately. This is because \code{vec_rbind()} needs to align their

--- a/man/vec_c.Rd
+++ b/man/vec_c.Rd
@@ -8,7 +8,8 @@ vec_c(
   ...,
   .ptype = NULL,
   .name_spec = NULL,
-  .name_repair = c("minimal", "unique", "check_unique", "universal"),
+  .name_repair = c("minimal", "unique", "check_unique", "universal", "unique_quiet",
+    "universal_quiet"),
   .error_arg = "",
   .error_call = current_env()
 )

--- a/man/vec_chop.Rd
+++ b/man/vec_chop.Rd
@@ -12,7 +12,8 @@ list_unchop(
   indices = NULL,
   ptype = NULL,
   name_spec = NULL,
-  name_repair = c("minimal", "unique", "check_unique", "universal"),
+  name_repair = c("minimal", "unique", "check_unique", "universal", "unique_quiet",
+    "universal_quiet"),
   error_arg = "x",
   error_call = current_env()
 )

--- a/man/vec_interleave.Rd
+++ b/man/vec_interleave.Rd
@@ -8,7 +8,8 @@ vec_interleave(
   ...,
   .ptype = NULL,
   .name_spec = NULL,
-  .name_repair = c("minimal", "unique", "check_unique", "universal")
+  .name_repair = c("minimal", "unique", "check_unique", "universal", "unique_quiet",
+    "universal_quiet")
 )
 }
 \arguments{

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -55,6 +55,19 @@
       x These names are duplicated:
         * "a" at locations 1 and 2.
 
+# can repair names quietly
+
+    Code
+      res_unique <- vec_rbind(c(x = 1, x = 2), c(x = 3, x = 4), .name_repair = "unique_quiet")
+      res_universal <- vec_rbind(c(`if` = 1, `in` = 2), c(`if` = 3, `for` = 4),
+      .name_repair = "universal_quiet")
+
+---
+
+    Code
+      res_unique <- vec_cbind(x = 1, x = 2, .name_repair = "unique_quiet")
+      res_universal <- vec_cbind(`if` = 1, `in` = 2, .name_repair = "universal_quiet")
+
 # vec_rbind() fails with arrays of dimensionality > 3
 
     Code

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -60,6 +60,12 @@
       Error in `vec_c()`:
       ! Can't combine `foo$x$y$z` <double> and `bar$x$y$z` <character>.
 
+# vec_c() can repair names quietly
+
+    Code
+      res_unique <- vec_c(x = TRUE, x = 0, .name_repair = "unique_quiet")
+      res_universal <- vec_c(`if` = TRUE, `in` = 0, .name_repair = "universal_quiet")
+
 # vec_c() fails with complex foreign S3 classes
 
     Code

--- a/tests/testthat/_snaps/slice-chop.md
+++ b/tests/testthat/_snaps/slice-chop.md
@@ -139,6 +139,16 @@
       ! Can't convert from `arg[[1]]` <double> to <integer> due to loss of precision.
       * Locations: 1
 
+# list_unchop() can repair names quietly
+
+    Code
+      res <- list_unchop(vec_chop(x, indices), indices, name_repair = "unique_quiet")
+
+---
+
+    Code
+      res <- list_unchop(vec_chop(x, indices), indices, name_repair = "universal_quiet")
+
 # list_unchop() errors on unsupported location values
 
     Code

--- a/tests/testthat/_snaps/slice-interleave.md
+++ b/tests/testthat/_snaps/slice-interleave.md
@@ -10,6 +10,12 @@
       x...1 x...2 
           1     1 
 
+# can repair names quietly
+
+    Code
+      res_unique <- vec_interleave(c(x = 1), c(x = 2), .name_repair = "unique_quiet")
+      res_universal <- vec_interleave(c(`if` = 1), c(`in` = 2), .name_repair = "universal_quiet")
+
 # uses recycling errors
 
     Code

--- a/tests/testthat/_snaps/type-data-frame.md
+++ b/tests/testthat/_snaps/type-data-frame.md
@@ -236,6 +236,14 @@
       Error in `df_list()`:
       ! `.unpack` must be `TRUE` or `FALSE`.
 
+# `.name_repair` can be quiet
+
+    Code
+      dfl_unique <- df_list(1, 2, .name_repair = "unique_quiet")
+      dfl_universal <- df_list(`if` = 1, `in` = 2, .name_repair = "universal_quiet")
+      df_unique <- data_frame(1, 2, .name_repair = "unique_quiet")
+      df_universal <- data_frame(`if` = 1, `in` = 2, .name_repair = "universal_quiet")
+
 # data frame fallback handles column types (#999)
 
     Code

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -207,6 +207,17 @@ test_that("can repair names in `vec_rbind()` (#229)", {
   expect_named(vec_rbind(list(a = 1, a = 2), .name_repair = ~ toupper(.)), c("A", "A"))
 })
 
+test_that("can repair names quietly", {
+  local_name_repair_verbose()
+
+  expect_snapshot({
+    res_unique <- vec_rbind(c(x = 1, x = 2), c(x = 3, x = 4), .name_repair = "unique_quiet")
+    res_universal <- vec_rbind(c("if" = 1, "in" = 2), c("if" = 3, "for" = 4), .name_repair = "universal_quiet")
+  })
+  expect_named(res_unique, c("x...1", "x...2"))
+  expect_named(res_universal, c(".if", ".in", ".for"))
+})
+
 test_that("can construct an id column", {
   df <- data.frame(x = 1)
 
@@ -491,6 +502,17 @@ test_that("can repair names in `vec_cbind()` (#227)", {
 
   expect_named(vec_cbind(a = 1, a = 2, .name_repair = "minimal"), c("a", "a"))
   expect_named(vec_cbind(a = 1, a = 2, .name_repair = toupper), c("A", "A"))
+})
+
+test_that("can repair names quietly", {
+  local_name_repair_verbose()
+
+  expect_snapshot({
+    res_unique <- vec_cbind(x = 1, x = 2, .name_repair = "unique_quiet")
+    res_universal <- vec_cbind("if" = 1, "in" = 2, .name_repair = "universal_quiet")
+  })
+  expect_named(res_unique, c("x...1", "x...2"))
+  expect_named(res_universal, c(".if", ".in"))
 })
 
 test_that("can supply `.names_to` to `vec_rbind()` (#229)", {

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -138,6 +138,17 @@ test_that("vec_c() repairs names", {
   expect_named(vec_c(a = 1, a = 2, .name_repair = ~ toupper(.)), c("A", "A"))
 })
 
+test_that("vec_c() can repair names quietly", {
+  local_name_repair_verbose()
+
+   expect_snapshot({
+     res_unique <- vec_c(x = TRUE, x = 0, .name_repair = "unique_quiet")
+     res_universal <- vec_c("if" = TRUE, "in" = 0, .name_repair = "universal_quiet")
+   })
+   expect_named(res_unique, c("x...1", "x...2"))
+   expect_named(res_universal, c(".if", ".in"))
+})
+
 test_that("vec_c() doesn't use outer names for data frames (#524)", {
   x <- data.frame(inner = 1)
   expect_equal(vec_c(outer = x), x)

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -580,6 +580,24 @@ test_that("name repair is respected and happens after ordering according to `ind
   expect_named(list_unchop(x, indices, name_repair = "unique"), c("a...1", "a...2"))
 })
 
+test_that("list_unchop() can repair names quietly", {
+  local_name_repair_verbose()
+
+  x <- c(x = "a", x = "b", x = "c")
+  indices <- list(2, c(3, 1))
+  expect_snapshot({
+    res <- list_unchop(vec_chop(x, indices), indices, name_repair = "unique_quiet")
+  })
+  expect_named(res, c("x...1", "x...2", "x...3"))
+
+  x <- c("if" = "a", "in" = "b", "for" = "c")
+  indices <- list(2, c(3, 1))
+  expect_snapshot({
+    res <- list_unchop(vec_chop(x, indices), indices, name_repair = "universal_quiet")
+  })
+  expect_named(res, c(".if", ".in", ".for"))
+})
+
 test_that("list_unchop() errors on unsupported location values", {
   expect_snapshot({
     (expect_error(

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -586,14 +586,14 @@ test_that("list_unchop() can repair names quietly", {
   x <- c(x = "a", x = "b", x = "c")
   indices <- list(2, c(3, 1))
   expect_snapshot({
-    res <- list_unchop(vec_chop(x, indices), indices, name_repair = "unique_quiet")
+    res <- list_unchop(vec_chop(x, indices), indices = indices, name_repair = "unique_quiet")
   })
   expect_named(res, c("x...1", "x...2", "x...3"))
 
   x <- c("if" = "a", "in" = "b", "for" = "c")
   indices <- list(2, c(3, 1))
   expect_snapshot({
-    res <- list_unchop(vec_chop(x, indices), indices, name_repair = "universal_quiet")
+    res <- list_unchop(vec_chop(x, indices), indices = indices, name_repair = "universal_quiet")
   })
   expect_named(res, c(".if", ".in", ".for"))
 })

--- a/tests/testthat/test-slice-interleave.R
+++ b/tests/testthat/test-slice-interleave.R
@@ -37,6 +37,17 @@ test_that("allows for name repair", {
   expect_snapshot(vec_interleave(x, x, .name_repair = "unique"))
 })
 
+test_that("can repair names quietly", {
+  local_name_repair_verbose()
+
+  expect_snapshot({
+    res_unique <- vec_interleave(c(x = 1), c(x = 2), .name_repair = "unique_quiet")
+    res_universal <- vec_interleave(c("if" = 1), c("in" = 2), .name_repair = "universal_quiet")
+  })
+  expect_named(res_unique, c("x...1", "x...2"))
+  expect_named(res_universal, c(".if", ".in"))
+})
+
 test_that("works with name specs", {
   x <- c(x = 1)
   y <- 1

--- a/tests/testthat/test-type-data-frame.R
+++ b/tests/testthat/test-type-data-frame.R
@@ -572,6 +572,22 @@ test_that("`.name_repair` happens after splicing", {
   expect_named(res, c("x...1", "x...2"))
 })
 
+test_that("`.name_repair` can be quiet", {
+  local_name_repair_verbose()
+
+  expect_snapshot({
+    dfl_unique <- df_list(1, 2, .name_repair = "unique_quiet")
+    dfl_universal <- df_list("if" = 1, "in" = 2, .name_repair = "universal_quiet")
+    df_unique <- data_frame(1, 2, .name_repair = "unique_quiet")
+    df_universal <- data_frame("if" = 1, "in" = 2, .name_repair = "universal_quiet")
+  })
+
+  expect_named(dfl_unique, c("...1", "...2"))
+  expect_named(dfl_universal, c(".if", ".in"))
+  expect_named(df_unique, c("...1", "...2"))
+  expect_named(df_universal, c(".if", ".in"))
+})
+
 # fallback ----------------------------------------------------------------
 
 test_that("data frame fallback handles column types (#999)", {


### PR DESCRIPTION
Closes #1713

* [x] `data_frame()`, `df_list()`
  - Add quiet name repair strings to signatures.
  - Add quiet name repair strings to `.name_repair` doc in both functions.
  - Add a test that covers both functions.
* [x] `vec_c()`, `list_unchop()`, `vec_interleave()`, ~`vec_unchop()`~
  - Add quiet name repair strings to signatures.
  - Add a test for each function.
  - *Did nothing to `vec_unchop()` since I see that it's deprecated.*
* [x] `vec_rbind()`, `vec_cbind()`
  - Add quiet name repair strings to signatures.
  - Add a test for each function.
* [x] Edit NEWS
