### PR TITLE
Update `needles_arg` and `haystack_arg` defaults

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # vctrs (development version)
 
+* `vec_locate_matches()` has changed its default `needles_arg` and
+  `haystack_arg` values from `""` to `"needles"` and `"haystack"`, respectively.
+  This generally generates more informative error messages (#1792).
+
 * `vec_locate_matches()` gains a new `relationship` argument that holistically
   handles multiple matches between `needles` and `haystack`. In particular,
   `relationship = "many_to_one"` replaces `multiple = "error"` and

--- a/R/match.R
+++ b/R/match.R
@@ -4,10 +4,10 @@
 #' `r lifecycle::badge("experimental")`
 #'
 #' `vec_locate_matches()` is a more flexible version of [vec_match()] used to
-#' identify locations where each observation of `needles` matches one or
-#' multiple observations in `haystack`. Unlike `vec_match()`,
-#' `vec_locate_matches()` returns all matches by default, and can match on
-#' binary conditions other than equality, such as `>`, `>=`, `<`, and `<=`.
+#' identify locations where each value of `needles` matches one or multiple
+#' values in `haystack`. Unlike `vec_match()`, `vec_locate_matches()` returns
+#' all matches by default, and can match on binary conditions other than
+#' equality, such as `>`, `>=`, `<`, and `<=`.
 #'
 #' @details
 #' [vec_match()] is identical to (but often slightly faster than):
@@ -26,36 +26,44 @@
 #' and `haystack`, with the default being most similar to a left join.
 #'
 #' Be very careful when specifying match `condition`s. If a condition is
-#' mis-specified, it is very easy to accidentally generate an exponentially
+#' misspecified, it is very easy to accidentally generate an exponentially
 #' large number of matches.
 #'
 #' @section Dependencies of `vec_locate_matches()`:
-#' * [vec_order_radix()]
-#' * [vec_detect_complete()]
+#' - [vec_order_radix()]
+#' - [vec_detect_complete()]
 #'
 #' @inheritParams rlang::args_dots_empty
 #' @inheritParams rlang::args_error_context
 #' @inheritParams order-radix
 #'
 #' @param needles,haystack Vectors used for matching.
+#'
 #'   - `needles` represents the vector to search for.
+#'
 #'   - `haystack` represents the vector to search in.
 #'
 #'   Prior to comparison, `needles` and `haystack` are coerced to the same type.
 #'
 #' @param condition Condition controlling how `needles` should be compared
 #'   against `haystack` to identify a successful match.
+#'
 #'   - One of: `"=="`, `">"`, `">="`, `"<"`, or `"<="`.
+#'
 #'   - For data frames, a length `1` or `ncol(needles)` character vector
 #'     containing only the above options, specifying how matching is determined
 #'     for each column.
 #'
 #' @param filter Filter to be applied to the matched results.
+#'
 #'   - `"none"` doesn't apply any filter.
+#'
 #'   - `"min"` returns only the minimum haystack value matching the current
 #'     needle.
+#'
 #'   - `"max"` returns only the maximum haystack value matching the current
 #'     needle.
+#'
 #'   - For data frames, a length `1` or `ncol(needles)` character vector
 #'     containing only the above options, specifying a filter to apply to
 #'     each column.
@@ -67,46 +75,61 @@
 #'   if the maximum or minimum haystack value is duplicated in `haystack`. These
 #'   can be further controlled with `multiple`.
 #'
-#' @param incomplete Handling of missing values and
-#'   [incomplete][vec_detect_complete] observations in `needles`.
+#' @param incomplete Handling of missing and [incomplete][vec_detect_complete]
+#'   values in `needles`.
+#'
 #'   - `"compare"` uses `condition` to determine whether or not a missing value
 #'     in `needles` matches a missing value in `haystack`. If `condition` is
 #'     `==`, `>=`, or `<=`, then missing values will match.
+#'
 #'   - `"match"` always allows missing values in `needles` to match missing
 #'     values in `haystack`, regardless of the `condition`.
-#'   - `"drop"` drops incomplete observations in `needles` from the result.
+#'
+#'   - `"drop"` drops incomplete values in `needles` from the result.
+#'
 #'   - `"error"` throws an error if any `needles` are incomplete.
+#'
 #'   - If a single integer is provided, this represents the value returned
-#'     in the `haystack` column for observations of `needles` that are
-#'     incomplete. If `no_match = NA`, setting `incomplete = NA` forces
-#'     incomplete observations in `needles` to be treated like unmatched values.
+#'     in the `haystack` column for values of `needles` that are incomplete. If
+#'     `no_match = NA`, setting `incomplete = NA` forces incomplete values in
+#'     `needles` to be treated like unmatched values.
 #'
 #'   `nan_distinct` determines whether a `NA` is allowed to match a `NaN`.
 #'
 #' @param no_match Handling of `needles` without a match.
+#'
 #'   - `"drop"` drops `needles` with zero matches from the result.
+#'
 #'   - `"error"` throws an error if any `needles` have zero matches.
+#'
 #'   - If a single integer is provided, this represents the value returned in
-#'     the `haystack` column for observations of `needles` that have zero
-#'     matches. The default represents an unmatched needle with `NA`.
+#'     the `haystack` column for values of `needles` that have zero matches. The
+#'     default represents an unmatched needle with `NA`.
 #'
 #' @param remaining Handling of `haystack` values that `needles` never matched.
+#'
 #'   - `"drop"` drops remaining `haystack` values from the result.
 #'     Typically, this is the desired behavior if you only care when `needles`
 #'     has a match.
+#'
 #'   - `"error"` throws an error if there are any remaining `haystack`
 #'     values.
+#'
 #'   - If a single integer is provided (often `NA`), this represents the value
 #'     returned in the `needles` column for the remaining `haystack` values
 #'     that `needles` never matched. Remaining `haystack` values are always
 #'     returned at the end of the result.
 #'
 #' @param multiple Handling of `needles` with multiple matches. For each needle:
+#'
 #'   - `"all"` returns all matches detected in `haystack`.
+#'
 #'   - `"any"` returns any match detected in `haystack` with no guarantees on
 #'     which match will be returned. It is often faster than `"first"` and
 #'     `"last"` if you just need to detect if there is at least one match.
+#'
 #'   - `"first"` returns the first match detected in `haystack`.
+#'
 #'   - `"last"` returns the last match detected in `haystack`.
 #'
 #' @param relationship Handling of the expected relationship between
@@ -150,8 +173,10 @@
 #'   used in error messages.
 #'
 #' @return A two column data frame containing the locations of the matches.
+#'
 #'   - `needles` is an integer vector containing the location of
 #'     the needle currently being matched.
+#'
 #'   - `haystack` is an integer vector containing the location of the
 #'     corresponding match in the haystack for the current needle.
 #'
@@ -160,7 +185,7 @@
 #' x <- c(1, 2, NA, 3, NaN)
 #' y <- c(2, 1, 4, NA, 1, 2, NaN)
 #'
-#' # By default, for each element of `x`, all matching locations in `y` are
+#' # By default, for each value of `x`, all matching locations in `y` are
 #' # returned
 #' matches <- vec_locate_matches(x, y)
 #' matches
@@ -183,13 +208,13 @@
 #' # In this case, the `NA` in `y` matches two rows in `x`
 #' try(vec_locate_matches(x, y, relationship = "one_to_many"))
 #'
-#' # By default, NA is treated as being identical to NaN.
-#' # Using `nan_distinct = TRUE` treats NA and NaN as different values, so NA
-#' # can only match NA, and NaN can only match NaN.
+#' # By default, `NA` is treated as being identical to `NaN`.
+#' # Using `nan_distinct = TRUE` treats `NA` and `NaN` as different values, so
+#' # `NA` can only match `NA`, and `NaN` can only match `NaN`.
 #' vec_locate_matches(x, y, nan_distinct = TRUE)
 #'
 #' # If you never want missing values to match, set `incomplete = NA` to return
-#' # `NA` in the `haystack` column anytime there was an incomplete observation
+#' # `NA` in the `haystack` column anytime there was an incomplete value
 #' # in `needles`.
 #' vec_locate_matches(x, y, incomplete = NA)
 #'
@@ -231,8 +256,8 @@
 #' )
 #'
 #' # In the very rare case that you need to generate locations for a
-#' # cross match, where every observation of `x` is forced to match every
-#' # observation of `y` regardless of what the actual values are, you can
+#' # cross match, where every value of `x` is forced to match every
+#' # value of `y` regardless of what the actual values are, you can
 #' # replace `x` and `y` with integer vectors of the same size that contain
 #' # a single value and match on those instead.
 #' x_proxy <- vec_rep(1L, vec_size(x))

--- a/man/vec_locate_matches.Rd
+++ b/man/vec_locate_matches.Rd
@@ -17,8 +17,8 @@ vec_locate_matches(
   relationship = "none",
   nan_distinct = FALSE,
   chr_proxy_collate = NULL,
-  needles_arg = "",
-  haystack_arg = "",
+  needles_arg = "needles",
+  haystack_arg = "haystack",
   error_call = current_env()
 )
 }

