### PR TITLE
Update `c.md` snapshots to reflect support for "wrappable" ALTLISTs 

### DIFF
--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -256,13 +256,13 @@
       })
       with_memory_prof(list_unchop(make_list_of(1000)))
     Output
-      [1] 103KB
+      [1] 55.9KB
     Code
       with_memory_prof(list_unchop(make_list_of(2000)))
     Output
-      [1] 205KB
+      [1] 111KB
     Code
       with_memory_prof(list_unchop(make_list_of(4000)))
     Output
-      [1] 408KB
+      [1] 220KB
 


### PR DESCRIPTION
I've been noticing that my snapshot tests were failing when running `devtools::test()` interactively

All of a sudden our memtests related to making `list_of()` objects were using much less memory

```
> profmem::profmem(list_unchop(make_list_of(1e3)))
Rprofmem memory profiling of:
list_unchop(make_list_of(1000))

Memory allocations:
       what  bytes                                                                                                                                                                                                                                         calls
1     alloc    280                                                                                                                                             list_unchop() -> make_list_of() -> <Anonymous> -> tibble_quos() -> new_environment() -> new.env()
2     alloc   8048                                                                                                     list_unchop() -> make_list_of() -> <Anonymous> -> tibble_quos() -> eval_tidy() -> new_list_of() -> obj_is_list() -> vec_chop() -> .Call()
3     alloc   4048                                                                                                     list_unchop() -> make_list_of() -> <Anonymous> -> tibble_quos() -> eval_tidy() -> new_list_of() -> obj_is_list() -> vec_chop() -> .Call()
4     alloc   8048                                                                                       list_unchop() -> make_list_of() -> <Anonymous> -> tibble_quos() -> eval_tidy() -> new_list_of() -> new_list_of0() -> new_vctr() -> vec_set_attributes()
5     alloc   8048                                                                                       list_unchop() -> make_list_of() -> <Anonymous> -> tibble_quos() -> eval_tidy() -> new_list_of() -> new_list_of0() -> new_vctr() -> vec_set_attributes()
6     alloc   8048 list_unchop() -> make_list_of() -> <Anonymous> -> tibble_quos() -> check_valid_col() -> check_valid_cols() -> which() -> map_lgl() -> map_mold() -> vapply() -> FUN() -> vec_is() -> obj_is_vector() -> .Call() -> <Anonymous> -> vec_proxy()
7     alloc   8048                                                                                                                        list_unchop() -> make_list_of() -> <Anonymous> -> tibble_quos() -> vec_size() -> .Call() -> <Anonymous> -> vec_proxy()
8     alloc    264                                                                                                                                    list_unchop() -> make_list_of() -> <Anonymous> -> tibble_quos() -> splice_dfs() -> vec_c() -> .External2()
9     alloc   8048                                                                                                                                                                                      list_unchop() -> make_list_of() -> vec_chop() -> .Call()
10    alloc   8048                                                                                                                                                        list_unchop() -> make_list_of() -> vec_chop() -> .Call() -> <Anonymous> -> vec_proxy()
11    alloc   8048                                                                                                                                                                                      list_unchop() -> make_list_of() -> vec_chop() -> .Call()
12    alloc    264                                                                                                                                                                                                                      list_unchop() -> .Call()
13    alloc   4048                                                                                                                                                                                                                      list_unchop() -> .Call()
14    alloc   8048                                                                                                                                                                                                                      list_unchop() -> .Call()
15    alloc   8048                                                                                             list_unchop() -> .Call() -> <Anonymous> -> vec_restore_dispatch() -> vec_restore.vctrs_vctr() -> NextMethod() -> vec_restore.default() -> .Call()
16    alloc   8048                                                                                                                                                                                        list_unchop() -> .Call() -> <Anonymous> -> vec_proxy()
17    alloc   8048                                                                                             list_unchop() -> .Call() -> <Anonymous> -> vec_restore_dispatch() -> vec_restore.vctrs_vctr() -> NextMethod() -> vec_restore.default() -> .Call()
total       105480   
```

became

```
> profmem::profmem(list_unchop(make_list_of(1e3)))
Rprofmem memory profiling of:
list_unchop(make_list_of(1000))

Memory allocations:
Number of 'new page' entries not displayed: 71
       what bytes                                                                                                                                             calls
1     alloc   280                                                 list_unchop() -> make_list_of() -> <Anonymous> -> tibble_quos() -> new_environment() -> new.env()
2     alloc  8048         list_unchop() -> make_list_of() -> <Anonymous> -> tibble_quos() -> eval_tidy() -> new_list_of() -> obj_is_list() -> vec_chop() -> .Call()
3     alloc  4048         list_unchop() -> make_list_of() -> <Anonymous> -> tibble_quos() -> eval_tidy() -> new_list_of() -> obj_is_list() -> vec_chop() -> .Call()
4     alloc   264                                        list_unchop() -> make_list_of() -> <Anonymous> -> tibble_quos() -> splice_dfs() -> vec_c() -> .External2()
5     alloc  8048                                                                                          list_unchop() -> make_list_of() -> vec_chop() -> .Call()
6     alloc  8048                                                                                          list_unchop() -> make_list_of() -> vec_chop() -> .Call()
7     alloc   264                                                                                                                          list_unchop() -> .Call()
39    alloc  4048                                                                                                                          list_unchop() -> .Call()
48    alloc  8048                                                                                                                          list_unchop() -> .Call()
49    alloc  8048 list_unchop() -> .Call() -> <Anonymous> -> vec_restore_dispatch() -> vec_restore.vctrs_vctr() -> NextMethod() -> vec_restore.default() -> .Call()
50    alloc  8048                                                                                                                          list_unchop() -> .Call()
total       57192      

x <- rep(list(1), 1e5)
loadNamespace("vctrs")
profmem::profmem(vctrs:::vec_set_attributes(x, NULL))
```

This was cool but I wanted to know why.

Turns out between R 4.3 and 4.4, we worked with Gabor to make VECSXPs "wrappable" when using `attributes<-`, i.e. when you set attributes on a VECSXP you get an ALTREP "wrapped" list object. https://github.com/wch/r-source/commit/e34c85becf2c40b1fa5b93e437344f8050c7c047

This dramatically reduces the number of "shallow but still size length(x)" copies that have to be made, particularly when:
- Creating a list-of through `new_vctr()` by adding attributes with `vec_set_attributes()`, i.e. `attributes<-`, which wraps
- Proxying a list-of through `vec_proxy()` which calls `unclass()`, which also wraps

It's particularly nice for the proxying case, because you often proxy but then use the data in a read-only way, so you never force the full copy.

I'm a bit slow to update my R version, so I moved to R 4.4 around 6 months ago and haven't worked on vctrs much since, so never saw this until now. CI doesn't fail because profmem isn't installed on CI, so these tests get skipped there.