### PR TITLE
Call `vec_proxy_order()` with arrays, which aren't objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* Fixed a bug with the internal `vec_order_radix()` function related to matrix
+  columns (#1753).
+
 # vctrs 0.5.1
 
 * Fix for CRAN checks.

--- a/src/order.c
+++ b/src/order.c
@@ -4519,8 +4519,8 @@ static int df_decreasing_expansion(SEXP x);
 
 static
 int vec_decreasing_expansion(SEXP x) {
-  // Bare columns
-  if (!OBJECT(x)) {
+  // Bare vectors
+  if (!OBJECT(x) && !has_dim(x)) {
     return 1;
   }
 

--- a/tests/testthat/_snaps/order.md
+++ b/tests/testthat/_snaps/order.md
@@ -1,3 +1,19 @@
+# `direction` is recycled right with array columns (#1753)
+
+    Code
+      vec_order_radix(df, direction = c("asc", "desc", "desc"))
+    Condition
+      Error:
+      ! `direction` should have length 1 or length equal to the number of columns of `x` when `x` is a data frame.
+
+# `na_value` is recycled right with array columns (#1753)
+
+    Code
+      vec_order_radix(df, direction = c("smallest", "largest", "largest"))
+    Condition
+      Error:
+      ! `direction` must contain only "asc" or "desc".
+
 # dots must be empty (#1647)
 
     Code

--- a/tests/testthat/test-order.R
+++ b/tests/testthat/test-order.R
@@ -885,6 +885,60 @@ test_that("`na_value` and `direction` can both be vectors", {
   )
 })
 
+test_that("`direction` is recycled right with array columns (#1753)", {
+  df <- data_frame(
+    x = matrix(c(1, 1, 1, 3, 2, 2), ncol = 2),
+    y = 3:1
+  )
+  expect_identical(
+    vec_order_radix(df, direction = c("asc", "desc")),
+    c(2L, 3L, 1L)
+  )
+  expect_snapshot(error = TRUE, {
+    vec_order_radix(df, direction = c("asc", "desc", "desc"))
+  })
+
+  df <- data_frame(
+    x = array(c(1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 3, 3), dim = c(3, 2, 2)),
+    y = 3:1
+  )
+  expect_identical(
+    vec_order_radix(df, direction = c("asc", "desc")),
+    c(2L, 3L, 1L)
+  )
+})
+
+test_that("`na_value` is recycled right with array columns (#1753)", {
+  df <- data_frame(
+    x = matrix(c(1, 1, 1, 3, NA, 2), ncol = 2),
+    y = 3:1
+  )
+  expect_identical(
+    vec_order_radix(df, na_value = c("largest", "smallest")),
+    c(3L, 1L, 2L)
+  )
+  expect_identical(
+    vec_order_radix(df, na_value = c("smallest", "largest")),
+    c(2L, 3L, 1L)
+  )
+  expect_snapshot(error = TRUE, {
+    vec_order_radix(df, direction = c("smallest", "largest", "largest"))
+  })
+
+  df <- data_frame(
+    x = array(c(1, 1, 1, 2, 2, 2, 3, 3, 3, 4, NA, 3), dim = c(3, 2, 2)),
+    y = 3:1
+  )
+  expect_identical(
+    vec_order_radix(df, na_value = c("largest", "smallest")),
+    c(3L, 1L, 2L)
+  )
+  expect_identical(
+    vec_order_radix(df, na_value = c("smallest", "largest")),
+    c(2L, 3L, 1L)
+  )
+})
+
 # ------------------------------------------------------------------------------
 # vec_order_radix(<data.frame>) - counting
 


### PR DESCRIPTION
Closes #1753 

Luckily this was an easy one. `vec_decreasing_expansion()` tries to avoid calling the extra `vec_proxy_order()` call on super simple columns, just for performance. But I forgot that arrays technically aren't `OBJECT()`s and they do have data frame `vec_proxy_order()` proxies so we need to actually call `vec_proxy_order()` to compute the correct number of expansion units.