### PR TITLE
Allow `NULL` dimnames to propagate through `new_table()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* Fixed tests related to changes to `dim<-()` in R-devel (#1889).
+
 # vctrs 0.6.4
 
 * Fixed a performance issue with `vec_c()` and ALTREP vectors (in particular,

--- a/R/type-table.R
+++ b/R/type-table.R
@@ -48,8 +48,6 @@ new_table <- function(x = integer(), dim = NULL, dimnames = NULL) {
     abort("`dim` must be an integer vector.")
   }
 
-  dimnames <- dimnames %||% vec_init(list(), length(dim))
-
   n_elements <- prod(dim)
   n_x <- length(x)
 

--- a/tests/testthat/helper-size.R
+++ b/tests/testthat/helper-size.R
@@ -2,8 +2,3 @@
 expect_size <- function(object, n) {
   expect_identical(vec_size(object), vec_cast(n, int()))
 }
-
-zap_dimnames <- function(x) {
-  attr(x, "dimnames") <- NULL
-  x
-}

--- a/tests/testthat/test-type-table.R
+++ b/tests/testthat/test-type-table.R
@@ -18,34 +18,42 @@ test_that("can find a common type among tables with identical dimensions", {
   tab1 <- new_table()
   tab2 <- new_table(1:2, dim = c(1L, 2L, 1L))
 
-  expect_identical(vec_ptype2(tab1, tab1), zap_dimnames(new_table()))
-  expect_identical(vec_ptype2(tab2, tab2), zap_dimnames(new_table(dim = c(0L, 2L, 1L))))
+  expect_identical(vec_ptype2(tab1, tab1), new_table())
+  expect_identical(vec_ptype2(tab2, tab2), new_table(dim = c(0L, 2L, 1L)))
 })
 
 test_that("size is not considered in the ptype", {
   x <- new_table(1:2, dim = 2L)
   y <- new_table(1:3, dim = 3L)
 
-  expect_identical(vec_ptype2(x, y), zap_dimnames(new_table()))
+  expect_identical(vec_ptype2(x, y), new_table())
 })
 
 test_that("vec_ptype2() can broadcast table shapes", {
   x <- new_table(dim = c(0L, 1L))
   y <- new_table(dim = c(0L, 2L))
 
-  expect_identical(vec_ptype2(x, y), zap_dimnames(new_table(dim = c(0L, 2L))))
+  expect_identical(vec_ptype2(x, y), new_table(dim = c(0L, 2L)))
 
   x <- new_table(dim = c(0L, 1L, 3L))
   y <- new_table(dim = c(0L, 2L, 1L))
 
-  expect_identical(vec_ptype2(x, y), zap_dimnames(new_table(dim = c(0L, 2L, 3L))))
+  expect_identical(vec_ptype2(x, y), new_table(dim = c(0L, 2L, 3L)))
+})
+
+test_that("vec_ptype2() never propagates dimnames", {
+  x <- new_table(dim = c(0L, 1L), dimnames = list(character(), "x1"))
+  y <- new_table(dim = c(0L, 2L), dimnames = list(character(), c("y1", "y2")))
+
+  expect_null(dimnames(vec_ptype2(x, x)))
+  expect_null(dimnames(vec_ptype2(x, y)))
 })
 
 test_that("implicit axes are broadcast", {
   x <- new_table(dim = c(0L, 2L))
   y <- new_table(dim = c(0L, 1L, 3L))
 
-  expect_identical(vec_ptype2(x, y), zap_dimnames(new_table(dim = c(0L, 2L, 3L))))
+  expect_identical(vec_ptype2(x, y), new_table(dim = c(0L, 2L, 3L)))
 })
 
 test_that("errors on non-broadcastable dimensions", {

--- a/tests/testthat/test-type-table.R
+++ b/tests/testthat/test-type-table.R
@@ -88,7 +88,7 @@ test_that("common types have symmetry when mixed with unspecified input", {
 test_that("`table` delegates coercion", {
   expect_identical(
     vec_ptype2(new_table(1), new_table(FALSE)),
-    zap_dimnames(new_table(double()))
+    new_table(double())
   )
   expect_error(
     vec_ptype2(new_table(1), new_table("")),


### PR DESCRIPTION
R-devel failures:

```r
══ Failed tests ════════════════════════════════════════════════════════════════
     ── Failure ('test-type-table.R:21:3'): can find a common type among tables with identical dimensions ──
     `actual` (vec_ptype2(tab1, tab1)) not identical to `expected` (zap_dimnames(new_table())).
    
     `dimnames(actual)` is a list
     `dimnames(expected)` is absent
     Backtrace:
     ▆
     1. └─vctrs:::expect_identical(vec_ptype2(tab1, tab1), zap_dimnames(new_table())) at test-type-table.R:21:2
     2. └─vctrs:::expect_waldo_equal("identical", act, exp, info, ...) at tests/testthat/helper-vctrs.R:43:2
     ── Failure ('test-type-table.R:29:3'): size is not considered in the ptype ─────
     `actual` (vec_ptype2(x, y)) not identical to `expected` (zap_dimnames(new_table())).
    
     `dimnames(actual)` is a list
     `dimnames(expected)` is absent
     Backtrace:
     ▆
     1. └─vctrs:::expect_identical(vec_ptype2(x, y), zap_dimnames(new_table())) at test-type-table.R:29:2
     2. └─vctrs:::expect_waldo_equal("identical", act, exp, info, ...) at tests/testthat/helper-vctrs.R:43:2
     ── Failure ('test-type-table.R:81:3'): `table` delegates coercion ──────────────
     `actual` (vec_ptype2(new_table(1), new_table(FALSE))) not identical to `expected` (zap_dimnames(new_table(double()))).
    
     `dimnames(actual)` is a list
     `dimnames(expected)` is absent
     Backtrace:
     ▆
     1. └─vctrs:::expect_identical(...) at test-type-table.R:81:2
     2. └─vctrs:::expect_waldo_equal("identical", act, exp, info, ...) at tests/testthat/helper-vctrs.R:43:2
    
     [ FAIL 3 | WARN 0 | SKIP 308 | PASS 5289 ]
     Error: Test failures
     Execution halted
