### PR TITLE
Add `vec_proxy()` and `vec_restore()` methods for `IDate`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* data.table's `IDate` class now has `vec_proxy()` and `vec_restore()` methods, fixing a number of issues with that class (#1549, #1961, #1972, #1781).
+
 * `vec_locate_sorted_groups()` and `vec_order_radix()` no longer crash on columns of type complex (tidyverse/dplyr#7708).
 
 * Functions backed by a dictionary based implementation are often significantly faster, depending on the exact inputs used. This includes: `vec_match()`, `vec_in()`, `vec_group_loc()`, `vec_count()`, `vec_unique()`, and more (#1976).

--- a/R/type-idate.R
+++ b/R/type-idate.R
@@ -1,0 +1,29 @@
+# Proxy method for <IDate>
+#
+# `vec_proxy.Date()` coerces integer storage dates to double. If we don't
+# intercept that, an IDate will also be converted to double storage, but that
+# results in a corrupt IDate. Since we provide some methods for <data.table>, we
+# also provide this one.
+#
+# Notably we don't provide `vec_ptype2.Date.IDate` methods. We don't think it is
+# our place to provide methods for that, especially since we'd likely prefer
+# <Date> as the more general common type, but `c.IDate` in data.table prefers
+# <IDate>, so we'd probably just add conflicting behavior.
+vec_proxy_IDate <- function(x, ...) {
+  if (typeof(x) != "integer") {
+    type <- typeof(x)
+    cli::cli_abort(
+      "Corrupt <IDate>. Expected integer storage, not {type} storage."
+    )
+  }
+
+  x
+}
+
+# Restore method for <IDate>
+#
+# Follow `vec_restore.Date` and pass through to `vec_restore.default` which
+# uses standard restore behavior
+vec_restore_IDate <- function(x, to, ...) {
+  NextMethod()
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -94,6 +94,13 @@
     }
   })
 
+  on_package_load("data.table", {
+    if (!env_has(ns_env("data.table"), "vec_proxy.IDate")) {
+      s3_register("vctrs::vec_proxy", "IDate", vec_proxy_IDate)
+      s3_register("vctrs::vec_restore", "IDate", vec_restore_IDate)
+    }
+  })
+
   utils::globalVariables("vec_set_attributes")
 
   # Prevent two copies from being made by `attributes(x) <- attrib` on R < 3.6.0

--- a/tests/testthat/_snaps/type-idate.md
+++ b/tests/testthat/_snaps/type-idate.md
@@ -1,0 +1,32 @@
+# can't get common type of Date and IDate
+
+    Code
+      vec_ptype2(x, y)
+    Condition
+      Error:
+      ! Can't combine `x` <date> and `y` <IDate>.
+
+---
+
+    Code
+      vec_ptype2(y, x)
+    Condition
+      Error:
+      ! Can't combine `y` <IDate> and `x` <date>.
+
+# can't cast Date to IDate
+
+    Code
+      vec_cast(x, y)
+    Condition
+      Error:
+      ! Can't convert `x` <date> to <IDate>.
+
+# can't cast IDate to Date
+
+    Code
+      vec_cast(x, y)
+    Condition
+      Error:
+      ! Can't convert `x` <IDate> to <date>.
+

