### PR TITLE
Add `error_call` to `vec_slice()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `vec_slice()` has gained an `error_call` argument (#1785).
+
 * New `obj_is_vector()`, `obj_check_vector()`, and `vec_check_size()` validation
   helpers. We believe these are a better approach to vector validation than
   `vec_assert()` and `vec_is()`, which have been marked as questioning because

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -65,7 +65,7 @@ stop_vctrs <- function(message = NULL,
     message,
     class = c(class, "vctrs_error"),
     ...,
-    call = vctrs_error_call(call)
+    call = call
   )
 }
 warn_vctrs <- function(message = NULL,
@@ -869,47 +869,4 @@ append_arg <- function(x, arg) {
   } else {
     x
   }
-}
-
-vctrs_local_error_call <- function(call = frame, frame = caller_env()) {
-  # This doesn't implement the semantics of a `local_` function
-  # perfectly in order to be as fast as possible
-  frame$.__vctrs_error_call__. <- call
-  invisible(NULL)
-}
-
-vctrs_error_call <- function(call) {
-  if (is_function(call)) {
-    call <- call()
-  }
-
-  if (is_environment(call)) {
-    caller_call <- get_vctrs_error_call(call)
-    if (!is_null(caller_call)) {
-      return(caller_call)
-    }
-  }
-
-  call
-}
-
-vctrs_error_borrowed_call <- function(call = caller_env(),
-                                      borrower = caller_env(2)) {
-  borrower_call <- get_vctrs_error_call(borrower)
-
-  if (is_null(borrower_call)) {
-    call
-  } else {
-    borrower_call
-  }
-}
-
-get_vctrs_error_call <- function(call) {
-  env_get(
-    call,
-    ".__vctrs_error_call__.",
-    inherit = TRUE,
-    last = topenv(call),
-    default = NULL
-  )
 }

--- a/R/slice.R
+++ b/R/slice.R
@@ -4,6 +4,9 @@
 #' for all vector types, regardless of dimensionality. It is an analog to `[`
 #' that matches [vec_size()] instead of `length()`.
 #'
+#' @inheritParams rlang::args_dots_empty
+#' @inheritParams rlang::args_error_context
+#'
 #' @param x A vector
 #' @param i An integer, character or logical vector specifying the
 #'   locations or names of the observations to get/set. Specify
@@ -16,7 +19,7 @@
 #'   in error messages to inform the user about the locations of
 #'   incompatible types and sizes (see [stop_incompatible_type()] and
 #'   [stop_incompatible_size()]).
-#' @param ... These dots are for future extensions and must be empty.
+#'
 #' @return A vector of the same type as `x`.
 #'
 #' @section Genericity:
@@ -104,8 +107,8 @@
 #' # vector:
 #' x <- 1:3
 #' try(vec_slice(x, 2) <- 1.5)
-vec_slice <- function(x, i) {
-  delayedAssign("call", vctrs_error_borrowed_call())
+vec_slice <- function(x, i, ..., error_call = current_env()) {
+  check_dots_empty0(...)
   .Call(ffi_slice, x, i, environment())
 }
 

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -171,7 +171,7 @@ num_as_location2 <- function(i,
   check_dots_empty0(...)
 
   if (!is_integer(i) && !is_double(i)) {
-    abort("`i` must be a numeric vector.", call = vctrs_error_call(call))
+    abort("`i` must be a numeric vector.", call = call)
   }
   result_get(vec_as_location2_result(
     i,

--- a/R/subscript.R
+++ b/R/subscript.R
@@ -145,7 +145,7 @@ stop_subscript <- function(i,
     class = c(class, "vctrs_error_subscript"),
     i = i,
     ...,
-    call = vctrs_error_call(call)
+    call = call
   )
 }
 new_error_subscript <- function(class = NULL, i, ...) {
@@ -169,7 +169,7 @@ new_error_subscript_type <- function(i,
     numeric = numeric,
     character = character,
     ...,
-    call = vctrs_error_call(call)
+    call = call
   )
 }
 

--- a/man/vec_slice.Rd
+++ b/man/vec_slice.Rd
@@ -6,7 +6,7 @@
 \alias{vec_assign}
 \title{Get or set observations in a vector}
 \usage{
-vec_slice(x, i)
+vec_slice(x, i, ..., error_call = current_env())
 
 vec_slice(x, i) <- value
 
@@ -20,11 +20,16 @@ locations or names of the observations to get/set. Specify
 \code{TRUE} to index all elements (as in \code{x[]}), or \code{NULL}, \code{FALSE} or
 \code{integer()} to index none (as in \code{x[NULL]}).}
 
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{error_call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
+
 \item{value}{Replacement values. \code{value} is cast to the type of
 \code{x}, but only if they have a common type. See below for examples
 of this rule.}
-
-\item{...}{These dots are for future extensions and must be empty.}
 
 \item{x_arg, value_arg}{Argument names for \code{x} and \code{value}. These are used
 in error messages to inform the user about the locations of

--- a/src/slice.c
+++ b/src/slice.c
@@ -401,7 +401,7 @@ r_obj* ffi_slice(r_obj* x,
   struct vec_slice_opts opts = {
     .x_arg = vec_args.x,
     .i_arg = vec_args.i,
-    .call = {.x = r_syms.call, .env = frame}
+    .call = {.x = r_syms.error_call, .env = frame}
   };
   return vec_slice_opts(x, i, &opts);
 }

--- a/tests/testthat/_snaps/error-call.md
+++ b/tests/testthat/_snaps/error-call.md
@@ -277,43 +277,24 @@
       Error in `my_function()`:
       ! Input must be a vector, not a <vctrs_foobar> object.
 
-# can take ownership of vctrs errors
+# `vec_slice()` uses `error_call`
 
     Code
-      (expect_error(vec_assert(foobar(list()))))
+      (expect_error(my_function(env(), 1)))
     Output
       <error/vctrs_error_scalar_type>
-      Error in `foo()`:
-      ! `foobar(list())` must be a vector, not a <vctrs_foobar> object.
-    Code
-      (expect_error(local(vec_assert(foobar(list())))))
-    Output
-      <error/vctrs_error_scalar_type>
-      Error in `foo()`:
-      ! `foobar(list())` must be a vector, not a <vctrs_foobar> object.
-    Code
-      (expect_error(vec_cast(1, list())))
-    Output
-      <error/vctrs_error_cast>
-      Error in `foo()`:
-      ! Can't convert `1` <double> to <list>.
-    Code
-      (expect_error(vec_slice(env(), list())))
-    Output
-      <error/vctrs_error_scalar_type>
-      Error in `foo()`:
+      Error in `my_function()`:
       ! `x` must be a vector, not an environment.
     Code
-      local({
-        vctrs_local_error_call(NULL)
-        (expect_error(vec_slice(env(), list())))
-      })
+      (expect_error(my_function(1, 2)))
     Output
-      <error/vctrs_error_scalar_type>
-      Error in `vec_slice()`:
-      ! `x` must be a vector, not an environment.
+      <error/vctrs_error_subscript_oob>
+      Error in `my_function()`:
+      ! Can't subset elements past the end.
+      i Location 2 doesn't exist.
+      i There is only 1 element.
 
-# vec_slice() reports error context
+# vec_slice() reports self in error context
 
     Code
       (expect_error(vec_slice(foobar(list()), 1)))

--- a/tests/testthat/test-error-call.R
+++ b/tests/testthat/test-error-call.R
@@ -114,29 +114,15 @@ test_that("`vec_ptype()` reports correct error call", {
   })
 })
 
-test_that("can take ownership of vctrs errors", {
-  vctrs_local_error_call(call("foo"))
-
+test_that("`vec_slice()` uses `error_call`", {
+  my_function <- function(x, i) vec_slice(x, i, error_call = current_env())
   expect_snapshot({
-    (expect_error(vec_assert(foobar(list()))))
-    (expect_error(local(vec_assert(foobar(list())))))
-
-    (expect_error(vec_cast(1, list())))
-
-    # Suboptimal because `foo()` might not have an `x` argument. It
-    # might be better to comprehensively check inputs with explicit
-    # error context and treat all other errors as programming errors.
-    (expect_error(vec_slice(env(), list())))
-
-    # This should show `vec_slice()` if no local call
-    local({
-      vctrs_local_error_call(NULL)
-      (expect_error(vec_slice(env(), list())))
-    })
+    (expect_error(my_function(env(), 1)))
+    (expect_error(my_function(1, 2)))
   })
 })
 
-test_that("vec_slice() reports error context", {
+test_that("vec_slice() reports self in error context", {
   expect_snapshot({
     (expect_error(vec_slice(foobar(list()), 1)))
     (expect_error(vec_slice(list(), env())))


### PR DESCRIPTION
Closes https://github.com/r-lib/vctrs/issues/1785

Allowing us to remove `local_vctrs_error_call()` and all that infrastructure.

Removing the `delayedAssign()` call means `vec_slice()` has slightly less overhead

``` r
library(vctrs)

x <- 1:5 + 0L

bench::mark(vec_slice(x, 1L), iterations = 500000)

# Main
#> # A tibble: 1 × 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_slice(x, 1L)   2.54µs   3.26µs   282604.     6.3KB     17.5

# This PR
#> # A tibble: 1 × 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_slice(x, 1L)   1.72µs    2.1µs   452281.    5.47KB     14.5
```

<sup>Created on 2023-02-14 with [reprex v2.0.2.9000](https://reprex.tidyverse.org)</sup>