### PR TITLE
Use correct `uint64_t` to right shift with

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -19,7 +19,7 @@ static inline uint32_t hash_int32(uint32_t x) {
 
 // 64-bit mixer from murmurhash
 // https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp#L81
-static inline uint32_t hash_int64(int64_t x) {
+static inline uint32_t hash_int64(uint64_t x) {
   x ^= x >> 33;
   x *= UINT64_C(0xff51afd7ed558ccd);
   x ^= x >> 33;

--- a/src/hash.c
+++ b/src/hash.c
@@ -7,7 +7,7 @@ static inline uint32_t hash_combine(uint32_t x, uint32_t y) {
 
 // 32-bit mixer from murmurhash
 // https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp#L68
-static inline uint32_t hash_int32(uint32_t x) {
+static inline uint32_t hash_uint32(uint32_t x) {
   x ^= x >> 16;
   x *= 0x85ebca6b;
   x ^= x >> 13;
@@ -19,7 +19,7 @@ static inline uint32_t hash_int32(uint32_t x) {
 
 // 64-bit mixer from murmurhash
 // https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp#L81
-static inline uint32_t hash_int64(uint64_t x) {
+static inline uint32_t hash_uint64(uint64_t x) {
   x ^= x >> 33;
   x *= UINT64_C(0xff51afd7ed558ccd);
   x ^= x >> 33;
@@ -42,11 +42,11 @@ static inline uint32_t hash_double(double x) {
   } value;
   value.d = x;
 
-  return hash_int64(value.i);
+  return hash_uint64(value.i);
 }
 
 static inline uint32_t hash_char(SEXP x) {
-  return hash_int64((uintptr_t) x);
+  return hash_uint64((uintptr_t) x);
 }
 
 // Hashing scalars -----------------------------------------------------
@@ -60,10 +60,10 @@ static inline uint32_t raw_hash_scalar(const Rbyte* x);
 
 
 static inline uint32_t lgl_hash_scalar(const int* x) {
-  return hash_int32(*x);
+  return hash_uint32(*x);
 }
 static inline uint32_t int_hash_scalar(const int* x) {
-  return hash_int32(*x);
+  return hash_uint32(*x);
 }
 static inline uint32_t dbl_hash_scalar(const double* x) {
   double val = *x;
@@ -87,7 +87,7 @@ static inline uint32_t chr_hash_scalar(const SEXP* x) {
   return hash_char(*x);
 }
 static inline uint32_t raw_hash_scalar(const Rbyte* x) {
-  return hash_int32(*x);
+  return hash_uint32(*x);
 }
 
 static inline uint32_t list_hash_scalar_na_equal(SEXP x, R_len_t i) {
@@ -153,7 +153,7 @@ static uint32_t sexp_hash(SEXP x) {
   case SPECIALSXP:
   case BUILTINSXP:
   case ENVSXP:
-  case EXTPTRSXP: return hash_int64((uintptr_t) x);
+  case EXTPTRSXP: return hash_uint64((uintptr_t) x);
   default: Rf_errorcall(R_NilValue, "Unsupported type %s", Rf_type2char(TYPEOF(x)));
   }
 }

--- a/tests/testthat/_snaps/hash.md
+++ b/tests/testthat/_snaps/hash.md
@@ -25,39 +25,39 @@
       [376] f4 1a a5 4f 41 4b 7a 10 f2 d2 98 6e 7e 7f 11 0f c9 93 eb 84 3a a3 d6 05 9c
       
       $dbl1
-        [1] 00 c1 04 29 59 03 e1 f3 6a 26 91 1e a7 0a 94 81 d0 c2 58 ef 6a b0 2f 59 c2
-       [26] f7 fe 63 c3 ce 8a 90 1d 1d ce 14 05 c8 d4 e8 2f cf 98 46 e2 99 af e3 b9 cf
-       [51] 1b 4b 39 8b 47 f3 e3 49 63 d1 0a af 42 9d 48 fe c7 7b ab b4 ab 5b a8 d7 94
-       [76] 6e 0c 82 24 08 fc 20 d8 cb 7a bb c7 ba 9e 3b 0d d5 d6 8c 9e 2b 48 97 9e c8
-      [101] f0 c9 4b ad da 6b 9e 41 8b 82 e8 82 ba 6a f2 99 a1 81 82 d5 c0 ca 3d fb ce
-      [126] 54 60 0e 7d 93 bd 32 8e 02 d8 db e0 cb f9 e7 f5 ae e1 b9 73 17 5d ed ff a7
-      [151] 43 68 23 ee 2d 63 73 d9 a0 43 f6 72 2d 68 19 ff fc 46 0b 49 69 3e 1f bc 03
-      [176] 1d 1a ab de c9 b0 4a ed 85 af 2f e3 fc 80 99 b7 c4 7f 65 ac c1 96 17 5b 86
-      [201] 78 2e c8 67 65 45 5d 95 77 3d 3a 9b d8 c7 01 fd e7 1d 5b 2d f6 19 7b 18 20
-      [226] 67 7c af 43 01 54 b6 2c 99 10 85 28 c4 68 e1 99 67 d9 ae f4 5a e2 04 87 14
-      [251] 63 8a 89 96 5e f6 fc 9c a3 6a f1 23 29 09 82 c9 2a cc 51 b7 8f 27 53 47 a0
-      [276] a6 fa 73 2d 07 86 f5 cc 07 98 1a f2 6c d4 e0 f2 43 31 90 98 2c 94 28 25 40
-      [301] 23 1f 2f 2f 41 50 c3 d2 65 6f 01 32 a1 7f 7a 40 a8 5c 11 db 88 7d 7e a4 1d
-      [326] 7d 43 c3 17 cd 2e ca dc 56 aa c3 74 8d 37 1a 16 07 d4 c5 0a f9 03 8f a7 6d
-      [351] 23 c5 b8 05 ad 7c e1 33 d1 0e 0e 8c 19 72 0d 80 3e c7 80 5c 77 58 b1 ef 89
-      [376] 39 a5 a2 72 0a c4 c4 c5 16 47 90 da 47 49 a1 b1 81 70 ce cf cf b3 5c ca 3a
+        [1] 6b 2c 06 3b 59 03 e1 f3 6a 26 91 9e dd 27 af 6c d0 c2 58 6f a7 71 b0 a8 c2
+       [26] f7 fe 63 40 5a f1 9d 92 c5 0e c6 05 c8 d4 68 2f cf 98 c6 69 41 ad 1d 2a 6f
+       [51] bb a3 b1 f9 09 f0 e3 49 63 d1 0a af 42 9d 59 31 8b 1e db 3f f1 61 a8 d7 94
+       [76] 6e fd ec bf 5c fc 20 d8 cb 7a bb c7 ba 8b 60 53 00 d6 8c 9e 2b fc 76 73 e7
+      [101] f0 c9 4b ad da 6b 9e 41 9f 88 3f 20 ba 6a f2 99 56 48 e0 57 c0 ca 3d 7b ce
+      [126] 54 60 0e 5b ad 1b 94 a3 cb 2f c3 e0 cb f9 67 f5 ae e1 39 73 17 5d 6d 70 0a
+      [151] a5 bc 01 08 f3 9d 8c de 10 d3 f6 72 2d e8 19 ff fc c6 24 4e 95 b4 90 5e 7b
+      [176] da e2 12 4e f4 b0 4a ed 85 af 2f e3 fc 48 33 5d aa 7f 78 05 2f d3 d2 44 c4
+      [201] 78 2e c8 e7 65 45 5d 15 af 8b 5e 5c 49 48 fb 55 d1 4e 09 d0 f6 19 7b 98 20
+      [226] 67 7c 2f 2e ba 70 2a 0a ad c8 48 3d 69 7b c5 99 67 d9 2e f4 5a e2 84 24 9c
+      [251] 00 22 1d 75 e7 c6 fc 9c a3 6a dd 1d 96 b0 53 67 35 59 51 b7 8f a7 3f 78 39
+      [276] ed fa 73 2d 07 24 3b 9e 97 83 06 0d 2a d4 e0 f2 43 75 c3 6f 09 94 28 25 40
+      [301] f8 c1 9e 13 41 50 c3 d2 65 6f 01 b2 26 fb 1f d2 a8 5c 11 db b4 e6 4d e1 1d
+      [326] 7d 43 c3 17 cd 2e ca ad 05 b4 bd 74 8d 37 9a 5a 1e 85 d4 0a f9 03 8f a7 6d
+      [351] 23 c5 7b e7 54 ee e1 33 d1 8e a3 5d a4 cb 0d 80 3e c7 80 5c 77 d8 36 fb 94
+      [376] a5 a5 a2 72 8a 95 ab f3 da 47 90 da c7 49 a1 b1 81 01 19 29 96 b3 5c ca ba
       
       $dbl2
-        [1] b9 79 37 9e 87 e6 d0 04 ff 57 34 47 e9 da db 08 35 18 46 24 36 7b 48 f3 75
-       [26] 78 db 2d 6c 77 76 c5 67 0a 4b b9 64 57 19 b8 f4 69 d5 5d c2 04 8f 91 55 6a
-       [51] d5 2f 33 2d 76 e9 9d f6 f8 5e cf c6 06 5d 6a 73 96 c6 21 e5 ca ad 3f d6 4c
-       [76] 1d 3c 72 9b b3 3a 66 7a e4 91 0d 96 82 63 22 50 12 56 6b 1a 7f 0f 3e 5b e8
-      [101] bc 28 55 9c 90 22 9c f7 9a f9 60 5f 64 8c d0 c8 c4 cd fa 2d 20 1a db 65 c0
-      [126] 7e 70 5f 2d 59 57 6f cc 52 4f 75 87 f9 6a 7a e8 1e 2c 5c e7 1b 72 ea 69 8a
-      [151] 6b fb a5 7d 41 05 1a e3 ed e6 ea 50 2b 06 3f 39 e8 a1 e0 69 29 56 5e 0e 72
-      [176] 29 b2 4c 65 ae 76 d2 cd 18 6c 74 3d f4 62 1f 67 51 37 e4 1f eb 54 0f 00 71
-      [201] 5b da 32 37 d5 fc 9d f3 c3 0e a6 81 09 19 25 1e 06 61 2f 2c 62 7a 33 fc 41
-      [226] 13 fc f9 44 55 57 9d d6 4b a7 ba 87 fe 1e 00 d7 1c 0c 34 ba 25 ce 21 7f 97
-      [251] d5 11 f5 cf 2f a4 34 2f 60 a7 b2 a5 2c 8f 90 29 c5 55 06 c6 6a 19 e4 bc 46
-      [276] 24 c0 43 8c bf ac d9 db 43 ea 2f 29 da 48 64 fa 51 55 85 81 40 cd ac bc 6e
-      [301] 9b d2 07 e2 94 df 2a 7d c2 bd 63 87 5e 5e 47 8d 2d 21 ac 92 0a b8 52 e4 e5
-      [326] fb ec d6 5b 17 34 01 02 21 78 b2 83 28 f9 f0 f5 ae 90 27 30 aa 4b 5c 6a d2
-      [351] da 71 2e 3c c6 68 a7 9f a9 36 16 81 cb cb d8 6d 07 96 6e f4 f9 29 8d 61 f7
-      [376] 86 51 af f2 7e cc 3d 4f 24 8e e0 9f 70 be b1 af c9 73 f2 4b c9 00 c1 04 29
+        [1] b9 79 37 9e ea 40 52 d2 fa 14 1e 2f c1 55 60 05 35 18 46 24 ba 76 ed 56 75
+       [26] 78 db ad 6c 77 76 c5 67 0a 4b b9 d2 19 61 03 f4 69 d5 5d db d2 f9 7d 55 6a
+       [51] d5 af 33 2d 76 69 9d f6 f8 de 6f d3 54 05 97 a0 7f 08 f0 19 33 e0 e4 4a 20
+       [76] 61 67 40 d0 00 b5 ad 11 fb 94 d6 28 78 ef 95 69 a6 e5 9f ed cf 10 69 4f 59
+      [101] bc 28 55 9c e7 bd ea 9d c2 cb 77 e7 9d 22 f6 ee ad 0c 46 0d 6d 15 f2 26 c0
+      [126] 7e 70 df 9c 1b ce cc cc 52 4f 75 87 f9 6a fa 5f b8 4d 42 e7 1b 72 ea 69 8a
+      [151] 6b 7b ab 97 7b 86 e6 9a 7c 62 ac eb 08 df 3f 39 e8 a1 ec ce 45 f9 26 c5 27
+      [176] 47 b2 4c 65 ae 11 07 52 d4 6c 74 3d f4 62 1f 67 51 37 e4 1f eb b7 3e 51 26
+      [201] 5b da 32 b7 d5 fc 9d 73 8d 98 42 fa 90 23 50 bf 06 61 2f ac 54 8c 87 0e 53
+      [226] 3d 98 5f 44 55 57 9d 69 b7 59 9f 87 fe 1e 00 d7 1c 0c 34 ba 25 ce a1 77 68
+      [251] cc 7a f5 cf 2f a4 34 2f 60 a7 a0 c7 e9 cd 90 29 c5 55 06 c6 6a 99 e4 bc 46
+      [276] a4 c0 43 8c 3f f8 8c ee 17 d7 9f 8d 03 48 64 fa d1 55 85 81 c0 cd ac bc 6e
+      [301] d5 59 0a 28 94 df 2a 7d ea ca 7f 09 5e 5e 47 0d 02 ad 8c 67 0a b8 52 e4 17
+      [326] 3a 25 5d 5b 17 34 01 09 18 7e ca 83 28 f9 f0 c1 b0 10 bc 30 aa 4b 5c 85 68
+      [351] 75 71 2e 3c c6 e8 a7 9f a9 36 16 81 cb 4b d7 94 88 15 6e f4 f9 a9 03 ac 21
+      [376] 65 43 cb 1a ca cd 69 96 b6 8e e0 9f 70 be b1 af c9 73 f2 4b c9 6b 2c 06 3b
       
 


### PR DESCRIPTION
Right shifting an `int64_t` that has a negative value is implementation defined, see:
https://stackoverflow.com/a/28681258/7394743

I don't think we should rely on implementation defined behavior at all. We definitely have negative values that go through here, because we reinterpret `double`s as `uint64_t` before passing them to `hash_int64()`, so we are bound to end up with a negative value when the `uint64_t` is converted to an `int64_t` on the way in.

I am almost 100% certain this was meant to be an _unsigned_ integer here. It is unsigned in the original murmurhash we took this from too. I think this was meant to be done as part of https://github.com/r-lib/vctrs/pull/352 but was just forgotten?