### PR TITLE
Add a class to the `vec_locate_matches()` overflow error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* Added a class to the `vec_locate_matches()` error that is thrown when an
+  overflow would otherwise occur (#1845).
+
 * Fixed an issue with `vec_rank()` and 0-column data frames (#1863).
 
 # vctrs 0.6.3

--- a/R/match.R
+++ b/R/match.R
@@ -356,8 +356,9 @@ compute_nesting_container_info <- function(x, condition) {
 
 # ------------------------------------------------------------------------------
 
-stop_matches <- function(class = NULL, ..., call = caller_env()) {
+stop_matches <- function(message = NULL, class = NULL, ..., call = caller_env()) {
   stop_vctrs(
+    message = message,
     class = c(class, "vctrs_error_matches"),
     ...,
     call = call
@@ -370,6 +371,27 @@ warn_matches <- function(message, class = NULL, ..., call = caller_env()) {
     class = c(class, "vctrs_warning_matches"),
     ...,
     call = call
+  )
+}
+
+# ------------------------------------------------------------------------------
+
+stop_matches_overflow <- function(size, call) {
+  size <- format(size, scientific = FALSE)
+
+  # Pre-generating the message in this case because we want to use
+  # `.internal = TRUE` and that doesn't work with lazy messages
+  message <- c(
+    "Match procedure results in an allocation larger than 2^31-1 elements.",
+    i = glue::glue("Attempted allocation size was {size}.")
+  )
+
+  stop_matches(
+    message = message,
+    class = "vctrs_error_matches_overflow",
+    size = size,
+    call = call,
+    .internal = TRUE
   )
 }
 

--- a/src/decl/match-decl.h
+++ b/src/decl/match-decl.h
@@ -214,7 +214,7 @@ static inline
 r_ssize midpoint(r_ssize lhs, r_ssize rhs);
 
 static inline
-void stop_matches_overflow(double size);
+void stop_matches_overflow(double size, struct r_lazy call);
 
 static inline
 void stop_matches_nothing(r_ssize i,

--- a/src/utils.c
+++ b/src/utils.c
@@ -1584,6 +1584,7 @@ SEXP syms_s3_fallback = NULL;
 SEXP syms_stop_incompatible_type = NULL;
 SEXP syms_stop_incompatible_size = NULL;
 SEXP syms_stop_assert_size = NULL;
+SEXP syms_stop_matches_overflow = NULL;
 SEXP syms_stop_matches_nothing = NULL;
 SEXP syms_stop_matches_remaining = NULL;
 SEXP syms_stop_matches_incomplete = NULL;
@@ -1865,6 +1866,7 @@ void vctrs_init_utils(SEXP ns) {
   syms_stop_incompatible_type = Rf_install("stop_incompatible_type");
   syms_stop_incompatible_size = Rf_install("stop_incompatible_size");
   syms_stop_assert_size = Rf_install("stop_assert_size");
+  syms_stop_matches_overflow = Rf_install("stop_matches_overflow");
   syms_stop_matches_nothing = Rf_install("stop_matches_nothing");
   syms_stop_matches_remaining = Rf_install("stop_matches_remaining");
   syms_stop_matches_incomplete = Rf_install("stop_matches_incomplete");

--- a/src/utils.h
+++ b/src/utils.h
@@ -486,6 +486,7 @@ extern SEXP syms_s3_fallback;
 extern SEXP syms_stop_incompatible_type;
 extern SEXP syms_stop_incompatible_size;
 extern SEXP syms_stop_assert_size;
+extern SEXP syms_stop_matches_overflow;
 extern SEXP syms_stop_matches_nothing;
 extern SEXP syms_stop_matches_remaining;
 extern SEXP syms_stop_matches_incomplete;

--- a/tests/testthat/_snaps/match.md
+++ b/tests/testthat/_snaps/match.md
@@ -670,10 +670,10 @@
     Code
       (expect_error(vec_locate_matches(1:1e+07, 1:1e+07, condition = ">=")))
     Output
-      <error/rlang_error>
+      <error/vctrs_error_matches_overflow>
       Error in `vec_locate_matches()`:
-      ! Match procedure results in an allocation larger than 2^31-1 elements. Attempted allocation size was 50000005000000.
-      i In file 'match.c' at line <scrubbed>.
+      ! Match procedure results in an allocation larger than 2^31-1 elements.
+      i Attempted allocation size was 50000005000000.
       i This is an internal error that was detected in the vctrs package.
         Please report it at <https://github.com/r-lib/vctrs/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -1791,7 +1791,7 @@ test_that("potential overflow on large output size is caught informatively", {
   # intermediate `r_ssize` will be too large
   skip_if(.Machine$sizeof.pointer < 8L, message = "No long vector support")
 
-  expect_snapshot(transform = scrub_internal_error_line_number, {
+  expect_snapshot({
     (expect_error(vec_locate_matches(1:1e7, 1:1e7, condition = ">=")))
   })
 })


### PR DESCRIPTION
Closes #1845 

For use in dplyr to throw a better join message (and hopefully redirect internal error reports there)