--- a/man/vec_locate_matches.Rd
+++ b/man/vec_locate_matches.Rd
@@ -61,20 +61,20 @@ A filter can return multiple haystack matches for a particular needle
 if the maximum or minimum haystack value is duplicated in \code{haystack}. These
 can be further controlled with \code{multiple}.}
 
-\item{incomplete}{Handling of missing values and
-\link[=vec_detect_complete]{incomplete} observations in \code{needles}.
+\item{incomplete}{Handling of missing and \link[=vec_detect_complete]{incomplete}
+values in \code{needles}.
 \itemize{
 \item \code{"compare"} uses \code{condition} to determine whether or not a missing value
 in \code{needles} matches a missing value in \code{haystack}. If \code{condition} is
 \code{==}, \code{>=}, or \code{<=}, then missing values will match.
 \item \code{"match"} always allows missing values in \code{needles} to match missing
 values in \code{haystack}, regardless of the \code{condition}.
-\item \code{"drop"} drops incomplete observations in \code{needles} from the result.
+\item \code{"drop"} drops incomplete values in \code{needles} from the result.
 \item \code{"error"} throws an error if any \code{needles} are incomplete.
 \item If a single integer is provided, this represents the value returned
-in the \code{haystack} column for observations of \code{needles} that are
-incomplete. If \code{no_match = NA}, setting \code{incomplete = NA} forces
-incomplete observations in \code{needles} to be treated like unmatched values.
+in the \code{haystack} column for values of \code{needles} that are incomplete. If
+\code{no_match = NA}, setting \code{incomplete = NA} forces incomplete values in
+\code{needles} to be treated like unmatched values.
 }
 
 \code{nan_distinct} determines whether a \code{NA} is allowed to match a \code{NaN}.}
@@ -84,8 +84,8 @@ incomplete observations in \code{needles} to be treated like unmatched values.
 \item \code{"drop"} drops \code{needles} with zero matches from the result.
 \item \code{"error"} throws an error if any \code{needles} have zero matches.
 \item If a single integer is provided, this represents the value returned in
-the \code{haystack} column for observations of \code{needles} that have zero
-matches. The default represents an unmatched needle with \code{NA}.
+the \code{haystack} column for values of \code{needles} that have zero matches. The
+default represents an unmatched needle with \code{NA}.
 }}
 
 \item{remaining}{Handling of \code{haystack} values that \code{needles} never matched.
@@ -195,10 +195,10 @@ corresponding match in the haystack for the current needle.
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
 \code{vec_locate_matches()} is a more flexible version of \code{\link[=vec_match]{vec_match()}} used to
-identify locations where each observation of \code{needles} matches one or
-multiple observations in \code{haystack}. Unlike \code{vec_match()},
-\code{vec_locate_matches()} returns all matches by default, and can match on
-binary conditions other than equality, such as \code{>}, \code{>=}, \code{<}, and \code{<=}.
+identify locations where each value of \code{needles} matches one or multiple
+values in \code{haystack}. Unlike \code{vec_match()}, \code{vec_locate_matches()} returns
+all matches by default, and can match on binary conditions other than
+equality, such as \code{>}, \code{>=}, \code{<}, and \code{<=}.
 }
 \details{
 \code{\link[=vec_match]{vec_match()}} is identical to (but often slightly faster than):
@@ -216,7 +216,7 @@ binary conditions other than equality, such as \code{>}, \code{>=}, \code{<}, an
 and \code{haystack}, with the default being most similar to a left join.
 
 Be very careful when specifying match \code{condition}s. If a condition is
-mis-specified, it is very easy to accidentally generate an exponentially
+misspecified, it is very easy to accidentally generate an exponentially
 large number of matches.
 }
 \section{Dependencies of \code{vec_locate_matches()}}{
@@ -231,7 +231,7 @@ large number of matches.
 x <- c(1, 2, NA, 3, NaN)
 y <- c(2, 1, 4, NA, 1, 2, NaN)
 
-# By default, for each element of `x`, all matching locations in `y` are
+# By default, for each value of `x`, all matching locations in `y` are
 # returned
 matches <- vec_locate_matches(x, y)
 matches
@@ -254,13 +254,13 @@ try(vec_locate_matches(x, y, relationship = "one_to_one"))
 # In this case, the `NA` in `y` matches two rows in `x`
 try(vec_locate_matches(x, y, relationship = "one_to_many"))
 
-# By default, NA is treated as being identical to NaN.
-# Using `nan_distinct = TRUE` treats NA and NaN as different values, so NA
-# can only match NA, and NaN can only match NaN.
+# By default, `NA` is treated as being identical to `NaN`.
+# Using `nan_distinct = TRUE` treats `NA` and `NaN` as different values, so
+# `NA` can only match `NA`, and `NaN` can only match `NaN`.
 vec_locate_matches(x, y, nan_distinct = TRUE)
 
 # If you never want missing values to match, set `incomplete = NA` to return
-# `NA` in the `haystack` column anytime there was an incomplete observation
+# `NA` in the `haystack` column anytime there was an incomplete value
 # in `needles`.
 vec_locate_matches(x, y, incomplete = NA)
 
@@ -302,8 +302,8 @@ data_frame(
 )
 
 # In the very rare case that you need to generate locations for a
-# cross match, where every observation of `x` is forced to match every
-# observation of `y` regardless of what the actual values are, you can
+# cross match, where every value of `x` is forced to match every
+# value of `y` regardless of what the actual values are, you can
 # replace `x` and `y` with integer vectors of the same size that contain
 # a single value and match on those instead.
 x_proxy <- vec_rep(1L, vec_size(x))

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -20,7 +20,7 @@
       vec_locate_matches(x, y)
     Condition
       Error in `vec_locate_matches()`:
-      ! Can't combine <double> and <character>.
+      ! Can't combine `needles` <double> and `haystack` <character>.
 
 ---
 
@@ -28,7 +28,7 @@
       vec_locate_matches(x, y, needles_arg = "x", error_call = call("foo"))
     Condition
       Error in `foo()`:
-      ! Can't combine `x` <double> and <character>.
+      ! Can't combine `x` <double> and `haystack` <character>.
 
 # `incomplete` can error informatively
 
@@ -37,24 +37,24 @@
     Output
       <error/vctrs_error_matches_incomplete>
       Error in `vec_locate_matches()`:
-      ! No element can contain missing values.
-      x The element at location 1 contains missing values.
+      ! `needles` can't contain missing values.
+      x Location 1 contains missing values.
     Code
       (expect_error(vec_locate_matches(NA, 1, incomplete = "error", needles_arg = "foo"))
       )
     Output
       <error/vctrs_error_matches_incomplete>
       Error in `vec_locate_matches()`:
-      ! No element of `foo` can contain missing values.
-      x The element at location 1 contains missing values.
+      ! `foo` can't contain missing values.
+      x Location 1 contains missing values.
     Code
       (expect_error(vec_locate_matches(NA, 1, incomplete = "error", needles_arg = "foo",
         error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_incomplete>
       Error in `fn()`:
-      ! No element of `foo` can contain missing values.
-      x The element at location 1 contains missing values.
+      ! `foo` can't contain missing values.
+      x Location 1 contains missing values.
 
 # `incomplete` is validated
 
@@ -120,32 +120,32 @@
     Output
       <error/vctrs_error_matches_multiple>
       Error in `vec_locate_matches()`:
-      ! Each element can match at most 1 observation.
-      x The element at location 1 has multiple matches.
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
     Code
       (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error",
       needles_arg = "foo")))
     Output
       <error/vctrs_error_matches_multiple>
       Error in `vec_locate_matches()`:
-      ! Each element of `foo` can match at most 1 observation.
-      x The element at location 1 has multiple matches.
+      ! Each value of `foo` can match at most 1 value from `haystack`.
+      x Location 1 of `foo` matches multiple values.
     Code
       (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error",
       needles_arg = "foo", error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_multiple>
       Error in `fn()`:
-      ! Each element of `foo` can match at most 1 observation.
-      x The element at location 1 has multiple matches.
+      ! Each value of `foo` can match at most 1 value from `haystack`.
+      x Location 1 of `foo` matches multiple values.
     Code
       (expect_error(vec_locate_matches(1L, c(1L, 1L), multiple = "error",
       needles_arg = "foo", haystack_arg = "bar")))
     Output
       <error/vctrs_error_matches_multiple>
       Error in `vec_locate_matches()`:
-      ! Each element of `foo` can match at most 1 observation from `bar`.
-      x The element at location 1 has multiple matches.
+      ! Each value of `foo` can match at most 1 value from `bar`.
+      x Location 1 of `foo` matches multiple values.
 
 # `multiple` can warn informatively
 
@@ -154,32 +154,50 @@
     Output
       <warning/vctrs_warning_matches_multiple>
       Warning in `vec_locate_matches()`:
-      Each element can match at most 1 observation.
-      x The element at location 1 has multiple matches.
+      Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
     Code
       (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning",
       needles_arg = "foo")))
     Output
       <warning/vctrs_warning_matches_multiple>
       Warning in `vec_locate_matches()`:
-      Each element of `foo` can match at most 1 observation.
-      x The element at location 1 has multiple matches.
+      Each value of `foo` can match at most 1 value from `haystack`.
+      x Location 1 of `foo` matches multiple values.
     Code
       (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning",
       needles_arg = "foo", error_call = call("fn"))))
     Output
       <warning/vctrs_warning_matches_multiple>
       Warning in `fn()`:
