### PR TITLE
Don't `memset()` with `DICT_EMPTY`

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -85,7 +85,10 @@ static struct dictionary* new_dictionary_opts(SEXP x, struct dictionary_opts* op
     uint32_t size = dict_key_size(x);
 
     d->key = (R_len_t*) R_alloc(size, sizeof(R_len_t));
-    memset(d->key, DICT_EMPTY, size * sizeof(R_len_t));
+
+    for (uint32_t i = 0; i < size; ++i) {
+      d->key[i] = DICT_EMPTY;
+    }
 
     d->size = size;
   }


### PR DESCRIPTION
I think it is fairly dangerous to `memset()` with `DICT_EMPTY` here. It does work as is, because `DICT_EMPTY` is set to `-1` and that is one of the two values that happens to work as you'd expect with `memset()`. The other is `0`, which we do quite a bit.

See https://stackoverflow.com/a/7202474/7394743 for more details about why `-1` actually works.

A few people noted that it only works because of how two's complement works. I doubt vctrs could ever work on a computer that doesn't abide by two's complement, but I don't love relying on things like this when we can easily avoid it.

It would also obviously break if we ever changed the `DICT_EMPTY` value to anything else.

I feel like only using `memset()` with `0` is a reasonable restriction to make