Flavor: [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/vctrs-00check.html)
```

I have tracked this down to this undocumented R-devel change:

https://github.com/wch/r-source/commit/2653cc6203fce4c48874111c75bbccac3ac4e803#diff-dbc5252913c71f32fa7295e497486c4c2b07ff43aa51b25c33e4dbdd397d3714R1249-R1253

```c
// currently it is documented that `dim<-` removes dimnames() .. but ..
    SEXP odim = getAttrib0(vec, R_DimSymbol); // keep dimnames(.) if dim() entries are unchanged
    if((LENGTH(odim) != ndim) || memcmp((void *)INTEGER(odim),
					(void *)INTEGER(val), ndim * sizeof(int)))
	removeAttrib(vec, R_DimNamesSymbol);
```

This applies to `dim<-` and `Rf_setAttrib(*, R_DimSymbol, *)`, which is what causes us issues.

---

Previously, in https://github.com/r-lib/vctrs/pull/1230/ we were fairly aggressive about making the `dimnames` attribute returned from `new_table()` type stable, i.e. always a `list()` with either `NULL` or character vector elements.

This causes us some grief in `vec_ptype2.table.table()` because of the way `Rf_setAttrib(*, R_DimSymbol, *)` changed:

In R release:
- If `vec_ptype2(tbl[, 2], tbl[, 2])` are combined, there is no `dimnames` attribute
- If `vec_ptype2(tbl[, 1], tbl[, 2])` are combined, there is no `dimnames` attribute

In R-devel:
- If `vec_ptype2(tbl[, 2], tbl[, 2])` are combined, we get `list(NULL, NULL)` dimnames (from our attempt to type stabilize them in `new_table()` + R-devel leaving them alone since the dimensions are the same)
- If `vec_ptype2(tbl[, 1], tbl[, 2])` are combined, there is no `dimnames` attribute


I think the easiest thing to do is to just say that `new_table()` propagates `NULL` dimnames untouched, resulting in no dimnames attribute. I don't think `vec_ptype2()` should ever return any "names" related information, so this ensures we consistently don't add a `dimnames` attribute in R-devel and R-release.