-      Each element of `foo` can match at most 1 observation.
-      x The element at location 1 has multiple matches.
+      Each value of `foo` can match at most 1 value from `haystack`.
+      x Location 1 of `foo` matches multiple values.
     Code
       (expect_warning(vec_locate_matches(1L, c(1L, 1L), multiple = "warning",
       needles_arg = "foo", haystack_arg = "bar")))
     Output
       <warning/vctrs_warning_matches_multiple>
       Warning in `vec_locate_matches()`:
-      Each element of `foo` can match at most 1 observation from `bar`.
-      x The element at location 1 has multiple matches.
+      Each value of `foo` can match at most 1 value from `bar`.
+      x Location 1 of `foo` matches multiple values.
+
+# errors on multiple matches that come from different nesting containers
+
+    Code
+      vec_locate_matches(df, df2, condition = c("<=", "<="), multiple = "error")
+    Condition
+      Error in `vec_locate_matches()`:
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
+
+# errors when a match from a different nesting container is processed early on
+
+    Code
+      vec_locate_matches(needles, haystack, condition = "<", multiple = "error")
+    Condition
+      Error in `vec_locate_matches()`:
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
 
 # `relationship` handles one-to-one case
 
@@ -189,16 +207,16 @@
     Output
       <error/vctrs_error_matches_relationship_one_to_one>
       Error in `vec_locate_matches()`:
