### PR TITLE
Fix hard-coded link

### DIFF
--- a/R/type-rcrd.R
+++ b/R/type-rcrd.R
@@ -11,9 +11,9 @@
 #' @details
 #' Record-style objects created with [new_rcrd()] do not do much on their own.
 #' For instance they do not have a default [format()] method, which means
-#' printing the object causes an error. See the *Record-style objects* section
-#' from `vignette("s3-vector")` for details on implementing methods for
-#' record vectors.
+#' printing the object causes an error. See [Record-style
+#' objects](https://vctrs.r-lib.org/articles/s3-vector.html#record-style-objects)
+#' for details on implementing methods for record vectors.
 #'
 #' @param fields A list or a data frame. Lists must be rectangular
 #'   (same sizes), and contain uniquely named vectors (at least

--- a/R/type-rcrd.R
+++ b/R/type-rcrd.R
@@ -10,9 +10,10 @@
 #'
 #' @details
 #' Record-style objects created with [new_rcrd()] do not do much on their own.
-#' For instance they do not have a default [format()] method, which means printing
-#' the object causes an error. See [Record-style objects](https://vctrs.r-lib.org/articles/s3-vector.html?q=record#record-style-objects
-#' for details on implementing methods for record vectors.
+#' For instance they do not have a default [format()] method, which means
+#' printing the object causes an error. See the *Record-style objects* section
+#' from `vignette("s3-vector")` for details on implementing methods for
+#' record vectors.
 #'
 #' @param fields A list or a data frame. Lists must be rectangular
 #'   (same sizes), and contain uniquely named vectors (at least

--- a/man/new_rcrd.Rd
+++ b/man/new_rcrd.Rd
@@ -27,8 +27,9 @@ an implementation detail invisible to the user (unlike a \link{data.frame}).
 }
 \details{
 Record-style objects created with \code{\link[=new_rcrd]{new_rcrd()}} do not do much on their own.
-For instance they do not have a default \code{\link[=format]{format()}} method, which means printing
-the object causes an error. See \link{Record-style objects}(https://vctrs.r-lib.org/articles/s3-vector.html?q=record#record-style-objects
-for details on implementing methods for record vectors.
+For instance they do not have a default \code{\link[=format]{format()}} method, which means
+printing the object causes an error. See the \emph{Record-style objects} section
+from \code{vignette("s3-vector")} for details on implementing methods for
+record vectors.
 }
 \keyword{internal}

--- a/man/new_rcrd.Rd
+++ b/man/new_rcrd.Rd
@@ -28,8 +28,7 @@ an implementation detail invisible to the user (unlike a \link{data.frame}).
 \details{
 Record-style objects created with \code{\link[=new_rcrd]{new_rcrd()}} do not do much on their own.
 For instance they do not have a default \code{\link[=format]{format()}} method, which means
-printing the object causes an error. See the \emph{Record-style objects} section
-from \code{vignette("s3-vector")} for details on implementing methods for
-record vectors.
+printing the object causes an error. See \href{https://vctrs.r-lib.org/articles/s3-vector.html#record-style-objects}{Record-style objects}
+for details on implementing methods for record vectors.
 }
 \keyword{internal}


### PR DESCRIPTION
I realize the hard-coded link's aim was to directly send to the section in the article, but I think we shouldn't do that. I guess there's no way to specify a section when using `vignette("s3-vector")`, but I still prefer to just name the section which the user should visit. If you don't like this and still prefer the hard-coded link, at least make it 

```https://vctrs.r-lib.org/articles/s3-vector.html#record-style-objects``` 

so that R CMD check doesn't fail.