### PR TITLE
ALTREP list performance fix: Never clone in `vec_clone_referenced()` when `owned`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # vctrs (development version)
 
+* Fixed a performance issue with `vec_c()` and ALTREP vectors (in particular,
+  the new ALTREP list vectors in R-devel).
+
 * Fixed an issue with complex vector tests related to changes in R-devel
   (#1883).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # vctrs (development version)
 
 * Fixed a performance issue with `vec_c()` and ALTREP vectors (in particular,
-  the new ALTREP list vectors in R-devel).
+  the new ALTREP list vectors in R-devel) (#1884).
 
 * Fixed an issue with complex vector tests related to changes in R-devel
   (#1883).

--- a/src/owned.h
+++ b/src/owned.h
@@ -11,15 +11,8 @@ static inline enum vctrs_owned vec_owned(SEXP x) {
 }
 
 // Wrapper around `r_clone_referenced()` that only attempts to clone if
-// we indicate that we don't own `x`, or if `x` is ALTREP.
-// If `x` is ALTREP, we must unconditionally clone it before dereferencing,
-// otherwise we get a pointer into the ALTREP internals rather than into the
-// object it truly represents.
+// we indicate that we don't own `x`
 static inline SEXP vec_clone_referenced(SEXP x, const enum vctrs_owned owned) {
-  if (ALTREP(x)) {
-    return r_clone_referenced(x);
-  }
-
   if (owned == VCTRS_OWNED_false) {
     return r_clone_referenced(x);
   } else {

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -98,9 +98,11 @@ r_obj* vec_assign_switch(r_obj* proxy,
 // on a number of factors.
 //
 // - If a fallback is required, the `proxy` is duplicated at the R level.
-// - If `owned` is `VCTRS_OWNED_true`, the `proxy` is typically not duplicated.
-//   However, if it is an ALTREP object, it is duplicated because we need to be
-//   able to assign into the object it represents, not the ALTREP r_obj* itself.
+// - If `owned` is `VCTRS_OWNED_true`, the `proxy` is not duplicated. If the
+//   `proxy` happens to be an ALTREP object, materialization will be forced when
+//   we do the actual assignment, but this should really only happen with
+//   cheap-to-materialize ALTREP "wrapper" objects since we've claimed that we
+//   "own" the `proxy`.
 // - If `owned` is `VCTRS_OWNED_false`, the `proxy` is only
 //   duplicated if it is referenced, i.e. `MAYBE_REFERENCED()` returns `true`.
 //


### PR DESCRIPTION
In https://github.com/r-lib/vctrs/pull/1151, I reverted us to a simpler ownership model.

However, I added in an idea where we unconditionally shallow duplicate ALTREP objects before we try to assign to them. I left a few comments about this in the description and in the code

> When we own the object, we only ever attempt to duplicate it if it is ALTREP. If vec_init() ever creates ALTREP objects in the future (https://github.com/r-lib/vctrs/pull/837), this will be required. When doing assignment, we have to duplicate ALTREP objects before dereferencing even if we own them, because we need access to the actual data that it is representing, not the ALTREP object's internals.

```
// If `x` is ALTREP, we must unconditionally clone it before dereferencing,
// otherwise we get a pointer into the ALTREP internals rather than into the
// object it truly represents.
```

```
// - If `owned` is `VCTRS_OWNED_true`, the `proxy` is typically not duplicated.
//   However, if it is an ALTREP object, it is duplicated because we need to be
//   able to assign into the object it represents, not the ALTREP SEXP itself.
// - If `owned` is `VCTRS_OWNED_false`, the `proxy` is only
```

I now believe I was mistaken about how ALTREP worked. In particular, the idea that we need to duplicate ALTREP objects before dereferencing them (with something like `INTEGER()`) is just wrong:
- Duplicating an ALTREP object with `Rf_shallow_duplicate()` doesn't guarantee that you get a non-ALTREP object. In particular, shallow duplication is actually a nice way to generate wrapper ALTREP objects. I also think vroom ALTREP objects can be duplicated and return another ALTREP object.
- Dereferencing an ALTREP object with anything that goes through `DATAPTR()` should be completely safe. It forces ALTREP materialization but is then required to give you a pointer to "actual" memory representing that type. And I'm not worried about the "force materialization" idea here being expensive - since we "own" the data in the path where we would force materialization at assignment time (i.e. from `vec_init()`), the only kind of ALTREP objects we should encounter are cheap-to-materialize wrapper ALTREP objects like you get from proxying the init-ed object, like with `vec_proxy.vctrs_list_of()` calling `unclass()` to drop off the class attribute.

---

So that is a description of why I don't think we need to duplicate ALTREP objects unconditionally, but why has this come up all of a sudden? In R-devel (4.4.0), ALTREP list vectors were added. That has caused this memory related test to start failing:
https://github.com/r-lib/vctrs/blob/8bbd8c4a69a9b3e2c42aa752c5339f949562af96/tests/testthat/test-c.R#L578-L587

With a reprex of:

```r
library(vctrs)

make_list_of <- function(n) {
  df <- tibble::tibble(
    x = new_list_of(vec_chop(1:n), ptype = integer())
  )
  vec_chop(df)
}

xx <- make_list_of(4e3)
profmem::profmem(list_unchop(xx))
```

Indeed this runs much slower and allocates MUCH more memory in R-devel. It is a little complicated due to the tibble in the mix, but I can try to explain it. `make_list_of()` allocates a list of very small tibbles containing list-ofs:

``` r
make_list_of(2)
#> [[1]]
#> # A tibble: 1 × 1
#>             x
#>   <list<int>>
#> 1         [1]
#> 
#> [[2]]
#> # A tibble: 1 × 1
#>             x
#>   <list<int>>
#> 1         [1]
```

Note that `4e3 == 4,000` so `with_memory_prof(list_unchop(make_list_of(4e3)))` allocates a list of 4000 of these tibbles and then binds them together using `list_unchop()`. To do this:

- `vec_init()` allocates the result data frame containing the list-of column and recursively proxies it (so the list-of column is proxied too)
- `vec_proxy.vctrs_list_of()` is called, which only does `unclass(x)`, but this makes an ALTREP wrapper version of the list-of column in R-devel (as long as the object has "enough" elements, and 4k is enough).
- We start the assignment loop in `vec_c()`. On the first iteration we dig into `df_assign()`, extract the proxy ALTREP list-of column we are going to assign to, and then go into `vec_proxy_assign_opts()` to assign into it
- In `vec_proxy_assign_opts(<proxy-altrep-list-of>, 0, <first-list-of>)` we try to assign the first list-of element into the `proxy` by going through `list_assign()`. But this guards the assignment with `vec_clone_referenced(proxy, owned)`. Since `proxy` is an ALTREP list-of, this GETS SHALLOW DUPLICATED and a fresh ALTREP wrapper is made, and then at `SET_VECTOR_ELT()` time a _full_ duplication is made so we can assign to it, even though we fully own it!
- Because the new `proxy` returned from that iteration of `vec_proxy_assign_opts()` is _also_ an ALTREP wrapper, we go through this on every iteration, making 4k duplicates of `proxy` in total.

In this PR, we change this cycle by _not_ doing a shallow duplication in `vec_clone_referenced()` because we own the `proxy` ALTREP list-of. When we call `SET_VECTOR_ELT()` the first time, this may do 1 full duplication on the first iteration (not sure) to materialize the wrapper ALTREP's data, but after that it is treated like a non-ALTREP object for every other iteration because data2 is filled out and we don't get this explosive duplication.

```r
library(vctrs)

make_list_of <- function(n) {
  df <- tibble::tibble(
    x = new_list_of(vec_chop(1:n), ptype = integer())
  )
  vec_chop(df)
}

xx <- make_list_of(4e3)

y <- list_unchop(xx)
y <- list_unchop(xx)
y <- list_unchop(xx)

# CRAN vctrs - R 4.3.1
bench::mark(list_unchop(xx), iterations = 20)
#> # A tibble: 1 × 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 list_unchop(xx)    145ms    149ms      6.65     141KB     45.6

# CRAN vctrs - R 4.4.0 (oh no!)
bench::mark(list_unchop(xx), iterations = 20)
#> # A tibble: 1 × 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 list_unchop(xx)    220ms    246ms      3.97     122MB     33.5

# This PR - R 4.4.0
bench::mark(list_unchop(xx), iterations = 20)
#> # A tibble: 1 × 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 list_unchop(xx)    146ms    148ms      6.65     110KB     49.6
```