-      ! Each element can match at most 1 observation.
-      x The element at location 2 has multiple matches.
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 2 of `needles` matches multiple values.
     Code
       (expect_error(vec_locate_matches(c(1, 1), c(1, 2), relationship = "one_to_one"))
       )
     Output
       <error/vctrs_error_matches_relationship_one_to_one>
       Error in `vec_locate_matches()`:
-      ! Each element can match at most 1 observation.
-      x The element at location 1 has multiple matches.
+      ! Each value of `haystack` can match at most 1 value from `needles`.
+      x Location 1 of `haystack` matches multiple values.
 
 # `relationship` handles one-to-many case
 
@@ -208,8 +226,8 @@
     Output
       <error/vctrs_error_matches_relationship_one_to_many>
       Error in `vec_locate_matches()`:
-      ! Each element can match at most 1 observation.
-      x The element at location 1 has multiple matches.
+      ! Each value of `haystack` can match at most 1 value from `needles`.
+      x Location 1 of `haystack` matches multiple values.
 
 # `relationship` handles many-to-one case
 
@@ -219,8 +237,8 @@
     Output
       <error/vctrs_error_matches_relationship_many_to_one>
       Error in `vec_locate_matches()`:
-      ! Each element can match at most 1 observation.
-      x The element at location 2 has multiple matches.
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 2 of `needles` matches multiple values.
 
 # `relationship` handles warn-many-to-many case
 
