### PR TITLE
Update rlang C lib

### DIFF
--- a/src/names.c
+++ b/src/names.c
@@ -122,7 +122,7 @@ r_obj* vec_as_custom_names(r_obj* names, const struct name_repair_opts* opts) {
 
   // Don't use vctrs dispatch utils because we match argument positionally
   r_obj* call = KEEP(r_call2(syms_repair, syms_names));
-  r_obj* mask = KEEP(r_new_environment(R_GlobalEnv));
+  r_obj* mask = KEEP(r_alloc_empty_environment(R_GlobalEnv));
   r_env_poke(mask, syms_repair, opts->fn);
   r_env_poke(mask, syms_names, names);
   r_obj* out = KEEP(r_eval(call, mask));

--- a/src/order-collate.c
+++ b/src/order-collate.c
@@ -44,7 +44,7 @@ SEXP chr_apply(SEXP x, SEXP chr_proxy_collate) {
   // Don't use vctrs dispatch utils because we match argument positionally
   SEXP call = PROTECT(Rf_lang2(syms_chr_proxy_collate, syms_x));
 
-  SEXP mask = PROTECT(r_new_environment(R_GlobalEnv));
+  SEXP mask = PROTECT(r_alloc_empty_environment(R_GlobalEnv));
   Rf_defineVar(syms_chr_proxy_collate, chr_proxy_collate, mask);
   Rf_defineVar(syms_x, x, mask);
 

--- a/src/rlang-rcc.cpp
+++ b/src/rlang-rcc.cpp
@@ -1,1 +1,0 @@
-#include "rlang/cpp/rlang.cpp"

--- a/src/rlang/attrib.c
+++ b/src/rlang/attrib.c
@@ -78,7 +78,7 @@ r_obj* r_attrs_zap_at(r_obj* attrs, r_obj* node, r_obj* value) {
   return attrs;
 }
 r_obj* r_clone2(r_obj* x) {
-  r_obj* attrs = r_attrib(x);
+  r_obj* attrs = KEEP(r_attrib(x));
 
   // Prevent attributes from being cloned
   r_poke_attrib(x, r_null);
@@ -86,6 +86,7 @@ r_obj* r_clone2(r_obj* x) {
   r_poke_attrib(x, attrs);
   r_poke_attrib(out, attrs);
 
+  FREE(1);
   return out;
 }
 

--- a/src/rlang/c-utils.h
+++ b/src/rlang/c-utils.h
@@ -23,6 +23,26 @@
 void* r_shelter_deref(r_obj* x);
 
 
+// Allow integers up to 2^52, same as R_XLEN_T_MAX when long vector
+// support is enabled
+#define RLANG_MAX_DOUBLE_INT 4503599627370496
+#define RLANG_MIN_DOUBLE_INT -4503599627370496
+
+static inline
+bool r_dbl_is_whole(double x) {
+  if (x > RLANG_MAX_DOUBLE_INT || x < RLANG_MIN_DOUBLE_INT) {
+    return false;
+  }
+
+  // C99 guarantees existence of the int_least_N_t types, even on
+  // machines that don't support arithmetic on width N:
+  if (x != (int_least64_t) x) {
+    return false;
+  }
+
+  return true;
+}
+
 // Adapted from CERT C coding standards
 static inline
 intmax_t r__intmax_add(intmax_t x, intmax_t y) {

--- a/src/rlang/decl/env-decl.h
+++ b/src/rlang/decl/env-decl.h
@@ -2,6 +2,7 @@ r_obj* eval_with_x(r_obj* call, r_obj* x);
 r_obj* eval_with_xy(r_obj* call, r_obj* x, r_obj* y);
 r_obj* eval_with_xyz(r_obj* call, r_obj* x, r_obj* y, r_obj* z);
 
+#if R_VERSION < R_Version(4, 1, 0)
 static
 r_obj* new_env_call;
 
@@ -10,6 +11,7 @@ r_obj* new_env__parent_node;
 
 static
 r_obj* new_env__size_node;
+#endif
 
 static
 r_obj* exists_call;

--- a/src/rlang/env.c
+++ b/src/rlang/env.c
@@ -41,6 +41,7 @@ r_obj* rlang_ns_get(const char* name) {
 
 
 r_obj* r_alloc_environment(r_ssize size, r_obj* parent) {
+#if R_VERSION < R_Version(4, 1, 0)
   parent = parent ? parent : r_envs.empty;
   r_node_poke_car(new_env__parent_node, parent);
 
@@ -53,6 +54,10 @@ r_obj* r_alloc_environment(r_ssize size, r_obj* parent) {
   r_node_poke_car(new_env__parent_node, r_null);
 
   return env;
+#else
+  const int hash = 1;
+  return R_NewEnv(parent, hash, size);
+#endif
 }
 
 
@@ -287,11 +292,13 @@ void r_init_rlang_ns_env(void) {
 }
 
 void r_init_library_env(void) {
+#if R_VERSION < R_Version(4, 1, 0)
   new_env_call = r_parse_eval("as.call(list(new.env, TRUE, NULL, NULL))", r_envs.base);
   r_preserve(new_env_call);
 
   new_env__parent_node = r_node_cddr(new_env_call);
   new_env__size_node = r_node_cdr(new_env__parent_node);
+#endif
 
   env2list_call = r_parse("as.list.environment(x, all.names = TRUE)");
   r_preserve(env2list_call);
@@ -316,6 +323,7 @@ void r_init_library_env(void) {
 r_obj* rlang_ns_env = NULL;
 r_obj* r_methods_ns_env = NULL;
 
+#if R_VERSION < R_Version(4, 1, 0)
 static
 r_obj* new_env_call = NULL;
 
@@ -324,6 +332,7 @@ r_obj* new_env__parent_node = NULL;
 
 static
 r_obj* new_env__size_node = NULL;
+#endif
 
 static
 r_obj* exists_call = NULL;

--- a/src/rlang/env.h
+++ b/src/rlang/env.h
@@ -81,6 +81,15 @@ r_obj* r_base_ns_get(const char* name);
 
 r_obj* r_alloc_environment(r_ssize size, r_obj* parent);
 
+static inline
+r_obj* r_alloc_empty_environment(r_obj* parent) {
+  // Non-hashed environment.
+  // Very fast and useful when you aren't getting/setting from the result.
+  r_obj* env = Rf_allocSExp(R_TYPE_environment);
+  r_env_poke_parent(env, parent);
+  return env;
+}
+
 r_obj* r_env_as_list(r_obj* x);
 r_obj* r_list_as_environment(r_obj* x, r_obj* parent);
 r_obj* r_env_clone(r_obj* env, r_obj* parent);

--- a/src/rlang/globals.c
+++ b/src/rlang/globals.c
@@ -58,6 +58,7 @@ void r_init_library_globals(r_obj* ns) {
 void r_init_library_globals_syms(void) {
   r_syms.abort = r_sym("abort");
   r_syms.arg = r_sym("arg");
+  r_syms.brace = R_BraceSymbol;
   r_syms.brackets = R_BracketSymbol;
   r_syms.brackets2 = R_Bracket2Symbol;
   r_syms.call = r_sym("call");
@@ -88,9 +89,11 @@ void r_init_library_globals_syms(void) {
   r_syms.dot_x = r_sym(".x");
   r_syms.dot_y = r_sym(".y");
   r_syms.function = r_sym("function");
+  r_syms.srcfile = r_sym("srcfile");
   r_syms.srcref = r_sym("srcref");
   r_syms.tilde = r_sym("~");
   r_syms.w = r_sym("w");
+  r_syms.wholeSrcref = r_sym("wholeSrcref");
   r_syms.x = r_sym("x");
   r_syms.y = r_sym("y");
   r_syms.z = r_sym("z");

--- a/src/rlang/globals.h
+++ b/src/rlang/globals.h
@@ -42,6 +42,7 @@ struct r_globals_strs {
 struct r_globals_syms {
   r_obj* abort;
   r_obj* arg;
+  r_obj* brace;
   r_obj* brackets;
   r_obj* brackets2;
   r_obj* call;
@@ -67,6 +68,7 @@ struct r_globals_syms {
   r_obj* options;
   r_obj* colon2;
   r_obj* colon3;
+  r_obj* srcfile;
   r_obj* srcref;
   r_obj* dim;
   r_obj* dim_names;
@@ -76,6 +78,7 @@ struct r_globals_syms {
   r_obj* unbound;
   r_obj* w;
   r_obj* warning;
+  r_obj* wholeSrcref;
   r_obj* x;
   r_obj* y;
   r_obj* z;

--- a/src/rlang/node.c
+++ b/src/rlang/node.c
@@ -28,10 +28,11 @@ r_obj* r_new_pairlist(const struct r_pair* args,
 }
 
 
-// Shallow copy of a node tree
+// Shallow copy of a node tree. Other objects are not cloned.
 r_obj* r_node_tree_clone(r_obj* x) {
-  if (r_typeof(x) != R_TYPE_pairlist) {
-    r_abort("Internal error: Expected node tree for shallow copy");
+  enum r_type type = r_typeof(x);
+  if (type != R_TYPE_pairlist && type != R_TYPE_call) {
+    return x;
   }
 
   x = KEEP(r_clone(x));
@@ -39,7 +40,9 @@ r_obj* r_node_tree_clone(r_obj* x) {
   r_obj* rest = x;
   while (rest != r_null) {
     r_obj* head = r_node_car(rest);
-    if (r_typeof(head) == R_TYPE_pairlist) {
+    enum r_type head_type = r_typeof(head);
+
+    if (head_type == R_TYPE_pairlist || head_type == R_TYPE_call) {
       r_node_poke_car(rest, r_node_tree_clone(head));
     }
     rest = r_node_cdr(rest);

--- a/src/rlang/rlang.c
+++ b/src/rlang/rlang.c
@@ -40,10 +40,16 @@ r_ssize r_arg_as_ssize(r_obj* n, const char* arg) {
     if (r_length(n) != 1) {
       goto invalid;
     }
+
     double out = r_dbl_get(n, 0);
+
     if (out > R_SSIZE_MAX) {
       r_abort("`%s` is too large a number.", arg);
     }
+    if (out != (int_least64_t) out) {
+      r_abort("`%s` must be a whole number, not a decimal number.", arg);
+    }
+
     return (r_ssize) floor(out);
   }
 

--- a/src/rlang/rlang.hpp
+++ b/src/rlang/rlang.hpp
@@ -3,6 +3,9 @@
 
 #include <exception>
 
+#define R_NO_REMAP
+#include <Rinternals.h>
+
 extern "C" {
 #include <rlang.h>
 }

--- a/src/rlang/vec-lgl.c
+++ b/src/rlang/vec-lgl.c
@@ -1,24 +1,25 @@
 #include "rlang.h"
+#include <stdlib.h>
 
 r_ssize r_lgl_sum(r_obj* x, bool na_true) {
   if (r_typeof(x) != R_TYPE_logical) {
     r_abort("Internal error: Excepted logical vector in `r_lgl_sum()`");
   }
 
-  r_ssize n = r_length(x);
+  const r_ssize n = r_length(x);
+  const int* v_x = r_lgl_cbegin(x);
 
+  // This can't overflow since `sum` is necessarily smaller or equal
+  // to the vector length expressed in `r_ssize`
   r_ssize sum = 0;
-  const int* p_x = r_lgl_cbegin(x);
 
-  for (r_ssize i = 0; i < n; ++i) {
-    // This can't overflow since `sum` is necessarily smaller or equal
-    // to the vector length expressed in `r_ssize`.
-    int x_i = p_x[i];
-
-    if (na_true && x_i) {
-      sum += 1;
-    } else if (x_i == 1) {
-      sum += 1;
+  if (na_true) {
+    for (r_ssize i = 0; i < n; ++i) {
+      sum += (bool) v_x[i];
+    }
+  } else {
+    for (r_ssize i = 0; i < n; ++i) {
+      sum += (v_x[i] == 1);
     }
   }
 
@@ -35,60 +36,71 @@ r_obj* r_lgl_which(r_obj* x, bool na_propagate) {
   const r_ssize n = r_length(x);
   const int* v_x = r_lgl_cbegin(x);
 
-  r_obj* names = r_names(x);
-  const bool has_names = names != r_null;
-  r_obj* const* v_names = NULL;
-  if (has_names) {
-    v_names = r_chr_cbegin(names);
-  }
+  const r_ssize out_n = r_lgl_sum(x, na_propagate);
 
-  const r_ssize which_n = r_lgl_sum(x, na_propagate);
-
-  if (which_n > INT_MAX) {
+  if (out_n > INT_MAX) {
     r_stop_internal("Can't fit result in an integer vector.");
   }
 
-  r_obj* which = KEEP(r_alloc_integer(which_n));
-  int* v_which = r_int_begin(which);
+  r_obj* out = KEEP(r_alloc_integer(out_n));
+  int* v_out = r_int_begin(out);
 
-  r_obj* which_names = r_null;
-  if (has_names) {
-    which_names = r_alloc_character(which_n);
-    r_attrib_poke_names(which, which_names);
-  }
-
-  r_ssize j = 0;
+  r_obj* names = r_names(x);
+  const bool has_names = (names != r_null);
 
   if (na_propagate) {
-    for (r_ssize i = 0; i < n; ++i) {
-      const int elt = v_x[i];
-
-      if (elt != 0) {
-        v_which[j] = (elt == r_globals.na_lgl) ? r_globals.na_int : i + 1;
-
-        if (has_names) {
-          r_chr_poke(which_names, j, v_names[i]);
-        }
-
-        ++j;
+    if (has_names) {
+      // Mark `NA` locations with negative location for extracting names later
+      for (r_ssize i = 0, j = 0; i < n && j < out_n; ++i) {
+        const int x_elt = v_x[i];
+        const bool missing = x_elt == r_globals.na_lgl;
+        const int elt = missing * (-i - 1) + !missing * x_elt * (i + 1);
+        v_out[j] = elt;
+        j += (bool) elt;
+      }
+    } else {
+      for (r_ssize i = 0, j = 0; i < n && j < out_n; ++i) {
+        const int x_elt = v_x[i];
+        const bool missing = x_elt == r_globals.na_lgl;
+        const int elt = missing * r_globals.na_int + !missing * x_elt * (i + 1);
+        v_out[j] = elt;
+        j += (bool) elt;
       }
     }
   } else {
-    for (r_ssize i = 0; i < n; ++i) {
-      const int elt = v_x[i];
+    for (r_ssize i = 0, j = 0; i < n && j < out_n; ++i) {
+      const int x_elt = v_x[i];
+      v_out[j] = i + 1;
+      j += (x_elt == 1);
+    }
+  }
 
-      if (elt == 1) {
-        v_which[j] = i + 1;
+  if (has_names) {
+    r_obj* const* v_names = r_chr_cbegin(names);
 
-        if (has_names) {
-          r_chr_poke(which_names, j, v_names[i]);
-        }
+    r_obj* out_names = r_alloc_character(out_n);
+    r_attrib_poke_names(out, out_names);
 
-        ++j;
+    if (na_propagate) {
+      // `v_out` contains negative locations which tells you the location of the
+      // name to extract while also serving as a signal of where `NA`s should go
+      // in the finalized output
+      for (r_ssize i = 0; i < out_n; ++i) {
+        const int loc = v_out[i];
+        const int abs_loc = abs(loc);
+        const bool same = (loc == abs_loc);
+        v_out[i] = same * loc + !same * r_globals.na_int;
+        r_chr_poke(out_names, i, v_names[abs_loc - 1]);
+      }
+    } else {
+      // `v_out` doesn't contain `NA`, so we can use the locations directly
+      for (r_ssize i = 0; i < out_n; ++i) {
+        const int loc = v_out[i] - 1;
+        r_chr_poke(out_names, i, v_names[loc]);
       }
     }
   }
 
   FREE(1);
-  return which;
+  return out;
 }

--- a/src/rlang/vec.h
+++ b/src/rlang/vec.h
@@ -363,7 +363,7 @@ int r_as_int(r_obj* x) {
 static inline
 double r_arg_as_double(r_obj* x, const char* arg) {
   // TODO: Coercion of int and lgl values
-  if (!_r_is_double(x, 1, 1)) {
+  if (!_r_is_double(x, 1, -1)) {
     r_abort("`%s` must be a single double value.", arg);
   }
   return r_dbl_get(x, 0);

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -406,7 +406,7 @@ r_obj* chop_fallback(r_obj* x, struct vctrs_chop_indices* p_indices) {
   // definition to ensure consistent look-up. This is the same logic
   // as in `vctrs_dispatch_n()`, reimplemented here to allow repeated
   // evaluations in a loop.
-  r_obj* env = KEEP(r_new_environment(r_envs.global));
+  r_obj* env = KEEP(r_alloc_empty_environment(r_envs.global));
   r_env_poke(env, syms_x, x);
 
   // Construct call with symbols, not values, for performance.

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -135,7 +135,19 @@ bool list_all_vectors(r_obj* x) {
   if (r_typeof(x) != R_TYPE_list) {
     r_stop_unexpected_type(r_typeof(x));
   }
-  return r_list_all_of(x, &obj_is_vector);
+
+  const r_ssize size = r_length(x);
+  r_obj* const* v_x = r_list_cbegin(x);
+
+  for (r_ssize i = 0; i < size; ++i) {
+    r_obj* elt = v_x[i];
+
+    if (!obj_is_vector(elt)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1179,23 +1179,6 @@ static SEXP new_env_call = NULL;
 static SEXP new_env__parent_node = NULL;
 static SEXP new_env__size_node = NULL;
 
-#if 0
-SEXP r_new_environment(SEXP parent, R_len_t size) {
-  parent = parent ? parent : R_EmptyEnv;
-  SETCAR(new_env__parent_node, parent);
-
-  size = size ? size : 29;
-  SETCAR(new_env__size_node, Rf_ScalarInteger(size));
-
-  SEXP env = Rf_eval(new_env_call, R_BaseEnv);
-
-  // Free for gc
-  SETCAR(new_env__parent_node, R_NilValue);
-
-  return env;
-}
-#endif
-
 // [[ include("utils.h") ]]
 SEXP r_protect(SEXP x) {
   return Rf_lang2(fns_quote, x);

--- a/src/utils.c
+++ b/src/utils.c
@@ -205,7 +205,7 @@ SEXP vctrs_dispatch6(SEXP fn_sym, SEXP fn,
 }
 
 static SEXP vctrs_eval_mask_n_impl(SEXP fn_sym, SEXP fn, SEXP* syms, SEXP* args, SEXP env) {
-  SEXP mask = PROTECT(r_new_environment(env));
+  SEXP mask = PROTECT(r_alloc_empty_environment(env));
 
   if (fn_sym != R_NilValue) {
     Rf_defineVar(fn_sym, fn, mask);

--- a/src/utils.h
+++ b/src/utils.h
@@ -256,13 +256,6 @@ SEXP r_new_list(R_len_t n) {
   return Rf_allocVector(VECSXP, n);
 }
 
-static inline
-SEXP r_new_environment(SEXP parent) {
-  SEXP env = Rf_allocSExp(ENVSXP);
-  SET_ENCLOS(env, parent);
-  return env;
-}
-
 SEXP r_protect(SEXP x);
 bool r_is_number(SEXP x);
 bool r_is_positive_number(SEXP x);

--- a/tests/testthat/_snaps/assert.md
+++ b/tests/testthat/_snaps/assert.md
@@ -280,10 +280,9 @@
 
     Code
       vec_check_size(1, size = 1.5)
-      abort("`vec_check_size()` should error for us")
     Condition
-      Error:
-      ! `vec_check_size()` should error for us
+      Error in `vec_check_size()`:
+      ! `size` must be a whole number, not a decimal number.
 
 # list_all_vectors() works
 

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -314,12 +314,8 @@ test_that("vec_check_size() validates `size`", {
   expect_snapshot(error = TRUE, {
     vec_check_size(1, size = c(1L, 2L))
   })
-
-  # TODO: This should be an error, and we want to know when it changes
-  # https://github.com/r-lib/rlang/issues/1562
   expect_snapshot(error = TRUE, {
     vec_check_size(1, size = 1.5)
-    abort("`vec_check_size()` should error for us")
   })
 })
 


### PR DESCRIPTION
- Removed reliance on C++ to build vctrs
- We did use `r_list_all_of()` in 1 place, so I removed that
- Updated snapshot test related to rlang changes
- There was a very old unused `r_new_environment()` implementation in vctrs that is now rlang's `r_alloc_environment()`, so I removed it
- There was an actually used `r_new_environment()` implementation in vctrs that is now rlang's `r_alloc_empty_environment()`, so I updated to that