### PR TITLE
make vec_restore(<AsIs>) apply AsIs to the restored object, not its proxy

### DIFF
--- a/R/type-asis.R
+++ b/R/type-asis.R
@@ -35,7 +35,7 @@ vec_proxy.AsIs <- function(x, ...) {
 
 #' @export
 vec_restore.AsIs <- function(x, to, ...) {
-  asis_restore(x)
+  asis_restore(NextMethod())
 }
 
 #' @export


### PR DESCRIPTION
I ran into a weird ggplot2 bug when using `I(...)` with some aesthetics that I eventually traced back to a bug in the implementation of `vec_restore.AsIs()`. It currently applies the `"AsIs"` class to the *proxy* of the wrapped type without actually restoring the underlying type. I believe this is a simple fix.

Before:

``` r
x = posterior::rvar(1)

vctrs::vec_slice(x, 1)
#> rvar<1>[1] mean ± sd:
#> [1] 1 ± NA

vctrs::vec_slice(I(x), 1)
#> [[1]]
#> [[1]]$index
#> [1] 1
#> 
#> [[1]]$nchains
#> [1] 1
#> 
#> [[1]]$draws
#>   [,1]
#> 1    1
```

<sup>Created on 2023-12-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>


After:

``` r
x = posterior::rvar(1)

vctrs::vec_slice(x, 1)
#> rvar<1>[1] mean ± sd:
#> [1] 1 ± NA

vctrs::vec_slice(I(x), 1)
#> rvar<1>[1] mean ± sd:
#> [1] 1 ± NA
```

<sup>Created on 2023-12-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