@@ -230,18 +248,18 @@
     Output
       <warning/vctrs_warning_matches_relationship_many_to_many>
       Warning in `vec_locate_matches()`:
-      Detected an unexpected many-to-many relationship.
-      x The element at location 2 has multiple matches.
-      x The element at location 1 has multiple matches.
+      Detected an unexpected many-to-many relationship between `needles` and `haystack`.
+      x Location 2 of `needles` matches multiple values.
+      x Location 1 of `haystack` matches multiple values.
     Code
       (expect_warning(vec_locate_matches(c(1, 1, 2), c(2, 2, 1), relationship = "warn_many_to_many"))
       )
     Output
       <warning/vctrs_warning_matches_relationship_many_to_many>
       Warning in `vec_locate_matches()`:
-      Detected an unexpected many-to-many relationship.
-      x The element at location 3 has multiple matches.
-      x The element at location 3 has multiple matches.
+      Detected an unexpected many-to-many relationship between `needles` and `haystack`.
+      x Location 3 of `needles` matches multiple values.
+      x Location 3 of `haystack` matches multiple values.
 
 # `relationship` considers `incomplete` matches as possible multiple matches
 
@@ -250,8 +268,8 @@
     Output
       <error/vctrs_error_matches_relationship_one_to_many>
       Error in `vec_locate_matches()`:
