### PR TITLE
Use alternate `any_multiple_needles` detection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* Fixed a rare `vec_locate_matches()` bug that could occur when using a max/min
+  `filter` (tidyverse/dplyr#6835).
+
 # vctrs 0.6.2
 
 * Fixed conditional S3 registration to avoid a CRAN check NOTE that appears in

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -424,6 +424,16 @@
       ! Each value of `needles` can match at most 1 value from `haystack`.
       x Location 1 of `needles` matches multiple values.
 
+# `relationship` errors when we have >1 size 1 matches across containers (tidyverse/dplyr#6835)
+
+    Code
+      vec_locate_matches(x, y, condition = c("<=", ">="), filter = c("none", "none"),
+      relationship = "one-to-one")
+    Condition
+      Error in `vec_locate_matches()`:
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
+
 # `relationship` errors respect argument tags and error call
 
     Code


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6835

We can't use the simple `loc < size_needles` check to see if we are in the "extra" match section. When a filter is involved, that isn't enough because we could have filtered out a match that occurred before the extra matches, so the extra match could actually be the first one.

However, since we process the `needles` in sequential order (i.e. needles 1 containment group 1, needle 1 containment group 2, needle 2 containment group 1, etc) we can track the previous needles loc in `loc_needles_previous` as a more correct way to see if we've already seen 1 match for that particular `needle`.