### PR TITLE
Relax common type of incompatible ordered factors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # vctrs (development version)
 
+* The common type of incompatible ordered factors is now
+  `character()`. This relaxed behaviour makes it easier to combine
+  different ordered factors.
+
 * New `list_all_size()` and `list_check_all_size()` to quickly determine if a
   list contains elements of a particular `size` (#1582).
 

--- a/src/cast-dispatch.c
+++ b/src/cast-dispatch.c
@@ -106,8 +106,8 @@ r_obj* ffi_cast_dispatch_native(r_obj* x,
   if (lossy || out == r_null) {
     return vec_cast_default(x,
                             to,
-                            x_arg,
-                            to_arg,
+                            &c_x_arg,
+                            &c_to_arg,
                             c_opts.call,
                             &c_opts.fallback);
   } else {

--- a/src/cast.h
+++ b/src/cast.h
@@ -13,6 +13,19 @@ struct cast_opts {
   struct fallback_opts fallback;
 };
 
+// FIXME: Should we merge these two structs?
+static inline
+struct ptype2_opts cast_opts_as_ptype2_opts(const struct cast_opts* p_opts) {
+  return (struct ptype2_opts) {
+    .x = p_opts->x,
+    .y = p_opts->to,
+    .p_x_arg = p_opts->p_x_arg,
+    .p_y_arg = p_opts->p_to_arg,
+    .call = p_opts->call,
+    .fallback = p_opts->fallback,
+  };
+}
+
 struct cast_common_opts {
   struct vctrs_arg* p_arg;
   struct r_lazy call;

--- a/src/cast.h
+++ b/src/cast.h
@@ -99,11 +99,11 @@ r_obj* vec_cast_e(const struct cast_opts* opts,
                   ERR* err);
 
 r_obj* vec_cast_default(r_obj* x,
-                        r_obj* y,
-                        r_obj* p_x_arg,
-                        r_obj* p_to_arg,
+                        r_obj* to,
+                        struct vctrs_arg* p_x_arg,
+                        struct vctrs_arg* p_to_arg,
                         struct r_lazy call,
-                        const struct fallback_opts* opts);
+                        const struct fallback_opts* p_opts);
 
 
 #endif

--- a/src/ptype2-dispatch.h
+++ b/src/ptype2-dispatch.h
@@ -2,6 +2,7 @@
 #define VCTRS_PTYPE2_DISPATCH_H
 
 #include "vctrs-core.h"
+#include "ptype2.h"
 
 r_obj* vec_ptype2_dispatch_native(const struct ptype2_opts* opts,
                                   enum vctrs_type x_type,
@@ -17,6 +18,13 @@ r_obj* vec_invoke_coerce_method(r_obj* method_sym, r_obj* method,
                                 r_obj* y_arg_sym, r_obj* y_arg,
                                 struct r_lazy call,
                                 const struct fallback_opts* opts);
+
+r_obj* vec_ptype2_default(r_obj* x,
+                          r_obj* y,
+                          struct vctrs_arg* x_arg,
+                          struct vctrs_arg* y_arg,
+                          struct r_lazy call,
+                          const struct fallback_opts* p_opts);
 
 
 #endif

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -32,33 +32,34 @@ SEXP fct_ptype2(const struct ptype2_opts* opts) {
 }
 
 static
-SEXP ord_ptype2_validate(SEXP x,
-                         SEXP y,
-                         struct vctrs_arg* x_arg,
-                         struct vctrs_arg* y_arg,
-                         bool cast) {
-  SEXP x_levels = Rf_getAttrib(x, R_LevelsSymbol);
-  SEXP y_levels = Rf_getAttrib(y, R_LevelsSymbol);
-
+bool ord_ptype2_validate(r_obj* x_levels,
+                         r_obj* y_levels,
+                         const struct ptype2_opts* p_opts) {
   if (TYPEOF(x_levels) != STRSXP) {
-    stop_corrupt_ordered_levels(x, x_arg);
+    stop_corrupt_ordered_levels(p_opts->x, p_opts->p_x_arg);
   }
   if (TYPEOF(y_levels) != STRSXP) {
-    stop_corrupt_ordered_levels(y, y_arg);
+    stop_corrupt_ordered_levels(p_opts->y, p_opts->p_y_arg);
   }
 
-  if (!equal_object(x_levels, y_levels)) {
-    stop_incompatible_type(x, y, x_arg, y_arg, cast);
-  }
-
-  return x_levels;
+  return equal_object(x_levels, y_levels);
 }
 
 // [[ include("type-factor.h") ]]
-SEXP ord_ptype2(const struct ptype2_opts* opts) {
-  SEXP levels = PROTECT(ord_ptype2_validate(opts->x, opts->y, opts->p_x_arg, opts->p_y_arg, false));
-  SEXP out = new_empty_ordered(levels);
-  return UNPROTECT(1), out;
+r_obj* ord_ptype2(const struct ptype2_opts* p_opts) {
+  r_obj* x_levels = r_attrib_get(p_opts->x, R_LevelsSymbol);
+  r_obj* y_levels = r_attrib_get(p_opts->y, R_LevelsSymbol);
+
+  if (ord_ptype2_validate(x_levels, y_levels, p_opts)) {
+    return new_empty_ordered(x_levels);
+  } else {
+    return vec_ptype2_default(p_opts->x,
+                              p_opts->y,
+                              p_opts->p_x_arg,
+                              p_opts->p_y_arg,
+                              r_lazy_null,
+                              &p_opts->fallback);
+  }
 }
 
 static SEXP levels_union(SEXP x, SEXP y) {
@@ -255,9 +256,22 @@ SEXP fct_as_factor(SEXP x,
 }
 
 // [[ include("factor.h") ]]
-SEXP ord_as_ordered(const struct cast_opts* opts) {
-  ord_ptype2_validate(opts->x, opts->to, opts->p_x_arg, opts->p_to_arg, true);
-  return opts->x;
+SEXP ord_as_ordered(const struct cast_opts* p_opts) {
+  r_obj* x_levels = r_attrib_get(p_opts->x, R_LevelsSymbol);
+  r_obj* y_levels = r_attrib_get(p_opts->to, R_LevelsSymbol);
+
+  struct ptype2_opts ptype2_opts = cast_opts_as_ptype2_opts(p_opts);
+
+  if (ord_ptype2_validate(x_levels, y_levels, &ptype2_opts)) {
+    return p_opts->x;
+  } else {
+    // FIXME: Call default cast method
+    stop_incompatible_type(p_opts->x,
+                           p_opts->to,
+                           p_opts->p_x_arg,
+                           p_opts->p_to_arg,
+                           true);
+  }
 }
 
 static SEXP fct_as_factor_impl(SEXP x, SEXP x_levels, SEXP to_levels, bool* lossy, bool ordered) {

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -53,12 +53,7 @@ r_obj* ord_ptype2(const struct ptype2_opts* p_opts) {
   if (ord_ptype2_validate(x_levels, y_levels, p_opts)) {
     return new_empty_ordered(x_levels);
   } else {
-    return vec_ptype2_default(p_opts->x,
-                              p_opts->y,
-                              p_opts->p_x_arg,
-                              p_opts->p_y_arg,
-                              r_lazy_null,
-                              &p_opts->fallback);
+    return r_globals.empty_chr;
   }
 }
 

--- a/src/type-factor.c
+++ b/src/type-factor.c
@@ -265,12 +265,12 @@ SEXP ord_as_ordered(const struct cast_opts* p_opts) {
   if (ord_ptype2_validate(x_levels, y_levels, &ptype2_opts)) {
     return p_opts->x;
   } else {
-    // FIXME: Call default cast method
-    stop_incompatible_type(p_opts->x,
-                           p_opts->to,
-                           p_opts->p_x_arg,
-                           p_opts->p_to_arg,
-                           true);
+    return vec_cast_default(p_opts->x,
+                            p_opts->to,
+                            p_opts->p_x_arg,
+                            p_opts->p_to_arg,
+                            p_opts->call,
+                            &p_opts->fallback);
   }
 }
 

--- a/tests/testthat/test-type-factor.R
+++ b/tests/testthat/test-type-factor.R
@@ -106,14 +106,11 @@ test_that("vec_ptype2() errors with malformed ordered factors", {
 })
 
 test_that("ordered factors with different levels are not compatible", {
-  expect_error(
-    vec_ptype2(ordered("a"), ordered("b")),
-    class = "vctrs_error_incompatible_type"
-  )
-  expect_error(
-    vec_ptype2(ordered("a"), ordered(c("a", "b"))),
-    class = "vctrs_error_incompatible_type"
-  )
+  # Common type upcasts to character
+  expect_equal(vec_ptype2(ordered("a"), ordered("b")), chr())
+  expect_equal(vec_ptype2(ordered("a"), ordered(c("a", "b"))), chr())
+
+  # Casting to incompatible ordered is not allowed
   expect_error(
     vec_cast(ordered("a"), ordered("b")),
     class = "vctrs_error_incompatible_type"


### PR DESCRIPTION
1. Refactor ordered validation into a predicate. If `false` call default ptype/cast method. This prepares for (2) and makes the coercion methods for `ordered` more consistent (default fallbacks, `I()` behaviour, allows restarts with #1719).

2. Relax common type for incompatible ordered factors.