### PR TITLE
Fix CRAN warning due to S3 conditional registration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* Fixed conditional S3 registration to avoid a CRAN check NOTE that appears in
+  R >=4.3.0 (#1832).
+
 * Fixed tests to maintain compatibility with the next version of waldo (#1829).
 
 # vctrs 0.6.1

--- a/R/cast.R
+++ b/R/cast.R
@@ -240,6 +240,6 @@ is_bare_df <- function(x) {
   inherits_only(x, "data.frame") || inherits_only(x, c("tbl_df", "tbl", "data.frame"))
 }
 
-is_informative_error.vctrs_error_cast_lossy <- function(x, ...) {
+is_informative_error_vctrs_error_cast_lossy <- function(x, ...) {
   FALSE
 }

--- a/R/type-data-frame.R
+++ b/R/type-data-frame.R
@@ -382,7 +382,7 @@ df_lossy_cast <- function(out,
   )
 }
 
-is_informative_error.vctrs_error_cast_lossy_dropped <- function(x, ...) {
+is_informative_error_vctrs_error_cast_lossy_dropped <- function(x, ...) {
   FALSE
 }
 

--- a/R/type-dplyr.R
+++ b/R/type-dplyr.R
@@ -8,7 +8,7 @@ group_intersect <- function(x, new) {
   intersect(dplyr::group_vars(x), names(new))
 }
 
-vec_restore.grouped_df <- function(x, to, ...) {
+vec_restore_grouped_df <- function(x, to, ...) {
   vars <- group_intersect(to, x)
   drop <- dplyr::group_by_drop_default(to)
   dplyr::grouped_df(x, vars, drop = drop)
@@ -17,21 +17,21 @@ vec_restore.grouped_df <- function(x, to, ...) {
 
 # `vec_ptype2()` -----------------------------------------------------
 
-vec_ptype2.grouped_df.grouped_df <- function(x, y, ...) {
+vec_ptype2_grouped_df_grouped_df <- function(x, y, ...) {
   gdf_ptype2(x, y, ...)
 }
 
-vec_ptype2.grouped_df.data.frame <- function(x, y, ...) {
+vec_ptype2_grouped_df_data.frame <- function(x, y, ...) {
   gdf_ptype2(x, y, ...)
 }
-vec_ptype2.data.frame.grouped_df <- function(x, y, ...) {
+vec_ptype2_data.frame_grouped_df <- function(x, y, ...) {
   gdf_ptype2(x, y, ...)
 }
 
-vec_ptype2.grouped_df.tbl_df <- function(x, y, ...) {
+vec_ptype2_grouped_df_tbl_df <- function(x, y, ...) {
   gdf_ptype2(x, y, ...)
 }
-vec_ptype2.tbl_df.grouped_df <- function(x, y, ...) {
+vec_ptype2_tbl_df_grouped_df <- function(x, y, ...) {
   gdf_ptype2(x, y, ...)
 }
 
@@ -50,21 +50,21 @@ gdf_ptype2 <- function(x, y, ...) {
 
 # `vec_cast()` -------------------------------------------------------
 
-vec_cast.grouped_df.grouped_df <- function(x, to, ...) {
+vec_cast_grouped_df_grouped_df <- function(x, to, ...) {
   gdf_cast(x, to, ...)
 }
 
-vec_cast.grouped_df.data.frame <- function(x, to, ...) {
+vec_cast_grouped_df_data.frame <- function(x, to, ...) {
   gdf_cast(x, to, ...)
 }
-vec_cast.data.frame.grouped_df <- function(x, to, ...) {
+vec_cast_data.frame_grouped_df <- function(x, to, ...) {
   df_cast(x, to, ...)
 }
 
-vec_cast.grouped_df.tbl_df <- function(x, to, ...) {
+vec_cast_grouped_df_tbl_df <- function(x, to, ...) {
   gdf_cast(x, to, ...)
 }
-vec_cast.tbl_df.grouped_df <- function(x, to, ...) {
+vec_cast_tbl_df_grouped_df <- function(x, to, ...) {
   tib_cast(x, to, ...)
 }
 
@@ -80,28 +80,28 @@ gdf_cast <- function(x, to, ...) {
 
 ### `rowwise` --------------------------------------------------------
 
-vec_restore.rowwise_df <- function(x, to, ...) {
+vec_restore_rowwise_df <- function(x, to, ...) {
   dplyr::rowwise(x)
 }
 
 
 # `vec_ptype2()` -----------------------------------------------------
 
-vec_ptype2.rowwise_df.rowwise_df <- function(x, y, ...) {
+vec_ptype2_rowwise_df_rowwise_df <- function(x, y, ...) {
   rww_ptype2(x, y, ...)
 }
 
-vec_ptype2.rowwise_df.data.frame <- function(x, y, ...) {
+vec_ptype2_rowwise_df_data.frame <- function(x, y, ...) {
   rww_ptype2(x, y, ...)
 }
-vec_ptype2.data.frame.rowwise_df <- function(x, y, ...) {
+vec_ptype2_data.frame_rowwise_df <- function(x, y, ...) {
   rww_ptype2(x, y, ...)
 }
 
-vec_ptype2.rowwise_df.tbl_df <- function(x, y, ...) {
+vec_ptype2_rowwise_df_tbl_df <- function(x, y, ...) {
   rww_ptype2(x, y, ...)
 }
-vec_ptype2.tbl_df.rowwise_df <- function(x, y, ...) {
+vec_ptype2_tbl_df_rowwise_df <- function(x, y, ...) {
   rww_ptype2(x, y, ...)
 }
 
@@ -112,21 +112,21 @@ rww_ptype2 <- function(x, y, ...) {
 
 # `vec_cast()` -------------------------------------------------------
 
-vec_cast.rowwise_df.rowwise_df <- function(x, to, ...) {
+vec_cast_rowwise_df_rowwise_df <- function(x, to, ...) {
   rww_cast(x, to, ...)
 }
 
-vec_cast.rowwise_df.data.frame <- function(x, to, ...) {
+vec_cast_rowwise_df_data.frame <- function(x, to, ...) {
   rww_cast(x, to, ...)
 }
-vec_cast.data.frame.rowwise_df <- function(x, to, ...) {
+vec_cast_data.frame_rowwise_df <- function(x, to, ...) {
   df_cast(x, to, ...)
 }
 
-vec_cast.rowwise_df.tbl_df <- function(x, to, ...) {
+vec_cast_rowwise_df_tbl_df <- function(x, to, ...) {
   rww_cast(x, to, ...)
 }
-vec_cast.tbl_df.rowwise_df <- function(x, to, ...) {
+vec_cast_tbl_df_rowwise_df <- function(x, to, ...) {
   tib_cast(x, to, ...)
 }
 

--- a/R/type-sf.R
+++ b/R/type-sf.R
@@ -17,11 +17,11 @@ sf_env = env()
 local(envir = sf_env, {
 
 # Registered at load-time (same for all other methods)
-vec_proxy.sf = function(x, ...) {
+vec_proxy_sf = function(x, ...) {
 	x
 }
 
-vec_restore.sf = function(x, to, ...) {
+vec_restore_sf = function(x, to, ...) {
 	sfc_name = attr(to, "sf_column")
 	crs = st_crs(to)
 	prec = st_precision(to)
@@ -76,22 +76,22 @@ sf_ptype2 = function(x, y, ...) {
 	)
 }
 
-vec_ptype2.sf.sf = function(x, y, ...) {
+vec_ptype2_sf_sf = function(x, y, ...) {
 	sf_ptype2(x, y, ...)
 }
-vec_ptype2.sf.data.frame = function(x, y, ...) {
+vec_ptype2_sf_data.frame = function(x, y, ...) {
 	sf_ptype2(x, y, ...)
 }
-vec_ptype2.data.frame.sf = function(x, y, ...) {
+vec_ptype2_data.frame_sf = function(x, y, ...) {
 	sf_ptype2(x, y, ...)
 }
 
 # Maybe we should not have these methods, but they are currently
 # required to avoid the base-df fallback
-vec_ptype2.sf.tbl_df = function(x, y, ...) {
+vec_ptype2_sf_tbl_df = function(x, y, ...) {
 	new_data_frame(sf_ptype2(x, y, ...))
 }
-vec_ptype2.tbl_df.sf = function(x, y, ...) {
+vec_ptype2_tbl_df_sf = function(x, y, ...) {
 	new_data_frame(sf_ptype2(x, y, ...))
 }
 
@@ -118,17 +118,17 @@ sf_cast = function(x, to, ...) {
 	)
 }
 
-vec_cast.sf.sf = function(x, to, ...) {
+vec_cast_sf_sf = function(x, to, ...) {
 	sf_cast(x, to, ...)
 }
-vec_cast.sf.data.frame = function(x, to, ...) {
+vec_cast_sf_data.frame = function(x, to, ...) {
 	sf_cast(x, to, ...)
 }
-vec_cast.data.frame.sf = function(x, to, ...) {
+vec_cast_data.frame_sf = function(x, to, ...) {
 	df_cast(x, to, ...)
 }
 
-vec_proxy_order.sfc <- function(x, ...) {
+vec_proxy_order_sfc <- function(x, ...) {
   # These are list columns, so they need to use the order-by-appearance proxy
   # that is defined by `vec_proxy_order.list()`
   x <- unstructure(x)

--- a/R/type-tibble.R
+++ b/R/type-tibble.R
@@ -40,22 +40,22 @@ df_as_tibble <- function(df) {
 
 # Conditionally registered in .onLoad()
 
-vec_ptype2.tbl_df.tbl_df <- function(x, y, ...) {
+vec_ptype2_tbl_df_tbl_df <- function(x, y, ...) {
   vec_ptype2_dispatch_native(x, y, ...)
 }
-vec_ptype2.tbl_df.data.frame <- function(x, y, ...) {
+vec_ptype2_tbl_df_data.frame <- function(x, y, ...) {
   vec_ptype2_dispatch_native(x, y, ...)
 }
-vec_ptype2.data.frame.tbl_df <- function(x, y, ...) {
+vec_ptype2_data.frame_tbl_df <- function(x, y, ...) {
   vec_ptype2_dispatch_native(x, y, ...)
 }
 
-vec_cast.tbl_df.tbl_df <- function(x, to, ...) {
+vec_cast_tbl_df_tbl_df <- function(x, to, ...) {
   vec_cast_dispatch_native(x, to, ...)
 }
-vec_cast.data.frame.tbl_df <- function(x, to, ...) {
+vec_cast_data.frame_tbl_df <- function(x, to, ...) {
   vec_cast_dispatch_native(x, to, ...)
 }
-vec_cast.tbl_df.data.frame <- function(x, to, ...) {
+vec_cast_tbl_df_data.frame <- function(x, to, ...) {
   vec_cast_dispatch_native(x, to, ...)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -7,8 +7,8 @@
   run_on_load()
 
   on_package_load("testthat", {
-    s3_register("testthat::is_informative_error", "vctrs_error_cast_lossy", is_informative_error.vctrs_error_cast_lossy)
-    s3_register("testthat::is_informative_error", "vctrs_error_cast_lossy_dropped", is_informative_error.vctrs_error_cast_lossy_dropped)
+    s3_register("testthat::is_informative_error", "vctrs_error_cast_lossy", is_informative_error_vctrs_error_cast_lossy)
+    s3_register("testthat::is_informative_error", "vctrs_error_cast_lossy_dropped", is_informative_error_vctrs_error_cast_lossy_dropped)
   })
 
   s3_register("generics::as.factor", "vctrs_vctr")
@@ -18,57 +18,57 @@
   # Remove once tibble has implemented the methods
   on_package_load("tibble", {
     if (!env_has(ns_env("tibble"), "vec_ptype2.tbl_df.tbl_df")) {
-      s3_register("vctrs::vec_ptype2", "tbl_df.tbl_df", vec_ptype2.tbl_df.tbl_df)
-      s3_register("vctrs::vec_ptype2", "tbl_df.data.frame", vec_ptype2.tbl_df.data.frame)
-      s3_register("vctrs::vec_ptype2", "data.frame.tbl_df", vec_ptype2.data.frame.tbl_df)
+      s3_register("vctrs::vec_ptype2", "tbl_df.tbl_df", vec_ptype2_tbl_df_tbl_df)
+      s3_register("vctrs::vec_ptype2", "tbl_df.data.frame", vec_ptype2_tbl_df_data.frame)
+      s3_register("vctrs::vec_ptype2", "data.frame.tbl_df", vec_ptype2_data.frame_tbl_df)
     }
 
     if (!env_has(ns_env("tibble"), "vec_cast.tbl_df.tbl_df")) {
-      s3_register("vctrs::vec_cast", "tbl_df.tbl_df", vec_cast.tbl_df.tbl_df)
-      s3_register("vctrs::vec_cast", "tbl_df.data.frame", vec_cast.tbl_df.data.frame)
-      s3_register("vctrs::vec_cast", "data.frame.tbl_df", vec_cast.data.frame.tbl_df)
+      s3_register("vctrs::vec_cast", "tbl_df.tbl_df", vec_cast_tbl_df_tbl_df)
+      s3_register("vctrs::vec_cast", "tbl_df.data.frame", vec_cast_tbl_df_data.frame)
+      s3_register("vctrs::vec_cast", "data.frame.tbl_df", vec_cast_data.frame_tbl_df)
     }
   })
 
   on_package_load("dplyr", {
     if (!env_has(ns_env("dplyr"), "vec_restore.grouped_df")) {
-      s3_register("vctrs::vec_restore", "grouped_df", vec_restore.grouped_df)
+      s3_register("vctrs::vec_restore", "grouped_df", vec_restore_grouped_df)
     }
 
     if (!env_has(ns_env("dplyr"), "vec_ptype2.grouped_df.grouped_df")) {
-      s3_register("vctrs::vec_ptype2", "grouped_df.grouped_df", vec_ptype2.grouped_df.grouped_df)
-      s3_register("vctrs::vec_ptype2", "grouped_df.data.frame", vec_ptype2.grouped_df.data.frame)
-      s3_register("vctrs::vec_ptype2", "grouped_df.tbl_df", vec_ptype2.grouped_df.tbl_df)
-      s3_register("vctrs::vec_ptype2", "data.frame.grouped_df", vec_ptype2.data.frame.grouped_df)
-      s3_register("vctrs::vec_ptype2", "tbl_df.grouped_df", vec_ptype2.tbl_df.grouped_df)
+      s3_register("vctrs::vec_ptype2", "grouped_df.grouped_df", vec_ptype2_grouped_df_grouped_df)
+      s3_register("vctrs::vec_ptype2", "grouped_df.data.frame", vec_ptype2_grouped_df_data.frame)
+      s3_register("vctrs::vec_ptype2", "grouped_df.tbl_df", vec_ptype2_grouped_df_tbl_df)
+      s3_register("vctrs::vec_ptype2", "data.frame.grouped_df", vec_ptype2_data.frame_grouped_df)
+      s3_register("vctrs::vec_ptype2", "tbl_df.grouped_df", vec_ptype2_tbl_df_grouped_df)
     }
 
     if (!env_has(ns_env("dplyr"), "vec_cast.grouped_df.grouped_df")) {
-      s3_register("vctrs::vec_cast", "grouped_df.grouped_df", vec_cast.grouped_df.grouped_df)
-      s3_register("vctrs::vec_cast", "grouped_df.data.frame", vec_cast.grouped_df.data.frame)
-      s3_register("vctrs::vec_cast", "grouped_df.tbl_df", vec_cast.grouped_df.tbl_df)
-      s3_register("vctrs::vec_cast", "data.frame.grouped_df", vec_cast.data.frame.grouped_df)
-      s3_register("vctrs::vec_cast", "tbl_df.grouped_df", vec_cast.tbl_df.grouped_df)
+      s3_register("vctrs::vec_cast", "grouped_df.grouped_df", vec_cast_grouped_df_grouped_df)
+      s3_register("vctrs::vec_cast", "grouped_df.data.frame", vec_cast_grouped_df_data.frame)
+      s3_register("vctrs::vec_cast", "grouped_df.tbl_df", vec_cast_grouped_df_tbl_df)
+      s3_register("vctrs::vec_cast", "data.frame.grouped_df", vec_cast_data.frame_grouped_df)
+      s3_register("vctrs::vec_cast", "tbl_df.grouped_df", vec_cast_tbl_df_grouped_df)
     }
 
     if (!env_has(ns_env("dplyr"), "vec_restore.rowwise_df")) {
-      s3_register("vctrs::vec_restore", "rowwise_df", vec_restore.rowwise_df)
+      s3_register("vctrs::vec_restore", "rowwise_df", vec_restore_rowwise_df)
     }
 
     if (!env_has(ns_env("dplyr"), "vec_ptype2.rowwise_df.rowwise_df")) {
-      s3_register("vctrs::vec_ptype2", "rowwise_df.rowwise_df", vec_ptype2.rowwise_df.rowwise_df)
-      s3_register("vctrs::vec_ptype2", "rowwise_df.data.frame", vec_ptype2.rowwise_df.data.frame)
-      s3_register("vctrs::vec_ptype2", "rowwise_df.tbl_df", vec_ptype2.rowwise_df.tbl_df)
-      s3_register("vctrs::vec_ptype2", "data.frame.rowwise_df", vec_ptype2.data.frame.rowwise_df)
-      s3_register("vctrs::vec_ptype2", "tbl_df.rowwise_df", vec_ptype2.tbl_df.rowwise_df)
+      s3_register("vctrs::vec_ptype2", "rowwise_df.rowwise_df", vec_ptype2_rowwise_df_rowwise_df)
+      s3_register("vctrs::vec_ptype2", "rowwise_df.data.frame", vec_ptype2_rowwise_df_data.frame)
+      s3_register("vctrs::vec_ptype2", "rowwise_df.tbl_df", vec_ptype2_rowwise_df_tbl_df)
+      s3_register("vctrs::vec_ptype2", "data.frame.rowwise_df", vec_ptype2_data.frame_rowwise_df)
+      s3_register("vctrs::vec_ptype2", "tbl_df.rowwise_df", vec_ptype2_tbl_df_rowwise_df)
     }
 
     if (!env_has(ns_env("dplyr"), "vec_cast.rowwise_df.rowwise_df")) {
-      s3_register("vctrs::vec_cast", "rowwise_df.rowwise_df", vec_cast.rowwise_df.rowwise_df)
-      s3_register("vctrs::vec_cast", "rowwise_df.data.frame", vec_cast.rowwise_df.data.frame)
-      s3_register("vctrs::vec_cast", "rowwise_df.tbl_df", vec_cast.rowwise_df.tbl_df)
-      s3_register("vctrs::vec_cast", "data.frame.rowwise_df", vec_cast.data.frame.rowwise_df)
-      s3_register("vctrs::vec_cast", "tbl_df.rowwise_df", vec_cast.tbl_df.rowwise_df)
+      s3_register("vctrs::vec_cast", "rowwise_df.rowwise_df", vec_cast_rowwise_df_rowwise_df)
+      s3_register("vctrs::vec_cast", "rowwise_df.data.frame", vec_cast_rowwise_df_data.frame)
+      s3_register("vctrs::vec_cast", "rowwise_df.tbl_df", vec_cast_rowwise_df_tbl_df)
+      s3_register("vctrs::vec_cast", "data.frame.rowwise_df", vec_cast_data.frame_rowwise_df)
+      s3_register("vctrs::vec_cast", "tbl_df.rowwise_df", vec_cast_tbl_df_rowwise_df)
     }
   })
 
@@ -76,21 +76,21 @@
     import_from("sf", sf_deps, env = sf_env)
 
     if (!env_has(ns_env("sf"), "vec_restore.sf")) {
-      s3_register("vctrs::vec_proxy", "sf", vec_proxy.sf)
-      s3_register("vctrs::vec_restore", "sf", vec_restore.sf)
+      s3_register("vctrs::vec_proxy", "sf", vec_proxy_sf)
+      s3_register("vctrs::vec_restore", "sf", vec_restore_sf)
     }
     if (!env_has(ns_env("sf"), "vec_ptype2.sf.sf")) {
-      s3_register("vctrs::vec_ptype2", "sf.sf", vec_ptype2.sf.sf)
-      s3_register("vctrs::vec_ptype2", "sf.data.frame", vec_ptype2.sf.data.frame)
-      s3_register("vctrs::vec_ptype2", "data.frame.sf", vec_ptype2.data.frame.sf)
-      s3_register("vctrs::vec_ptype2", "sf.tbl_df", vec_ptype2.sf.tbl_df)
-      s3_register("vctrs::vec_ptype2", "tbl_df.sf", vec_ptype2.tbl_df.sf)
-      s3_register("vctrs::vec_cast", "sf.sf", vec_cast.sf.sf)
-      s3_register("vctrs::vec_cast", "sf.data.frame", vec_cast.sf.data.frame)
-      s3_register("vctrs::vec_cast", "data.frame.sf", vec_cast.data.frame.sf)
+      s3_register("vctrs::vec_ptype2", "sf.sf", vec_ptype2_sf_sf)
+      s3_register("vctrs::vec_ptype2", "sf.data.frame", vec_ptype2_sf_data.frame)
+      s3_register("vctrs::vec_ptype2", "data.frame.sf", vec_ptype2_data.frame_sf)
+      s3_register("vctrs::vec_ptype2", "sf.tbl_df", vec_ptype2_sf_tbl_df)
+      s3_register("vctrs::vec_ptype2", "tbl_df.sf", vec_ptype2_tbl_df_sf)
+      s3_register("vctrs::vec_cast", "sf.sf", vec_cast_sf_sf)
+      s3_register("vctrs::vec_cast", "sf.data.frame", vec_cast_sf_data.frame)
+      s3_register("vctrs::vec_cast", "data.frame.sf", vec_cast_data.frame_sf)
     }
     if (!env_has(ns_env("sf"), "vec_proxy_order.sfc")) {
-      s3_register("vctrs::vec_proxy_order", "sfc", vec_proxy_order.sfc)
+      s3_register("vctrs::vec_proxy_order", "sfc", vec_proxy_order_sfc)
     }
   })
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -7,8 +7,8 @@
   run_on_load()
 
   on_package_load("testthat", {
-    s3_register("testthat::is_informative_error", "vctrs_error_cast_lossy")
-    s3_register("testthat::is_informative_error", "vctrs_error_cast_lossy_dropped")
+    s3_register("testthat::is_informative_error", "vctrs_error_cast_lossy", is_informative_error.vctrs_error_cast_lossy)
+    s3_register("testthat::is_informative_error", "vctrs_error_cast_lossy_dropped", is_informative_error.vctrs_error_cast_lossy_dropped)
   })
 
   s3_register("generics::as.factor", "vctrs_vctr")
@@ -18,57 +18,57 @@
   # Remove once tibble has implemented the methods
   on_package_load("tibble", {
     if (!env_has(ns_env("tibble"), "vec_ptype2.tbl_df.tbl_df")) {
-      s3_register("vctrs::vec_ptype2", "tbl_df.tbl_df")
-      s3_register("vctrs::vec_ptype2", "tbl_df.data.frame")
-      s3_register("vctrs::vec_ptype2", "data.frame.tbl_df")
+      s3_register("vctrs::vec_ptype2", "tbl_df.tbl_df", vec_ptype2.tbl_df.tbl_df)
+      s3_register("vctrs::vec_ptype2", "tbl_df.data.frame", vec_ptype2.tbl_df.data.frame)
+      s3_register("vctrs::vec_ptype2", "data.frame.tbl_df", vec_ptype2.data.frame.tbl_df)
     }
 
     if (!env_has(ns_env("tibble"), "vec_cast.tbl_df.tbl_df")) {
-      s3_register("vctrs::vec_cast", "tbl_df.tbl_df")
-      s3_register("vctrs::vec_cast", "tbl_df.data.frame")
-      s3_register("vctrs::vec_cast", "data.frame.tbl_df")
+      s3_register("vctrs::vec_cast", "tbl_df.tbl_df", vec_cast.tbl_df.tbl_df)
+      s3_register("vctrs::vec_cast", "tbl_df.data.frame", vec_cast.tbl_df.data.frame)
+      s3_register("vctrs::vec_cast", "data.frame.tbl_df", vec_cast.data.frame.tbl_df)
     }
   })
 
   on_package_load("dplyr", {
     if (!env_has(ns_env("dplyr"), "vec_restore.grouped_df")) {
-      s3_register("vctrs::vec_restore", "grouped_df")
+      s3_register("vctrs::vec_restore", "grouped_df", vec_restore.grouped_df)
     }
 
     if (!env_has(ns_env("dplyr"), "vec_ptype2.grouped_df.grouped_df")) {
-      s3_register("vctrs::vec_ptype2", "grouped_df.grouped_df")
-      s3_register("vctrs::vec_ptype2", "grouped_df.data.frame")
-      s3_register("vctrs::vec_ptype2", "grouped_df.tbl_df")
-      s3_register("vctrs::vec_ptype2", "data.frame.grouped_df")
-      s3_register("vctrs::vec_ptype2", "tbl_df.grouped_df")
+      s3_register("vctrs::vec_ptype2", "grouped_df.grouped_df", vec_ptype2.grouped_df.grouped_df)
+      s3_register("vctrs::vec_ptype2", "grouped_df.data.frame", vec_ptype2.grouped_df.data.frame)
+      s3_register("vctrs::vec_ptype2", "grouped_df.tbl_df", vec_ptype2.grouped_df.tbl_df)
+      s3_register("vctrs::vec_ptype2", "data.frame.grouped_df", vec_ptype2.data.frame.grouped_df)
+      s3_register("vctrs::vec_ptype2", "tbl_df.grouped_df", vec_ptype2.tbl_df.grouped_df)
     }
 
     if (!env_has(ns_env("dplyr"), "vec_cast.grouped_df.grouped_df")) {
-      s3_register("vctrs::vec_cast", "grouped_df.grouped_df")
-      s3_register("vctrs::vec_cast", "grouped_df.data.frame")
-      s3_register("vctrs::vec_cast", "grouped_df.tbl_df")
-      s3_register("vctrs::vec_cast", "data.frame.grouped_df")
-      s3_register("vctrs::vec_cast", "tbl_df.grouped_df")
+      s3_register("vctrs::vec_cast", "grouped_df.grouped_df", vec_cast.grouped_df.grouped_df)
+      s3_register("vctrs::vec_cast", "grouped_df.data.frame", vec_cast.grouped_df.data.frame)
+      s3_register("vctrs::vec_cast", "grouped_df.tbl_df", vec_cast.grouped_df.tbl_df)
+      s3_register("vctrs::vec_cast", "data.frame.grouped_df", vec_cast.data.frame.grouped_df)
+      s3_register("vctrs::vec_cast", "tbl_df.grouped_df", vec_cast.tbl_df.grouped_df)
     }
 
     if (!env_has(ns_env("dplyr"), "vec_restore.rowwise_df")) {
-      s3_register("vctrs::vec_restore", "rowwise_df")
+      s3_register("vctrs::vec_restore", "rowwise_df", vec_restore.rowwise_df)
     }
 
     if (!env_has(ns_env("dplyr"), "vec_ptype2.rowwise_df.rowwise_df")) {
-      s3_register("vctrs::vec_ptype2", "rowwise_df.rowwise_df")
-      s3_register("vctrs::vec_ptype2", "rowwise_df.data.frame")
-      s3_register("vctrs::vec_ptype2", "rowwise_df.tbl_df")
-      s3_register("vctrs::vec_ptype2", "data.frame.rowwise_df")
-      s3_register("vctrs::vec_ptype2", "tbl_df.rowwise_df")
+      s3_register("vctrs::vec_ptype2", "rowwise_df.rowwise_df", vec_ptype2.rowwise_df.rowwise_df)
+      s3_register("vctrs::vec_ptype2", "rowwise_df.data.frame", vec_ptype2.rowwise_df.data.frame)
+      s3_register("vctrs::vec_ptype2", "rowwise_df.tbl_df", vec_ptype2.rowwise_df.tbl_df)
+      s3_register("vctrs::vec_ptype2", "data.frame.rowwise_df", vec_ptype2.data.frame.rowwise_df)
+      s3_register("vctrs::vec_ptype2", "tbl_df.rowwise_df", vec_ptype2.tbl_df.rowwise_df)
     }
 
     if (!env_has(ns_env("dplyr"), "vec_cast.rowwise_df.rowwise_df")) {
-      s3_register("vctrs::vec_cast", "rowwise_df.rowwise_df")
-      s3_register("vctrs::vec_cast", "rowwise_df.data.frame")
-      s3_register("vctrs::vec_cast", "rowwise_df.tbl_df")
-      s3_register("vctrs::vec_cast", "data.frame.rowwise_df")
-      s3_register("vctrs::vec_cast", "tbl_df.rowwise_df")
+      s3_register("vctrs::vec_cast", "rowwise_df.rowwise_df", vec_cast.rowwise_df.rowwise_df)
+      s3_register("vctrs::vec_cast", "rowwise_df.data.frame", vec_cast.rowwise_df.data.frame)
+      s3_register("vctrs::vec_cast", "rowwise_df.tbl_df", vec_cast.rowwise_df.tbl_df)
+      s3_register("vctrs::vec_cast", "data.frame.rowwise_df", vec_cast.data.frame.rowwise_df)
+      s3_register("vctrs::vec_cast", "tbl_df.rowwise_df", vec_cast.tbl_df.rowwise_df)
     }
   })
 
@@ -76,21 +76,21 @@
     import_from("sf", sf_deps, env = sf_env)
 
     if (!env_has(ns_env("sf"), "vec_restore.sf")) {
-      s3_register("vctrs::vec_proxy", "sf")
-      s3_register("vctrs::vec_restore", "sf")
+      s3_register("vctrs::vec_proxy", "sf", vec_proxy.sf)
+      s3_register("vctrs::vec_restore", "sf", vec_restore.sf)
     }
     if (!env_has(ns_env("sf"), "vec_ptype2.sf.sf")) {
-      s3_register("vctrs::vec_ptype2", "sf.sf")
-      s3_register("vctrs::vec_ptype2", "sf.data.frame")
-      s3_register("vctrs::vec_ptype2", "data.frame.sf")
-      s3_register("vctrs::vec_ptype2", "sf.tbl_df")
-      s3_register("vctrs::vec_ptype2", "tbl_df.sf")
-      s3_register("vctrs::vec_cast", "sf.sf")
-      s3_register("vctrs::vec_cast", "sf.data.frame")
-      s3_register("vctrs::vec_cast", "data.frame.sf")
+      s3_register("vctrs::vec_ptype2", "sf.sf", vec_ptype2.sf.sf)
+      s3_register("vctrs::vec_ptype2", "sf.data.frame", vec_ptype2.sf.data.frame)
+      s3_register("vctrs::vec_ptype2", "data.frame.sf", vec_ptype2.data.frame.sf)
+      s3_register("vctrs::vec_ptype2", "sf.tbl_df", vec_ptype2.sf.tbl_df)
+      s3_register("vctrs::vec_ptype2", "tbl_df.sf", vec_ptype2.tbl_df.sf)
+      s3_register("vctrs::vec_cast", "sf.sf", vec_cast.sf.sf)
+      s3_register("vctrs::vec_cast", "sf.data.frame", vec_cast.sf.data.frame)
+      s3_register("vctrs::vec_cast", "data.frame.sf", vec_cast.data.frame.sf)
     }
     if (!env_has(ns_env("sf"), "vec_proxy_order.sfc")) {
-      s3_register("vctrs::vec_proxy_order", "sfc")
+      s3_register("vctrs::vec_proxy_order", "sfc", vec_proxy_order.sfc)
     }
   })
 


### PR DESCRIPTION
CC @lionel- 

Fixes this NOTE seen in CRAN's checks on R-devel (>=4.3.0 at the time).

```
* checking S3 generic/method consistency ... NOTE
Apparent methods for exported generics not registered:
  vec_cast.data.frame.grouped_df vec_cast.data.frame.rowwise_df
  vec_cast.data.frame.sf vec_cast.data.frame.tbl_df
  vec_cast.grouped_df.data.frame vec_cast.grouped_df.grouped_df
  vec_cast.grouped_df.tbl_df vec_cast.rowwise_df.data.frame
  vec_cast.rowwise_df.rowwise_df vec_cast.rowwise_df.tbl_df
  vec_cast.sf.data.frame vec_cast.sf.sf vec_cast.tbl_df.data.frame
  vec_cast.tbl_df.grouped_df vec_cast.tbl_df.rowwise_df
  vec_cast.tbl_df.tbl_df vec_proxy.sf vec_proxy_order.sfc
  vec_ptype2.data.frame.grouped_df vec_ptype2.data.frame.rowwise_df
  vec_ptype2.data.frame.sf vec_ptype2.data.frame.tbl_df
  vec_ptype2.grouped_df.data.frame vec_ptype2.grouped_df.grouped_df
  vec_ptype2.grouped_df.tbl_df vec_ptype2.rowwise_df.data.frame
  vec_ptype2.rowwise_df.rowwise_df vec_ptype2.rowwise_df.tbl_df
  vec_ptype2.sf.data.frame vec_ptype2.sf.sf vec_ptype2.sf.tbl_df
  vec_ptype2.tbl_df.data.frame vec_ptype2.tbl_df.grouped_df
  vec_ptype2.tbl_df.rowwise_df vec_ptype2.tbl_df.sf
  vec_ptype2.tbl_df.tbl_df vec_restore.grouped_df
  vec_restore.rowwise_df vec_restore.sf
See section 'Registering S3 methods' in the 'Writing R Extensions'
manual.
```

This is due to some rewriting of the S3 generics/method check system:
https://github.com/r-devel/r-svn/commit/d34f52a63b093482da9d0e6eb185a4684964a09b

It only affects methods that we _conditionally_ register which aren't actually registered at vctrs load time. i.e. the dplyr methods are conditionally registered:
- When dplyr is eventually loaded
- If dplyr doesn't already have these methods itself (which it doesn't as of dplyr 1.1.1)

I imagine the CRAN check sees that vctrs is "fully loaded" _but_ it didn't officially register S3 methods for these functions that "look" like S3 methods due to the `.` in their names, and that triggers the note.

Switching from a `.` to an `_` should avoid the NOTE, but also requires manual registration of the method in `s3_register()`.