### PR TITLE
Use `-` rather than `_` for `relationship` options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 * `vec_locate_matches()` gains a new `relationship` argument that holistically
   handles multiple matches between `needles` and `haystack`. In particular,
-  `relationship = "many_to_one"` replaces `multiple = "error"` and
+  `relationship = "many-to-one"` replaces `multiple = "error"` and
   `multiple = "warning"`, which have been removed from the documentation and
   silently soft-deprecated. Official deprecation for those options will start in
   a future release (#1791).

--- a/R/match.R
+++ b/R/match.R
@@ -138,30 +138,30 @@
 #'
 #'   - `"none"` doesn't perform any relationship checks.
 #'
-#'   - `"one_to_one"` expects:
+#'   - `"one-to-one"` expects:
 #'     - Each value in `needles` matches at most 1 value in `haystack`.
 #'     - Each value in `haystack` matches at most 1 value in `needles`.
 #'
-#'   - `"one_to_many"` expects:
+#'   - `"one-to-many"` expects:
 #'     - Each value in `needles` matches any number of values in `haystack`.
 #'     - Each value in `haystack` matches at most 1 value in `needles`.
 #'
-#'   - `"many_to_one"` expects:
+#'   - `"many-to-one"` expects:
 #'     - Each value in `needles` matches at most 1 value in `haystack`.
 #'     - Each value in `haystack` matches any number of values in `needles`.
 #'
-#'   - `"many_to_many"` expects:
+#'   - `"many-to-many"` expects:
 #'     - Each value in `needles` matches any number of values in `haystack`.
 #'     - Each value in `haystack` matches any number of values in `needles`.
 #'
 #'     This performs no checks, and is identical to `"none"`, but is provided to
 #'     allow you to be explicit about this relationship if you know it exists.
 #'
-#'   - `"warn_many_to_many"` doesn't assume there is any known relationship, but
+#'   - `"warn-many-to-many"` doesn't assume there is any known relationship, but
 #'     will warn if `needles` and `haystack` have a many-to-many relationship
 #'     (which is typically unexpected), encouraging you to either take a closer
 #'     look at your inputs or make this relationship explicit by specifying
-#'     `"many_to_many"`.
+#'     `"many-to-many"`.
 #'
 #'   `relationship` is applied after `filter` and `multiple` to allow potential
 #'   multiple matches to be filtered out first.
@@ -203,10 +203,10 @@
 #'
 #' # Use `relationship` to add constraints and error on multiple matches if
 #' # they aren't expected
-#' try(vec_locate_matches(x, y, relationship = "one_to_one"))
+#' try(vec_locate_matches(x, y, relationship = "one-to-one"))
 #'
 #' # In this case, the `NA` in `y` matches two rows in `x`
-#' try(vec_locate_matches(x, y, relationship = "one_to_many"))
+#' try(vec_locate_matches(x, y, relationship = "one-to-many"))
 #'
 #' # By default, `NA` is treated as being identical to `NaN`.
 #' # Using `nan_distinct = TRUE` treats `NA` and `NaN` as different values, so
@@ -220,7 +220,7 @@
 #'
 #' # Using `incomplete = NA` allows us to enforce the one-to-many relationship
 #' # that we couldn't before
-#' vec_locate_matches(x, y, relationship = "one_to_many", incomplete = NA)
+#' vec_locate_matches(x, y, relationship = "one-to-many", incomplete = NA)
 #'
 #' # `no_match` allows you to specify the returned value for a needle with
 #' # zero matches. Note that this is different from an incomplete value,

--- a/man/vec_locate_matches.Rd
+++ b/man/vec_locate_matches.Rd
@@ -116,22 +116,22 @@ which match will be returned. It is often faster than \code{"first"} and
 are invalidated, an error is thrown.
 \itemize{
 \item \code{"none"} doesn't perform any relationship checks.
-\item \code{"one_to_one"} expects:
+\item \code{"one-to-one"} expects:
 \itemize{
 \item Each value in \code{needles} matches at most 1 value in \code{haystack}.
 \item Each value in \code{haystack} matches at most 1 value in \code{needles}.
 }
-\item \code{"one_to_many"} expects:
+\item \code{"one-to-many"} expects:
 \itemize{
 \item Each value in \code{needles} matches any number of values in \code{haystack}.
 \item Each value in \code{haystack} matches at most 1 value in \code{needles}.
 }
-\item \code{"many_to_one"} expects:
+\item \code{"many-to-one"} expects:
 \itemize{
 \item Each value in \code{needles} matches at most 1 value in \code{haystack}.
 \item Each value in \code{haystack} matches any number of values in \code{needles}.
 }
-\item \code{"many_to_many"} expects:
+\item \code{"many-to-many"} expects:
 \itemize{
 \item Each value in \code{needles} matches any number of values in \code{haystack}.
 \item Each value in \code{haystack} matches any number of values in \code{needles}.
@@ -139,11 +139,11 @@ are invalidated, an error is thrown.
 
 This performs no checks, and is identical to \code{"none"}, but is provided to
 allow you to be explicit about this relationship if you know it exists.
-\item \code{"warn_many_to_many"} doesn't assume there is any known relationship, but
+\item \code{"warn-many-to-many"} doesn't assume there is any known relationship, but
 will warn if \code{needles} and \code{haystack} have a many-to-many relationship
 (which is typically unexpected), encouraging you to either take a closer
 look at your inputs or make this relationship explicit by specifying
-\code{"many_to_many"}.
+\code{"many-to-many"}.
 }
 
 \code{relationship} is applied after \code{filter} and \code{multiple} to allow potential
@@ -249,10 +249,10 @@ vec_locate_matches(x, y, multiple = "any")
 
 # Use `relationship` to add constraints and error on multiple matches if
 # they aren't expected
-try(vec_locate_matches(x, y, relationship = "one_to_one"))
+try(vec_locate_matches(x, y, relationship = "one-to-one"))
 
 # In this case, the `NA` in `y` matches two rows in `x`
-try(vec_locate_matches(x, y, relationship = "one_to_many"))
+try(vec_locate_matches(x, y, relationship = "one-to-many"))
 
 # By default, `NA` is treated as being identical to `NaN`.
 # Using `nan_distinct = TRUE` treats `NA` and `NaN` as different values, so
@@ -266,7 +266,7 @@ vec_locate_matches(x, y, incomplete = NA)
 
 # Using `incomplete = NA` allows us to enforce the one-to-many relationship
 # that we couldn't before
-vec_locate_matches(x, y, relationship = "one_to_many", incomplete = NA)
+vec_locate_matches(x, y, relationship = "one-to-many", incomplete = NA)
 
 # `no_match` allows you to specify the returned value for a needle with
 # zero matches. Note that this is different from an incomplete value,

--- a/src/match.c
+++ b/src/match.c
@@ -1404,15 +1404,15 @@ enum vctrs_relationship parse_relationship(r_obj* relationship, struct r_lazy ca
   const char* c_relationship = r_chr_get_c_string(relationship, 0);
 
   if (!strcmp(c_relationship, "none")) return VCTRS_RELATIONSHIP_none;
-  if (!strcmp(c_relationship, "one_to_one")) return VCTRS_RELATIONSHIP_one_to_one;
-  if (!strcmp(c_relationship, "one_to_many")) return VCTRS_RELATIONSHIP_one_to_many;
-  if (!strcmp(c_relationship, "many_to_one")) return VCTRS_RELATIONSHIP_many_to_one;
-  if (!strcmp(c_relationship, "many_to_many")) return VCTRS_RELATIONSHIP_many_to_many;
-  if (!strcmp(c_relationship, "warn_many_to_many")) return VCTRS_RELATIONSHIP_warn_many_to_many;
+  if (!strcmp(c_relationship, "one-to-one")) return VCTRS_RELATIONSHIP_one_to_one;
+  if (!strcmp(c_relationship, "one-to-many")) return VCTRS_RELATIONSHIP_one_to_many;
+  if (!strcmp(c_relationship, "many-to-one")) return VCTRS_RELATIONSHIP_many_to_one;
+  if (!strcmp(c_relationship, "many-to-many")) return VCTRS_RELATIONSHIP_many_to_many;
+  if (!strcmp(c_relationship, "warn-many-to-many")) return VCTRS_RELATIONSHIP_warn_many_to_many;
 
   r_abort_lazy_call(
     call,
-    "`relationship` must be one of \"none\", \"one_to_one\", \"one_to_many\", \"many_to_one\", \"many_to_many\", or \"warn_many_to_many\"."
+    "`relationship` must be one of \"none\", \"one-to-one\", \"one-to-many\", \"many-to-one\", \"many-to-many\", or \"warn-many-to-many\"."
   );
 }
 
@@ -1996,7 +1996,7 @@ r_obj* expand_compact_indices(const int* v_o_haystack,
                 );
               case VCTRS_RELATIONSHIP_warn_many_to_many:
                 r_stop_internal(
-                  "`relationship = 'warn_many_to_many'` with "
+                  "`relationship = 'warn-many-to-many'` with "
                   "`multiple = 'first'/'last' should have resulted in "
                   "`check_multiple_haystack = false`."
                 );

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -202,7 +202,7 @@
 # `multiple = 'error' / 'warning'` throw correctly when combined with `relationship`
 
     Code
-      (expect_error(vec_locate_matches(x, y, relationship = "one_to_one", multiple = "error"))
+      (expect_error(vec_locate_matches(x, y, relationship = "one-to-one", multiple = "error"))
       )
     Output
       <error/vctrs_error_matches_multiple>
@@ -213,7 +213,7 @@
 ---
 
     Code
-      (expect_error(vec_locate_matches(x, y, relationship = "warn_many_to_many",
+      (expect_error(vec_locate_matches(x, y, relationship = "warn-many-to-many",
         multiple = "error")))
     Output
       <error/vctrs_error_matches_multiple>
@@ -224,7 +224,7 @@
 ---
 
     Code
-      vec_locate_matches(x, y, relationship = "warn_many_to_many", multiple = "warning")
+      vec_locate_matches(x, y, relationship = "warn-many-to-many", multiple = "warning")
     Condition
       Warning in `vec_locate_matches()`:
       Each value of `needles` can match at most 1 value from `haystack`.
@@ -244,7 +244,7 @@
 ---
 
     Code
-      vec_locate_matches(x, y, relationship = "one_to_one", multiple = "warning")
+      vec_locate_matches(x, y, relationship = "one-to-one", multiple = "warning")
     Condition
       Warning in `vec_locate_matches()`:
       Each value of `needles` can match at most 1 value from `haystack`.
@@ -256,7 +256,7 @@
 ---
 
     Code
-      (expect_error(vec_locate_matches(x, y, relationship = "warn_many_to_many",
+      (expect_error(vec_locate_matches(x, y, relationship = "warn-many-to-many",
         multiple = "error")))
     Output
       <error/vctrs_error_matches_multiple>
@@ -267,7 +267,7 @@
 ---
 
     Code
-      vec_locate_matches(x, y, relationship = "warn_many_to_many", multiple = "warning")
+      vec_locate_matches(x, y, relationship = "warn-many-to-many", multiple = "warning")
     Condition
       Warning in `vec_locate_matches()`:
       Each value of `needles` can match at most 1 value from `haystack`.
@@ -281,7 +281,7 @@
 # `relationship` handles one-to-one case
 
     Code
-      (expect_error(vec_locate_matches(c(2, 1), c(1, 1), relationship = "one_to_one"))
+      (expect_error(vec_locate_matches(c(2, 1), c(1, 1), relationship = "one-to-one"))
       )
     Output
       <error/vctrs_error_matches_relationship_one_to_one>
@@ -289,7 +289,7 @@
       ! Each value of `needles` can match at most 1 value from `haystack`.
       x Location 2 of `needles` matches multiple values.
     Code
-      (expect_error(vec_locate_matches(c(1, 1), c(1, 2), relationship = "one_to_one"))
+      (expect_error(vec_locate_matches(c(1, 1), c(1, 2), relationship = "one-to-one"))
       )
     Output
       <error/vctrs_error_matches_relationship_one_to_one>
@@ -300,7 +300,7 @@
 # `relationship` handles one-to-many case
 
     Code
-      (expect_error(vec_locate_matches(c(1, 2, 2), c(2, 1), relationship = "one_to_many"))
+      (expect_error(vec_locate_matches(c(1, 2, 2), c(2, 1), relationship = "one-to-many"))
       )
     Output
       <error/vctrs_error_matches_relationship_one_to_many>
@@ -311,7 +311,7 @@
 # `relationship` handles many-to-one case
 
     Code
-      (expect_error(vec_locate_matches(c(1, 2), c(1, 2, 2), relationship = "many_to_one"))
+      (expect_error(vec_locate_matches(c(1, 2), c(1, 2, 2), relationship = "many-to-one"))
       )
     Output
       <error/vctrs_error_matches_relationship_many_to_one>
@@ -322,7 +322,7 @@
 # `relationship` handles warn-many-to-many case
 
     Code
-      (expect_warning(vec_locate_matches(c(1, 2, 1), c(1, 2, 2), relationship = "warn_many_to_many"))
+      (expect_warning(vec_locate_matches(c(1, 2, 1), c(1, 2, 2), relationship = "warn-many-to-many"))
       )
     Output
       <warning/vctrs_warning_matches_relationship_many_to_many>
@@ -331,7 +331,7 @@
       x Location 2 of `needles` matches multiple values.
       x Location 1 of `haystack` matches multiple values.
     Code
-      (expect_warning(vec_locate_matches(c(1, 1, 2), c(2, 2, 1), relationship = "warn_many_to_many"))
+      (expect_warning(vec_locate_matches(c(1, 1, 2), c(2, 2, 1), relationship = "warn-many-to-many"))
       )
     Output
       <warning/vctrs_warning_matches_relationship_many_to_many>
@@ -343,7 +343,7 @@
 # `relationship` considers `incomplete` matches as possible multiple matches
 
     Code
-      (expect_error(vec_locate_matches(x, y, relationship = "one_to_many")))
+      (expect_error(vec_locate_matches(x, y, relationship = "one-to-many")))
     Output
       <error/vctrs_error_matches_relationship_one_to_many>
       Error in `vec_locate_matches()`:
@@ -354,7 +354,7 @@
 
     Code
       (expect_error(vec_locate_matches(df, df2, condition = c("<=", "<="),
-      relationship = "many_to_one")))
+      relationship = "many-to-one")))
     Output
       <error/vctrs_error_matches_relationship_many_to_one>
       Error in `vec_locate_matches()`:
@@ -365,7 +365,7 @@
 
     Code
       (expect_error(vec_locate_matches(needles, haystack, condition = "<",
-        relationship = "many_to_one")))
+        relationship = "many-to-one")))
     Output
       <error/vctrs_error_matches_relationship_many_to_one>
       Error in `vec_locate_matches()`:
@@ -376,7 +376,7 @@
 
     Code
       (expect_error(vec_locate_matches(c(3, 1, 1), c(2, 1, 3, 3), multiple = "first",
-      relationship = "one_to_one")))
+      relationship = "one-to-one")))
     Output
       <error/vctrs_error_matches_relationship_one_to_one>
       Error in `vec_locate_matches()`:
@@ -384,7 +384,7 @@
       x Location 2 of `haystack` matches multiple values.
     Code
       (expect_error(vec_locate_matches(c(3, 1, 1), c(2, 1, 3, 3), multiple = "first",
-      relationship = "one_to_many")))
+      relationship = "one-to-many")))
     Output
       <error/vctrs_error_matches_relationship_one_to_many>
       Error in `vec_locate_matches()`:
@@ -394,7 +394,7 @@
 # `relationship` and `remaining` work properly together
 
     Code
-      out <- vec_locate_matches(c(1, 2, 2), c(2, 3, 1, 1, 4), relationship = "warn_many_to_many",
+      out <- vec_locate_matches(c(1, 2, 2), c(2, 3, 1, 1, 4), relationship = "warn-many-to-many",
       remaining = NA_integer_)
     Condition
       Warning in `vec_locate_matches()`:
@@ -405,7 +405,7 @@
 # `relationship` errors if `condition` creates multiple matches
 
     Code
-      (expect_error(vec_locate_matches(1, c(1, 2), condition = "<=", relationship = "many_to_one"))
+      (expect_error(vec_locate_matches(1, c(1, 2), condition = "<=", relationship = "many-to-one"))
       )
     Output
       <error/vctrs_error_matches_relationship_many_to_one>
@@ -417,7 +417,7 @@
 
     Code
       (expect_error(vec_locate_matches(1, c(1, 2, 1), condition = "<=", filter = "min",
-      relationship = "many_to_one")))
+      relationship = "many-to-one")))
     Output
       <error/vctrs_error_matches_relationship_many_to_one>
       Error in `vec_locate_matches()`:
@@ -427,7 +427,7 @@
 # `relationship` errors respect argument tags and error call
 
     Code
-      (expect_error(vec_locate_matches(1L, c(1L, 1L), relationship = "one_to_one",
+      (expect_error(vec_locate_matches(1L, c(1L, 1L), relationship = "one-to-one",
       needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_relationship_one_to_one>
@@ -435,7 +435,7 @@
       ! Each value of `foo` can match at most 1 value from `bar`.
       x Location 1 of `foo` matches multiple values.
     Code
-      (expect_error(vec_locate_matches(c(1L, 1L), 1L, relationship = "one_to_one",
+      (expect_error(vec_locate_matches(c(1L, 1L), 1L, relationship = "one-to-one",
       needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_relationship_one_to_one>
@@ -443,7 +443,7 @@
       ! Each value of `bar` can match at most 1 value from `foo`.
       x Location 1 of `bar` matches multiple values.
     Code
-      (expect_error(vec_locate_matches(c(1L, 1L), 1L, relationship = "one_to_many",
+      (expect_error(vec_locate_matches(c(1L, 1L), 1L, relationship = "one-to-many",
       needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_relationship_one_to_many>
@@ -451,7 +451,7 @@
       ! Each value of `bar` can match at most 1 value from `foo`.
       x Location 1 of `bar` matches multiple values.
     Code
-      (expect_error(vec_locate_matches(1L, c(1L, 1L), relationship = "many_to_one",
+      (expect_error(vec_locate_matches(1L, c(1L, 1L), relationship = "many-to-one",
       needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
     Output
       <error/vctrs_error_matches_relationship_many_to_one>
@@ -462,7 +462,7 @@
 # `relationship` warnings respect argument tags and error call
 
     Code
-      (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn_many_to_many",
+      (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn-many-to-many",
       needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
     Output
       <warning/vctrs_warning_matches_relationship_many_to_many>
@@ -471,7 +471,7 @@
       x Location 1 of `foo` matches multiple values.
       x Location 1 of `bar` matches multiple values.
     Code
-      (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn_many_to_many",
+      (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn-many-to-many",
       needles_arg = "foo", error_call = call("fn"))))
     Output
       <warning/vctrs_warning_matches_relationship_many_to_many>
@@ -480,7 +480,7 @@
       x Location 1 of `foo` matches multiple values.
       x Location 1 of `haystack` matches multiple values.
     Code
-      (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn_many_to_many",
+      (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn-many-to-many",
       haystack_arg = "bar", error_call = call("fn"))))
     Output
       <warning/vctrs_warning_matches_relationship_many_to_many>
@@ -498,8 +498,8 @@
       Error in `vec_locate_matches()`:
       ! `relationship` must be a string.
     Code
-      (expect_error(vec_locate_matches(1, 2, relationship = c("one_to_one",
-        "one_to_many"))))
+      (expect_error(vec_locate_matches(1, 2, relationship = c("one-to-one",
+        "one-to-many"))))
     Output
       <error/rlang_error>
       Error in `vec_locate_matches()`:
@@ -509,14 +509,14 @@
     Output
       <error/rlang_error>
       Error in `vec_locate_matches()`:
-      ! `relationship` must be one of "none", "one_to_one", "one_to_many", "many_to_one", "many_to_many", or "warn_many_to_many".
+      ! `relationship` must be one of "none", "one-to-one", "one-to-many", "many-to-one", "many-to-many", or "warn-many-to-many".
     Code
       (expect_error(vec_locate_matches(1, 2, relationship = "x", error_call = call(
         "fn"))))
     Output
       <error/rlang_error>
       Error in `vec_locate_matches()`:
-      ! `relationship` must be one of "none", "one_to_one", "one_to_many", "many_to_one", "many_to_many", or "warn_many_to_many".
+      ! `relationship` must be one of "none", "one-to-one", "one-to-many", "many-to-one", "many-to-many", or "warn-many-to-many".
 
 # `no_match` can error informatively
 

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -1045,31 +1045,31 @@ test_that("`multiple = 'error' / 'warning'` throw correctly when combined with `
 
   # `multiple` error technically fires first
   expect_snapshot({
-    (expect_error(vec_locate_matches(x, y, relationship = "one_to_one", multiple = "error")))
+    (expect_error(vec_locate_matches(x, y, relationship = "one-to-one", multiple = "error")))
   })
 
   # Works when warning is also requested
   expect_snapshot({
-    (expect_error(vec_locate_matches(x, y, relationship = "warn_many_to_many", multiple = "error")))
+    (expect_error(vec_locate_matches(x, y, relationship = "warn-many-to-many", multiple = "error")))
   })
   # Both warnings are thrown if applicable
   expect_snapshot({
-    vec_locate_matches(x, y, relationship = "warn_many_to_many", multiple = "warning")
+    vec_locate_matches(x, y, relationship = "warn-many-to-many", multiple = "warning")
   })
   # Both warning and error are thrown if applicable
   expect_snapshot(error = TRUE, {
-    vec_locate_matches(x, y, relationship = "one_to_one", multiple = "warning")
+    vec_locate_matches(x, y, relationship = "one-to-one", multiple = "warning")
   })
 
   x <- c(1, 2)
   y <- c(2, 1, 2)
 
   expect_snapshot({
-    (expect_error(vec_locate_matches(x, y, relationship = "warn_many_to_many", multiple = "error")))
+    (expect_error(vec_locate_matches(x, y, relationship = "warn-many-to-many", multiple = "error")))
   })
   # Only `multiple` warning is applicable here
   expect_snapshot({
-    vec_locate_matches(x, y, relationship = "warn_many_to_many", multiple = "warning")
+    vec_locate_matches(x, y, relationship = "warn-many-to-many", multiple = "warning")
   })
 })
 
@@ -1079,80 +1079,80 @@ test_that("`multiple = 'error' / 'warning'` throw correctly when combined with `
 test_that("`relationship` handles one-to-one case", {
   # No error
   expect_identical(
-    vec_locate_matches(1:2, 2:1, relationship = "one_to_one"),
+    vec_locate_matches(1:2, 2:1, relationship = "one-to-one"),
     vec_locate_matches(1:2, 2:1)
   )
 
   # Doesn't care about the zero match case
   expect_identical(
-    vec_locate_matches(1:2, 3:4, relationship = "one_to_one"),
+    vec_locate_matches(1:2, 3:4, relationship = "one-to-one"),
     vec_locate_matches(1:2, 3:4)
   )
 
   expect_snapshot({
-    (expect_error(vec_locate_matches(c(2, 1), c(1, 1), relationship = "one_to_one")))
-    (expect_error(vec_locate_matches(c(1, 1), c(1, 2), relationship = "one_to_one")))
+    (expect_error(vec_locate_matches(c(2, 1), c(1, 1), relationship = "one-to-one")))
+    (expect_error(vec_locate_matches(c(1, 1), c(1, 2), relationship = "one-to-one")))
   })
 })
 
 test_that("`relationship` handles one-to-many case", {
   # No error
   expect_identical(
-    vec_locate_matches(c(1, 2), c(1, 2, 2), relationship = "one_to_many"),
+    vec_locate_matches(c(1, 2), c(1, 2, 2), relationship = "one-to-many"),
     vec_locate_matches(c(1, 2), c(1, 2, 2))
   )
 
   # Doesn't care about the zero match case
   expect_identical(
-    vec_locate_matches(1:2, 3:4, relationship = "one_to_many"),
+    vec_locate_matches(1:2, 3:4, relationship = "one-to-many"),
     vec_locate_matches(1:2, 3:4)
   )
 
   expect_snapshot({
-    (expect_error(vec_locate_matches(c(1, 2, 2), c(2, 1), relationship = "one_to_many")))
+    (expect_error(vec_locate_matches(c(1, 2, 2), c(2, 1), relationship = "one-to-many")))
   })
 })
 
 test_that("`relationship` handles many-to-one case", {
   # No error
   expect_identical(
-    vec_locate_matches(c(1, 2, 2), c(1, 2), relationship = "many_to_one"),
+    vec_locate_matches(c(1, 2, 2), c(1, 2), relationship = "many-to-one"),
     vec_locate_matches(c(1, 2, 2), c(1, 2))
   )
 
   # Doesn't care about the zero match case
   expect_identical(
-    vec_locate_matches(1:2, 3:4, relationship = "many_to_one"),
+    vec_locate_matches(1:2, 3:4, relationship = "many-to-one"),
     vec_locate_matches(1:2, 3:4)
   )
 
   expect_snapshot({
-    (expect_error(vec_locate_matches(c(1, 2), c(1, 2, 2), relationship = "many_to_one")))
+    (expect_error(vec_locate_matches(c(1, 2), c(1, 2, 2), relationship = "many-to-one")))
   })
 })
 
 test_that("`relationship` handles many-to-many case", {
   # No error
   expect_identical(
-    vec_locate_matches(c(1, 2, 2), c(1, 2), relationship = "many_to_many"),
+    vec_locate_matches(c(1, 2, 2), c(1, 2), relationship = "many-to-many"),
     vec_locate_matches(c(1, 2, 2), c(1, 2))
   )
 
   # No error
   expect_identical(
-    vec_locate_matches(c(1, 2), c(1, 2, 2), relationship = "many_to_many"),
+    vec_locate_matches(c(1, 2), c(1, 2, 2), relationship = "many-to-many"),
     vec_locate_matches(c(1, 2), c(1, 2, 2))
   )
 
   # No error
   expect_identical(
-    vec_locate_matches(c(1, 1, 2), c(1, 2, 2), relationship = "many_to_many"),
+    vec_locate_matches(c(1, 1, 2), c(1, 2, 2), relationship = "many-to-many"),
     vec_locate_matches(c(1, 1, 2), c(1, 2, 2))
   )
 
   # Doesn't care about the zero match case
   expect_identical(
-    vec_locate_matches(1:2, 3:4, relationship = "many_to_many"),
+    vec_locate_matches(1:2, 3:4, relationship = "many-to-many"),
     vec_locate_matches(1:2, 3:4)
   )
 })
@@ -1161,7 +1161,7 @@ test_that("`relationship` handles warn-many-to-many case", {
   # No warning
   expect_identical(
     expect_silent(
-      vec_locate_matches(c(1, 2, 2), c(1, 2), relationship = "warn_many_to_many")
+      vec_locate_matches(c(1, 2, 2), c(1, 2), relationship = "warn-many-to-many")
     ),
     vec_locate_matches(c(1, 2, 2), c(1, 2))
   )
@@ -1169,7 +1169,7 @@ test_that("`relationship` handles warn-many-to-many case", {
   # No warning
   expect_identical(
     expect_silent(
-      vec_locate_matches(c(1, 2), c(1, 2, 2), relationship = "warn_many_to_many")
+      vec_locate_matches(c(1, 2), c(1, 2, 2), relationship = "warn-many-to-many")
     ),
     vec_locate_matches(c(1, 2), c(1, 2, 2))
   )
@@ -1177,7 +1177,7 @@ test_that("`relationship` handles warn-many-to-many case", {
   # Doesn't care about the zero match case
   expect_identical(
     expect_silent(
-      vec_locate_matches(1:2, 3:4, relationship = "warn_many_to_many")
+      vec_locate_matches(1:2, 3:4, relationship = "warn-many-to-many")
     ),
     vec_locate_matches(1:2, 3:4)
   )
@@ -1186,8 +1186,8 @@ test_that("`relationship` handles warn-many-to-many case", {
   # - Finding multiple `needles` matches before multiple `haystack` matches
   # - Finding multiple `haystack` matches before multiple `needles` matches
   expect_snapshot({
-    (expect_warning(vec_locate_matches(c(1, 2, 1), c(1, 2, 2), relationship = "warn_many_to_many")))
-    (expect_warning(vec_locate_matches(c(1, 1, 2), c(2, 2, 1), relationship = "warn_many_to_many")))
+    (expect_warning(vec_locate_matches(c(1, 2, 1), c(1, 2, 2), relationship = "warn-many-to-many")))
+    (expect_warning(vec_locate_matches(c(1, 1, 2), c(2, 2, 1), relationship = "warn-many-to-many")))
   })
 })
 
@@ -1196,18 +1196,18 @@ test_that("`relationship` considers `incomplete` matches as possible multiple ma
   y <- c(NA, 1)
 
   expect_snapshot({
-    (expect_error(vec_locate_matches(x, y, relationship = "one_to_many")))
+    (expect_error(vec_locate_matches(x, y, relationship = "one-to-many")))
   })
 
   # No error
   expect_identical(
-    vec_locate_matches(x, y, relationship = "one_to_many", incomplete = NA),
+    vec_locate_matches(x, y, relationship = "one-to-many", incomplete = NA),
     vec_locate_matches(x, y, incomplete = NA)
   )
 
   # No error
   expect_identical(
-    vec_locate_matches(x, y, relationship = "one_to_many", nan_distinct = TRUE),
+    vec_locate_matches(x, y, relationship = "one-to-many", nan_distinct = TRUE),
     vec_locate_matches(x, y, nan_distinct = TRUE)
   )
 })
@@ -1217,7 +1217,7 @@ test_that("`relationship` errors on multiple matches that come from different ne
   df2 <- data_frame(x = 1:2, y = 2:1)
 
   expect_snapshot({
-    (expect_error(vec_locate_matches(df, df2, condition = c("<=", "<="), relationship = "many_to_one")))
+    (expect_error(vec_locate_matches(df, df2, condition = c("<=", "<="), relationship = "many-to-one")))
   })
 })
 
@@ -1241,34 +1241,34 @@ test_that("`relationship` errors when a match from a different nesting container
   # is processed 2nd (i.e. we need to use `loc` rather than `i` when detecting
   # multiple matches)
   expect_snapshot({
-    (expect_error(vec_locate_matches(needles, haystack, condition = "<", relationship = "many_to_one")))
+    (expect_error(vec_locate_matches(needles, haystack, condition = "<", relationship = "many-to-one")))
   })
 })
 
 test_that("`relationship` doesn't error errneously on the last observation", {
-  expect_error(res <- vec_locate_matches(1:2, 1:2, relationship = "many_to_one"), NA)
+  expect_error(res <- vec_locate_matches(1:2, 1:2, relationship = "many-to-one"), NA)
   expect_identical(res$needles, 1:2)
   expect_identical(res$haystack, 1:2)
 })
 
 test_that("`relationship` doesn't error if `multiple` removes multiple matches", {
-  out <- vec_locate_matches(c(1, 2), c(1, 1), multiple = "any", relationship = "one_to_one")
+  out <- vec_locate_matches(c(1, 2), c(1, 1), multiple = "any", relationship = "one-to-one")
   expect_identical(out$needles, c(1L, 2L))
   expect_identical(out$haystack, c(1L, NA))
 
-  out <- vec_locate_matches(c(1, 2), c(1, 1), multiple = "first", relationship = "one_to_one")
+  out <- vec_locate_matches(c(1, 2), c(1, 1), multiple = "first", relationship = "one-to-one")
   expect_identical(out$needles, c(1L, 2L))
   expect_identical(out$haystack, c(1L, NA))
 
-  out <- vec_locate_matches(c(1, 2), c(1, 1), multiple = "last", relationship = "one_to_one")
+  out <- vec_locate_matches(c(1, 2), c(1, 1), multiple = "last", relationship = "one-to-one")
   expect_identical(out$needles, c(1L, 2L))
   expect_identical(out$haystack, c(2L, NA))
 })
 
 test_that("`relationship` can still detect problematic `haystack` relationships when `multiple = first/last` are used", {
   expect_snapshot({
-    (expect_error(vec_locate_matches(c(3, 1, 1), c(2, 1, 3, 3), multiple = "first", relationship = "one_to_one")))
-    (expect_error(vec_locate_matches(c(3, 1, 1), c(2, 1, 3, 3), multiple = "first", relationship = "one_to_many")))
+    (expect_error(vec_locate_matches(c(3, 1, 1), c(2, 1, 3, 3), multiple = "first", relationship = "one-to-one")))
+    (expect_error(vec_locate_matches(c(3, 1, 1), c(2, 1, 3, 3), multiple = "first", relationship = "one-to-many")))
   })
 })
 
@@ -1277,7 +1277,7 @@ test_that("`relationship` and `remaining` work properly together", {
     out <- vec_locate_matches(
       c(1, 2, 2),
       c(2, 3, 1, 1, 4),
-      relationship = "warn_many_to_many",
+      relationship = "warn-many-to-many",
       remaining = NA_integer_
     )
   })
@@ -1287,52 +1287,52 @@ test_that("`relationship` and `remaining` work properly together", {
 
 test_that("`relationship` errors if `condition` creates multiple matches", {
   expect_snapshot({
-    (expect_error(vec_locate_matches(1, c(1, 2), condition = "<=", relationship = "many_to_one")))
+    (expect_error(vec_locate_matches(1, c(1, 2), condition = "<=", relationship = "many-to-one")))
   })
 })
 
 test_that("`relationship` doesn't error if `filter` removes multiple matches", {
-  out <- vec_locate_matches(1, c(1, 2), condition = "<=", filter = "min", relationship = "many_to_one")
+  out <- vec_locate_matches(1, c(1, 2), condition = "<=", filter = "min", relationship = "many-to-one")
   expect_identical(out$needles, 1L)
   expect_identical(out$haystack, 1L)
 
-  out <- vec_locate_matches(1, c(1, 2), condition = "<=", filter = "max", relationship = "many_to_one")
+  out <- vec_locate_matches(1, c(1, 2), condition = "<=", filter = "max", relationship = "many-to-one")
   expect_identical(out$needles, 1L)
   expect_identical(out$haystack, 2L)
 })
 
 test_that("`relationship` still errors if `filter` hasn't removed all multiple matches", {
   expect_snapshot({
-    (expect_error(vec_locate_matches(1, c(1, 2, 1), condition = "<=", filter = "min", relationship = "many_to_one")))
+    (expect_error(vec_locate_matches(1, c(1, 2, 1), condition = "<=", filter = "min", relationship = "many-to-one")))
   })
 
   # But not here
-  out <- vec_locate_matches(c(1, 1), c(1, 2, 1), condition = "<=", filter = "max", relationship = "many_to_one")
+  out <- vec_locate_matches(c(1, 1), c(1, 2, 1), condition = "<=", filter = "max", relationship = "many-to-one")
   expect_identical(out$needles, c(1L, 2L))
   expect_identical(out$haystack, c(2L, 2L))
 })
 
 test_that("`relationship` errors respect argument tags and error call", {
   expect_snapshot({
-    (expect_error(vec_locate_matches(1L, c(1L, 1L), relationship = "one_to_one", needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
-    (expect_error(vec_locate_matches(c(1L, 1L), 1L, relationship = "one_to_one", needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
-    (expect_error(vec_locate_matches(c(1L, 1L), 1L, relationship = "one_to_many", needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
-    (expect_error(vec_locate_matches(1L, c(1L, 1L), relationship = "many_to_one", needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
+    (expect_error(vec_locate_matches(1L, c(1L, 1L), relationship = "one-to-one", needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
+    (expect_error(vec_locate_matches(c(1L, 1L), 1L, relationship = "one-to-one", needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
+    (expect_error(vec_locate_matches(c(1L, 1L), 1L, relationship = "one-to-many", needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
+    (expect_error(vec_locate_matches(1L, c(1L, 1L), relationship = "many-to-one", needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
   })
 })
 
 test_that("`relationship` warnings respect argument tags and error call", {
   expect_snapshot({
-    (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn_many_to_many", needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
-    (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn_many_to_many", needles_arg = "foo", error_call = call("fn"))))
-    (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn_many_to_many", haystack_arg = "bar", error_call = call("fn"))))
+    (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn-many-to-many", needles_arg = "foo", haystack_arg = "bar", error_call = call("fn"))))
+    (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn-many-to-many", needles_arg = "foo", error_call = call("fn"))))
+    (expect_warning(vec_locate_matches(c(1L, 1L), c(1L, 1L), relationship = "warn-many-to-many", haystack_arg = "bar", error_call = call("fn"))))
   })
 })
 
 test_that("`relationship` is validated", {
   expect_snapshot({
     (expect_error(vec_locate_matches(1, 2, relationship = 1.5)))
-    (expect_error(vec_locate_matches(1, 2, relationship = c("one_to_one", "one_to_many"))))
+    (expect_error(vec_locate_matches(1, 2, relationship = c("one-to-one", "one-to-many"))))
     (expect_error(vec_locate_matches(1, 2, relationship = "x")))
     # Uses internal error
     (expect_error(vec_locate_matches(1, 2, relationship = "x", error_call = call("fn"))))


### PR DESCRIPTION
Because:
- `one-to-one` is the name of the entire concept, and is how we refer to it in documentation, so it does make sense here to use hyphens even though we often use `_`
- It is slightly faster to type
- We just accept that we then inherit `warn-many-to-many` because `warn_many-to-many` would be too awkward. This shouldn't matter much because it won't be exposed anywhere else.