### PR TITLE
Unconditionally clone in `df_proxy()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # vctrs (development version)
 
+* Fixed an issue where `vec_set_*()` used with data frames could accidentally
+  return an object with the type of the proxy rather than the type of the
+  original inputs (#1837).
+
 * Fixed a rare `vec_locate_matches()` bug that could occur when using a max/min
   `filter` (tidyverse/dplyr#6835).
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -215,7 +215,10 @@ r_obj* vec_proxy_order_invoke(r_obj* x, r_obj* method) {
 
 static inline
 r_obj* df_proxy(r_obj* x, enum vctrs_proxy_kind kind) {
-  x = KEEP(r_clone_referenced(x));
+  // Always clone to avoid modifying the original object, even if it is one
+  // we freshly created in C, because we often work with both the proxy and the
+  // original object within the same function (#1837)
+  x = KEEP(r_clone(x));
 
   switch (kind) {
   case VCTRS_PROXY_KIND_equal: DF_PROXY(vec_proxy_equal); break;

--- a/tests/testthat/test-set.R
+++ b/tests/testthat/test-set.R
@@ -341,6 +341,20 @@ test_that("works with rcrds", {
 
 # common ------------------------------------------------------------------
 
+test_that("works with package version columns of data frames (#1837)", {
+  package_frame <- function(x) {
+    data_frame(version = package_version(x))
+  }
+
+  x <- package_frame(c("4.0", "2.0"))
+  y <- package_frame(c("1.0", "3.0" ,"4.0"))
+
+  expect_identical(vec_set_intersect(x, y), package_frame("4.0"))
+  expect_identical(vec_set_difference(x, y), package_frame("2.0"))
+  expect_identical(vec_set_union(x, y), package_frame(c("4.0", "2.0", "1.0", "3.0")))
+  expect_identical(vec_set_symmetric_difference(x, y), package_frame(c("2.0", "1.0", "3.0")))
+})
+
 test_that("errors nicely if common type can't be taken", {
   expect_snapshot(error = TRUE, {
     vec_set_intersect(1, "x")


### PR DESCRIPTION
Closes #1837 

I think it was a mistake to _not_ clone in `df_proxy()` if the original input was not referenced. There are cases where we:
- Create a fresh object at the C level (like with `x = vec_cast(x, ptype)` to cast to a common type)
- Proxy that object to get `x_proxy = vec_proxy_equal(x)` and perform some manipulation on the proxy
- Slice the original fresh `x` using information gained from the proxy

This is what is done in `vec_set_*()`. 

When a data frame is supplied as `x`, the current implementation of `df_proxy()` means the `vec_proxy_equal()` step from above modifies `x` directly (because it wasn't referenced), so the last step of slicing `x` ends up slicing and returning a proxy rather than the original object.

---

It doesn't look like the more sensitive functions are affected by this. 

I checked `vec_rbind()` in particular, and it isn't affected because we do `xs <- vec_cast_common(xs)`, which does create fresh `x` elements, but it immediately stores them in a list so `MAYBE_REFERENCED()` was already returning `true` for them.

``` r
library(bench)
library(tidyr)

run(against = c("vctrs", "r-lib/vctrs#1838"), local = FALSE, {
  library(vctrs)
  
  x <- vec_rep(list(data_frame(x = 1)), 1000)
  
  bench::mark(vec_rbind(!!!x))
}) %>% 
  unnest(result)
#> # A tibble: 2 × 14
#>   reference       expression    min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory    
#>   <chr>           <bch:expr> <bch:> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>    
#> 1 vctrs           vec_rbind… 2.34ms 2.55ms      387.    33.2KB     53.5   152    21      393ms <df>   <Rprofmem>
#> 2 r-lib/vctrs#18… vec_rbind… 2.26ms 2.45ms      398.    33.3KB     56.2   156    22      392ms <df>   <Rprofmem>
#> # ℹ 2 more variables: time <list>, gc <list>

run(against = c("vctrs", "r-lib/vctrs#1838"), local = FALSE, {
  library(vctrs)
  
  x <- vec_rep(list(data_frame(x = 1)), 1000)
  
  bench::mark(vec_ptype_common(!!!x))
}) %>% 
  unnest(result)
#> # A tibble: 2 × 14
#>   reference        expression   min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory    
#>   <chr>            <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>    
#> 1 vctrs            vec_ptype… 644µs  718µs     1372.    10.7KB     50.2   601    22      438ms <df>   <Rprofmem>
#> 2 r-lib/vctrs#1838 vec_ptype… 646µs  721µs     1369.    10.7KB     50.2   600    22      438ms <df>   <Rprofmem>
#> # ℹ 2 more variables: time <list>, gc <list>
```