### PR TITLE
Implement `vec_chop(sizes = )`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
   is identical to the `times` column from `vec_unrep()`, but is faster if you
   don't need the run key (#1210).
 
+* New `sizes` argument to `vec_chop()` which allows you to partition a vector
+  using an integer vector describing the size of each expected slice. It is
+  particularly useful in combination with `vec_run_sizes()` and `list_sizes()`
+  (#1210, #1598).
+
 * New `obj_is_vector()`, `obj_check_vector()`, and `vec_check_size()` validation
   helpers. We believe these are a better approach to vector validation than
   `vec_assert()` and `vec_is()`, which have been marked as questioning because

--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,11 @@
   `haystack_arg` values from `""` to `"needles"` and `"haystack"`, respectively.
   This generally generates more informative error messages (#1792).
 
+* `vec_chop()` has gained empty `...` between `x` and the optional `indices`
+  argument. For backwards compatibility, supplying `vec_chop(x, indices)`
+  without naming `indices` still silently works, but will be deprecated in a
+  future release (#1813).
+
 * `vec_slice()` has gained an `error_call` argument (#1785).
 
 * The `numeric_version` type from base R is now better supported in equality,

--- a/R/slice-chop.R
+++ b/R/slice-chop.R
@@ -121,9 +121,33 @@
 #' x_flat <- list_unchop(x)
 #' x_flat <- x_flat + max(x_flat)
 #' vec_chop(x_flat, sizes = list_sizes(x))
-vec_chop <- function(x, indices = NULL, ..., sizes = NULL) {
-  check_dots_empty0(...)
+vec_chop <- function(x, ..., indices = NULL, sizes = NULL) {
+  if (!missing(...)) {
+    indices <- check_dots_chop(..., indices = indices)
+  }
   .Call(ffi_vec_chop, x, indices, sizes)
+}
+
+check_dots_chop <- function(..., indices = NULL, call = caller_env()) {
+  if (!is_null(indices)) {
+    # Definitely can't supply both `indices` and `...`
+    check_dots_empty0(..., call = call)
+  }
+
+  if (dots_n(...) != 1L) {
+    # Backwards compatible case doesn't allow for length >1 `...`.
+    # This must be an error case.
+    check_dots_empty0(..., call = call)
+  }
+
+  # TODO: Soft-deprecate this after dplyr/tidyr have updated all `vec_chop()`
+  # calls to be explicit about `indices =`
+
+  # Assume this is an old style `vec_chop(x, indices)` call, before we
+  # added the `...`
+  indices <- list(...)[[1L]]
+
+  indices
 }
 
 #' @rdname vec_chop

--- a/R/slice-chop.R
+++ b/R/slice-chop.R
@@ -24,7 +24,8 @@
 #'
 #' @param x A vector
 #' @param indices For `vec_chop()`, a list of positive integer vectors to
-#'   slice `x` with, or `NULL`. If `NULL`, `x` is split into its individual
+#'   slice `x` with, or `NULL`. Can't be used if `sizes` is already specified.
+#'   If both `indices` and `sizes` are `NULL`, `x` is split into its individual
 #'   elements, equivalent to using an `indices` of `as.list(vec_seq_along(x))`.
 #'
 #'   For `list_unchop()`, a list of positive integer vectors specifying the
@@ -32,12 +33,22 @@
 #'   the size of the corresponding index vector. The size of `indices` must
 #'   match the size of `x`. If `NULL`, `x` is combined in the order it is
 #'   provided in, which is equivalent to using [vec_c()].
+#' @param sizes An integer vector of non-negative sizes representing sequential
+#'   indices to slice `x` with, or `NULL`. Can't be used if `indices` is already
+#'   specified.
+#'
+#'   For example, `sizes = c(2, 4)` is equivalent to `indices = list(1:2, 3:6)`,
+#'   but is typically faster.
+#'
+#'   `sum(sizes)` must be equal to `vec_size(x)`, i.e. `sizes` must completely
+#'   partition `x`, but an individual size is allowed to be `0`.
 #' @param ptype If `NULL`, the default, the output type is determined by
 #'   computing the common type across all elements of `x`. Alternatively, you
 #'   can supply `ptype` to give the output a known type.
 #' @return
-#' - `vec_chop()`: A list of size `vec_size(indices)` or, if `indices == NULL`,
-#'   `vec_size(x)`.
+#' - `vec_chop()`: A list where each element has the same type as `x`. The size
+#'   of the list is equal to `vec_size(indices)`, `vec_size(sizes)`, or
+#'   `vec_size(x)` depending on whether or not `indices` or `sizes` is provided.
 #'
 #' - `list_unchop()`: A vector of type `vec_ptype_common(!!!x)`, or `ptype`, if
 #'   specified. The size is computed as `vec_size_common(!!!indices)` unless
@@ -52,7 +63,12 @@
 #' @export
 #' @examples
 #' vec_chop(1:5)
-#' vec_chop(1:5, list(1, 1:2))
+#'
+#' # These two are equivalent
+#' vec_chop(1:5, indices = list(1:2, 3:5))
+#' vec_chop(1:5, sizes = c(2, 3))
+#'
+#' # Can also be used on data frames
 #' vec_chop(mtcars, list(1:3, 4:6))
 #'
 #' # If `indices` selects every value in `x` exactly once,
@@ -89,8 +105,25 @@
 #'   ave2(breaks, wool, mean),
 #'   ave(breaks, wool, FUN = mean)
 #' )
-vec_chop <- function(x, indices = NULL) {
-  .Call(ffi_vec_chop, x, indices)
+#'
+#' # If you know your input is sorted and you'd like to split on the groups,
+#' # `vec_run_sizes()` can be efficiently combined with `sizes`
+#' df <- data_frame(
+#'   g = c(2, 5, 5, 6, 6, 6, 6, 8, 9, 9),
+#'   x = 1:10
+#' )
+#' vec_chop(df, sizes = vec_run_sizes(df$g))
+#'
+#' # If you have a list of homogeneous vectors, sometimes it can be useful to
+#' # unchop, apply a function to the flattened vector, and then rechop according
+#' # to the original indices. This can be done efficiently with `list_sizes()`.
+#' x <- list(c(1, 2, 1), c(3, 1), 5, double())
+#' x_flat <- list_unchop(x)
+#' x_flat <- x_flat + max(x_flat)
+#' vec_chop(x_flat, sizes = list_sizes(x))
+vec_chop <- function(x, indices = NULL, ..., sizes = NULL) {
+  check_dots_empty0(...)
+  .Call(ffi_vec_chop, x, indices, sizes)
 }
 
 #' @rdname vec_chop

--- a/R/slice-chop.R
+++ b/R/slice-chop.R
@@ -16,7 +16,7 @@
 #' holds:
 #'
 #' ```
-#' list_unchop(vec_chop(x, indices), indices) == x
+#' list_unchop(vec_chop(x, indices = indices), indices = indices) == x
 #' ```
 #'
 #' @inheritParams rlang::args_dots_empty
@@ -69,14 +69,14 @@
 #' vec_chop(1:5, sizes = c(2, 3))
 #'
 #' # Can also be used on data frames
-#' vec_chop(mtcars, list(1:3, 4:6))
+#' vec_chop(mtcars, indices = list(1:3, 4:6))
 #'
 #' # If `indices` selects every value in `x` exactly once,
 #' # in any order, then `list_unchop()` inverts `vec_chop()`
 #' x <- c("a", "b", "c", "d")
 #' indices <- list(2, c(3, 1), 4)
-#' vec_chop(x, indices)
-#' list_unchop(vec_chop(x, indices), indices = indices)
+#' vec_chop(x, indices = indices)
+#' list_unchop(vec_chop(x, indices = indices), indices = indices)
 #'
 #' # When unchopping, size 1 elements of `x` are recycled
 #' # to the size of the corresponding index
@@ -91,7 +91,7 @@
 #' # `vec_chop()` and `list_unchop()` in combination with `vec_group_loc()`
 #' ave2 <- function(.x, .by, .f, ...) {
 #'   indices <- vec_group_loc(.by)$loc
-#'   chopped <- vec_chop(.x, indices)
+#'   chopped <- vec_chop(.x, indices = indices)
 #'   out <- lapply(chopped, .f, ...)
 #'   list_unchop(out, indices = indices)
 #' }

--- a/R/type-misc.R
+++ b/R/type-misc.R
@@ -63,7 +63,7 @@ proxy_equal_numeric_version <- function(x, error_call = caller_env()) {
     index <- index + size
   }
 
-  out <- vec_chop(x, indices)
+  out <- vec_chop(x, indices = indices)
 
   n_zeros <- N_COMPONENTS - max
 

--- a/man/vec_chop.Rd
+++ b/man/vec_chop.Rd
@@ -82,7 +82,7 @@ mentioned in error messages as the source of the error. See the
 \value{
 \itemize{
 \item \code{vec_chop()}: A list where each element has the same type as \code{x}. The size
-of the list is equal to \code{vec_size(indices)}, \code{vec_size(sizes)} or
+of the list is equal to \code{vec_size(indices)}, \code{vec_size(sizes)}, or
 \code{vec_size(x)} depending on whether or not \code{indices} or \code{sizes} is provided.
 \item \code{list_unchop()}: A vector of type \code{vec_ptype_common(!!!x)}, or \code{ptype}, if
 specified. The size is computed as \code{vec_size_common(!!!indices)} unless
@@ -105,7 +105,7 @@ If \code{indices} selects every value in \code{x} exactly once, in any order, th
 \code{list_unchop()} is the inverse of \code{vec_chop()} and the following invariant
 holds:
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{list_unchop(vec_chop(x, indices), indices) == x
+\if{html}{\out{<div class="sourceCode">}}\preformatted{list_unchop(vec_chop(x, indices = indices), indices = indices) == x
 }\if{html}{\out{</div>}}
 }
 \section{Dependencies of \code{vec_chop()}}{
@@ -126,18 +126,18 @@ holds:
 vec_chop(1:5)
 
 # These two are equivalent
-vec_chop(1:5, list(1:2, 3:5))
+vec_chop(1:5, indices = list(1:2, 3:5))
 vec_chop(1:5, sizes = c(2, 3))
 
 # Can also be used on data frames
-vec_chop(mtcars, list(1:3, 4:6))
+vec_chop(mtcars, indices = list(1:3, 4:6))
 
 # If `indices` selects every value in `x` exactly once,
 # in any order, then `list_unchop()` inverts `vec_chop()`
 x <- c("a", "b", "c", "d")
 indices <- list(2, c(3, 1), 4)
-vec_chop(x, indices)
-list_unchop(vec_chop(x, indices), indices = indices)
+vec_chop(x, indices = indices)
+list_unchop(vec_chop(x, indices = indices), indices = indices)
 
 # When unchopping, size 1 elements of `x` are recycled
 # to the size of the corresponding index
@@ -152,7 +152,7 @@ list_unchop(lst, indices = list(c(3, 2), c(1, 4)), name_spec = "{outer}_{inner}"
 # `vec_chop()` and `list_unchop()` in combination with `vec_group_loc()`
 ave2 <- function(.x, .by, .f, ...) {
   indices <- vec_group_loc(.by)$loc
-  chopped <- vec_chop(.x, indices)
+  chopped <- vec_chop(.x, indices = indices)
   out <- lapply(chopped, .f, ...)
   list_unchop(out, indices = indices)
 }

--- a/man/vec_chop.Rd
+++ b/man/vec_chop.Rd
@@ -5,7 +5,7 @@
 \alias{list_unchop}
 \title{Chopping}
 \usage{
-vec_chop(x, indices = NULL, ..., sizes = NULL)
+vec_chop(x, ..., indices = NULL, sizes = NULL)
 
 list_unchop(
   x,
@@ -22,6 +22,8 @@ list_unchop(
 \arguments{
 \item{x}{A vector}
 
+\item{...}{These dots are for future extensions and must be empty.}
+
 \item{indices}{For \code{vec_chop()}, a list of positive integer vectors to
 slice \code{x} with, or \code{NULL}. Can't be used if \code{sizes} is already specified.
 If both \code{indices} and \code{sizes} are \code{NULL}, \code{x} is split into its individual
@@ -32,8 +34,6 @@ locations to place elements of \code{x} in. Each element of \code{x} is recycled
 the size of the corresponding index vector. The size of \code{indices} must
 match the size of \code{x}. If \code{NULL}, \code{x} is combined in the order it is
 provided in, which is equivalent to using \code{\link[=vec_c]{vec_c()}}.}
-
-\item{...}{These dots are for future extensions and must be empty.}
 
 \item{sizes}{An integer vector of non-negative sizes representing sequential
 indices to slice \code{x} with, or \code{NULL}. Can't be used if \code{indices} is already

--- a/man/vec_chop.Rd
+++ b/man/vec_chop.Rd
@@ -5,7 +5,7 @@
 \alias{list_unchop}
 \title{Chopping}
 \usage{
-vec_chop(x, indices = NULL)
+vec_chop(x, indices = NULL, ..., sizes = NULL)
 
 list_unchop(
   x,
@@ -23,7 +23,8 @@ list_unchop(
 \item{x}{A vector}
 
 \item{indices}{For \code{vec_chop()}, a list of positive integer vectors to
-slice \code{x} with, or \code{NULL}. If \code{NULL}, \code{x} is split into its individual
+slice \code{x} with, or \code{NULL}. Can't be used if \code{sizes} is already specified.
+If both \code{indices} and \code{sizes} are \code{NULL}, \code{x} is split into its individual
 elements, equivalent to using an \code{indices} of \code{as.list(vec_seq_along(x))}.
 
 For \code{list_unchop()}, a list of positive integer vectors specifying the
@@ -33,6 +34,16 @@ match the size of \code{x}. If \code{NULL}, \code{x} is combined in the order it
 provided in, which is equivalent to using \code{\link[=vec_c]{vec_c()}}.}
 
 \item{...}{These dots are for future extensions and must be empty.}
+
+\item{sizes}{An integer vector of non-negative sizes representing sequential
+indices to slice \code{x} with, or \code{NULL}. Can't be used if \code{indices} is already
+specified.
+
+For example, \code{sizes = c(2, 4)} is equivalent to \code{indices = list(1:2, 3:6)},
+but is typically faster.
+
+\code{sum(sizes)} must be equal to \code{vec_size(x)}, i.e. \code{sizes} must completely
+partition \code{x}, but an individual size is allowed to be \code{0}.}
 
 \item{ptype}{If \code{NULL}, the default, the output type is determined by
 computing the common type across all elements of \code{x}. Alternatively, you
@@ -70,8 +81,9 @@ mentioned in error messages as the source of the error. See the
 }
 \value{
 \itemize{
-\item \code{vec_chop()}: A list of size \code{vec_size(indices)} or, if \code{indices == NULL},
-\code{vec_size(x)}.
+\item \code{vec_chop()}: A list where each element has the same type as \code{x}. The size
+of the list is equal to \code{vec_size(indices)}, \code{vec_size(sizes)} or
+\code{vec_size(x)} depending on whether or not \code{indices} or \code{sizes} is provided.
 \item \code{list_unchop()}: A vector of type \code{vec_ptype_common(!!!x)}, or \code{ptype}, if
 specified. The size is computed as \code{vec_size_common(!!!indices)} unless
 the indices are \code{NULL}, in which case the size is \code{vec_size_common(!!!x)}.
@@ -112,7 +124,12 @@ holds:
 
 \examples{
 vec_chop(1:5)
-vec_chop(1:5, list(1, 1:2))
+
+# These two are equivalent
+vec_chop(1:5, list(1:2, 3:5))
+vec_chop(1:5, sizes = c(2, 3))
+
+# Can also be used on data frames
 vec_chop(mtcars, list(1:3, 4:6))
 
 # If `indices` selects every value in `x` exactly once,
@@ -149,4 +166,20 @@ identical(
   ave2(breaks, wool, mean),
   ave(breaks, wool, FUN = mean)
 )
+
+# If you know your input is sorted and you'd like to split on the groups,
+# `vec_run_sizes()` can be efficiently combined with `sizes`
+df <- data_frame(
+  g = c(2, 5, 5, 6, 6, 6, 6, 8, 9, 9),
+  x = 1:10
+)
+vec_chop(df, sizes = vec_run_sizes(df$g))
+
+# If you have a list of homogeneous vectors, sometimes it can be useful to
+# unchop, apply a function to the flattened vector, and then rechop according
+# to the original indices. This can be done efficiently with `list_sizes()`.
+x <- list(c(1, 2, 1), c(3, 1), 5, double())
+x_flat <- list_unchop(x)
+x_flat <- x_flat + max(x_flat)
+vec_chop(x_flat, sizes = list_sizes(x))
 }

--- a/man/vec_unchop.Rd
+++ b/man/vec_unchop.Rd
@@ -16,7 +16,8 @@ vec_unchop(
 \item{x}{A vector}
 
 \item{indices}{For \code{vec_chop()}, a list of positive integer vectors to
-slice \code{x} with, or \code{NULL}. If \code{NULL}, \code{x} is split into its individual
+slice \code{x} with, or \code{NULL}. Can't be used if \code{sizes} is already specified.
+If both \code{indices} and \code{sizes} are \code{NULL}, \code{x} is split into its individual
 elements, equivalent to using an \code{indices} of \code{as.list(vec_seq_along(x))}.
 
 For \code{list_unchop()}, a list of positive integer vectors specifying the
@@ -52,8 +53,9 @@ See the \link[=name_spec]{name specification topic}.}
 }
 \value{
 \itemize{
-\item \code{vec_chop()}: A list of size \code{vec_size(indices)} or, if \code{indices == NULL},
-\code{vec_size(x)}.
+\item \code{vec_chop()}: A list where each element has the same type as \code{x}. The size
+of the list is equal to \code{vec_size(indices)}, \code{vec_size(sizes)} or
+\code{vec_size(x)} depending on whether or not \code{indices} or \code{sizes} is provided.
 \item \code{list_unchop()}: A vector of type \code{vec_ptype_common(!!!x)}, or \code{ptype}, if
 specified. The size is computed as \code{vec_size_common(!!!indices)} unless
 the indices are \code{NULL}, in which case the size is \code{vec_size_common(!!!x)}.

--- a/man/vec_unchop.Rd
+++ b/man/vec_unchop.Rd
@@ -54,7 +54,7 @@ See the \link[=name_spec]{name specification topic}.}
 \value{
 \itemize{
 \item \code{vec_chop()}: A list where each element has the same type as \code{x}. The size
-of the list is equal to \code{vec_size(indices)}, \code{vec_size(sizes)} or
+of the list is equal to \code{vec_size(indices)}, \code{vec_size(sizes)}, or
 \code{vec_size(x)} depending on whether or not \code{indices} or \code{sizes} is provided.
 \item \code{list_unchop()}: A vector of type \code{vec_ptype_common(!!!x)}, or \code{ptype}, if
 specified. The size is computed as \code{vec_size_common(!!!indices)} unless

--- a/src/bind.c
+++ b/src/bind.c
@@ -304,7 +304,7 @@ r_obj* as_df_row_impl(r_obj* x,
   // Remove names first as they are promoted to data frame column names
   x = KEEP(vec_set_names(x, r_null));
 
-  x = KEEP(vec_chop(x, r_null));
+  x = KEEP(vec_chop_unsafe(x, r_null, r_null));
   r_attrib_poke_names(x, nms);
   x = new_data_frame(x, 1);
 

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -85,7 +85,7 @@ r_obj* list_unchop(r_obj* xs,
     out_size += r_length(r_list_get(indices, i));
   }
 
-  r_obj* locs = KEEP(vec_as_indices(indices, out_size, r_null));
+  r_obj* locs = KEEP(list_as_locations(indices, out_size, r_null));
 
   r_obj* proxy = vec_proxy_recurse(ptype);
   r_keep_loc proxy_pi;
@@ -254,7 +254,7 @@ r_obj* list_unchop_fallback(r_obj* ptype,
     r_list_poke(xs, i, vec_recycle_fallback(x, index_size, p_x_arg, error_call));
   }
 
-  indices = KEEP(vec_as_indices(indices, out_size, r_null));
+  indices = KEEP(list_as_locations(indices, out_size, r_null));
 
   r_obj* out = r_null;
   if (homogeneous) {

--- a/src/callables.c
+++ b/src/callables.c
@@ -19,7 +19,7 @@ SEXP exp_vec_cast(SEXP x, SEXP to) {
 }
 
 SEXP exp_vec_chop(SEXP x, SEXP indices) {
-  return vec_chop(x, indices);
+  return vec_chop_unsafe(x, indices, r_null);
 }
 
 SEXP exp_vec_slice_impl(SEXP x, SEXP subscript) {

--- a/src/decl/slice-chop-decl.h
+++ b/src/decl/slice-chop-decl.h
@@ -1,7 +1,25 @@
-static r_obj* vec_chop_base(r_obj* x, r_obj* indices, struct vctrs_chop_info info);
+static
+r_obj* vec_chop_base(r_obj* x,
+                     struct vctrs_proxy_info info,
+                     struct vctrs_chop_indices* p_indices);
 
-static r_obj* chop(r_obj* x, r_obj* indices, struct vctrs_chop_info info);
-static r_obj* chop_shaped(r_obj* x, r_obj* indices, struct vctrs_chop_info info);
-static r_obj* chop_df(r_obj* x, r_obj* indices, struct vctrs_chop_info info);
-static r_obj* chop_fallback(r_obj* x, r_obj* indices, struct vctrs_chop_info info);
-static r_obj* chop_fallback_shaped(r_obj* x, r_obj* indices, struct vctrs_chop_info info);
+static
+r_obj* chop(r_obj* x,
+            struct vctrs_proxy_info info,
+            struct vctrs_chop_indices* p_indices);
+static
+r_obj* chop_shaped(r_obj* x,
+                   struct vctrs_proxy_info info,
+                   struct vctrs_chop_indices* p_indices);
+static
+r_obj* chop_df(r_obj* x,
+               struct vctrs_proxy_info info,
+               struct vctrs_chop_indices* p_indices);
+
+static
+r_obj* chop_fallback(r_obj* x, struct vctrs_chop_indices* p_indices);
+static
+r_obj* chop_fallback_shaped(r_obj* x, struct vctrs_chop_indices* p_indices);
+
+static
+r_obj* vec_as_chop_sizes(r_obj* sizes, r_ssize size);

--- a/src/globals.c
+++ b/src/globals.c
@@ -78,6 +78,7 @@ void vctrs_init_globals(r_obj* ns) {
   INIT_ARG(value);
   INIT_ARG(x);
   INIT_ARG(indices);
+  INIT_ARG(sizes);
 
   // Lazy args ---------------------------------------------------------
   INIT_LAZY_ARG_2(dot_name_repair, ".name_repair");

--- a/src/globals.h
+++ b/src/globals.h
@@ -53,6 +53,7 @@ struct vec_args {
   struct vctrs_arg* value;
   struct vctrs_arg* x;
   struct vctrs_arg* indices;
+  struct vctrs_arg* sizes;
 };
 
 struct lazy_args {

--- a/src/init.c
+++ b/src/init.c
@@ -50,7 +50,7 @@ extern r_obj* ffi_cast(r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_as_location(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_slice(r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_init(r_obj*, r_obj*, r_obj*);
-extern r_obj* ffi_vec_chop(r_obj*, r_obj*);
+extern r_obj* ffi_vec_chop(r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_list_unchop(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_vec_chop_seq(r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_slice_seq(r_obj*, r_obj*, r_obj*, r_obj*);
@@ -229,7 +229,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"ffi_as_location",                       (DL_FUNC) &ffi_as_location, 8},
   {"ffi_slice",                             (DL_FUNC) &ffi_slice, 3},
   {"ffi_init",                              (DL_FUNC) &ffi_init, 3},
-  {"ffi_vec_chop",                          (DL_FUNC) &ffi_vec_chop, 2},
+  {"ffi_vec_chop",                          (DL_FUNC) &ffi_vec_chop, 3},
   {"ffi_list_unchop",                       (DL_FUNC) &ffi_list_unchop, 6},
   {"ffi_vec_chop_seq",                      (DL_FUNC) &ffi_vec_chop_seq, 4},
   {"ffi_slice_seq",                         (DL_FUNC) &ffi_slice_seq, 4},

--- a/src/slice-chop.h
+++ b/src/slice-chop.h
@@ -3,8 +3,10 @@
 
 #include "vctrs-core.h"
 
+r_obj* vec_chop(r_obj* x, r_obj* indices, r_obj* sizes);
+r_obj* vec_chop_unsafe(r_obj*, r_obj* indices, r_obj* sizes);
 
-r_obj* vec_as_indices(r_obj* indices, r_ssize n, r_obj* names);
+r_obj* list_as_locations(r_obj* indices, r_ssize n, r_obj* names);
 
 
 #endif

--- a/src/split.c
+++ b/src/split.c
@@ -10,7 +10,7 @@ SEXP vec_split(SEXP x, SEXP by) {
 
   SEXP indices = VECTOR_ELT(out, 1);
 
-  SEXP val = vec_chop(x, indices);
+  SEXP val = vec_chop_unsafe(x, indices, r_null);
   SET_VECTOR_ELT(out, 1, val);
 
   SEXP names = PROTECT(Rf_getAttrib(out, R_NamesSymbol));

--- a/src/utils.c
+++ b/src/utils.c
@@ -822,7 +822,7 @@ r_obj* list_pluck(r_obj* xs, r_ssize i) {
 SEXP compact_seq_attrib = NULL;
 
 // p[0] = Start value
-// p[1] = Sequence size. Always >= 1.
+// p[1] = Sequence size. Always >= 0.
 // p[2] = Step size to increment/decrement `start` with
 void init_compact_seq(int* p, R_len_t start, R_len_t size, bool increasing) {
   int step = increasing ? 1 : -1;

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -77,7 +77,6 @@ SEXP vec_proxy_equal(SEXP x);
 SEXP vec_proxy_compare(SEXP x);
 SEXP vec_proxy_order(SEXP x);
 SEXP vec_proxy_unwrap(SEXP x);
-r_obj* vec_chop(r_obj* x, r_obj* indices);
 SEXP vec_slice_shaped(enum vctrs_type type, SEXP x, SEXP index);
 bool vec_requires_fallback(SEXP x, struct vctrs_proxy_info info);
 r_obj* vec_ptype(r_obj* x, struct vctrs_arg* x_arg, struct r_lazy call);

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -256,13 +256,13 @@
       })
       with_memory_prof(list_unchop(make_list_of(1000)))
     Output
-      [1] 111KB
+      [1] 103KB
     Code
       with_memory_prof(list_unchop(make_list_of(2000)))
     Output
-      [1] 220KB
+      [1] 205KB
     Code
       with_memory_prof(list_unchop(make_list_of(4000)))
     Output
-      [1] 439KB
+      [1] 408KB
 

--- a/tests/testthat/_snaps/slice-chop.md
+++ b/tests/testthat/_snaps/slice-chop.md
@@ -222,12 +222,14 @@
 # list_unchop() can repair names quietly
 
     Code
-      res <- list_unchop(vec_chop(x, indices), indices = indices, name_repair = "unique_quiet")
+      res <- list_unchop(vec_chop(x, indices = indices), indices = indices,
+      name_repair = "unique_quiet")
 
 ---
 
     Code
-      res <- list_unchop(vec_chop(x, indices), indices = indices, name_repair = "universal_quiet")
+      res <- list_unchop(vec_chop(x, indices = indices), indices = indices,
+      name_repair = "universal_quiet")
 
 # list_unchop() errors on unsupported location values
 

--- a/tests/testthat/_snaps/slice-chop.md
+++ b/tests/testthat/_snaps/slice-chop.md
@@ -1,3 +1,82 @@
+# `indices` are validated
+
+    Code
+      vec_chop(1, indices = 1)
+    Condition
+      Error:
+      ! `indices` must be a list of index values, or `NULL`.
+
+---
+
+    Code
+      (expect_error(vec_chop(1, indices = list(1.5)), class = "vctrs_error_subscript_type")
+      )
+    Output
+      <error/vctrs_error_subscript_type>
+      Error:
+      ! Can't subset elements.
+      x Can't convert from <double> to <integer> due to loss of precision.
+
+---
+
+    Code
+      (expect_error(vec_chop(1, indices = list(2)), class = "vctrs_error_subscript_oob")
+      )
+    Output
+      <error/vctrs_error_subscript_oob>
+      Error:
+      ! Can't subset elements past the end.
+      i Location 2 doesn't exist.
+      i There is only 1 element.
+
+# `sizes` are validated
+
+    Code
+      vec_chop("a", sizes = "a")
+    Condition
+      Error:
+      ! Can't convert `sizes` <character> to <integer>.
+
+---
+
+    Code
+      vec_chop("a", sizes = 2)
+    Condition
+      Error:
+      ! `sizes` can't contain sizes larger than 1.
+
+---
+
+    Code
+      vec_chop("a", sizes = -1)
+    Condition
+      Error:
+      ! `sizes` can't contain negative sizes.
+
+---
+
+    Code
+      vec_chop("a", sizes = NA_integer_)
+    Condition
+      Error:
+      ! `sizes` can't contain missing values.
+
+---
+
+    Code
+      vec_chop("a", sizes = c(1, 1))
+    Condition
+      Error:
+      ! `sizes` must sum to size 1, not size 2.
+
+# can't use both `indices` and `sizes`
+
+    Code
+      vec_chop(1, indices = list(1), sizes = 1)
+    Condition
+      Error:
+      ! Can't supply both `indices` and `sizes`.
+
 # `x` must be a list
 
     Code

--- a/tests/testthat/_snaps/slice-chop.md
+++ b/tests/testthat/_snaps/slice-chop.md
@@ -77,6 +77,45 @@
       Error:
       ! Can't supply both `indices` and `sizes`.
 
+# `vec_chop(x, indices)` backwards compatible behavior works
+
+    Code
+      vec_chop(1:2, 1)
+    Condition
+      Error:
+      ! `indices` must be a list of index values, or `NULL`.
+
+---
+
+    Code
+      vec_chop(1, list(1), sizes = 1)
+    Condition
+      Error:
+      ! Can't supply both `indices` and `sizes`.
+
+---
+
+    Code
+      vec_chop(1, list(1), 2)
+    Condition
+      Error in `vec_chop()`:
+      ! `...` must be empty.
+      x Problematic arguments:
+      * ..1 = list(1)
+      * ..2 = 2
+      i Did you forget to name an argument?
+
+---
+
+    Code
+      vec_chop(1, list(1), indices = list(1))
+    Condition
+      Error in `vec_chop()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = list(1)
+      i Did you forget to name an argument?
+
 # `x` must be a list
 
     Code

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -344,6 +344,30 @@ test_that("ALTREP objects always generate materialized chops (#1450)", {
   expect_identical(result, expect)
 })
 
+test_that("`vec_chop(x, indices)` backwards compatible behavior works", {
+  # No issues here
+  expect_identical(
+    vec_chop(1:2, list(1, 2)),
+    vec_chop(1:2, indices = list(1, 2))
+  )
+
+  # Errors still talk about `indices`
+  expect_snapshot(error = TRUE, {
+    vec_chop(1:2, 1)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_chop(1, list(1), sizes = 1)
+  })
+
+  # These cases aren't allowed because they weren't possible previously either
+  expect_snapshot(error = TRUE, {
+    vec_chop(1, list(1), 2)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_chop(1, list(1), indices = list(1))
+  })
+})
+
 # vec_chop + compact_seq --------------------------------------------------
 
 # `start` is 0-based

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -204,21 +204,21 @@ test_that("`sizes` allows `0`", {
 })
 
 test_that("size 0 `indices` list is allowed", {
-  expect_equal(vec_chop(1, list()), list())
+  expect_equal(vec_chop(1, indices = list()), list())
 })
 
 test_that("individual index values of size 0 are allowed", {
-  expect_equal(vec_chop(1, list(integer())), list(numeric()))
+  expect_equal(vec_chop(1, indices = list(integer())), list(numeric()))
 
   df <- data.frame(a = 1, b = "1")
-  expect_equal(vec_chop(df, list(integer())), list(vec_ptype(df)))
+  expect_equal(vec_chop(df, indices = list(integer())), list(vec_ptype(df)))
 })
 
 test_that("individual index values of `NULL` are allowed", {
-  expect_equal(vec_chop(1, list(NULL)), list(numeric()))
+  expect_equal(vec_chop(1, indices = list(NULL)), list(numeric()))
 
   df <- data.frame(a = 1, b = "1")
-  expect_equal(vec_chop(df, list(NULL)), list(vec_ptype(df)))
+  expect_equal(vec_chop(df, indices = list(NULL)), list(vec_ptype(df)))
 })
 
 test_that("data frame row names are kept when `indices` or `sizes` are used", {
@@ -256,7 +256,7 @@ test_that("vec_chop(<array>, indices/sizes =) can be equivalent to the default",
   x <- array(1:8, c(2, 2, 2))
 
   indices <- as.list(vec_seq_along(x))
-  expect_equal(vec_chop(x, indices), vec_chop(x))
+  expect_equal(vec_chop(x, indices = indices), vec_chop(x))
 
   sizes <- vec_rep(1L, times = vec_size(x))
   expect_equal(vec_chop(x, sizes = sizes), vec_chop(x))
@@ -264,13 +264,13 @@ test_that("vec_chop(<array>, indices/sizes =) can be equivalent to the default",
 
 test_that("`indices` cannot use names", {
   x <- set_names(1:3, c("a", "b", "c"))
-  expect_error(vec_chop(x, list("a", c("b", "c"))), class = "vctrs_error_subscript_type")
+  expect_error(vec_chop(x, indices = list("a", c("b", "c"))), class = "vctrs_error_subscript_type")
 
   x <- array(1:4, c(2, 2), dimnames = list(c("r1", "r2")))
-  expect_error(vec_chop(x, list("r1")), class = "vctrs_error_subscript_type")
+  expect_error(vec_chop(x, indices = list("r1")), class = "vctrs_error_subscript_type")
 
   x <- data.frame(x = 1, row.names = "r1")
-  expect_error(vec_chop(x, list("r1")), class = "vctrs_error_subscript_type")
+  expect_error(vec_chop(x, indices = list("r1")), class = "vctrs_error_subscript_type")
 })
 
 test_that("fallback method with `indices` and `sizes` works", {
@@ -727,14 +727,14 @@ test_that("list_unchop() can repair names quietly", {
   x <- c(x = "a", x = "b", x = "c")
   indices <- list(2, c(3, 1))
   expect_snapshot({
-    res <- list_unchop(vec_chop(x, indices), indices = indices, name_repair = "unique_quiet")
+    res <- list_unchop(vec_chop(x, indices = indices), indices = indices, name_repair = "unique_quiet")
   })
   expect_named(res, c("x...1", "x...2", "x...3"))
 
   x <- c("if" = "a", "in" = "b", "for" = "c")
   indices <- list(2, c(3, 1))
   expect_snapshot({
-    res <- list_unchop(vec_chop(x, indices), indices = indices, name_repair = "universal_quiet")
+    res <- list_unchop(vec_chop(x, indices = indices), indices = indices, name_repair = "universal_quiet")
   })
   expect_named(res, c(".if", ".in", ".for"))
 })

--- a/tests/testthat/test-slice-chop.R
+++ b/tests/testthat/test-slice-chop.R
@@ -63,6 +63,10 @@ test_that("vec_chop() keeps data frame row names for data frames with 0 columns 
   out <- vec_chop(x, indices = list(c(2, NA), 3))
   out <- lapply(out, rownames)
   expect_identical(out, list(c("r2", "...2"), "r3"))
+
+  out <- vec_chop(x, sizes = c(1, 2, 0))
+  out <- lapply(out, rownames)
+  expect_identical(out, list("r1", c("r2", "r3"), character()))
 })
 
 test_that("data frames with 0 columns retain the right number of rows (#1722)", {
@@ -76,7 +80,19 @@ test_that("data frames with 0 columns retain the right number of rows (#1722)", 
 
   expect_identical(
     vec_chop(x, indices = list(c(1, 3, 2), c(3, NA))),
-    list(data_frame(.size = 3), data_frame(.size = 2))
+    list(
+      data_frame(.size = 3),
+      data_frame(.size = 2)
+    )
+  )
+
+  expect_identical(
+    vec_chop(x, sizes = c(3, 1, 0)),
+    list(
+      data_frame(.size = 3),
+      data_frame(.size = 1),
+      data_frame(.size = 0)
+    )
   )
 })
 
@@ -106,6 +122,12 @@ test_that("vec_chop() doesn't restore when attributes have already been restored
 
   result <- vec_chop(foobar(NA))[[1]]
   expect_equal(result, structure("dispatched", foo = "bar"))
+
+  result <- vec_chop(foobar(NA), indices = list(1))[[1]]
+  expect_equal(result, structure("dispatched", foo = "bar"))
+
+  result <- vec_chop(foobar(NA), sizes = 1)[[1]]
+  expect_equal(result, structure("dispatched", foo = "bar"))
 })
 
 test_that("vec_chop() does not restore when attributes have not been restored by `[`", {
@@ -116,19 +138,69 @@ test_that("vec_chop() does not restore when attributes have not been restored by
 
   result <- vec_chop(foobar(NA))[[1]]
   expect_equal(result, "dispatched")
+
+  result <- vec_chop(foobar(NA), indices = list(1))[[1]]
+  expect_equal(result, "dispatched")
+
+  result <- vec_chop(foobar(NA), sizes = 1)[[1]]
+  expect_equal(result, "dispatched")
 })
 
 test_that("vec_chop() falls back to `[` for shaped objects with no proxy", {
   x <- foobar(1)
   dim(x) <- c(1, 1)
+
   result <- vec_chop(x)[[1]]
+  expect_equal(result, x)
+
+  result <- vec_chop(x, indices = list(1))[[1]]
+  expect_equal(result, x)
+
+  result <- vec_chop(x, sizes = 1)[[1]]
   expect_equal(result, x)
 })
 
 test_that("`indices` are validated", {
-  expect_error(vec_chop(1, 1), "`indices` must be a list of index values, or `NULL`")
-  expect_error(vec_chop(1, list(1.5)), class = "vctrs_error_subscript_type")
-  expect_error(vec_chop(1, list(2)), class = "vctrs_error_subscript_oob")
+  expect_snapshot(error = TRUE, {
+    vec_chop(1, indices = 1)
+  })
+  expect_snapshot({
+    (expect_error(vec_chop(1, indices = list(1.5)), class = "vctrs_error_subscript_type"))
+  })
+  expect_snapshot({
+    (expect_error(vec_chop(1, indices = list(2)), class = "vctrs_error_subscript_oob"))
+  })
+})
+
+test_that("`sizes` are validated", {
+  expect_snapshot(error = TRUE, {
+    vec_chop("a", sizes = "a")
+  })
+  expect_snapshot(error = TRUE, {
+    vec_chop("a", sizes = 2)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_chop("a", sizes = -1)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_chop("a", sizes = NA_integer_)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_chop("a", sizes = c(1, 1))
+  })
+})
+
+test_that("can't use both `indices` and `sizes`", {
+  expect_snapshot(error = TRUE, {
+    vec_chop(1, indices = list(1), sizes = 1)
+  })
+})
+
+test_that("`sizes` allows `0`", {
+  expect_identical(
+    vec_chop(c("a", "b"), sizes = c(1, 0, 0, 1, 0)),
+    list("a", character(), character(), "b", character())
+  )
 })
 
 test_that("size 0 `indices` list is allowed", {
@@ -142,29 +214,52 @@ test_that("individual index values of size 0 are allowed", {
   expect_equal(vec_chop(df, list(integer())), list(vec_ptype(df)))
 })
 
-test_that("data frame row names are kept when `indices` are used", {
+test_that("individual index values of `NULL` are allowed", {
+  expect_equal(vec_chop(1, list(NULL)), list(numeric()))
+
+  df <- data.frame(a = 1, b = "1")
+  expect_equal(vec_chop(df, list(NULL)), list(vec_ptype(df)))
+})
+
+test_that("data frame row names are kept when `indices` or `sizes` are used", {
   x <- data_frame(x = 1:2, y = c("a", "b"))
   rownames(x) <- c("r1", "r2")
-  result <- lapply(vec_chop(x, list(1, 1:2)), rownames)
+
+  result <- lapply(vec_chop(x, indices = list(1, 1:2)), rownames)
   expect_equal(result, list("r1", c("r1", "r2")))
+
+  result <- lapply(vec_chop(x, sizes = c(1, 0, 1)), rownames)
+  expect_equal(result, list("r1", character(), "r2"))
 })
 
-test_that("vec_chop(<atomic>, indices =) can be equivalent to the default", {
+test_that("vec_chop(<atomic>, indices/sizes =) can be equivalent to the default", {
   x <- 1:5
+
   indices <- as.list(vec_seq_along(x))
-  expect_equal(vec_chop(x, indices), vec_chop(x))
+  expect_equal(vec_chop(x, indices = indices), vec_chop(x))
+
+  sizes <- vec_rep(1L, times = vec_size(x))
+  expect_equal(vec_chop(x, sizes = sizes), vec_chop(x))
 })
 
-test_that("vec_chop(<data.frame>, indices =) can be equivalent to the default", {
+test_that("vec_chop(<data.frame>, indices/sizes =) can be equivalent to the default", {
   x <- data.frame(x = 1:5)
+
   indices <- as.list(vec_seq_along(x))
-  expect_equal(vec_chop(x, indices), vec_chop(x))
+  expect_equal(vec_chop(x, indices = indices), vec_chop(x))
+
+  sizes <- vec_rep(1L, times = vec_size(x))
+  expect_equal(vec_chop(x, sizes = sizes), vec_chop(x))
 })
 
-test_that("vec_chop(<array>, indices =) can be equivalent to the default", {
+test_that("vec_chop(<array>, indices/sizes =) can be equivalent to the default", {
   x <- array(1:8, c(2, 2, 2))
+
   indices <- as.list(vec_seq_along(x))
   expect_equal(vec_chop(x, indices), vec_chop(x))
+
+  sizes <- vec_rep(1L, times = vec_size(x))
+  expect_equal(vec_chop(x, sizes = sizes), vec_chop(x))
 })
 
 test_that("`indices` cannot use names", {
@@ -178,20 +273,30 @@ test_that("`indices` cannot use names", {
   expect_error(vec_chop(x, list("r1")), class = "vctrs_error_subscript_type")
 })
 
-test_that("fallback method with `indices` works", {
+test_that("fallback method with `indices` and `sizes` works", {
   fctr <- factor(c("a", "b"))
+
   indices <- list(1, c(1, 2))
+  sizes <- c(1, 0, 1)
 
   expect_equal(
-    vec_chop(fctr, indices),
+    vec_chop(fctr, indices = indices),
     map(indices, vec_slice, x = fctr)
+  )
+  expect_equal(
+    vec_chop(fctr, sizes = sizes),
+    list(vec_slice(fctr, 1), vec_slice(fctr, 0), vec_slice(fctr, 2))
   )
 })
 
-test_that("vec_chop() falls back to `[` for shaped objects with no proxy when indices are provided", {
+test_that("vec_chop() falls back to `[` for shaped objects with no proxy when `indices` or `sizes` are provided", {
   x <- foobar(1)
   dim(x) <- c(1, 1)
-  result <- vec_chop(x, list(1))[[1]]
+
+  result <- vec_chop(x, indices = list(1))[[1]]
+  expect_equal(result, x)
+
+  result <- vec_chop(x, sizes = 1)[[1]]
   expect_equal(result, x)
 })
 

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -690,7 +690,7 @@ test_that("vec_slice() restores unrestored but named foreign classes", {
 
   expect_identical(vec_slice(x, 1), x)
   expect_identical(vec_chop(x), list(x))
-  expect_identical(vec_chop(x, list(1)), list(x))
+  expect_identical(vec_chop(x, indices = list(1)), list(x))
   expect_identical(vec_ptype(x), foobar(named(dbl())))
   expect_identical(vec_ptype(x), foobar(named(dbl())))
   expect_identical(vec_ptype_common(x, x), foobar(named(dbl())))

--- a/tests/testthat/test-type-integer64.R
+++ b/tests/testthat/test-type-integer64.R
@@ -116,7 +116,7 @@ test_that("can chop integer64 objects with `NA_integer_` indices", {
     bit64::as.integer64(1)
   )
 
-  expect_identical(vec_chop(x, idx), expect)
+  expect_identical(vec_chop(x, indices = idx), expect)
 
   dim(x) <- c(4, 2)
   expect <- list(
@@ -126,7 +126,7 @@ test_that("can chop integer64 objects with `NA_integer_` indices", {
   dim(expect[[1]]) <- c(1, 2)
   dim(expect[[2]]) <- c(1, 2)
 
-  expect_identical(vec_chop(x, idx), expect)
+  expect_identical(vec_chop(x, indices = idx), expect)
 
   dim(x) <- c(2, 2, 2)
   expect <- list(
@@ -136,7 +136,7 @@ test_that("can chop integer64 objects with `NA_integer_` indices", {
   dim(expect[[1]]) <- c(1, 2, 2)
   dim(expect[[2]]) <- c(1, 2, 2)
 
-  expect_identical(vec_chop(x, idx), expect)
+  expect_identical(vec_chop(x, indices = idx), expect)
 })
 
 test_that("equality proxy converts atomic input to data frames of doubles", {


### PR DESCRIPTION
Closes https://github.com/r-lib/vctrs/issues/1598
Closes https://github.com/r-lib/vctrs/issues/1210

This PR implements a new `sizes` argument to `vec_chop()`, with the following specs:
- `sizes` must be an integer vector containing only non-negative sizes (`0` is ok, but `-1` and `NA` are not)
- `sizes` must sum to `vec_size(x)`
- `sizes` can't be used alongside `indices`

`sizes` allows us to efficiently chop a vector using the results of either `vec_run_sizes()` or `list_sizes()`. It is typically faster than chopping with locations from `vec_group_loc()` if you know the input is ordered (or already grouped).

```r
set.seed(123)

x <- sample(1e5, 1e6, replace = TRUE)
x <- sort(x)

head(x, n = 20)
#>  [1] 1 1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 3

# Split `x` on its groups
bench::mark(
  sizes = vec_chop(x, sizes = vec_run_sizes(x)),
  indices = vec_chop(x, indices = vec_group_loc(x)$loc)
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 sizes        8.37ms   10.7ms      94.9     2.1MB     9.49
#> 2 indices     52.61ms   53.1ms      18.9    20.2MB    31.4
```

With ^, typically you chop something else, but you use the run sizes of `x` to index it.

It also allows for some neat patterns with `list_sizes()` related to "unchop, do something, rechop" that were clunky before:

``` r
x <- list(c(1, 2, 1), c(3, 1), 5, double())

x_flat <- list_unchop(x)
x_flat <- x_flat + max(x_flat)

vec_chop(x_flat, sizes = list_sizes(x))
#> [[1]]
#> [1] 6 7 6
#> 
#> [[2]]
#> [1] 8 6
#> 
#> [[3]]
#> [1] 10
#> 
#> [[4]]
#> numeric(0)
```

---

I've spent a significant amount of time cleaning up the `vec_chop()` internals. I think they are now much easier to read. In particular, `vctrs_chop_info` was doing way too much:
- `vctrs_chop_info` was managing the `out` container, which it no longer does
- `vctrs_chop_info` was taking and managing the `proxy` info, which it no longer does

I've now narrowly scoped `vctrs_chop_info` to only manage the index generation process, and have renamed it to `vctrs_chop_indices`. It handles 3 different paths depending on which of the following cases we are in:
- `indices = NULL, sizes = NULL`
- `indices != NULL`
- `sizes != NULL`

That seemed to dramatically clean things up. I think if you just skim over the new `slice-chop.c` without the diffs, then that should be apparent.