### PR TITLE
fix typos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -815,7 +815,7 @@ The following errors are caused by breaking changes.
   coercion methods are now in principle incompatible.
 
   This is particularly problematic with subclasses of data frames for
-  which throwing incompatible errors would be too incovenient for
+  which throwing incompatible errors would be too inconvenient for
   users. To work around this, we have implemented a fallback to the
   relevant base data frame class (either `data.frame` or `tbl_df`) in
   coercion methods (#981). This fallback is silent unless you set the

--- a/README.md
+++ b/README.md
@@ -15,22 +15,22 @@ maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)
 There are three main goals to the vctrs package, each described in a
 vignette:
 
--   To propose `vec_size()` and `vec_ptype()` as alternatives to
-    `length()` and `class()`; `vignette("type-size")`. These definitions
-    are paired with a framework for size-recycling and type-coercion.
-    `ptype` should evoke the notion of a prototype, i.e. the original or
-    typical form of something.
+- To propose `vec_size()` and `vec_ptype()` as alternatives to
+  `length()` and `class()`; `vignette("type-size")`. These definitions
+  are paired with a framework for size-recycling and type-coercion.
+  `ptype` should evoke the notion of a prototype, i.e. the original or
+  typical form of something.
 
--   To define size- and type-stability as desirable function properties,
-    use them to analyse existing base functions, and to propose better
-    alternatives; `vignette("stability")`. This work has been
-    particularly motivated by thinking about the ideal properties of
-    `c()`, `ifelse()`, and `rbind()`.
+- To define size- and type-stability as desirable function properties,
+  use them to analyse existing base functions, and to propose better
+  alternatives; `vignette("stability")`. This work has been particularly
+  motivated by thinking about the ideal properties of `c()`, `ifelse()`,
+  and `rbind()`.
 
--   To provide a new `vctr` base class that makes it easy to create new
-    S3 vectors; `vignette("s3-vector")`. vctrs provides methods for many
-    base generics in terms of a few new vctrs generics, making
-    implementation considerably simpler and more robust.
+- To provide a new `vctr` base class that makes it easy to create new S3
+  vectors; `vignette("s3-vector")`. vctrs provides methods for many base
+  generics in terms of a few new vctrs generics, making implementation
+  considerably simpler and more robust.
 
 vctrs is a developer-focussed package. Understanding and extending vctrs
 requires some effort from developers, but should be invisible to most
@@ -88,16 +88,17 @@ behaviour when you mix different S3 vectors:
 ``` r
 # combining factors makes integers
 c(factor("a"), factor("b"))
-#> [1] 1 1
+#> [1] a b
+#> Levels: a b
 
 # combining dates and date-times gives incorrect values; also, order matters
 dt <- as.Date("2020-01-01")
 dttm <- as.POSIXct(dt)
 
 c(dt, dttm)
-#> [1] "2020-01-01"    "4321940-06-07"
+#> [1] "2020-01-01" "2020-01-01"
 c(dttm, dt)
-#> [1] "2019-12-31 19:00:00 EST" "1970-01-01 00:04:22 EST"
+#> [1] "2020-01-01 UTC" "2020-01-01 UTC"
 ```
 
 This behaviour arises because `c()` has dual purposes: as well as its

--- a/bench/unique.Rmd
+++ b/bench/unique.Rmd
@@ -7,7 +7,7 @@ output: github_document
 knitr::opts_chunk$set(collapse = TRUE, comment = "#> ")
 ```
 
-Exploration of the performance of unique as a proxy for the performance of the underyling dictionary + hash code.
+Exploration of the performance of unique as a proxy for the performance of the underlying dictionary + hash code.
 
 ```{r setup, message = FALSE}
 library(tidyverse)

--- a/bench/unique.md
+++ b/bench/unique.md
@@ -2,7 +2,7 @@ Unique performance
 ================
 
 Exploration of the performance of unique as a proxy for the performance
