### PR TITLE
Do not define VECTOR_PTR_RO on R >= 4.5

### DIFF
--- a/src/vctrs-core.h
+++ b/src/vctrs-core.h
@@ -106,7 +106,9 @@ enum vctrs_dbl dbl_classify(double x);
 # define DATAPTR_RO(x) ((const void*) STRING_PTR(x))
 #endif
 
-#define VECTOR_PTR_RO(x) ((const SEXP*) DATAPTR_RO(x))
+#if (R_VERSION < R_Version(4, 5, 0))
+# define VECTOR_PTR_RO(x) ((const SEXP*) DATAPTR_RO(x))
+#endif
 
 // Likely supplied in R 4.4.0
 // https://github.com/wch/r-source/commit/38403c9c347dd5426da6009573b087188ec6be04


### PR DESCRIPTION
Official `VECTOR_PTR_RO` will be available on R 4.5

cf. https://github.com/r-devel/r-svn/commit/d499fab95b1ba23ee7842293030d4af1e69ae0fe