### PR TITLE
Remove some experimental labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # vctrs (development version)
 
+* The following functions are no longer experimental:
+  * `vec_fill_missing()`
+  * `vec_group_id()`
+  * `vec_group_loc()`
+  * `vec_group_rle()`
+  * `vec_locate_matches()`
+
 * Hashing is now supported for lists containing complex vectors, enabling functions like `vec_unique_loc()` to work on these objects (#1992).
 
 * `vec_detect_complete(NULL)` now returns `logical()`, consistent with

--- a/R/fill.R
+++ b/R/fill.R
@@ -1,8 +1,6 @@
 #' Fill in missing values with the previous or following value
 #'
 #' @description
-#' `r lifecycle::badge("experimental")`
-#'
 #' `vec_fill_missing()` fills gaps of missing values with the previous or
 #' following non-missing value.
 #'

--- a/R/group.R
+++ b/R/group.R
@@ -1,9 +1,6 @@
 #' Identify groups
 #'
 #' @description
-#'
-#' `r lifecycle::badge("experimental")`
-#'
 #' * `vec_group_id()` returns an identifier for the group that each element of
 #'   `x` falls in, constructed in the order that they appear. The number of
 #'   groups is also returned as an attribute, `n`.

--- a/R/match.R
+++ b/R/match.R
@@ -1,8 +1,6 @@
 #' Locate observations matching specified conditions
 #'
 #' @description
-#' `r lifecycle::badge("experimental")`
-#'
 #' `vec_locate_matches()` is a more flexible version of [vec_match()] used to
 #' identify locations where each value of `needles` matches one or multiple
 #' values in `haystack`. Unlike `vec_match()`, `vec_locate_matches()` returns

--- a/man/vec_fill_missing.Rd
+++ b/man/vec_fill_missing.Rd
@@ -21,8 +21,6 @@ sequential missing values that will be filled. If \code{NULL}, there is
 no limit.}
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 \code{vec_fill_missing()} fills gaps of missing values with the previous or
 following non-missing value.
 }

--- a/man/vec_group.Rd
+++ b/man/vec_group.Rd
@@ -34,7 +34,6 @@ Note that when using \code{vec_group_loc()} for complex types, the default
 into a tibble to better understand the output.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 \itemize{
 \item \code{vec_group_id()} returns an identifier for the group that each element of
 \code{x} falls in, constructed in the order that they appear. The number of

--- a/man/vec_locate_matches.Rd
+++ b/man/vec_locate_matches.Rd
@@ -192,8 +192,6 @@ corresponding match in the haystack for the current needle.
 }
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 \code{vec_locate_matches()} is a more flexible version of \code{\link[=vec_match]{vec_match()}} used to
 identify locations where each value of \code{needles} matches one or multiple
 values in \code{haystack}. Unlike \code{vec_match()}, \code{vec_locate_matches()} returns


### PR DESCRIPTION
Closes #1974 

- `vec_fill_missing()` is used by tidyr
- `vec_locate_matches()` is used by dplyr
- `vec_group_loc()` is used by dplyr
- `vec_group_id()` is used by ggplot2