### PR TITLE
RC 0.5.2

### DIFF
--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,0 @@
-Version: 0.5.2
-Date: 2023-01-21 20:11:35 UTC
-SHA: 9f5f4e12db8740e0cae3c0fa0ace31e81a4f38ba

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,0 +1,3 @@
+Version: 0.5.2
+Date: 2023-01-21 20:11:35 UTC
+SHA: 9f5f4e12db8740e0cae3c0fa0ace31e81a4f38ba

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vctrs
 Title: Vector Helpers
-Version: 0.5.1.9000
+Version: 0.5.2
 Authors@R: 
     c(person(given = "Hadley",
              family = "Wickham",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# vctrs (development version)
+# vctrs 0.5.2
 
 * New `vec_expand_grid()`, which is a lower level helper that is similar to
   `tidyr::expand_grid()` (#1325).

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,1 +1,1 @@
-Fixes the failure with R-devel.
+This is a patch release with no expected breakage of any reverse dependencies.

--- a/src/bind.c
+++ b/src/bind.c
@@ -242,6 +242,7 @@ r_obj* vec_rbind(r_obj* xs,
 
   df_c_fallback(out, ptype, xs, n_rows, name_spec, name_repair, error_call);
   out = vec_restore_recurse(out, ptype, VCTRS_OWNED_true);
+  KEEP_AT(out, out_pi);
 
   if (has_names_to) {
     out = df_poke(out, names_to_loc, names_to_col);

--- a/src/version.c
+++ b/src/version.c
@@ -1,7 +1,7 @@
 #define R_NO_REMAP
 #include <Rinternals.h>
 
-const char* vctrs_version = "0.5.1.9000";
+const char* vctrs_version = "0.5.2";
 
 /**
  * This file records the expected package version in the shared


### PR DESCRIPTION
Closes #1772 

Ran revdeps with dplyr, tidyr, purrr included and had 3 false alarm failures that all seemed to do with download failures in the packages.

rchk detected the following issues. Only the last one seems to be a real issue and I fixed it in this PR. 

We do protect `elt` in `slice-chop.c` before calling `vec_subscript_size()` by using `SET_VECTOR_ELT()` to store it in a list, so that is a false alarm.

```
#> Function chop_df
[4582](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4582)#> [UP] unprotected variable elt while calling allocating function vec_subscript_size /home/docker/R-svn/packages/build/MBHF3DPc/vctrs/src/slice-chop.c:223
[4583](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4583)#> [UP] allocating function init_data_frame(V,?) may destroy its unprotected argument (elt ), which is later used. /home/docker/R-svn/packages/build/MBHF3DPc/vctrs/src/slice-chop.c:229
[4584](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4584)#> [UP] calling allocating function init_data_frame(V,?) with a fresh pointer (elt ) /home/docker/R-svn/packages/build/MBHF3DPc/vctrs/src/slice-chop.c:229
[4585](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4585)#> [UP] unprotected variable elt while calling allocating function slice_rownames /home/docker/R-svn/packages/build/MBHF3DPc/vctrs/src/slice-chop.c:232


[4586](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4586)#> Function dict_hash
[4587](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4587)#> [UP] ignoring variable key as it has address taken, results will be incomplete

[4588](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4588)#> Function vec_as_ssize
[4589](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4589)#> [UP] ignoring variable err as it has address taken, results will be incomplete

[4590](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4590)#> Function vec_implements_ptype2
[4591](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4591)#> [UP] ignoring variable method_sym as it has address taken, results will be incomplete

[4592](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4592)#> Function vec_is_coercible
[4593](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4593)#> [UP] ignoring variable err as it has address taken, results will be incomplete

[4594](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4594)#> Function vec_order_info_impl
[4595](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4595)#> [UP] unsupported form of unprotect, unprotecting all variables, results will be incomplete /home/docker/R-svn/packages/build/MBHF3DPc/vctrs/src/order.c:482

[4596](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4596)#> Function vec_ptype2_dispatch_s3
[4597](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4597)#> [UP] ignoring variable method_sym as it has address taken, results will be incomplete

[4598](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4598)#> Function vec_rbind
[4599](https://builder.r-hub.io/status/vctrs_0.5.2.tar.gz-3af68b107c184fa78cb24c141628e087#L4599)#> [UP] calling allocating function df_poke with a fresh pointer (out ) /home/docker/R-svn/packages/build/MBHF3DPc/vctrs/src/bind.c:247
```