-      ! Each element can match at most 1 observation.
-      x The element at location 1 has multiple matches.
+      ! Each value of `haystack` can match at most 1 value from `needles`.
+      x Location 1 of `haystack` matches multiple values.
 
 # `relationship` errors on multiple matches that come from different nesting containers
 
@@ -261,8 +279,8 @@
     Output
       <error/vctrs_error_matches_relationship_many_to_one>
       Error in `vec_locate_matches()`:
-      ! Each element can match at most 1 observation.
-      x The element at location 1 has multiple matches.
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
 
 # `relationship` errors when a match from a different nesting container is processed early on
 
@@ -272,8 +290,8 @@
     Output
       <error/vctrs_error_matches_relationship_many_to_one>
       Error in `vec_locate_matches()`:
-      ! Each element can match at most 1 observation.
-      x The element at location 1 has multiple matches.
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
 
 # `relationship` can still detect problematic `haystack` relationships when `multiple = first/last` are used
 
@@ -283,16 +301,16 @@
     Output
       <error/vctrs_error_matches_relationship_one_to_one>
       Error in `vec_locate_matches()`:
-      ! Each element can match at most 1 observation.
-      x The element at location 2 has multiple matches.
+      ! Each value of `haystack` can match at most 1 value from `needles`.
+      x Location 2 of `haystack` matches multiple values.
     Code
       (expect_error(vec_locate_matches(c(3, 1, 1), c(2, 1, 3, 3), multiple = "first",
       relationship = "one_to_many")))
     Output
       <error/vctrs_error_matches_relationship_one_to_many>
       Error in `vec_locate_matches()`:
-      ! Each element can match at most 1 observation.
-      x The element at location 2 has multiple matches.
+      ! Each value of `haystack` can match at most 1 value from `needles`.
+      x Location 2 of `haystack` matches multiple values.
 
 # `relationship` and `remaining` work properly together
 
@@ -301,9 +319,9 @@
       remaining = NA_integer_)
     Condition
       Warning in `vec_locate_matches()`:
-      Detected an unexpected many-to-many relationship.
-      x The element at location 1 has multiple matches.
-      x The element at location 1 has multiple matches.
+      Detected an unexpected many-to-many relationship between `needles` and `haystack`.
+      x Location 1 of `needles` matches multiple values.
+      x Location 1 of `haystack` matches multiple values.
 
 # `relationship` errors if `condition` creates multiple matches
 
@@ -313,8 +331,8 @@
     Output
       <error/vctrs_error_matches_relationship_many_to_one>
       Error in `vec_locate_matches()`:
-      ! Each element can match at most 1 observation.
-      x The element at location 1 has multiple matches.
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
 
 # `relationship` still errors if `filter` hasn't removed all multiple matches
 
@@ -324,8 +342,8 @@
     Output
       <error/vctrs_error_matches_relationship_many_to_one>
       Error in `vec_locate_matches()`:
-      ! Each element can match at most 1 observation.
-      x The element at location 1 has multiple matches.
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
 
 # `relationship` errors respect argument tags and error call
 
@@ -335,32 +353,32 @@
     Output
       <error/vctrs_error_matches_relationship_one_to_one>
       Error in `fn()`:
-      ! Each element of `foo` can match at most 1 observation from `bar`.
-      x The element of `foo` at location 1 has multiple matches.
+      ! Each value of `foo` can match at most 1 value from `bar`.
+      x Location 1 of `foo` matches multiple values.
     Code
       (expect_error(vec_locate_matches(c(1L, 1L), 1L, relationship = "one_to_one",
       needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_relationship_one_to_one>
       Error in `fn()`:
-      ! Each element of `bar` can match at most 1 observation from `foo`.
-      x The element of `bar` at location 1 has multiple matches.
+      ! Each value of `bar` can match at most 1 value from `foo`.
+      x Location 1 of `bar` matches multiple values.
     Code
       (expect_error(vec_locate_matches(c(1L, 1L), 1L, relationship = "one_to_many",
       needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_relationship_one_to_many>
       Error in `fn()`:
-      ! Each element of `bar` can match at most 1 observation from `foo`.
-      x The element of `bar` at location 1 has multiple matches.
+      ! Each value of `bar` can match at most 1 value from `foo`.
+      x Location 1 of `bar` matches multiple values.
     Code
       (expect_error(vec_locate_matches(1L, c(1L, 1L), relationship = "many_to_one",
       needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_relationship_many_to_one>
       Error in `fn()`:
-      ! Each element of `foo` can match at most 1 observation from `bar`.
-      x The element of `foo` at location 1 has multiple matches.
+      ! Each value of `foo` can match at most 1 value from `bar`.
+      x Location 1 of `foo` matches multiple values.
 
 # `relationship` warnings respect argument tags and error call
 
@@ -371,26 +389,26 @@
       <warning/vctrs_warning_matches_relationship_many_to_many>
       Warning in `fn()`:
       Detected an unexpected many-to-many relationship between `foo` and `bar`.
-      x The element of `foo` at location 1 has multiple matches.
-      x The element of `bar` at location 1 has multiple matches.
+      x Location 1 of `foo` matches multiple values.
+      x Location 1 of `bar` matches multiple values.
     Code
       (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn_many_to_many",
       needles_arg = "foo", error_call = call("fn"))))
     Output
       <warning/vctrs_warning_matches_relationship_many_to_many>
       Warning in `fn()`:
-      Detected an unexpected many-to-many relationship.
-      x The element of `foo` at location 1 has multiple matches.
-      x The element at location 1 has multiple matches.
+      Detected an unexpected many-to-many relationship between `foo` and `haystack`.
+      x Location 1 of `foo` matches multiple values.
+      x Location 1 of `haystack` matches multiple values.
     Code
       (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn_many_to_many",
       haystack_arg = "bar", error_call = call("fn"))))
     Output
       <warning/vctrs_warning_matches_relationship_many_to_many>
       Warning in `fn()`:
-      Detected an unexpected many-to-many relationship.
-      x The element at location 1 has multiple matches.
-      x The element of `bar` at location 1 has multiple matches.
+      Detected an unexpected many-to-many relationship between `needles` and `bar`.
+      x Location 1 of `needles` matches multiple values.
+      x Location 1 of `bar` matches multiple values.
 
 # `relationship` is validated
 
@@ -428,32 +446,32 @@
     Output
       <error/vctrs_error_matches_nothing>
       Error in `vec_locate_matches()`:
-      ! Each element must have a match.
-      x The element at location 1 does not have a match.
+      ! Each value of `needles` must have a match in `haystack`.
+      x Location 1 of `needles` does not have a match.
     Code
       (expect_error(vec_locate_matches(1, 2, no_match = "error", needles_arg = "foo"))
       )
     Output
       <error/vctrs_error_matches_nothing>
       Error in `vec_locate_matches()`:
-      ! Each element of `foo` must have a match.
-      x The element at location 1 does not have a match.
+      ! Each value of `foo` must have a match in `haystack`.
+      x Location 1 of `foo` does not have a match.
     Code
       (expect_error(vec_locate_matches(1, 2, no_match = "error", needles_arg = "foo",
         error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_nothing>
       Error in `fn()`:
-      ! Each element of `foo` must have a match.
-      x The element at location 1 does not have a match.
+      ! Each value of `foo` must have a match in `haystack`.
+      x Location 1 of `foo` does not have a match.
     Code
       (expect_error(vec_locate_matches(1, 2, no_match = "error", needles_arg = "foo",
         haystack_arg = "bar")))
     Output
       <error/vctrs_error_matches_nothing>
       Error in `vec_locate_matches()`:
-      ! Each element of `foo` must have a match in `bar`.
-      x The element at location 1 does not have a match.
+      ! Each value of `foo` must have a match in `bar`.
+      x Location 1 of `foo` does not have a match.
 
 # errors with the right location on unmatched needles when different nesting containers are present
 
@@ -463,8 +481,8 @@
     Output
       <error/vctrs_error_matches_nothing>
       Error in `vec_locate_matches()`:
-      ! Each element must have a match.
-      x The element at location 2 does not have a match.
+      ! Each value of `needles` must have a match in `haystack`.
+      x Location 2 of `needles` does not have a match.
 
 # `no_match` is validated
 
@@ -502,32 +520,32 @@
     Output
       <error/vctrs_error_matches_remaining>
       Error in `vec_locate_matches()`:
-      ! Each haystack value must be matched.
-      x The value at location 1 was not matched.
+      ! Each value of `haystack` must be matched by `needles`.
+      x Location 1 of `haystack` was not matched.
     Code
       (expect_error(vec_locate_matches(1, 2, remaining = "error", needles_arg = "foo"))
       )
     Output
       <error/vctrs_error_matches_remaining>
       Error in `vec_locate_matches()`:
-      ! Each haystack value must be matched by `foo`.
-      x The value at location 1 was not matched.
+      ! Each value of `haystack` must be matched by `foo`.
+      x Location 1 of `haystack` was not matched.
     Code
       (expect_error(vec_locate_matches(1, 2, remaining = "error", needles_arg = "foo",
         error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_remaining>
       Error in `fn()`:
-      ! Each haystack value must be matched by `foo`.
-      x The value at location 1 was not matched.
+      ! Each value of `haystack` must be matched by `foo`.
+      x Location 1 of `haystack` was not matched.
     Code
       (expect_error(vec_locate_matches(1, 2, remaining = "error", needles_arg = "foo",
         haystack_arg = "bar")))
     Output
       <error/vctrs_error_matches_remaining>
       Error in `vec_locate_matches()`:
-      ! Each haystack value of `bar` must be matched by `foo`.
-      x The value at location 1 was not matched.
+      ! Each value of `bar` must be matched by `foo`.
+      x Location 1 of `bar` was not matched.
 
 # `remaining` is validated
 

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -1004,10 +1004,9 @@ test_that("errors on multiple matches that come from different nesting container
   df <- data_frame(x = 0, y = 0)
   df2 <- data_frame(x = 1:2, y = 2:1)
 
-  expect_error(
-    vec_locate_matches(df, df2, condition = c("<=", "<="), multiple = "error"),
-    "multiple matches"
-  )
+  expect_snapshot(error = TRUE, {
+    vec_locate_matches(df, df2, condition = c("<=", "<="), multiple = "error")
+  })
 })
 
 test_that("errors when a match from a different nesting container is processed early on", {
@@ -1029,10 +1028,9 @@ test_that("errors when a match from a different nesting container is processed e
   # which is in the 3rd value of `loc_first_match_o_haystack` even though it
   # is processed 2nd (i.e. we need to use `loc` rather than `i` when detecting
   # multiple matches)
-  expect_error(
-    vec_locate_matches(needles, haystack, condition = "<", multiple = "error"),
-    "multiple matches"
-  )
+  expect_snapshot(error = TRUE, {
+    vec_locate_matches(needles, haystack, condition = "<", multiple = "error")
+  })
 })
 
 test_that("`multiple = 'error'` doesn't error errneously on the last observation", {


### PR DESCRIPTION
- Changes defaults to `"needles"` and `"haystack"` respectively
- Which allows me to remove a lot of the error generation code related to handling `""` specially. This also made it easier to improve the error messages to match more modern conventions (like using `can't` and `Location {i}`)
- I don't error on `""` names, it didn't seem like there was an easy way to do so, and adding extra code for that edge case didn't seem worth it here
- Also some minor doc updating and standardization