### PR TITLE
Recycle size 1 `value` efficiently in `vec_assign()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `vec_assign()` and `vec_slice<-()` now efficiently internally recycle `value` of size 1 at the C level, resulting in less memory usage.
+
 * `vec_assign()` no longer modifies `POSIXlt` and `vctrs_rcrd` types in place (#1951).
 
 * data.table's `IDate` class now has `vec_proxy()` and `vec_restore()` methods, fixing a number of issues with that class (#1549, #1961, #1972, #1781).

--- a/man/vec_slice.Rd
+++ b/man/vec_slice.Rd
@@ -29,7 +29,8 @@ mentioned in error messages as the source of the error. See the
 
 \item{value}{Replacement values. \code{value} is cast to the type of
 \code{x}, but only if they have a common type. See below for examples
-of this rule.}
+of this rule. \code{value} must be recyclable to the size of \code{i} after \code{i}
+has been converted to a valid integer location vector.}
 
 \item{x_arg, value_arg}{Argument names for \code{x} and \code{value}. These are used
 in error messages to inform the user about the locations of
@@ -50,10 +51,23 @@ that matches \code{\link[=vec_size]{vec_size()}} instead of \code{length()}.
 Support for S3 objects depends on whether the object implements a
 \code{\link[=vec_proxy]{vec_proxy()}} method.
 \itemize{
-\item When a \code{vec_proxy()} method exists, the proxy is sliced and
+\item When a \code{vec_proxy()} method exists, the proxy is sliced or assigned to and
 \code{vec_restore()} is called on the result.
-\item Otherwise \code{vec_slice()} falls back to the base generic \code{[}.
+\item Otherwise, \code{vec_slice()} falls back to the base generic \code{[} and
+\verb{vec_slice<-()} falls back to the base generic \verb{[<-}.
 }
+
+When \verb{vec_slice<-()} falls back to \verb{[<-}, it is expected that the subclass's
+\verb{[<-} method can handle the following subset of cases that base R's \verb{[<-}
+can also handle:
+\itemize{
+\item An \code{i} vector of positive integer positions (notably excluding \code{NA}).
+\item A \code{value} vector of length 1 or length \code{length(i)}. If length 1, it
+should be recycled by the \verb{[<-} method to the length of \code{i}.
+}
+
+If your \verb{[<-} method eventually calls base R's native \verb{[<-} code, then these
+cases will be handled for you.
 
 Note that S3 lists are treated as scalars by default, and will
 cause an error if they don't implement a \code{\link[=vec_proxy]{vec_proxy()}} method.
@@ -82,10 +96,8 @@ as the LHS.
 \subsection{base dependencies}{
 \itemize{
 \item \code{base::`[`}
+\item \code{base::`[<-`}
 }
-
-If a non-data-frame vector class doesn't have a \code{\link[=vec_proxy]{vec_proxy()}}
-method, the vector is sliced with \code{[} instead.
 }
 }
 

--- a/src/size.c
+++ b/src/size.c
@@ -227,6 +227,23 @@ r_obj* vec_check_recycle(r_obj* x,
   stop_recycle_incompatible_size(n_x, size, x_arg, call);
 }
 
+// Doesn't allow `NULL`, you likely want the returned size to have a guarantee
+// of being either `1` or `size`, and `NULL` would be size `0`.
+r_ssize vec_check_recyclable(
+  r_obj* x,
+  r_ssize size,
+  struct vctrs_arg* x_arg,
+  struct r_lazy call
+) {
+  r_ssize x_size = vec_size(x);
+
+  if (x_size == size || x_size == 1) {
+    return x_size;
+  }
+
+  stop_recycle_incompatible_size(x_size, size, x_arg, call);
+}
+
 // [[ register() ]]
 r_obj* ffi_recycle(r_obj* x,
                    r_obj* size_obj,

--- a/src/size.h
+++ b/src/size.h
@@ -12,6 +12,13 @@ r_obj* vec_check_recycle(r_obj* x,
                          struct vctrs_arg* x_arg,
                          struct r_lazy call);
 
+r_ssize vec_check_recyclable(
+  r_obj* x,
+  r_ssize size,
+  struct vctrs_arg* x_arg,
+  struct r_lazy call
+);
+
 static inline
 r_obj* vec_recycle(r_obj* x,
                    r_ssize size) {

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -51,6 +51,11 @@ r_obj* df_assign(
   const struct vec_proxy_assign_opts* p_opts
 );
 
-r_obj* vec_assign_shaped(r_obj* proxy, r_obj* index, r_obj* value, const enum vctrs_ownership ownership);
+r_obj* vec_assign_shaped(
+  r_obj* proxy,
+  r_obj* index,
+  r_obj* value,
+  enum vctrs_ownership ownership
+);
 
 #endif

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -68,6 +68,32 @@ test_that("can assign base vectors", {
   expect_identical(x, as.raw(rep(0, 3)))
 })
 
+test_that("can assign base vectors with recycling of `value`", {
+  x <- rep(FALSE, 3)
+  expect_identical(vec_assign(x, c(3, 1), TRUE), lgl(TRUE, FALSE, TRUE))
+  expect_identical(x, rep(FALSE, 3))
+
+  x <- rep(0L, 3)
+  expect_identical(vec_assign(x, c(3, 1), 1L), int(1L, 0L, 1L))
+  expect_identical(x, rep(0L, 3))
+
+  x <- rep(0., 3)
+  expect_identical(vec_assign(x, c(3, 1), 1), dbl(1, 0, 1))
+  expect_identical(x, rep(0., 3))
+
+  x <- rep(0i, 3)
+  expect_identical(vec_assign(x, c(3, 1), 1i), cpl(1i, 0i, 1i))
+  expect_identical(x, rep(0i, 3))
+
+  x <- rep("", 3)
+  expect_identical(vec_assign(x, c(3, 1), "foo"), chr("foo", "", "foo"))
+  expect_identical(x, rep("", 3))
+
+  x <- as.raw(rep(0, 3))
+  expect_identical(vec_assign(x, c(3, 1), as.raw(1)), as.raw(c(1, 0, 1)))
+  expect_identical(x, as.raw(rep(0, 3)))
+})
+
 test_that("can assign shaped base vectors", {
   mat <- as.matrix
 
@@ -96,6 +122,34 @@ test_that("can assign shaped base vectors", {
   expect_identical(x, mat(as.raw(rep(0, 3))))
 })
 
+test_that("can assign shaped base vectors with recycling of `value`", {
+  mat <- as.matrix
+
+  x <- mat(rep(FALSE, 3))
+  expect_identical(vec_assign(x, c(3, 1), TRUE), mat(lgl(TRUE, FALSE, TRUE)))
+  expect_identical(x, mat(rep(FALSE, 3)))
+
+  x <- mat(rep(0L, 3))
+  expect_identical(vec_assign(x, c(3, 1), 1L), mat(int(1L, 0L, 1L)))
+  expect_identical(x, mat(rep(0L, 3)))
+
+  x <- mat(rep(0, 3))
+  expect_identical(vec_assign(x, c(3, 1), 1), mat(dbl(1, 0, 1)))
+  expect_identical(x, mat(rep(0, 3)))
+
+  x <- mat(rep(0i, 3))
+  expect_identical(vec_assign(x, c(3, 1), 1i), mat(cpl(1i, 0i, 1i)))
+  expect_identical(x, mat(rep(0i, 3)))
+
+  x <- mat(rep("", 3))
+  expect_identical(vec_assign(x, c(3, 1), "foo"), mat(chr("foo", "", "foo")))
+  expect_identical(x, mat(rep("", 3)))
+
+  x <- mat(as.raw(rep(0, 3)))
+  expect_identical(vec_assign(x, c(3, 1), as.raw(1)), mat(as.raw(c(1, 0, 1))))
+  expect_identical(x, mat(as.raw(rep(0, 3))))
+})
+
 test_that("can slice-assign lists", {
   x <- rep(list(NULL), 3)
   vec_slice(x, 2) <- list(NA)
@@ -115,6 +169,12 @@ test_that("can assign lists", {
   expect_identical(x, rep(list(NULL), 3))
 })
 
+test_that("can assign lists with recycling of `value`", {
+  x <- rep(list(NULL), 3)
+  expect_identical(vec_assign(x, c(3, 1), list(NA)), list(NA, NULL, NA))
+  expect_identical(x, rep(list(NULL), 3))
+})
+
 test_that("can assign shaped lists", {
   mat <- as.matrix
   x <- mat(rep(list(NULL), 3))
@@ -122,16 +182,29 @@ test_that("can assign shaped lists", {
   expect_identical(x, mat(rep(list(NULL), 3)))
 })
 
-test_that("can assign object of any dimensionality", {
-  x1 <- ones(2)
-  x2 <- ones(2, 3)
-  x3 <- ones(2, 3, 4)
-  x4 <- ones(2, 3, 4, 5)
+test_that("can assign shaped lists with recycling of `value`", {
+  mat <- as.matrix
+  x <- mat(rep(list(NULL), 3))
+  expect_identical(vec_assign(x, c(3, 1), list(NA)), mat(list(NA, NULL, NA)))
+  expect_identical(x, mat(rep(list(NULL), 3)))
+})
 
-  expect_identical(vec_assign(x1, 1L, 2L), array(rep(c(2, 1), 1),  dim = 2))
-  expect_identical(vec_assign(x2, 1L, 2L), array(rep(c(2, 1), 3),  dim = c(2, 3)))
-  expect_identical(vec_assign(x3, 1L, 2L), array(rep(c(2, 1), 12), dim = c(2, 3, 4)))
-  expect_identical(vec_assign(x4, 1L, 2L), array(rep(c(2, 1), 60), dim = c(2, 3, 4, 5)))
+test_that("can assign object of any dimensionality", {
+  x1 <- ones(3)
+  x2 <- ones(3, 4)
+  x3 <- ones(3, 4, 5)
+  x4 <- ones(3, 4, 5, 6)
+
+  expect_identical(vec_assign(x1, 1L, 2L), array(rep(c(2, 1, 1), 1),  dim = 3))
+  expect_identical(vec_assign(x2, 1L, 2L), array(rep(c(2, 1, 1), 3),  dim = c(3, 4)))
+  expect_identical(vec_assign(x3, 1L, 2L), array(rep(c(2, 1, 1), 12), dim = c(3, 4, 5)))
+  expect_identical(vec_assign(x4, 1L, 2L), array(rep(c(2, 1, 1), 60), dim = c(3, 4, 5, 6)))
+
+  # With recycling of `value`
+  expect_identical(vec_assign(x1, c(3L, 2L), 2L), array(rep(c(1, 2, 2), 1),  dim = 3))
+  expect_identical(vec_assign(x2, c(3L, 2L), 2L), array(rep(c(1, 2, 2), 3),  dim = c(3, 4)))
+  expect_identical(vec_assign(x3, c(3L, 2L), 2L), array(rep(c(1, 2, 2), 12), dim = c(3, 4, 5)))
+  expect_identical(vec_assign(x4, c(3L, 2L), 2L), array(rep(c(1, 2, 2), 60), dim = c(3, 4, 5, 6)))
 })
 
 test_that("atomics can't be assigned in lists", {
@@ -379,6 +452,16 @@ test_that("index and value are sliced before falling back", {
   rhs <- foobar(int(0L, 10L))
   exp <- foobar(int(10L, 1:4))
   expect_identical(vec_assign(lhs, c(NA, 1), rhs), exp)
+})
+
+test_that("size 1 value is expected to be handled by the `[<-` fallback", {
+  # i.e., we don't pre recycle size 1 value to the size of the index because
+  # we expect that most `[<-` fallbacks eventually call base `[<-`, which
+  # recycles size 1 value efficiently. See `vec_assign_fallback()`.
+  lhs <- foobar(1:4)
+  rhs <- foobar(0L)
+  exp <- foobar(c(1L, 0L, 3L, 0L))
+  expect_identical(vec_assign(lhs, c(2L, 4L), rhs), exp)
 })
 
 test_that("can assign to data frame", {


### PR DESCRIPTION
I'm really after the memory improvements here, but the performance improvements are nice too!

``` r
library(vctrs)

x <- seq_len(1e6) + 0L
i <- sample(1e6)
value <- 0L

# Before
bench::mark(vec_assign(x, i, value))
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_assign(x, i, value)   2.04ms   2.33ms      422.    7.63MB     161.

# After
bench::mark(vec_assign(x, i, value))
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vec_assign(x, i, value)   1.69ms   1.87ms      528.    3.82MB     52.6

# Base
bench::mark(`[<-`(x, i, value))
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 `[<-`(x, i, value)   2.49ms   2.63ms      378.    3.81MB     56.5
```