### PR TITLE
Don't const-qualify parameters in declaration

### DIFF
--- a/src/decl/rep-decl.h
+++ b/src/decl/rep-decl.h
@@ -31,7 +31,7 @@ r_obj* vec_rep_each_uniform(r_obj* x,
 static
 r_obj* vec_rep_each_impl(r_obj* x,
                          r_obj* times,
-                         const r_ssize times_size,
+                         r_ssize times_size,
                          struct r_lazy error_call,
                          struct vctrs_arg* p_times_arg);
 

--- a/src/vctrs.h
+++ b/src/vctrs.h
@@ -199,9 +199,9 @@ SEXP posixlt_as_posixct(SEXP x, SEXP to);
 SEXP posixct_as_posixlt(SEXP x, SEXP to);
 SEXP posixlt_as_posixlt(SEXP x, SEXP to);
 
-SEXP vec_date_restore(SEXP x, SEXP to, const enum vctrs_owned owned);
-SEXP vec_posixct_restore(SEXP x, SEXP to, const enum vctrs_owned owned);
-SEXP vec_posixlt_restore(SEXP x, SEXP to, const enum vctrs_owned owned);
+SEXP vec_date_restore(SEXP x, SEXP to, enum vctrs_owned owned);
+SEXP vec_posixct_restore(SEXP x, SEXP to, enum vctrs_owned owned);
+SEXP vec_posixlt_restore(SEXP x, SEXP to, enum vctrs_owned owned);
 
 SEXP date_datetime_ptype2(SEXP x, SEXP y);
 SEXP datetime_datetime_ptype2(SEXP x, SEXP y);


### PR DESCRIPTION
See https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-const-params-in-decls.html