### PR TITLE
Fix deprecated `multiple` options when combined with `relationship`

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -1834,6 +1834,30 @@ r_obj* expand_compact_indices(const int* v_o_haystack,
       if (any_multiple_needles) {
         loc_first_multiple_needles = loc_needles;
 
+        // TODO: Remove deprecated support for `multiple = "error"/"warning"`
+        switch (multiple) {
+        case VCTRS_MULTIPLE_all:
+          break;
+        case VCTRS_MULTIPLE_error:
+          stop_matches_multiple(
+            loc_first_multiple_needles,
+            needles_arg,
+            haystack_arg,
+            error_call
+          );
+        case VCTRS_MULTIPLE_warning: {
+          warn_matches_multiple(
+            loc_first_multiple_needles,
+            needles_arg,
+            haystack_arg,
+            error_call
+          );
+          break;
+        }
+        default:
+          r_stop_internal("`check_multiple_needles` should have been false.");
+        }
+
         switch (relationship) {
         case VCTRS_RELATIONSHIP_one_to_one:
           stop_matches_relationship_one_to_one(
@@ -1865,24 +1889,14 @@ r_obj* expand_compact_indices(const int* v_o_haystack,
         default: {
           switch (multiple) {
           case VCTRS_MULTIPLE_all:
+            // We are tracking if there are multiple matches, but don't throw
+            // any errors or warnings on them
             break;
           // TODO: Remove deprecated support for `multiple = "error"/"warning"`
           case VCTRS_MULTIPLE_error:
-            stop_matches_multiple(
-              loc_first_multiple_needles,
-              needles_arg,
-              haystack_arg,
-              error_call
-            );
-          case VCTRS_MULTIPLE_warning: {
-            warn_matches_multiple(
-              loc_first_multiple_needles,
-              needles_arg,
-              haystack_arg,
-              error_call
-            );
+            r_stop_internal("`multiple = 'error'` should have thrown by now.");
+          case VCTRS_MULTIPLE_warning:
             break;
-          }
           default:
             r_stop_internal("`check_multiple_needles` should have been false.");
           }

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -199,6 +199,85 @@
       ! Each value of `needles` can match at most 1 value from `haystack`.
       x Location 1 of `needles` matches multiple values.
 
+# `multiple = 'error' / 'warning'` throw correctly when combined with `relationship`
+
+    Code
+      (expect_error(vec_locate_matches(x, y, relationship = "one_to_one", multiple = "error"))
+      )
+    Output
+      <error/vctrs_error_matches_multiple>
+      Error in `vec_locate_matches()`:
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 2 of `needles` matches multiple values.
+
+---
+
+    Code
+      (expect_error(vec_locate_matches(x, y, relationship = "warn_many_to_many",
+        multiple = "error")))
+    Output
+      <error/vctrs_error_matches_multiple>
+      Error in `vec_locate_matches()`:
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 2 of `needles` matches multiple values.
+
+---
+
+    Code
+      vec_locate_matches(x, y, relationship = "warn_many_to_many", multiple = "warning")
+    Condition
+      Warning in `vec_locate_matches()`:
+      Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 2 of `needles` matches multiple values.
+      Warning in `vec_locate_matches()`:
+      Detected an unexpected many-to-many relationship between `needles` and `haystack`.
+      x Location 2 of `needles` matches multiple values.
+      x Location 1 of `haystack` matches multiple values.
+    Output
+        needles haystack
+      1       1        2
+      2       2        1
+      3       2        3
+      4       3        1
+      5       3        3
+
+---
+
+    Code
+      vec_locate_matches(x, y, relationship = "one_to_one", multiple = "warning")
+    Condition
+      Warning in `vec_locate_matches()`:
+      Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 2 of `needles` matches multiple values.
+      Error in `vec_locate_matches()`:
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 2 of `needles` matches multiple values.
+
+---
+
+    Code
+      (expect_error(vec_locate_matches(x, y, relationship = "warn_many_to_many",
+        multiple = "error")))
+    Output
+      <error/vctrs_error_matches_multiple>
+      Error in `vec_locate_matches()`:
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 2 of `needles` matches multiple values.
+
+---
+
+    Code
+      vec_locate_matches(x, y, relationship = "warn_many_to_many", multiple = "warning")
+    Condition
+      Warning in `vec_locate_matches()`:
+      Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 2 of `needles` matches multiple values.
+    Output
+        needles haystack
+      1       1        2
+      2       2        1
+      3       2        3
+
 # `relationship` handles one-to-one case
 
     Code

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -1039,6 +1039,40 @@ test_that("`multiple = 'error'` doesn't error errneously on the last observation
   expect_identical(res$haystack, 1:2)
 })
 
+test_that("`multiple = 'error' / 'warning'` throw correctly when combined with `relationship`", {
+  x <- c(1, 2, 2)
+  y <- c(2, 1, 2)
+
+  # `multiple` error technically fires first
+  expect_snapshot({
+    (expect_error(vec_locate_matches(x, y, relationship = "one_to_one", multiple = "error")))
+  })
+
+  # Works when warning is also requested
+  expect_snapshot({
+    (expect_error(vec_locate_matches(x, y, relationship = "warn_many_to_many", multiple = "error")))
+  })
+  # Both warnings are thrown if applicable
+  expect_snapshot({
+    vec_locate_matches(x, y, relationship = "warn_many_to_many", multiple = "warning")
+  })
+  # Both warning and error are thrown if applicable
+  expect_snapshot(error = TRUE, {
+    vec_locate_matches(x, y, relationship = "one_to_one", multiple = "warning")
+  })
+
+  x <- c(1, 2)
+  y <- c(2, 1, 2)
+
+  expect_snapshot({
+    (expect_error(vec_locate_matches(x, y, relationship = "warn_many_to_many", multiple = "error")))
+  })
+  # Only `multiple` warning is applicable here
+  expect_snapshot({
+    vec_locate_matches(x, y, relationship = "warn_many_to_many", multiple = "warning")
+  })
+})
+
 # ------------------------------------------------------------------------------
 # vec_locate_matches() - `relationship`
 


### PR DESCRIPTION
Follow up to #1791 