### PR TITLE
Rewrite run functions on top of "detect" implementation

### DIFF
--- a/R/runs.R
+++ b/R/runs.R
@@ -32,13 +32,13 @@
 #'
 #' vec_identify_runs(df)
 vec_identify_runs <- function(x) {
-  .Call(vctrs_identify_runs, x)
+  .Call(ffi_vec_identify_runs, x)
 }
 
-vec_locate_runs <- function(x, start = TRUE) {
-  .Call(vctrs_locate_runs, x, start)
+vec_locate_run_bounds <- function(x, start = TRUE) {
+  .Call(ffi_vec_locate_run_bounds, x, start)
 }
 
-vec_detect_runs <- function(x, start = TRUE) {
-  .Call(vctrs_detect_runs, x, start)
+vec_detect_run_bounds <- function(x, start = TRUE) {
+  .Call(ffi_vec_detect_run_bounds, x, start)
 }

--- a/src/decl/runs-decl.h
+++ b/src/decl/runs-decl.h
@@ -1,53 +1,41 @@
 static
-r_obj* vec_locate_runs(r_obj* x, bool start);
-
-static inline
-void vec_locate_run_starts(const int* v_id, r_ssize size, int* v_out);
-static inline
-void vec_locate_run_ends(const int* v_id, r_ssize size, int* v_out);
-
+r_obj* vec_detect_run_bounds(r_obj* x, bool start);
+static
+r_obj* vec_locate_run_bounds(r_obj* x, bool start);
 
 static
-r_obj* vec_detect_runs(r_obj* x, bool start);
+r_obj* vec_detect_run_bounds0(r_obj* x, bool start);
 
 static inline
-void vec_detect_run_starts(const int* v_id, r_ssize size, int* v_out);
+void lgl_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 static inline
-void vec_detect_run_ends(const int* v_id, r_ssize size, int* v_out);
-
-
+void int_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 static inline
-int lgl_identify_runs(r_obj* x, r_ssize size, int* v_out);
+void dbl_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 static inline
-int int_identify_runs(r_obj* x, r_ssize size, int* v_out);
+void cpl_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 static inline
-int dbl_identify_runs(r_obj* x, r_ssize size, int* v_out);
+void chr_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 static inline
-int cpl_identify_runs(r_obj* x, r_ssize size, int* v_out);
+void raw_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 static inline
-int chr_identify_runs(r_obj* x, r_ssize size, int* v_out);
-static inline
-int raw_identify_runs(r_obj* x, r_ssize size, int* v_out);
-static inline
-int list_identify_runs(r_obj* x, r_ssize size, int* v_out);
-static inline
-int df_identify_runs(r_obj* x, r_ssize size, int* v_out);
-
+void list_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 
 static inline
-void col_identify_runs(r_obj* x, r_ssize size, bool* v_where);
-
+void df_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 static inline
-void lgl_col_identify_runs(r_obj* x, r_ssize size, bool* v_where);
+void col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 static inline
-void int_col_identify_runs(r_obj* x, r_ssize size, bool* v_where);
+void lgl_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 static inline
-void dbl_col_identify_runs(r_obj* x, r_ssize size, bool* v_where);
+void int_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 static inline
-void cpl_col_identify_runs(r_obj* x, r_ssize size, bool* v_where);
+void dbl_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 static inline
-void chr_col_identify_runs(r_obj* x, r_ssize size, bool* v_where);
+void cpl_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 static inline
-void raw_col_identify_runs(r_obj* x, r_ssize size, bool* v_where);
+void chr_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
 static inline
-void list_col_identify_runs(r_obj* x, r_ssize size, bool* v_where);
+void raw_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);
+static inline
+void list_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out);