--- a/tests/testthat/test-type-idate.R
+++ b/tests/testthat/test-type-idate.R
@@ -1,0 +1,131 @@
+# Never run on CRAN, even if they have data.table, because we don't regularly
+# check these on CI and we don't want a change in data.table to force a CRAN
+# failure for vctrs.
+skip_on_cran()
+
+# Avoids adding `data.table` to Suggests.
+# These tests are only run on the devs' machines.
+testthat_import_from("data.table", "as.IDate")
+
+# `as.IDate()` drops names https://github.com/Rdatatable/data.table/issues/7252
+as_IDate_with_names <- function(x) {
+  out <- as.IDate(x)
+  names(out) <- names(x)
+  out
+}
+
+# ------------------------------------------------------------------------------
+# ptype
+
+test_that("ptype abbr", {
+  x <- as.IDate("2019-01-01")
+  expect_identical(vec_ptype_abbr(x), "IDate")
+})
+
+test_that("ptype full", {
+  x <- as.IDate("2019-01-01")
+  expect_identical(vec_ptype_full(x), "IDate")
+})
+
+# ------------------------------------------------------------------------------
+# ptype2
+
+test_that("can get common type of IDate and IDate", {
+  x <- as_IDate_with_names(c(a = "2019-01-01"))
+
+  # It shouldn't have names, but thats a vctrs problem
+  expect <- as_IDate_with_names(set_names(integer(), character()))
+
+  expect_identical(vec_ptype2(x, x), expect)
+})
+
+test_that("can't get common type of Date and IDate", {
+  x <- as.Date("2019-01-01")
+  y <- as.IDate("2019-01-01")
+
+  expect_snapshot(error = TRUE, {
+    vec_ptype2(x, y)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_ptype2(y, x)
+  })
+})
+
+# ------------------------------------------------------------------------------
+# cast
+
+test_that("can cast IDate to IDate", {
+  x <- as_IDate_with_names(c(a = "2019-01-01"))
+  expect_identical(vec_cast(x, x), x)
+})
+
+test_that("can't cast Date to IDate", {
+  x <- as.Date("2019-01-01")
+  y <- as.IDate("2019-01-01")
+
+  expect_snapshot(error = TRUE, {
+    vec_cast(x, y)
+  })
+})
+
+test_that("can't cast IDate to Date", {
+  x <- as.IDate("2019-01-01")
+  y <- as.Date("2019-01-01")
+
+  expect_snapshot(error = TRUE, {
+    vec_cast(x, y)
+  })
+})
+
+# ------------------------------------------------------------------------------
+# proxy / restore
+
+test_that("vec_proxy", {
+  # Retains integer type https://github.com/r-lib/vctrs/issues/1961
+  x <- as.IDate("2019-01-01")
+  expect_identical(vec_proxy(x), x)
+})
+
+test_that("vec_restore", {
+  x <- as.IDate("2019-01-01")
+  proxy <- vec_proxy(x)
+  expect_identical(vec_restore(proxy, x), x)
+})
+
+test_that("proxy / restore retains names", {
+  x <- as_IDate_with_names(c(a = "2019-01-01"))
+
+  proxy <- vec_proxy(x)
+  expect_named(proxy, "a")
+
+  restored <- vec_restore(proxy, x)
+  expect_named(restored, "a")
+})
+
+test_that("vec_proxy_equal, vec_proxy_compare, vec_proxy_order", {
+  # Doesn't change type, stays integer storage as well
+  x <- as.IDate("2019-01-01")
+
+  expect_identical(vec_proxy_equal(x), x)
+  expect_identical(vec_proxy_compare(x), x)
+  expect_identical(vec_proxy_order(x), x)
+})
+
+# ------------------------------------------------------------------------------
+# manipulation
+
+test_that("ptype retains integer type", {
+  x <- as.IDate(c("2019-01-01", "2019-01-02"))
+  expect_identical(typeof(vec_ptype(x)), "integer")
+  expect_identical(vec_ptype(x), as.IDate(integer()))
+})
+
+test_that("slicing retains integer type", {
+  x <- as.IDate(c("2019-01-01", "2019-01-02"))
+  expect_identical(typeof(vec_slice(x, 1)), "integer")
+})
+
+test_that("slicing retains names", {
+  x <- as_IDate_with_names(c(a = "2019-01-01"))
+  expect_identical(vec_slice(x, 1), x)
+})


### PR DESCRIPTION
Closes #1549 
Closes #1961
Closes #1972
Closes #1781

Adds delayed registration of `vec_proxy.IDate()` and `vec_restore.IDate()`

It's worth noting that the other vctrs methods for `<data.table>` are registered with `#' @export`, but I don't know why we did that? We don't seem super consistent. data.table and integer64 use `#' @export` but tibble, dplyr, and sf use delayed registration. Was the thought that maybe the latter packages would provide their own messages one day, but data.table and integer64 probably never will?