### PR TITLE
Avoid 0-length copy with potentially undefined behavior

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -389,7 +389,9 @@ SEXP df_map(SEXP df, SEXP (*fn)(SEXP)) {
                                                                \
   r_ssize copy_size = (size > x_size) ? x_size : size;         \
                                                                \
-  memcpy(p_out, p_x, copy_size * sizeof(CTYPE));               \
+  if (copy_size > 0) {                                         \
+    memcpy(p_out, p_x, copy_size * sizeof(CTYPE));             \
+  }                                                            \
                                                                \
   UNPROTECT(1);                                                \
   return out;                                                  \


### PR DESCRIPTION
Under "circumstances" I don't myself fully understand, updating R 4.4.1 to R 4.5.0 broke {vctrs} suites pretty badly (segfaults).

After some investigation, it looks like the root cause of https://github.com/Rdatatable/data.table/issues/6819 is the same.

To be a bit more specific, I found this for this test, though there are probably others:

https://github.com/r-lib/vctrs/blob/78d9f2b0b24131b5ce2230eb3c2c9f93620b10d9/tests/testthat/test-cast.R#L302

Stack trace hidden but available below.

Under `--enable-strict-barrier` R wants to prevent this:

https://github.com/r-devel/r-svn/blob/fe0ef1cc8d75a7ec62130f54187f46ecbdcf3658/src/main/memory.c#L4144-L4147

<details>

stack trace...

```
 *** caught illegal operation ***
address 0x7f405afb3a6a, cause 'illegal operand'

Traceback:
 1: vec_locate_sorted_groups(x, nan_distinct = TRUE)
 2: dplyr_locate_sorted_groups(group_vars)
 3: compute_groups(data, vars, drop = drop)
 4: dplyr::grouped_df(x, vars, drop = drop)
 5: vec_restore.grouped_df(x = x, to = to)
 6: vec_restore_dispatch(x = x, to = to)
 7: (function () vec_restore_dispatch(x = x, to = to))()
 8: vec_rbind(gdf, gdf)
 9: eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
10: withCallingHandlers(expr, condition = function(cnd) {    if (!is.null(matched) || !matches(cnd)) {        return()    }    if (can_entrace(cnd)) {        cnd <- cnd_entrace(cnd)    }    matched <<- cnd    if (inherits(cnd, "message") || inherits(cnd, "warning")) {        cnd_muffle(cnd)    }    else if (inherits(cnd, "error") || inherits(cnd, "skip")) {        return_from(tl, cnd)    }})
11: .capture(act$val <- eval_bare(quo_get_expr(.quo), quo_get_env(.quo)),     ...)
12: quasi_capture(enquo(object), label, capture_matching_condition,     matches = matcher)
13: expect_condition_matching("error", {    {        object    }}, regexp = regexp, class = class, ..., inherit = inherit, info = info,     label = label)
14: expect_error(vec_rbind(gdf, gdf), NA)
15: eval(code, test_env)
16: eval(code, test_env)
17: withCallingHandlers({    eval(code, test_env)    if (!handled && !is.null(test)) {        skip_empty()    }}, expectation = handle_expectation, skip = handle_skip, warning = handle_warning,     message = handle_message, error = handle_error)
18: doTryCatch(return(expr), name, parentenv, handler)
19: tryCatchOne(expr, names, parentenv, handlers[[1L]])
20: tryCatchList(expr, names[-nh], parentenv, handlers[-nh])
21: doTryCatch(return(expr), name, parentenv, handler)
22: tryCatchOne(tryCatchList(expr, names[-nh], parentenv, handlers[-nh]),     names[nh], parentenv, handlers[[nh]])
23: tryCatchList(expr, classes, parentenv, handlers)
24: tryCatch(withCallingHandlers({    eval(code, test_env)    if (!handled && !is.null(test)) {        skip_empty()    }}, expectation = handle_expectation, skip = handle_skip, warning = handle_warning,     message = handle_message, error = handle_error), error = handle_fatal,     skip = function(e) {    })
25: test_code(desc, code, env = parent.frame(), reporter = reporter)
26: test_that("bare-type fallback for df-cast works", {    local_methods(c.vctrs_foobaz = function(...) quux(NextMethod()))    df <- data_frame(x = 1, y = foobaz("foo"))    gdf <- dplyr::new_grouped_df(df, data_frame(x = 1, .rows = list(1L)),         class = "vctrs_foobar")    expect_error(vec_rbind(gdf, gdf), NA)})
27: eval(code, test_env)
28: eval(code, test_env)
29: withCallingHandlers({    eval(code, test_env)    if (!handled && !is.null(test)) {        skip_empty()    }}, expectation = handle_expectation, skip = handle_skip, warning = handle_warning,     message = handle_message, error = handle_error)
30: doTryCatch(return(expr), name, parentenv, handler)
31: tryCatchOne(expr, names, parentenv, handlers[[1L]])
32: tryCatchList(expr, names[-nh], parentenv, handlers[-nh])
33: doTryCatch(return(expr), name, parentenv, handler)
34: tryCatchOne(tryCatchList(expr, names[-nh], parentenv, handlers[-nh]),     names[nh], parentenv, handlers[[nh]])
35: tryCatchList(expr, classes, parentenv, handlers)
36: tryCatch(withCallingHandlers({    eval(code, test_env)    if (!handled && !is.null(test)) {        skip_empty()    }}, expectation = handle_expectation, skip = handle_skip, warning = handle_warning,     message = handle_message, error = handle_error), error = handle_fatal,     skip = function(e) {    })
37: test_code(test = NULL, code = exprs, env = env, reporter = get_reporter() %||%     StopReporter$new())
38: source_file(path, env = env(env), desc = desc, error_call = error_call)
39: FUN(X[[i]], ...)
40: lapply(test_paths, test_one_file, env = env, desc = desc, error_call = error_call)
41: doTryCatch(return(expr), name, parentenv, handler)
42: tryCatchOne(expr, names, parentenv, handlers[[1L]])
43: tryCatchList(expr, classes, parentenv, handlers)
44: tryCatch(code, testthat_abort_reporter = function(cnd) {    cat(conditionMessage(cnd), "\n")    NULL})
45: with_reporter(reporters$multi, lapply(test_paths, test_one_file,     env = env, desc = desc, error_call = error_call))
46: test_files_serial(test_dir = test_dir, test_package = test_package,     test_paths = test_paths, load_helpers = load_helpers, reporter = reporter,     env = env, stop_on_failure = stop_on_failure, stop_on_warning = stop_on_warning,     desc = desc, load_package = load_package, error_call = error_call)
47: test_files(test_dir = path, test_paths = test_paths, test_package = package,     reporter = reporter, load_helpers = load_helpers, env = env,     stop_on_failure = stop_on_failure, stop_on_warning = stop_on_warning,     load_package = load_package, parallel = parallel)
48: test_dir(test_path, package = package, reporter = reporter, ...,     load_package = "installed")
49: test_check("vctrs")
An irrecoverable exception occurred. R is aborting now ...
```

</details>