### PR TITLE
Make `vctrs_init_altrep_lazy_character ` function signatures consistent

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -189,7 +189,7 @@ void vctrs_init_altrep_rle(DllInfo*);
 // Defined in altrep-lazy-character.c
 extern r_obj* ffi_altrep_new_lazy_character(r_obj*);
 extern r_obj* ffi_altrep_lazy_character_is_materialized(r_obj*);
-extern r_obj* vctrs_init_altrep_lazy_character(DllInfo*);
+extern void vctrs_init_altrep_lazy_character(DllInfo*);
 
 static const R_CallMethodDef CallEntries[] = {
   {"vctrs_list_get",                            (DL_FUNC) &vctrs_list_get, 2},


### PR DESCRIPTION
In `src/altrep-lazy-character.c` we have,

```c
void vctrs_init_altrep_lazy_character(DllInfo* dll) {
[...]
}
```

but in `src/init.c` we have,

```c
extern r_obj* vctrs_init_altrep_lazy_character(DllInfo*);
```

This breaks vctrs 0.6.3 under webR because Wasm requires consistent function signatures across compilation units. The function doesn't seem to return anything, so I've switched the `extern` definition to use a return type of `void`.