--- a/src/init.c
+++ b/src/init.c
@@ -120,9 +120,9 @@ extern r_obj* ffi_cast_dispatch_native(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r
 extern SEXP vctrs_fast_c(SEXP, SEXP);
 extern r_obj* ffi_data_frame(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_df_list(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
-extern SEXP vctrs_identify_runs(SEXP);
-extern SEXP vctrs_locate_runs(SEXP, SEXP);
-extern SEXP vctrs_detect_runs(SEXP, SEXP);
+extern SEXP ffi_vec_detect_run_bounds(r_obj*, r_obj*);
+extern SEXP ffi_vec_locate_run_bounds(r_obj*, r_obj*);
+extern SEXP ffi_vec_identify_runs(r_obj*);
 extern SEXP vctrs_slice_complete(SEXP);
 extern SEXP vctrs_locate_complete(SEXP);
 extern SEXP vctrs_detect_complete(SEXP);
@@ -300,9 +300,9 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_fast_c",                          (DL_FUNC) &vctrs_fast_c, 2},
   {"ffi_data_frame",                        (DL_FUNC) &ffi_data_frame, 4},
   {"ffi_df_list",                           (DL_FUNC) &ffi_df_list, 5},
-  {"vctrs_identify_runs",                   (DL_FUNC) &vctrs_identify_runs, 1},
-  {"vctrs_locate_runs",                     (DL_FUNC) &vctrs_locate_runs, 2},
-  {"vctrs_detect_runs",                     (DL_FUNC) &vctrs_detect_runs, 2},
+  {"ffi_vec_detect_run_bounds",             (DL_FUNC) &ffi_vec_detect_run_bounds, 2},
+  {"ffi_vec_locate_run_bounds",             (DL_FUNC) &ffi_vec_locate_run_bounds, 2},
+  {"ffi_vec_identify_runs",                 (DL_FUNC) &ffi_vec_identify_runs, 1},
   {"vctrs_slice_complete",                  (DL_FUNC) &vctrs_slice_complete, 1},
   {"vctrs_locate_complete",                 (DL_FUNC) &vctrs_locate_complete, 1},
   {"vctrs_detect_complete",                 (DL_FUNC) &vctrs_detect_complete, 1},

--- a/src/runs.c
+++ b/src/runs.c
@@ -4,184 +4,119 @@
 
 // -----------------------------------------------------------------------------
 
-r_obj* vctrs_locate_runs(r_obj* x, r_obj* ffi_start) {
+r_obj* ffi_vec_detect_run_bounds(r_obj* x, r_obj* ffi_start) {
   const bool start = r_arg_as_bool(ffi_start, "start");
-  return vec_locate_runs(x, start);
+  return vec_detect_run_bounds(x, start);
 }
 
 static
-r_obj* vec_locate_runs(r_obj* x, bool start) {
-  r_obj* id = KEEP(vec_identify_runs(x));
-  const int* v_id = r_int_cbegin(id);
+r_obj* vec_detect_run_bounds(r_obj* x, bool start) {
+  r_obj* where = KEEP(vec_detect_run_bounds0(x, start));
+  const bool* v_where = r_raw_cbegin(where);
 
-  const r_ssize size = r_length(id);
-  const int n = r_int_get(r_attrib_get(id, syms_n), 0);
+  const r_ssize size = r_length(where) / sizeof(bool);
 
-  // Share memory with `id`.
-  // `vec_locate_run_starts/ends()` are carefully written to avoid
-  // overwrite issues.
-  r_obj* out = id;
-  int* v_out = r_int_begin(out);
-
-  if (start) {
-    vec_locate_run_starts(v_id, size, v_out);
-  } else {
-    vec_locate_run_ends(v_id, size, v_out);
-  }
-
-  // Resize shared memory to output size and clear attribute
-  out = KEEP(r_int_resize(out, n));
-  r_attrib_poke(out, syms_n, r_null);
-
-  FREE(2);
-  return out;
-}
-
-static inline
-void vec_locate_run_starts(const int* v_id, r_ssize size, int* v_out) {
-  if (size == 0) {
-    return;
-  }
-
-  r_ssize loc = 0;
-  int ref = v_id[0];
-
-  // Handle first case
-  v_out[loc] = 1;
-  ++loc;
-
-  for (r_ssize i = 1; i < size; ++i) {
-    const int elt = v_id[i];
-    v_out[loc] = i + 1;
-    loc += elt != ref;
-    ref = elt;
-  }
-}
-
-static inline
-void vec_locate_run_ends(const int* v_id, r_ssize size, int* v_out) {
-  if (size == 0) {
-    return;
-  }
-
-  r_ssize loc = 0;
-  int ref = v_id[0];
-
-  for (r_ssize i = 1; i < size; ++i) {
-    const int elt = v_id[i];
-    v_out[loc] = i;
-    loc += elt != ref;
-    ref = elt;
-  }
-
-  // Handle last case
-  v_out[loc] = size;
-}
-
-// -----------------------------------------------------------------------------
-
-r_obj* vctrs_detect_runs(r_obj* x, r_obj* ffi_start) {
-  bool start = r_arg_as_bool(ffi_start, "start");
-  return vec_detect_runs(x, start);
-}
-
-static
-r_obj* vec_detect_runs(r_obj* x, bool start) {
-  r_obj* id = KEEP(vec_identify_runs(x));
-  const int* v_id = r_int_cbegin(id);
-
-  r_ssize size = r_length(id);
-
-  r_obj* out = KEEP(r_new_logical(size));
+  r_obj* out = KEEP(r_alloc_logical(size));
   int* v_out = r_lgl_begin(out);
 
-  if (start) {
-    vec_detect_run_starts(v_id, size, v_out);
-  } else {
-    vec_detect_run_ends(v_id, size, v_out);
+  for (r_ssize i = 0; i < size; ++i) {
+    v_out[i] = v_where[i];
   }
 
   FREE(2);
   return out;
 }
 
-static inline
-void vec_detect_run_starts(const int* v_id, r_ssize size, int* v_out) {
-  if (size == 0) {
-    return;
-  }
+// -----------------------------------------------------------------------------
 
-  int ref = v_id[0];
-
-  // Handle first case
-  v_out[0] = 1;
-
-  for (r_ssize i = 1; i < size; ++i) {
-    const int elt = v_id[i];
-    v_out[i] = elt != ref;
-    ref = elt;
-  }
+r_obj* ffi_vec_locate_run_bounds(r_obj* x, r_obj* ffi_start) {
+  const bool start = r_arg_as_bool(ffi_start, "start");
+  return vec_locate_run_bounds(x, start);
 }
 
-static inline
-void vec_detect_run_ends(const int* v_id, r_ssize size, int* v_out) {
-  if (size == 0) {
-    return;
+static
+r_obj* vec_locate_run_bounds(r_obj* x, bool start) {
+  r_obj* where = KEEP(vec_detect_run_bounds0(x, start));
+  const bool* v_where = r_raw_cbegin(where);
+
+  const r_ssize size = r_length(where) / sizeof(bool);
+
+  r_ssize n = 0;
+  for (r_ssize i = 0; i < size; ++i) {
+    n += v_where[i];
   }
 
-  int ref = v_id[0];
+  r_obj* out = KEEP(r_alloc_integer(n));
+  int* v_out = r_int_begin(out);
 
-  for (r_ssize i = 1; i < size; ++i) {
-    const int elt = v_id[i];
-    v_out[i - 1] = elt != ref;
-    ref = elt;
+  for (r_ssize i = 0, j = 0; i < size && j < n; ++i) {
+    v_out[j] = i + 1;
+    j += v_where[i];
   }
 
-  // Handle last case
-  v_out[size - 1] = 1;
+  FREE(2);
+  return out;
 }
 
 // -----------------------------------------------------------------------------
 
-r_obj* vctrs_identify_runs(r_obj* x) {
+r_obj* ffi_vec_identify_runs(r_obj* x) {
   return vec_identify_runs(x);
 }
 
 r_obj* vec_identify_runs(r_obj* x) {
-  r_obj* proxy = KEEP(vec_proxy_equal(x));
-  r_ssize size = vec_size(proxy);
-  proxy = KEEP(vec_normalize_encoding(proxy));
+  const bool start = true;
+  r_obj* where = KEEP(vec_detect_run_bounds0(x, start));
+  const bool* v_where = r_raw_cbegin(where);
+
+  const r_ssize size = r_length(where) / sizeof(bool);
 
   r_obj* out = KEEP(r_alloc_integer(size));
   int* v_out = r_int_begin(out);
 
-  // Handle size 0 up front.
-  // All implementations assume at least 1 element.
-  if (size == 0) {
-    r_obj* ffi_n = r_int(0);
-    r_attrib_poke(out, syms_n, ffi_n);
-    FREE(3);
-    return out;
-  }
+  int n = 0;
 
-  const enum vctrs_type type = vec_proxy_typeof(proxy);
-
-  int n;
-
-  switch (type) {
-  case VCTRS_TYPE_logical: n = lgl_identify_runs(proxy, size, v_out); break;
-  case VCTRS_TYPE_integer: n = int_identify_runs(proxy, size, v_out); break;
-  case VCTRS_TYPE_double: n = dbl_identify_runs(proxy, size, v_out); break;
-  case VCTRS_TYPE_complex: n = cpl_identify_runs(proxy, size, v_out); break;
-  case VCTRS_TYPE_character: n = chr_identify_runs(proxy, size, v_out); break;
-  case VCTRS_TYPE_raw: n = raw_identify_runs(proxy, size, v_out); break;
-  case VCTRS_TYPE_list: n = list_identify_runs(proxy, size, v_out); break;
-  case VCTRS_TYPE_dataframe: n = df_identify_runs(proxy, size, v_out); break;
-  default: stop_unimplemented_vctrs_type("vec_identify_runs", type);
+  for (r_ssize i = 0; i < size; ++i) {
+    n += v_where[i];
+    v_out[i] = n;
   }
 
   r_obj* ffi_n = r_int(n);
   r_attrib_poke(out, syms_n, ffi_n);
+
+  FREE(2);
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+
+/*
+ * Like `vec_detect_run_bounds()`, but returns a less memory intensive
+ * boolean array as a raw vector.
+ */
+static
+r_obj* vec_detect_run_bounds0(r_obj* x, bool start) {
+  r_obj* proxy = KEEP(vec_proxy_equal(x));
+  proxy = KEEP(vec_normalize_encoding(proxy));
+
+  const r_ssize size = vec_size(proxy);
+
+  r_obj* out = KEEP(r_alloc_raw(size * sizeof(bool)));
+  bool* v_out = r_raw_begin(out);
+
+  const enum vctrs_type type = vec_proxy_typeof(proxy);
+
+  switch (type) {
+  case VCTRS_TYPE_logical: lgl_detect_run_bounds0(proxy, size, start, v_out); break;
+  case VCTRS_TYPE_integer: int_detect_run_bounds0(proxy, size, start, v_out); break;
+  case VCTRS_TYPE_double: dbl_detect_run_bounds0(proxy, size, start, v_out); break;
+  case VCTRS_TYPE_complex: cpl_detect_run_bounds0(proxy, size, start, v_out); break;
+  case VCTRS_TYPE_character: chr_detect_run_bounds0(proxy, size, start, v_out); break;
+  case VCTRS_TYPE_raw: raw_detect_run_bounds0(proxy, size, start, v_out); break;
+  case VCTRS_TYPE_list: list_detect_run_bounds0(proxy, size, start, v_out); break;
+  case VCTRS_TYPE_dataframe: df_detect_run_bounds0(proxy, size, start, v_out); break;
+  default: stop_unimplemented_vctrs_type("vec_detect_run_bounds0", type);
+  }
 
   FREE(3);
   return out;
@@ -189,142 +124,170 @@ r_obj* vec_identify_runs(r_obj* x) {
 
 // -----------------------------------------------------------------------------
 
-#define VEC_IDENTIFY_RUNS(CTYPE, CBEGIN, EQUAL_NA_EQUAL) {       \
-  int id = 1;                                                    \
-  CTYPE const* v_x = CBEGIN(x);                                  \
-                                                                 \
-  /* Handle first case */                                        \
-  CTYPE ref = v_x[0];                                            \
-  v_out[0] = id;                                                 \
-                                                                 \
-  for (r_ssize i = 1; i < size; ++i) {                           \
-    CTYPE const elt = v_x[i];                                    \
-    id += !EQUAL_NA_EQUAL(elt, ref);                             \
-    v_out[i] = id;                                               \
-    ref = elt;                                                   \
-  }                                                              \
-                                                                 \
-  return id;                                                     \
+// Algorithm for "ends" is same as "starts", we just iterate in reverse
+#define VEC_DETECT_RUN_BOUNDS0(CTYPE, CBEGIN, EQUAL_NA_EQUAL) { \
+  if (size == 0) {                                              \
+    /* Algorithm requires at least 1 value */                   \
+    return;                                                     \
+  }                                                             \
+                                                                \
+  CTYPE const* v_x = CBEGIN(x);                                 \
+                                                                \
+  if (start) {                                                  \
+    /* Handle first case */                                     \
+    CTYPE ref = v_x[0];                                         \
+    v_out[0] = true;                                            \
+                                                                \
+    for (r_ssize i = 1; i < size; ++i) {                        \
+      CTYPE const elt = v_x[i];                                 \
+      v_out[i] = !EQUAL_NA_EQUAL(elt, ref);                     \
+      ref = elt;                                                \
+    }                                                           \
+  } else {                                                      \
+    /* Handle last case */                                      \
+    CTYPE ref = v_x[size - 1];                                  \
+    v_out[size - 1] = true;                                     \
+                                                                \
+    for (r_ssize i = size - 2; i >= 0; --i) {                   \
+      CTYPE const elt = v_x[i];                                 \
+      v_out[i] = !EQUAL_NA_EQUAL(elt, ref);                     \
+      ref = elt;                                                \
+    }                                                           \
+  }                                                             \
 }
 
-static
-int lgl_identify_runs(r_obj* x, r_ssize size, int* v_out) {
-  VEC_IDENTIFY_RUNS(int, r_lgl_cbegin, lgl_equal_na_equal);
+static inline
+void lgl_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_DETECT_RUN_BOUNDS0(int, r_lgl_cbegin, lgl_equal_na_equal);
 }
-static
-int int_identify_runs(r_obj* x, r_ssize size, int* v_out) {
-  VEC_IDENTIFY_RUNS(int, r_int_cbegin, int_equal_na_equal);
+static inline
+void int_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_DETECT_RUN_BOUNDS0(int, r_int_cbegin, int_equal_na_equal);
 }
-static
-int dbl_identify_runs(r_obj* x, r_ssize size, int* v_out) {
-  VEC_IDENTIFY_RUNS(double, r_dbl_cbegin, dbl_equal_na_equal);
+static inline
+void dbl_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_DETECT_RUN_BOUNDS0(double, r_dbl_cbegin, dbl_equal_na_equal);
 }
-static
-int cpl_identify_runs(r_obj* x, r_ssize size, int* v_out) {
-  VEC_IDENTIFY_RUNS(Rcomplex, r_cpl_cbegin, cpl_equal_na_equal);
+static inline
+void cpl_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_DETECT_RUN_BOUNDS0(Rcomplex, r_cpl_cbegin, cpl_equal_na_equal);
 }
-static
-int chr_identify_runs(r_obj* x, r_ssize size, int* v_out) {
-  VEC_IDENTIFY_RUNS(r_obj*, r_chr_cbegin, chr_equal_na_equal);
+static inline
+void chr_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_DETECT_RUN_BOUNDS0(r_obj*, r_chr_cbegin, chr_equal_na_equal);
 }
-static
-int raw_identify_runs(r_obj* x, r_ssize size, int* v_out) {
-  VEC_IDENTIFY_RUNS(Rbyte, r_raw_cbegin, raw_equal_na_equal);
+static inline
+void raw_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_DETECT_RUN_BOUNDS0(Rbyte, r_raw_cbegin, raw_equal_na_equal);
 }
-static
-int list_identify_runs(r_obj* x, r_ssize size, int* v_out) {
-  VEC_IDENTIFY_RUNS(r_obj*, r_list_cbegin, list_equal_na_equal);
+static inline
+void list_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_DETECT_RUN_BOUNDS0(r_obj*, r_list_cbegin, list_equal_na_equal);
 }
 
-#undef VEC_IDENTIFY_RUNS
+#undef VEC_DETECT_RUN_BOUNDS0
 
 // -----------------------------------------------------------------------------
 
 static inline
-int df_identify_runs(r_obj* x, r_ssize size, int* v_out) {
+void df_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  if (size == 0) {
+    // Algorithm requires at least 1 value
+    return;
+  }
+
   const r_ssize n_col = r_length(x);
   r_obj* const* v_x = r_list_cbegin(x);
 
-  // Boolean vector that will eventually be `true` if we are in a run
+  // `v_out` will eventually be `true` if we are in a run
   // continuation, and `false` if we are starting a new run.
-  r_obj* where_shelter = KEEP(r_alloc_raw(size * sizeof(bool)));
-  bool* v_where = (bool*) r_raw_begin(where_shelter);
-
-  v_where[0] = false;
-  for (r_ssize i = 1; i < size; ++i) {
-    v_where[i] = true;
+  if (start) {
+    v_out[0] = false;
+    for (r_ssize i = 1; i < size; ++i) {
+      v_out[i] = true;
+    }
+  } else {
+    v_out[size - 1] = false;
+    for (r_ssize i = size - 2; i >= 0; --i) {
+      v_out[i] = true;
+    }
   }
 
   for (r_ssize i = 0; i < n_col; ++i) {
-    col_identify_runs(v_x[i], size, v_where);
+    col_detect_run_bounds0(v_x[i], size, start, v_out);
   }
 
-  int id = 1;
-
-  v_out[0] = id;
-  for (r_ssize i = 1; i < size; ++i) {
-    id += !v_where[i];
-    v_out[i] = id;
+  // Now invert to detect the bounds
+  for (r_ssize i = 0; i < size; ++i) {
+    v_out[i] = !v_out[i];
   }
-
-  FREE(1);
-  return id;
 }
 
 static inline
-void col_identify_runs(r_obj* x, r_ssize size, bool* v_where) {
+void col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
   switch (vec_proxy_typeof(x)) {
-  case VCTRS_TYPE_logical: lgl_col_identify_runs(x, size, v_where); break;
-  case VCTRS_TYPE_integer: int_col_identify_runs(x, size, v_where); break;
-  case VCTRS_TYPE_double: dbl_col_identify_runs(x, size, v_where); break;
-  case VCTRS_TYPE_complex: cpl_col_identify_runs(x, size, v_where); break;
-  case VCTRS_TYPE_character: chr_col_identify_runs(x, size, v_where); break;
-  case VCTRS_TYPE_raw: raw_col_identify_runs(x, size, v_where); break;
-  case VCTRS_TYPE_list: list_col_identify_runs(x, size, v_where); break;
+  case VCTRS_TYPE_logical: lgl_col_detect_run_bounds0(x, size, start, v_out); break;
+  case VCTRS_TYPE_integer: int_col_detect_run_bounds0(x, size, start, v_out); break;
+  case VCTRS_TYPE_double: dbl_col_detect_run_bounds0(x, size, start, v_out); break;
+  case VCTRS_TYPE_complex: cpl_col_detect_run_bounds0(x, size, start, v_out); break;
+  case VCTRS_TYPE_character: chr_col_detect_run_bounds0(x, size, start, v_out); break;
+  case VCTRS_TYPE_raw: raw_col_detect_run_bounds0(x, size, start, v_out); break;
+  case VCTRS_TYPE_list: list_col_detect_run_bounds0(x, size, start, v_out); break;
   case VCTRS_TYPE_dataframe: r_stop_internal("Data frame columns should be flattened.");
   case VCTRS_TYPE_scalar: r_abort("Can't compare scalars.");
   default: r_abort("Unimplemented type.");
   }
 }
 
-#define VEC_COL_IDENTIFY_RUNS(CTYPE, CBEGIN, EQUAL_NA_EQUAL) { \
-  CTYPE const* v_x = CBEGIN(x);                                \
-  CTYPE ref = v_x[0];                                          \
-                                                               \
-  for (r_ssize i = 1; i < size; ++i) {                         \
-    CTYPE const elt = v_x[i];                                  \
-    v_where[i] = v_where[i] && EQUAL_NA_EQUAL(ref, elt);       \
-    ref = elt;                                                 \
-  }                                                            \
+#define VEC_COL_DETECT_RUN_BOUNDS0(CTYPE, CBEGIN, EQUAL_NA_EQUAL) {   \
+  CTYPE const* v_x = CBEGIN(x);                                       \
+                                                                      \
+  if (start) {                                                        \
+    CTYPE ref = v_x[0];                                               \
+                                                                      \
+    for (r_ssize i = 1; i < size; ++i) {                              \
+      CTYPE const elt = v_x[i];                                       \
+      v_out[i] = v_out[i] && EQUAL_NA_EQUAL(ref, elt);                \
+      ref = elt;                                                      \
+    }                                                                 \
+  } else {                                                            \
+    CTYPE ref = v_x[size - 1];                                        \
+                                                                      \
+    for (r_ssize i = size - 2; i >= 0; --i) {                         \
+      CTYPE const elt = v_x[i];                                       \
+      v_out[i] = v_out[i] && EQUAL_NA_EQUAL(ref, elt);                \
+      ref = elt;                                                      \
+    }                                                                 \
+  }                                                                   \
 }
 
 static inline
-void lgl_col_identify_runs(r_obj* x, r_ssize size, bool* v_where) {
-  VEC_COL_IDENTIFY_RUNS(int, r_lgl_cbegin, lgl_equal_na_equal);
+void lgl_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_COL_DETECT_RUN_BOUNDS0(int, r_lgl_cbegin, lgl_equal_na_equal);
 }
 static inline
-void int_col_identify_runs(r_obj* x, r_ssize size, bool* v_where) {
-  VEC_COL_IDENTIFY_RUNS(int, r_int_cbegin, int_equal_na_equal);
+void int_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_COL_DETECT_RUN_BOUNDS0(int, r_int_cbegin, int_equal_na_equal);
 }
 static inline
-void dbl_col_identify_runs(r_obj* x, r_ssize size, bool* v_where) {
-  VEC_COL_IDENTIFY_RUNS(double, r_dbl_cbegin, dbl_equal_na_equal);
+void dbl_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_COL_DETECT_RUN_BOUNDS0(double, r_dbl_cbegin, dbl_equal_na_equal);
 }
 static inline
-void cpl_col_identify_runs(r_obj* x, r_ssize size, bool* v_where) {
-  VEC_COL_IDENTIFY_RUNS(Rcomplex, r_cpl_cbegin, cpl_equal_na_equal);
+void cpl_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_COL_DETECT_RUN_BOUNDS0(Rcomplex, r_cpl_cbegin, cpl_equal_na_equal);
 }
 static inline
-void chr_col_identify_runs(r_obj* x, r_ssize size, bool* v_where) {
-  VEC_COL_IDENTIFY_RUNS(r_obj*, r_chr_cbegin, chr_equal_na_equal);
+void chr_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_COL_DETECT_RUN_BOUNDS0(r_obj*, r_chr_cbegin, chr_equal_na_equal);
 }
 static inline
-void raw_col_identify_runs(r_obj* x, r_ssize size, bool* v_where) {
-  VEC_COL_IDENTIFY_RUNS(Rbyte, r_raw_cbegin, raw_equal_na_equal);
+void raw_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_COL_DETECT_RUN_BOUNDS0(Rbyte, r_raw_cbegin, raw_equal_na_equal);
 }
 static inline
-void list_col_identify_runs(r_obj* x, r_ssize size, bool* v_where) {
-  VEC_COL_IDENTIFY_RUNS(r_obj*, r_list_cbegin, list_equal_na_equal);
+void list_col_detect_run_bounds0(r_obj* x, r_ssize size, bool start, bool* v_out) {
+  VEC_COL_DETECT_RUN_BOUNDS0(r_obj*, r_list_cbegin, list_equal_na_equal);
 }
 
-#undef VEC_COL_IDENTIFY_RUNS
+#undef VEC_COL_DETECT_RUN_BOUNDS0

--- a/tests/testthat/_snaps/runs.md
+++ b/tests/testthat/_snaps/runs.md
@@ -1,48 +1,48 @@
-# vec_locate_runs() validates `start`
+# vec_locate_run_bounds() validates `start`
 
     Code
-      vec_locate_runs(1, start = "x")
+      vec_locate_run_bounds(1, start = "x")
     Condition
-      Error in `vec_locate_runs()`:
+      Error in `vec_locate_run_bounds()`:
       ! `start` must be `TRUE` or `FALSE`.
 
 ---
 
     Code
-      vec_locate_runs(1, start = NA)
+      vec_locate_run_bounds(1, start = NA)
     Condition
-      Error in `vec_locate_runs()`:
+      Error in `vec_locate_run_bounds()`:
       ! `start` must be `TRUE` or `FALSE`.
 
 ---
 
     Code
-      vec_locate_runs(1, start = c(TRUE, TRUE))
+      vec_locate_run_bounds(1, start = c(TRUE, TRUE))
     Condition
-      Error in `vec_locate_runs()`:
+      Error in `vec_locate_run_bounds()`:
       ! `start` must be `TRUE` or `FALSE`.
 
-# vec_detect_runs() validates `start`
+# vec_detect_run_bounds() validates `start`
 
     Code
-      vec_detect_runs(1, start = "x")
+      vec_detect_run_bounds(1, start = "x")
     Condition
-      Error in `vec_detect_runs()`:
-      ! `start` must be `TRUE` or `FALSE`.
-
----
-
-    Code
-      vec_detect_runs(1, start = NA)
-    Condition
-      Error in `vec_detect_runs()`:
+      Error in `vec_detect_run_bounds()`:
       ! `start` must be `TRUE` or `FALSE`.
 
 ---
 
     Code
-      vec_detect_runs(1, start = c(TRUE, TRUE))
+      vec_detect_run_bounds(1, start = NA)
     Condition
-      Error in `vec_detect_runs()`:
+      Error in `vec_detect_run_bounds()`:
+      ! `start` must be `TRUE` or `FALSE`.
+
+---
+
+    Code
+      vec_detect_run_bounds(1, start = c(TRUE, TRUE))
+    Condition
+      Error in `vec_detect_run_bounds()`:
       ! `start` must be `TRUE` or `FALSE`.
 

--- a/tests/testthat/test-runs.R
+++ b/tests/testthat/test-runs.R
@@ -86,68 +86,68 @@ test_that("works with columns of various types", {
   expect_identical(vec_identify_runs(add_col(list(1, 1, 2, 2, 3))), expect)
 })
 
-# vec_locate_runs --------------------------------------------------------------
+# vec_locate_run_bounds --------------------------------------------------------
 
 test_that("can locate run starts", {
   expect_identical(
-    vec_locate_runs(c(1, 3, 3, 1, 5, 5, 6)),
+    vec_locate_run_bounds(c(1, 3, 3, 1, 5, 5, 6)),
     c(1L, 2L, 4L, 5L, 7L)
   )
 })
 
 test_that("can locate run ends", {
   expect_identical(
-    vec_locate_runs(c(1, 3, 3, 1, 5, 5, 6), start = FALSE),
+    vec_locate_run_bounds(c(1, 3, 3, 1, 5, 5, 6), start = FALSE),
     c(1L, 3L, 4L, 6L, 7L)
   )
 })
 
-test_that("vec_locate_runs() works with size zero input", {
-  expect_identical(vec_locate_runs(integer(), start = TRUE), integer())
-  expect_identical(vec_locate_runs(integer(), start = FALSE), integer())
+test_that("vec_locate_run_bounds() works with size zero input", {
+  expect_identical(vec_locate_run_bounds(integer(), start = TRUE), integer())
+  expect_identical(vec_locate_run_bounds(integer(), start = FALSE), integer())
 })
 
-test_that("vec_locate_runs() validates `start`", {
+test_that("vec_locate_run_bounds() validates `start`", {
   expect_snapshot(error = TRUE, {
-    vec_locate_runs(1, start = "x")
+    vec_locate_run_bounds(1, start = "x")
   })
   expect_snapshot(error = TRUE, {
-    vec_locate_runs(1, start = NA)
+    vec_locate_run_bounds(1, start = NA)
   })
   expect_snapshot(error = TRUE, {
-    vec_locate_runs(1, start = c(TRUE, TRUE))
+    vec_locate_run_bounds(1, start = c(TRUE, TRUE))
   })
 })
 
-# vec_detect_runs --------------------------------------------------------------
+# vec_detect_run_bounds --------------------------------------------------------
 
 test_that("can detect run starts", {
   expect_identical(
-    vec_detect_runs(c(1, 3, 3, 1, 5, 5, 6)),
+    vec_detect_run_bounds(c(1, 3, 3, 1, 5, 5, 6)),
     c(TRUE, TRUE, FALSE, TRUE, TRUE, FALSE, TRUE)
   )
 })
 
 test_that("can detect run ends", {
   expect_identical(
-    vec_detect_runs(c(1, 3, 3, 1, 5, 5, 6), start = FALSE),
+    vec_detect_run_bounds(c(1, 3, 3, 1, 5, 5, 6), start = FALSE),
     c(TRUE, FALSE, TRUE, TRUE, FALSE, TRUE, TRUE)
   )
 })
 
-test_that("vec_detect_runs() works with size zero input", {
-  expect_identical(vec_detect_runs(integer(), start = TRUE), logical())
-  expect_identical(vec_detect_runs(integer(), start = FALSE), logical())
+test_that("vec_detect_run_bounds() works with size zero input", {
+  expect_identical(vec_detect_run_bounds(integer(), start = TRUE), logical())
+  expect_identical(vec_detect_run_bounds(integer(), start = FALSE), logical())
 })
 
-test_that("vec_detect_runs() validates `start`", {
+test_that("vec_detect_run_bounds() validates `start`", {
   expect_snapshot(error = TRUE, {
-    vec_detect_runs(1, start = "x")
+    vec_detect_run_bounds(1, start = "x")
   })
   expect_snapshot(error = TRUE, {
-    vec_detect_runs(1, start = NA)
+    vec_detect_run_bounds(1, start = NA)
   })
   expect_snapshot(error = TRUE, {
-    vec_detect_runs(1, start = c(TRUE, TRUE))
+    vec_detect_run_bounds(1, start = c(TRUE, TRUE))
   })
 })


### PR DESCRIPTION
We were already doing this for `df_identify_runs()`, and this way we optimize `vec_locate_run_bounds()` and `vec_detect_run_bounds()`. Plus it makes all of the implementations much simpler, since everything can easily be derived from the logical vector.

No change in behavior or noticeable change in performance for `vec_identify_runs()`. The other two are slightly faster and less memory intensive now.