-of the underyling dictionary + hash code.
+of the underlying dictionary + hash code.
 
 ``` r
 library(tidyverse)

--- a/src/group.c
+++ b/src/group.c
@@ -168,7 +168,7 @@ SEXP vec_group_loc(SEXP x) {
 
   const int n_groups = d->used;
 
-  // Location of first occurence of each group in `x`
+  // Location of first occurrence of each group in `x`
   SEXP key_loc = PROTECT_N(Rf_allocVector(INTSXP, n_groups), &nprot);
   int* p_key_loc = INTEGER(key_loc);
   int key_loc_current = 0;

--- a/src/hash.c
+++ b/src/hash.c
@@ -28,7 +28,7 @@ static inline uint32_t hash_uint64(uint64_t x) {
   return x;
 }
 
-// Seems like something designed specificaly for doubles should work better
+// Seems like something designed specifically for doubles should work better
 // but I haven't been able to find anything
 static inline uint32_t hash_double(double x) {
   // Treat positive/negative 0 as equivalent

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -98,7 +98,7 @@ r_obj* ffi_new_data_frame(r_obj* args) {
   if (!has_rownames) {
     // Data frame size is determined in the following order:
     // - By `row.names`, if provided, which will already be in `attrib`
-    // - By `n`, if provided (this is fully overriden by `row.names`)
+    // - By `n`, if provided (this is fully overridden by `row.names`)
     // - By `x`, if neither `n` nor `row.names` is provided, where `x` could be
     //   a data frame with its own row names attribute or a bare list
     const r_ssize size = n != r_null ? df_size_from_n(n) : df_raw_size(x);

--- a/src/utils.c
+++ b/src/utils.c
@@ -44,9 +44,9 @@ static SEXP vctrs_eval_mask_n_impl(SEXP fn_sym, SEXP fn, SEXP* syms, SEXP* args,
  * `syms`). The names should correspond to formal arguments of `fn`.
  * Elements of `args` are assigned to their corresponding name in
  * `syms` directly in the current environment, i.e. the environment of
- * the closure wrapping the `.Call()` invokation. Since masked
+ * the closure wrapping the `.Call()` invocation. Since masked
  * evaluation causes side effects and variable assignments in that
- * frame environment, the native code invokation must be tailing: no
+ * frame environment, the native code invocation must be tailing: no
  * further R code (including `on.exit()` expressions) should be
  * evaluated in that closure wrapper.
  *
@@ -1640,7 +1640,7 @@ void c_print_backtrace(void) {
 
   free(strings);
 #else
-  Rprintf("vctrs must be compliled with -DRLIB_DEBUG.");
+  Rprintf("vctrs must be compiled with -DRLIB_DEBUG.");
 #endif
 }
 


### PR DESCRIPTION
unattended to

```
$ grep -nr assumg vctrs
vctrs/tests/testthat/test-match.R:702:  # At the C level, our helpers assumg NA and NaN are the smallest values,
$ grep -nr errneously vctrs
vctrs/tests/testthat/test-match.R:1036:test_that("`multiple = 'error'` doesn't error errneously on the last observation", {
vctrs/tests/testthat/test-match.R:1248:test_that("`relationship` doesn't error errneously on the last observation", {
$ grep -nr presedence vctrs
vctrs/tests/testthat/test-order.R:798:test_that("first column has ordering presedence", {
$ grep -nr unsuported vctrs
vctrs/tests/testthat/test-equal.R:4:test_that("throws error for unsuported type", {
$ 
```

perhaps the author's intention here was homogeneous

```
$ grep -nr homogenous vctrs
vctrs/src/decl/c-unchop-decl.h:16:                            enum fallback_homogeneous homogenous,
vctrs/R/type-list-of.R:1:#' `list_of` S3 class for homogenous lists
vctrs/man/list_of.Rd:9:\title{\code{list_of} S3 class for homogenous lists}
$ 
```