### PR TITLE
Direct inclusion of used headers

### DIFF
--- a/src/altrep-lazy-character.c
+++ b/src/altrep-lazy-character.c
@@ -1,9 +1,22 @@
-#include "vctrs.h"
+#include <cstddef>
+
 #include "altrep.h"
 
 #if (!HAS_ALTREP)
 
+#include <R_ext/Altrep.h>
+#include <R_ext/Boolean.h>
+#include <R_ext/Print.h>
 #include <R_ext/Rdynload.h>
+#include <Rinternals.h>
+
+#include "call.h"
+#include "cnd.h"
+#include "eval.h"
+#include "globals.h"
+#include "obj.h"
+#include "rlang-types.h"
+#include "utils.h"
 
 void vctrs_init_altrep_lazy_character(DllInfo* dll) { }
 

--- a/src/altrep-lazy-character.c
+++ b/src/altrep-lazy-character.c
@@ -4,11 +4,11 @@
 
 #include <cstddef>
 
+#include <Rinternals.h>
 #include <R_ext/Altrep.h>
 #include <R_ext/Boolean.h>
 #include <R_ext/Print.h>
 #include <R_ext/Rdynload.h>
-#include <Rinternals.h>
 
 #include "call.h"
 #include "cnd.h"

--- a/src/altrep-lazy-character.c
+++ b/src/altrep-lazy-character.c
@@ -1,8 +1,8 @@
-#include <cstddef>
-
 #include "altrep.h"
 
 #if (!HAS_ALTREP)
+
+#include <cstddef>
 
 #include <R_ext/Altrep.h>
 #include <R_ext/Boolean.h>

--- a/src/init.c
+++ b/src/init.c
@@ -1,3 +1,4 @@
+#include "proxy.h"
 #include "vctrs.h"
 #include "altrep-rle.h"
 #include <R_ext/Rdynload.h>

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -1,3 +1,4 @@
+#include "size.h"
 #include "utils-dispatch.h"
 #include "vctrs.h"
 #include "type-data-frame.h"


### PR DESCRIPTION
As flagged by `clang-tidy`'s `misc-include-cleaner`:

https://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html