### PR TITLE
Use API setter/unsetter for S4 objects

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -264,12 +264,12 @@ SEXP r_clone_referenced(SEXP x);
 SEXP r_call_n(SEXP fn, SEXP* tags, SEXP* cars);
 
 static inline SEXP r_mark_s4(SEXP x) {
-  SET_S4_OBJECT(x);
-  return(x);
+  x = Rf_asS4(x, (Rboolean) 1, 1);
+  return x;
 }
 static inline SEXP r_unmark_s4(SEXP x) {
-  UNSET_S4_OBJECT(x);
-  return(x);
+  x = Rf_asS4(x, (Rboolean) 0, 1);
+  return x;
 }
 
 bool r_has_name_at(SEXP names, R_len_t i);


### PR DESCRIPTION
Part of #1933.

This passes tests for me. I haven't explored any performance implications (this can induce a copy, right?).