### PR TITLE
Collapse start/end loops into a single loop

### DIFF
--- a/src/decl/runs-decl.h
+++ b/src/decl/runs-decl.h
@@ -41,4 +41,9 @@ static inline
 void list_col_detect_run_bounds_bool(r_obj* x, r_ssize size, enum vctrs_run_bound which, bool* v_out);
 
 static inline
+r_ssize compute_iter_loc(r_ssize size, enum vctrs_run_bound which);
+static inline
+r_ssize compute_iter_step(enum vctrs_run_bound which);
+
+static inline
 enum vctrs_run_bound as_run_bound(r_obj* which, struct r_lazy error_call);


### PR DESCRIPTION
@lionel- I'm rather proud of this one. I was using two loops to manage the start/end bound cases of the runs functions, but I figured out a way to merge them. This greatly reduces the amount of code in the macros and makes it so that you can focus on the easier `start` case and then the `end` case "just works" too

All of the loops now increment `i` in an increasing sequence too (rather than decreasing when doing `end`), which is way more natural