### PR TITLE
Fix incorrect `sizeof()` type

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -98,7 +98,7 @@ static struct dictionary* new_dictionary_opts(SEXP x, struct dictionary_opts* op
       Rf_errorcall(R_NilValue, "Can't allocate hash lookup table. Please free memory.");
     }
 
-    memset(d->hash, 0, n * sizeof(R_len_t));
+    memset(d->hash, 0, n * sizeof(uint32_t));
     hash_fill(d->hash, n, x, opts->na_equal);
   } else {
     d->hash = NULL;


### PR DESCRIPTION
The hashes are defined as `uint32_t* hash` so we should use `uint32_t` here not `R_len_t`. We just got a bit lucky that they are typically the same size.

(just look at the lines right before this where we correctly use the following)

```c
d->hash = (uint32_t*) R_alloc(n, sizeof(uint32_t));
```