### PR TITLE
Implement `vec_assign(slice_value = TRUE)` and optimized logical `i` handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # vctrs (development version)
 
+* `vec_assign()` has gained a new `slice_value` argument to optionally slice `value` by `i` before performing the assignment. It is an optimized form of `vec_slice(x, i) <- vec_slice(value, i)` that avoids materializing `vec_slice(value, i)` (#2009).
+
+* `vec_assign()` and `vec_slice<-()` are now more efficient with logical `i` (#2009).
+
 * `vec_assign()` and `vec_slice<-()` now efficiently internally recycle `value` of size 1 at the C level, resulting in less memory usage.
 
 * `vec_assign()` no longer modifies `POSIXlt` and `vctrs_rcrd` types in place (#1951).

--- a/R/subscript-loc.R
+++ b/R/subscript-loc.R
@@ -19,8 +19,10 @@
 #' * `num_as_location()` and `num_as_location2()` are specialized variants
 #'   that have extra options for numeric indices.
 #'
-#' @inheritParams vec_slice
 #' @inheritParams rlang::args_error_context
+#' @inheritParams rlang::args_dots_empty
+#'
+#' @param i An index vector to convert.
 #'
 #' @param n A single integer representing the total size of the
 #'   object that `i` is meant to index into.

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,6 +10,9 @@ indent <- function(x, n) {
 ones <- function(...) {
   array(1, dim = c(...))
 }
+ones_list <- function(...) {
+  array(list(1), dim = c(...))
+}
 
 vec_coerce_bare <- function(x, type) {
   # FIXME! Unexported wrapper around Rf_coerceVector()

--- a/man/vec_as_index.Rd
+++ b/man/vec_as_index.Rd
@@ -7,10 +7,7 @@
 vec_as_index(i, n, names = NULL)
 }
 \arguments{
-\item{i}{An integer, character or logical vector specifying the
-locations or names of the observations to get/set. Specify
-\code{TRUE} to index all elements (as in \code{x[]}), or \code{NULL}, \code{FALSE} or
-\code{integer()} to index none (as in \code{x[NULL]}).}
+\item{i}{An index vector to convert.}
 
 \item{n}{A single integer representing the total size of the
 object that \code{i} is meant to index into.}

--- a/man/vec_as_location.Rd
+++ b/man/vec_as_location.Rd
@@ -50,10 +50,7 @@ num_as_location2(
 )
 }
 \arguments{
-\item{i}{An integer, character or logical vector specifying the
-locations or names of the observations to get/set. Specify
-\code{TRUE} to index all elements (as in \code{x[]}), or \code{NULL}, \code{FALSE} or
-\code{integer()} to index none (as in \code{x[NULL]}).}
+\item{i}{An index vector to convert.}
 
 \item{n}{A single integer representing the total size of the
 object that \code{i} is meant to index into.}

--- a/man/vec_as_subscript.Rd
+++ b/man/vec_as_subscript.Rd
@@ -25,10 +25,7 @@ vec_as_subscript2(
 )
 }
 \arguments{
-\item{i}{An integer, character or logical vector specifying the
-locations or names of the observations to get/set. Specify
-\code{TRUE} to index all elements (as in \code{x[]}), or \code{NULL}, \code{FALSE} or
-\code{integer()} to index none (as in \code{x[NULL]}).}
+\item{i}{An index vector to convert.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 

--- a/man/vec_slice.Rd
+++ b/man/vec_slice.Rd
@@ -10,15 +10,15 @@ vec_slice(x, i, ..., error_call = current_env())
 
 vec_slice(x, i) <- value
 
-vec_assign(x, i, value, ..., x_arg = "", value_arg = "")
+vec_assign(x, i, value, ..., slice_value = FALSE, x_arg = "", value_arg = "")
 }
 \arguments{
 \item{x}{A vector}
 
-\item{i}{An integer, character or logical vector specifying the
-locations or names of the observations to get/set. Specify
-\code{TRUE} to index all elements (as in \code{x[]}), or \code{NULL}, \code{FALSE} or
-\code{integer()} to index none (as in \code{x[NULL]}).}
+\item{i}{An integer, character or logical vector specifying the locations or
+names of the observations to get/set. Specify \code{TRUE} to index all elements
+(as in \code{x[]}), or \code{NULL}, \code{FALSE} or \code{integer()} to index none (as in
+\code{x[NULL]}).}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
@@ -27,10 +27,19 @@ running function, e.g. \code{caller_env()}. The function will be
 mentioned in error messages as the source of the error. See the
 \code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 
-\item{value}{Replacement values. \code{value} is cast to the type of
-\code{x}, but only if they have a common type. See below for examples
-of this rule. \code{value} must be recyclable to the size of \code{i} after \code{i}
-has been converted to a valid integer location vector.}
+\item{value}{A vector of replacement values
+
+\code{value} is cast to the type of \code{x}.
+
+If \code{slice_value = FALSE}, \code{value} must be size 1 or the same size as \code{i}
+after \code{i} has been converted to a positive integer location vector with
+\code{\link[=vec_as_location]{vec_as_location()}} (which may not be the same size as \code{i} originally).
+
+If \code{slice_value = TRUE}, \code{value} must be size 1 or the same size as \code{x}.}
+
+\item{slice_value}{A boolean. If \code{TRUE}, the assignment proceeds as if you
+had provided \code{vec_slice(x, i) <- vec_slice(value, i)}, but is optimized to
+avoid materializing the slice of \code{value}.}
 
 \item{x_arg, value_arg}{Argument names for \code{x} and \code{value}. These are used
 in error messages to inform the user about the locations of
@@ -42,8 +51,8 @@ A vector of the same type as \code{x}.
 }
 \description{
 This provides a common interface to extracting and modifying observations
-for all vector types, regardless of dimensionality. It is an analog to \code{[}
-that matches \code{\link[=vec_size]{vec_size()}} instead of \code{length()}.
+for all vector types, regardless of dimensionality. They are analogs to \code{[}
+and \verb{[<-} that match \code{\link[=vec_size]{vec_size()}} instead of \code{length()}.
 }
 \section{Genericity}{
 
@@ -147,5 +156,30 @@ try(vec_cast(1.5, integer()))
 # vector:
 x <- 1:3
 try(vec_slice(x, 2) <- 1.5)
+
+# Slicing `value` -------------------------------------------------
+
+# Sometimes both `x` and `value` start from objects that are the same length,
+# and you need to slice `value` by `i` before assigning it to `x`. This comes
+# up when thinking about how `base::ifelse()` and `dplyr::case_when()` work.
+condition <- c(TRUE, FALSE, TRUE, FALSE)
+yes <- 1:4
+no <- 5:8
+
+# Create an output container and fill it
+out <- vec_init(integer(), 4)
+out <- vec_assign(out, condition, vec_slice(yes, condition))
+out <- vec_assign(out, !condition, vec_slice(no, !condition))
+out
+
+# This is wasteful because you have to materialize the slices of `yes` and
+# `no` before they can be assigned, and you also have to validate `condition`
+# multiple times. Using `slice_value` internally performs
+# `vec_slice(yes, condition)` and `vec_slice(no, !condition)` for you,
+# but does so in a way that avoids the materialization.
+out <- vec_init(integer(), 4)
+out <- vec_assign(out, condition, yes, slice_value = TRUE)
+out <- vec_assign(out, !condition, no, slice_value = TRUE)
+out
 }
 \keyword{internal}

--- a/src/bind.c
+++ b/src/bind.c
@@ -155,6 +155,8 @@ r_obj* vec_rbind(r_obj* xs,
   const struct vec_proxy_assign_opts bind_proxy_assign_opts = {
     .ownership = VCTRS_OWNERSHIP_deep,
     .recursively_proxied = true,
+    .slice_value = ASSIGNMENT_SLICE_VALUE_no,
+    .index_style = VCTRS_INDEX_STYLE_location,
     .assign_names = assign_names,
     // Unlike in `vec_c()` we don't need to ignore outer names because
     // `df_assign()` doesn't deal with those
@@ -228,7 +230,14 @@ r_obj* vec_rbind(r_obj* xs,
         // If there is no name to assign, skip the assignment since
         // `out_names` already contains empty strings
         if (inner != chrs_empty) {
-          row_names = chr_assign(row_names, loc, x_nms, VCTRS_OWNERSHIP_deep);
+          row_names = chr_assign(
+            row_names,
+            loc,
+            x_nms,
+            VCTRS_OWNERSHIP_deep,
+            ASSIGNMENT_SLICE_VALUE_no,
+            VCTRS_INDEX_STYLE_location
+          );
           KEEP_AT(row_names, rownames_pi);
         }
       }
@@ -497,12 +506,26 @@ r_obj* vec_cbind(r_obj* xs,
     r_ssize xn = r_length(x);
     init_compact_seq(idx_ptr, counter, xn, true);
 
-    out = list_assign(out, idx, x, cbind_out_ownership);
+    out = list_assign(
+      out,
+      idx,
+      x,
+      cbind_out_ownership,
+      ASSIGNMENT_SLICE_VALUE_no,
+      VCTRS_INDEX_STYLE_location
+    );
     KEEP_AT(out, out_pi);
 
     r_obj* xnms = KEEP(r_names(x));
     if (xnms != r_null) {
-      names = chr_assign(names, idx, xnms, VCTRS_OWNERSHIP_deep);
+      names = chr_assign(
+        names,
+        idx,
+        xnms,
+        VCTRS_OWNERSHIP_deep,
+        ASSIGNMENT_SLICE_VALUE_no,
+        VCTRS_INDEX_STYLE_location
+      );
       KEEP_AT(names, names_pi);
     }
     FREE(1);

--- a/src/c-unchop.c
+++ b/src/c-unchop.c
@@ -104,6 +104,8 @@ r_obj* list_unchop(r_obj* xs,
   const struct vec_proxy_assign_opts unchop_proxy_assign_opts = {
     .ownership = VCTRS_OWNERSHIP_deep,
     .recursively_proxied = true,
+    .slice_value = ASSIGNMENT_SLICE_VALUE_no,
+    .index_style = VCTRS_INDEX_STYLE_location,
     .assign_names = assign_names,
     .ignore_outer_names = true,
     .call = error_call
@@ -153,7 +155,14 @@ r_obj* list_unchop(r_obj* xs,
         // If there is no name to assign, skip the assignment since
         // `out_names` already contains empty strings
         if (x_nms != chrs_empty) {
-          out_names = chr_assign(out_names, loc, x_nms, VCTRS_OWNERSHIP_deep);
+          out_names = chr_assign(
+            out_names,
+            loc,
+            x_nms,
+            VCTRS_OWNERSHIP_deep,
+            ASSIGNMENT_SLICE_VALUE_no,
+            VCTRS_INDEX_STYLE_location
+          );
           KEEP_AT(out_names, out_names_pi);
         }
       }

--- a/src/c.c
+++ b/src/c.c
@@ -85,6 +85,8 @@ r_obj* vec_c_opts(r_obj* xs,
   const struct vec_proxy_assign_opts c_proxy_assign_opts = {
     .ownership = VCTRS_OWNERSHIP_deep,
     .recursively_proxied = true,
+    .slice_value = ASSIGNMENT_SLICE_VALUE_no,
+    .index_style = VCTRS_INDEX_STYLE_location,
     .assign_names = assign_names,
     .ignore_outer_names = true,
     .call = error_call
@@ -134,7 +136,14 @@ r_obj* vec_c_opts(r_obj* xs,
         // If there is no name to assign, skip the assignment since
         // `out_names` already contains empty strings
         if (x_nms != chrs_empty) {
-          out_names = chr_assign(out_names, loc, x_nms, VCTRS_OWNERSHIP_deep);
+          out_names = chr_assign(
+            out_names,
+            loc,
+            x_nms,
+            VCTRS_OWNERSHIP_deep,
+            ASSIGNMENT_SLICE_VALUE_no,
+            VCTRS_INDEX_STYLE_location
+          );
           KEEP_AT(out_names, out_names_pi);
         }
       }

--- a/src/decl/slice-assign-decl.h
+++ b/src/decl/slice-assign-decl.h
@@ -2,22 +2,73 @@ static r_obj* syms_vec_assign_fallback;
 static r_obj* fns_vec_assign_fallback;
 
 static
-r_obj* vec_assign_fallback(r_obj* x, r_obj* index, r_obj* value);
+r_obj* vec_assign_fallback(
+  r_obj* x,
+  r_obj* index,
+  r_obj* value,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+);
 
 static
-r_obj* vec_proxy_assign_names(r_obj* proxy, r_obj* index, r_obj* value, const enum vctrs_ownership ownership);
+r_obj* vec_proxy_assign_names(
+  r_obj* proxy,
+  r_obj* index,
+  r_obj* value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+);
 
 static
-r_obj* lgl_assign(r_obj* x, r_obj* index, r_obj* value, const enum vctrs_ownership ownership);
+r_obj* lgl_assign(
+  r_obj* x,
+  r_obj* index,
+  r_obj* value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+);
 
 static
-r_obj* int_assign(r_obj* x, r_obj* index, r_obj* value, const enum vctrs_ownership ownership);
+r_obj* int_assign(
+  r_obj* x,
+  r_obj* index,
+  r_obj* value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+);
 
 static
-r_obj* dbl_assign(r_obj* x, r_obj* index, r_obj* value, const enum vctrs_ownership ownership);
+r_obj* dbl_assign(
+  r_obj* x,
+  r_obj* index,
+  r_obj* value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+);
 
 static
-r_obj* cpl_assign(r_obj* x, r_obj* index, r_obj* value, const enum vctrs_ownership ownership);
+r_obj* cpl_assign(
+  r_obj* x,
+  r_obj* index,
+  r_obj* value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+);
 
 static
-r_obj* raw_assign(r_obj* x, r_obj* index, r_obj* value, const enum vctrs_ownership ownership);
+r_obj* raw_assign(
+  r_obj* x,
+  r_obj* index,
+  r_obj* value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+);
+
+static inline
+bool should_slice_value(enum assignment_slice_value slice_value);

--- a/src/globals.c
+++ b/src/globals.c
@@ -66,6 +66,8 @@ void vctrs_init_globals(r_obj* ns) {
   // Strings and characters --------------------------------------------
   INIT_STRING(AsIs);
   INIT_STRING(repair);
+  INIT_STRING(location);
+  INIT_STRING(condition);
 
   // Args --------------------------------------------------------------
   INIT_ARG2(dot_name_repair, ".name_repair");
@@ -85,7 +87,6 @@ void vctrs_init_globals(r_obj* ns) {
 
   // Calls -------------------------------------------------------------
   INIT_CALL(vec_assign);
-  INIT_CALL(vec_assign_params);
   INIT_CALL(vec_assign_seq);
   INIT_CALL(vec_init);
   INIT_CALL(vec_ptype_finalise);

--- a/src/globals.h
+++ b/src/globals.h
@@ -30,10 +30,14 @@ struct syms {
 struct strings {
   r_obj* AsIs;
   r_obj* repair;
+  r_obj* location;
+  r_obj* condition;
 };
 struct chrs {
   r_obj* AsIs;
   r_obj* repair;
+  r_obj* location;
+  r_obj* condition;
 };
 
 struct fns {
@@ -62,7 +66,6 @@ struct lazy_args {
 
 struct lazy_calls {
   struct r_lazy vec_assign;
-  struct r_lazy vec_assign_params;
   struct r_lazy vec_assign_seq;
   struct r_lazy vec_init;
   struct r_lazy vec_ptype_finalise;

--- a/src/init.c
+++ b/src/init.c
@@ -79,8 +79,8 @@ extern SEXP ffi_proxy_info(SEXP);
 extern r_obj* ffi_class_type(r_obj*);
 extern r_obj* ffi_vec_bare_df_restore(r_obj*, r_obj*);
 extern r_obj* ffi_recycle(r_obj*, r_obj*, r_obj*);
-extern r_obj* ffi_assign(r_obj*, r_obj*, r_obj*, r_obj*);
-extern r_obj* ffi_assign_seq(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_assign(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_assign_seq(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_set_attributes(SEXP, SEXP);
 extern r_obj* ffi_as_df_row(r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_outer_names(r_obj*, r_obj*, r_obj*);
@@ -102,7 +102,7 @@ extern r_obj* df_flatten(r_obj*);
 extern SEXP vctrs_linked_version(void);
 extern r_obj* ffi_tib_ptype2(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_tib_cast(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
-extern r_obj* ffi_assign_params(r_obj*, r_obj*, r_obj*, r_obj*);
+extern r_obj* ffi_assign_params(r_obj*, r_obj*, r_obj*, r_obj*, r_obj*, r_obj*);
 extern SEXP vctrs_has_dim(SEXP);
 extern r_obj* ffi_vec_rep(r_obj*, r_obj*, r_obj*);
 extern r_obj* ffi_vec_rep_each(r_obj*, r_obj*, r_obj*);
@@ -265,8 +265,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"ffi_class_type",                            (DL_FUNC) &ffi_class_type, 1},
   {"ffi_vec_bare_df_restore",                   (DL_FUNC) &ffi_vec_bare_df_restore, 2},
   {"ffi_recycle",                               (DL_FUNC) &ffi_recycle, 3},
-  {"ffi_assign",                                (DL_FUNC) &ffi_assign, 4},
-  {"ffi_assign_seq",                            (DL_FUNC) &ffi_assign_seq, 5},
+  {"ffi_assign",                                (DL_FUNC) &ffi_assign, 5},
+  {"ffi_assign_seq",                            (DL_FUNC) &ffi_assign_seq, 6},
   {"vctrs_set_attributes",                      (DL_FUNC) &vctrs_set_attributes, 2},
   {"ffi_as_df_row",                             (DL_FUNC) &ffi_as_df_row, 3},
   {"ffi_outer_names",                           (DL_FUNC) &ffi_outer_names, 3},
@@ -292,7 +292,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"vctrs_linked_version",                      (DL_FUNC) &vctrs_linked_version, 0},
   {"ffi_tib_ptype2",                            (DL_FUNC) &ffi_tib_ptype2, 5},
   {"ffi_tib_cast",                              (DL_FUNC) &ffi_tib_cast, 5},
-  {"ffi_assign_params",                         (DL_FUNC) &ffi_assign_params, 4},
+  {"ffi_assign_params",                         (DL_FUNC) &ffi_assign_params, 6},
   {"vctrs_has_dim",                             (DL_FUNC) &vctrs_has_dim, 1},
   {"ffi_vec_rep",                               (DL_FUNC) &ffi_vec_rep, 3},
   {"ffi_vec_rep_each",                          (DL_FUNC) &ffi_vec_rep_each, 3},

--- a/src/slice-assign-array.c
+++ b/src/slice-assign-array.c
@@ -1,236 +1,445 @@
 #include "vctrs.h"
 
-#define ASSIGN_SHAPED_INDEX(                                           \
-  CTYPE,                                                               \
-  DEREF,                                                               \
-  CONST_DEREF,                                                         \
-  VALUE_POST_INDEX_INCREMENT,                                          \
-  VALUE_POST_SHAPE_INCREMENT                                           \
-)                                                                      \
-  SEXP out = PROTECT(vec_clone_referenced(proxy, ownership));          \
-  CTYPE* p_out = DEREF(out);                                           \
-                                                                       \
-  const CTYPE* p_value = CONST_DEREF(value);                           \
-  R_len_t k = 0;                                                       \
-                                                                       \
-  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {                 \
-    R_len_t loc = vec_strided_loc(                                     \
-      p_info->p_shape_index,                                           \
-      p_info->p_strides,                                               \
-      p_info->shape_n                                                  \
-    );                                                                 \
-                                                                       \
-    for (R_len_t j = 0; j < p_info->index_n; ++j) {                    \
-      const int step = p_info->p_steps[j];                             \
-                                                                       \
-      if (step != NA_INTEGER) {                                        \
-        loc += step;                                                   \
-        p_out[loc] = p_value[k];                                       \
-      }                                                                \
-                                                                       \
-      k += VALUE_POST_INDEX_INCREMENT;                                 \
-    }                                                                  \
-                                                                       \
-    vec_shape_index_increment(p_info);                                 \
-    k += VALUE_POST_SHAPE_INCREMENT;                                   \
-  }                                                                    \
-                                                                       \
-  UNPROTECT(1);                                                        \
+#define ASSIGN_SHAPED_LOCATION_INDEX(                                       \
+  CTYPE,                                                                    \
+  DEREF,                                                                    \
+  CONST_DEREF,                                                              \
+  SLICE_VALUE,                                                              \
+  VALUE_LOC_POST_INDEX_INCREMENT,                                           \
+  VALUE_LOC_POST_SHAPE_INCREMENT                                            \
+)                                                                           \
+  int n_protect = 0;                                                        \
+                                                                            \
+  struct strides_info info = new_strides_info(proxy, index);                \
+  struct strides_info* p_info = &info;                                      \
+  PROTECT_STRIDES_INFO(p_info, &n_protect);                                 \
+                                                                            \
+  SEXP out = PROTECT_N(vec_clone_referenced(proxy, ownership), &n_protect); \
+  CTYPE* p_out = DEREF(out);                                                \
+                                                                            \
+  const CTYPE* p_value = CONST_DEREF(value);                                \
+                                                                            \
+  /* The `value` location used in the `slice_value = FALSE` */              \
+  /* and `vec_size(value) == 1` cases. When `slice_value = TRUE` */         \
+  /* and we aren't recycling, `value` tracks `x` instead. */                \
+  R_len_t value_loc = 0;                                                    \
+                                                                            \
+  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {                      \
+    R_len_t out_loc = vec_strided_loc(                                      \
+      p_info->p_shape_index,                                                \
+      p_info->p_strides,                                                    \
+      p_info->shape_n                                                       \
+    );                                                                      \
+                                                                            \
+    for (R_len_t index_loc = 0; index_loc < p_info->index_n; ++index_loc) { \
+      const int step = p_info->p_steps[index_loc];                          \
+                                                                            \
+      if (step != NA_INTEGER) {                                             \
+        out_loc += step;                                                    \
+        p_out[out_loc] = p_value[SLICE_VALUE ? out_loc : value_loc];        \
+      }                                                                     \
+                                                                            \
+      value_loc += VALUE_LOC_POST_INDEX_INCREMENT;                          \
+    }                                                                       \
+                                                                            \
+    vec_shape_index_increment(p_info);                                      \
+    value_loc += VALUE_LOC_POST_SHAPE_INCREMENT;                            \
+  }                                                                         \
+                                                                            \
+  UNPROTECT(n_protect);                                                     \
   return out
 
-#define ASSIGN_SHAPED_COMPACT(                                         \
-  CTYPE,                                                               \
-  DEREF,                                                               \
-  CONST_DEREF,                                                         \
-  VALUE_POST_INDEX_INCREMENT,                                          \
-  VALUE_POST_SHAPE_INCREMENT                                           \
-)                                                                      \
-  SEXP out = PROTECT(vec_clone_referenced(proxy, ownership));          \
-  CTYPE* p_out = DEREF(out);                                           \
-                                                                       \
-  const R_len_t start = p_info->p_index[0];                            \
-  const R_len_t step = p_info->p_index[2];                             \
-                                                                       \
-  const CTYPE* p_value = CONST_DEREF(value);                           \
-  R_len_t k = 0;                                                       \
-                                                                       \
-  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {                 \
-    R_len_t loc = vec_strided_loc(                                     \
-      p_info->p_shape_index,                                           \
-      p_info->p_strides,                                               \
-      p_info->shape_n                                                  \
-    );                                                                 \
-                                                                       \
-    loc += start;                                                      \
-                                                                       \
-    for (R_len_t j = 0; j < p_info->index_n; ++j) {                    \
-      p_out[loc] = p_value[k];                                         \
-      loc += step;                                                     \
-      k += VALUE_POST_INDEX_INCREMENT;                                 \
-    }                                                                  \
-                                                                       \
-    vec_shape_index_increment(p_info);                                 \
-    k += VALUE_POST_SHAPE_INCREMENT;                                   \
-  }                                                                    \
-                                                                       \
-  UNPROTECT(1);                                                        \
+#define ASSIGN_SHAPED_LOCATION_COMPACT(                                     \
+  CTYPE,                                                                    \
+  DEREF,                                                                    \
+  CONST_DEREF,                                                              \
+  SLICE_VALUE,                                                              \
+  VALUE_LOC_POST_INDEX_INCREMENT,                                           \
+  VALUE_LOC_POST_SHAPE_INCREMENT                                            \
+)                                                                           \
+  int n_protect = 0;                                                        \
+                                                                            \
+  struct strides_info info = new_strides_info(proxy, index);                \
+  struct strides_info* p_info = &info;                                      \
+  PROTECT_STRIDES_INFO(p_info, &n_protect);                                 \
+                                                                            \
+  SEXP out = PROTECT_N(vec_clone_referenced(proxy, ownership), &n_protect); \
+  CTYPE* p_out = DEREF(out);                                                \
+                                                                            \
+  const R_len_t start = p_info->p_index[0];                                 \
+  const R_len_t step = p_info->p_index[2];                                  \
+                                                                            \
+  const CTYPE* p_value = CONST_DEREF(value);                                \
+                                                                            \
+  R_len_t value_loc = 0;                                                    \
+                                                                            \
+  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {                      \
+    R_len_t out_loc = vec_strided_loc(                                      \
+      p_info->p_shape_index,                                                \
+      p_info->p_strides,                                                    \
+      p_info->shape_n                                                       \
+    );                                                                      \
+                                                                            \
+    out_loc += start;                                                       \
+                                                                            \
+    for (R_len_t index_loc = 0; index_loc < p_info->index_n; ++index_loc) { \
+      p_out[out_loc] = p_value[SLICE_VALUE ? out_loc : value_loc];          \
+      out_loc += step;                                                      \
+      value_loc += VALUE_LOC_POST_INDEX_INCREMENT;                          \
+    }                                                                       \
+                                                                            \
+    vec_shape_index_increment(p_info);                                      \
+    value_loc += VALUE_LOC_POST_SHAPE_INCREMENT;                            \
+  }                                                                         \
+                                                                            \
+  UNPROTECT(n_protect);                                                     \
   return out
 
 // -----------------------------------------------------------------------------
 
-#define ASSIGN_SHAPED(CTYPE, DEREF, CONST_DEREF)                               \
-  r_ssize value_size = vec_size(value);                                        \
-                                                                               \
-  if (is_compact_seq(index)) {                                                 \
-    if (value_size == 1) {                                                     \
-      ASSIGN_SHAPED_COMPACT(CTYPE, DEREF, CONST_DEREF, 0, 1);                  \
-    } else if (value_size == p_info->index_n) {                                \
-      ASSIGN_SHAPED_COMPACT(CTYPE, DEREF, CONST_DEREF, 1, 0);                  \
-    } else {                                                                   \
-      r_stop_internal("`value` should have been recycled to match `index`.");  \
-    }                                                                          \
-  } else {                                                                     \
-    if (value_size == 1) {                                                     \
-      ASSIGN_SHAPED_INDEX(CTYPE, DEREF, CONST_DEREF, 0, 1);                    \
-    } else if (value_size == p_info->index_n) {                                \
-      ASSIGN_SHAPED_INDEX(CTYPE, DEREF, CONST_DEREF, 1, 0);                    \
-    } else {                                                                   \
-      r_stop_internal("`value` should have been recycled to match `index`.");  \
-    }                                                                          \
+// Strides information is not required here!
+#define ASSIGN_SHAPED_CONDITION_INDEX(                                 \
+  CTYPE,                                                               \
+  DEREF,                                                               \
+  CONST_DEREF,                                                         \
+  SLICE_VALUE,                                                         \
+  VALUE_LOC_POST_INDEX_INCREMENT,                                      \
+  VALUE_LOC_POST_SHAPE_INCREMENT                                       \
+)                                                                      \
+  r_obj* dim = PROTECT(vec_dim(proxy));                                \
+  const int* p_dim = INTEGER_RO(dim);                                  \
+  R_len_t dim_n = Rf_length(dim);                                      \
+  R_len_t shape_elem_n = vec_shape_elem_n(p_dim, dim_n);               \
+                                                                       \
+  R_len_t index_size = r_length(index);                                \
+  const int* p_index = r_int_cbegin(index);                            \
+                                                                       \
+  SEXP out = PROTECT(vec_clone_referenced(proxy, ownership));          \
+  CTYPE* p_out = DEREF(out);                                           \
+  R_len_t out_loc = 0;                                                 \
+                                                                       \
+  const CTYPE* p_value = CONST_DEREF(value);                           \
+  R_len_t value_loc = 0;                                               \
+                                                                       \
+  for (R_len_t i = 0; i < shape_elem_n; ++i) {                         \
+    for (R_len_t index_loc = 0; index_loc < index_size; ++index_loc) { \
+      const int index_elt = p_index[index_loc];                        \
+      if (index_elt == 1) {                                            \
+        p_out[out_loc] = p_value[SLICE_VALUE ? out_loc : value_loc];   \
+      }                                                                \
+      ++out_loc;                                                       \
+      value_loc += VALUE_LOC_POST_INDEX_INCREMENT;                     \
+    }                                                                  \
+    value_loc += VALUE_LOC_POST_SHAPE_INCREMENT;                       \
+  }                                                                    \
+                                                                       \
+  UNPROTECT(2);                                                        \
+  return out
+
+// -----------------------------------------------------------------------------
+
+#define ASSIGN_SHAPED_LOCATION(CTYPE, DEREF, CONST_DEREF)                           \
+  const r_ssize value_size = vec_size(value);                                       \
+  check_assign_sizes(proxy, index, value_size, slice_value, index_style);           \
+                                                                                    \
+  if (is_compact_seq(index)) {                                                      \
+    if (value_size == 1) {                                                          \
+      ASSIGN_SHAPED_LOCATION_COMPACT(CTYPE, DEREF, CONST_DEREF, false, 0, 1);       \
+    } else if (should_slice_value(slice_value)) {                                   \
+      ASSIGN_SHAPED_LOCATION_COMPACT(CTYPE, DEREF, CONST_DEREF, true, 0, 0);        \
+    } else {                                                                        \
+      ASSIGN_SHAPED_LOCATION_COMPACT(CTYPE, DEREF, CONST_DEREF, false, 1, 0);       \
+    }                                                                               \
+  } else {                                                                          \
+    if (value_size == 1) {                                                          \
+      ASSIGN_SHAPED_LOCATION_INDEX(CTYPE, DEREF, CONST_DEREF, false, 0, 1);         \
+    } else if (should_slice_value(slice_value)) {                                   \
+      ASSIGN_SHAPED_LOCATION_INDEX(CTYPE, DEREF, CONST_DEREF, true, 0, 0);          \
+    } else {                                                                        \
+      ASSIGN_SHAPED_LOCATION_INDEX(CTYPE, DEREF, CONST_DEREF, false, 1, 0);         \
+    }                                                                               \
   }
 
-static inline SEXP lgl_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     const enum vctrs_ownership ownership,
-                                     struct strides_info* p_info) {
+#define ASSIGN_SHAPED_CONDITION(CTYPE, DEREF, CONST_DEREF)                                \
+  const r_ssize value_size = vec_size(value);                                             \
+  check_assign_sizes(proxy, index, value_size, slice_value, index_style);                 \
+                                                                                          \
+  if (is_compact_seq(index)) {                                                            \
+    r_stop_internal(                                                                      \
+      "Compact sequence `index` are not supported in the condition path."                 \
+    );                                                                                    \
+  } else {                                                                                \
+    if (value_size == 1) {                                                                \
+      ASSIGN_SHAPED_CONDITION_INDEX(CTYPE, DEREF, CONST_DEREF, false, 0, 1);              \
+    } else if (should_slice_value(slice_value)) {                                         \
+      ASSIGN_SHAPED_CONDITION_INDEX(CTYPE, DEREF, CONST_DEREF, true, 0, 0);               \
+    } else {                                                                              \
+      ASSIGN_SHAPED_CONDITION_INDEX(CTYPE, DEREF, CONST_DEREF, false, index_elt != 0, 0); \
+    }                                                                                     \
+  }
+
+#define ASSIGN_SHAPED(CTYPE, DEREF, CONST_DEREF)                        \
+  switch (index_style) {                                                \
+  case VCTRS_INDEX_STYLE_location: {                                    \
+    ASSIGN_SHAPED_LOCATION(CTYPE, DEREF, CONST_DEREF);                  \
+  }                                                                     \
+  case VCTRS_INDEX_STYLE_condition: {                                   \
+    ASSIGN_SHAPED_CONDITION(CTYPE, DEREF, CONST_DEREF);                 \
+  }                                                                     \
+  default: r_stop_unreachable();                                        \
+  }
+
+static inline SEXP lgl_assign_shaped(
+  SEXP proxy,
+  SEXP index,
+  SEXP value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+) {
   ASSIGN_SHAPED(int, LOGICAL, LOGICAL_RO);
 }
-static inline SEXP int_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     const enum vctrs_ownership ownership,
-                                     struct strides_info* p_info) {
+static inline SEXP int_assign_shaped(
+  SEXP proxy,
+  SEXP index,
+  SEXP value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+) {
   ASSIGN_SHAPED(int, INTEGER, INTEGER_RO);
 }
-static inline SEXP dbl_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     const enum vctrs_ownership ownership,
-                                     struct strides_info* p_info) {
+static inline SEXP dbl_assign_shaped(
+  SEXP proxy,
+  SEXP index,
+  SEXP value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+) {
   ASSIGN_SHAPED(double, REAL, REAL_RO);
 }
-static inline SEXP cpl_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     const enum vctrs_ownership ownership,
-                                     struct strides_info* p_info) {
+static inline SEXP cpl_assign_shaped(
+  SEXP proxy,
+  SEXP index,
+  SEXP value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+) {
   ASSIGN_SHAPED(Rcomplex, COMPLEX, COMPLEX_RO);
 }
-static inline SEXP chr_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     const enum vctrs_ownership ownership,
-                                     struct strides_info* p_info) {
+static inline SEXP chr_assign_shaped(
+  SEXP proxy,
+  SEXP index,
+  SEXP value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+) {
   ASSIGN_SHAPED(SEXP, STRING_PTR, STRING_PTR_RO);
 }
-static inline SEXP raw_assign_shaped(SEXP proxy, SEXP index, SEXP value,
-                                     const enum vctrs_ownership ownership,
-                                     struct strides_info* p_info) {
+static inline SEXP raw_assign_shaped(
+  SEXP proxy,
+  SEXP index,
+  SEXP value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+) {
   ASSIGN_SHAPED(Rbyte, RAW, RAW_RO);
 }
 
 #undef ASSIGN_SHAPED
-#undef ASSIGN_SHAPED_COMPACT
-#undef ASSIGN_SHAPED_INDEX
+#undef ASSIGN_SHAPED_LOCATION
+#undef ASSIGN_SHAPED_LOCATION_COMPACT
+#undef ASSIGN_SHAPED_LOCATION_INDEX
+#undef ASSIGN_SHAPED_CONDITION
+#undef ASSIGN_SHAPED_CONDITION_INDEX
 
 // -----------------------------------------------------------------------------
 
-#define ASSIGN_BARRIER_SHAPED_INDEX(                                   \
+#define ASSIGN_BARRIER_SHAPED_LOCATION_INDEX(                               \
+  CTYPE,                                                                    \
+  CONST_DEREF,                                                              \
+  SET,                                                                      \
+  SLICE_VALUE,                                                              \
+  VALUE_LOC_POST_INDEX_INCREMENT,                                           \
+  VALUE_LOC_POST_SHAPE_INCREMENT                                            \
+)                                                                           \
+  int n_protect = 0;                                                        \
+                                                                            \
+  struct strides_info info = new_strides_info(proxy, index);                \
+  struct strides_info* p_info = &info;                                      \
+  PROTECT_STRIDES_INFO(p_info, &n_protect);                                 \
+                                                                            \
+  SEXP out = PROTECT_N(vec_clone_referenced(proxy, ownership), &n_protect); \
+                                                                            \
+  CTYPE const* p_value = CONST_DEREF(value);                                \
+                                                                            \
+  R_len_t value_loc = 0;                                                    \
+                                                                            \
+  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {                      \
+    R_len_t out_loc = vec_strided_loc(                                      \
+      p_info->p_shape_index,                                                \
+      p_info->p_strides,                                                    \
+      p_info->shape_n                                                       \
+    );                                                                      \
+                                                                            \
+    for (R_len_t index_loc = 0; index_loc < p_info->index_n; ++index_loc) { \
+      const int step = p_info->p_steps[index_loc];                          \
+                                                                            \
+      if (step != NA_INTEGER) {                                             \
+        out_loc += step;                                                    \
+        SET(out, out_loc, p_value[SLICE_VALUE ? out_loc : value_loc]);      \
+      }                                                                     \
+                                                                            \
+      value_loc += VALUE_LOC_POST_INDEX_INCREMENT;                          \
+    }                                                                       \
+                                                                            \
+    vec_shape_index_increment(p_info);                                      \
+    value_loc += VALUE_LOC_POST_SHAPE_INCREMENT;                            \
+  }                                                                         \
+                                                                            \
+  UNPROTECT(n_protect);                                                     \
+  return out
+
+#define ASSIGN_BARRIER_SHAPED_LOCATION_COMPACT(                             \
+  CTYPE,                                                                    \
+  CONST_DEREF,                                                              \
+  SET,                                                                      \
+  SLICE_VALUE,                                                              \
+  VALUE_LOC_POST_INDEX_INCREMENT,                                           \
+  VALUE_LOC_POST_SHAPE_INCREMENT                                            \
+)                                                                           \
+  int n_protect = 0;                                                        \
+                                                                            \
+  struct strides_info info = new_strides_info(proxy, index);                \
+  struct strides_info* p_info = &info;                                      \
+  PROTECT_STRIDES_INFO(p_info, &n_protect);                                 \
+                                                                            \
+  SEXP out = PROTECT_N(vec_clone_referenced(proxy, ownership), &n_protect); \
+                                                                            \
+  const R_len_t start = p_info->p_index[0];                                 \
+  const R_len_t step = p_info->p_index[2];                                  \
+                                                                            \
+  CTYPE const* p_value = CONST_DEREF(value);                                \
+                                                                            \
+  R_len_t value_loc = 0;                                                    \
+                                                                            \
+  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {                      \
+    R_len_t out_loc = vec_strided_loc(                                      \
+      p_info->p_shape_index,                                                \
+      p_info->p_strides,                                                    \
+      p_info->shape_n                                                       \
+    );                                                                      \
+                                                                            \
+    out_loc += start;                                                       \
+                                                                            \
+    for (R_len_t index_loc = 0; index_loc < p_info->index_n; ++index_loc) { \
+      SET(out, out_loc, p_value[SLICE_VALUE ? out_loc : value_loc]);        \
+      out_loc += step;                                                      \
+      value_loc += VALUE_LOC_POST_INDEX_INCREMENT;                          \
+    }                                                                       \
+                                                                            \
+    vec_shape_index_increment(p_info);                                      \
+    value_loc += VALUE_LOC_POST_SHAPE_INCREMENT;                            \
+  }                                                                         \
+                                                                            \
+  UNPROTECT(n_protect);                                                     \
+  return out
+
+// -----------------------------------------------------------------------------
+
+// Strides information is not required here!
+#define ASSIGN_BARRIER_SHAPED_CONDITION_INDEX(                         \
   CTYPE,                                                               \
   CONST_DEREF,                                                         \
   SET,                                                                 \
-  VALUE_POST_INDEX_INCREMENT,                                          \
-  VALUE_POST_SHAPE_INCREMENT                                           \
+  SLICE_VALUE,                                                         \
+  VALUE_LOC_POST_INDEX_INCREMENT,                                      \
+  VALUE_LOC_POST_SHAPE_INCREMENT                                       \
 )                                                                      \
+  r_obj* dim = PROTECT(vec_dim(proxy));                                \
+  const int* p_dim = INTEGER_RO(dim);                                  \
+  R_len_t dim_n = Rf_length(dim);                                      \
+  R_len_t shape_elem_n = vec_shape_elem_n(p_dim, dim_n);               \
+                                                                       \
+  R_len_t index_size = r_length(index);                                \
+  const int* p_index = r_int_cbegin(index);                            \
+                                                                       \
   SEXP out = PROTECT(vec_clone_referenced(proxy, ownership));          \
+  R_len_t out_loc = 0;                                                 \
                                                                        \
   CTYPE const* p_value = CONST_DEREF(value);                           \
-  R_len_t k = 0;                                                       \
+  R_len_t value_loc = 0;                                               \
                                                                        \
-  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {                 \
-    R_len_t loc = vec_strided_loc(                                     \
-      p_info->p_shape_index,                                           \
-      p_info->p_strides,                                               \
-      p_info->shape_n                                                  \
-    );                                                                 \
-                                                                       \
-    for (R_len_t j = 0; j < p_info->index_n; ++j) {                    \
-      const int step = p_info->p_steps[j];                             \
-                                                                       \
-      if (step != NA_INTEGER) {                                        \
-        loc += step;                                                   \
-        SET(out, loc, p_value[k]);                                     \
+  for (R_len_t i = 0; i < shape_elem_n; ++i) {                         \
+    for (R_len_t index_loc = 0; index_loc < index_size; ++index_loc) { \
+      const int index_elt = p_index[index_loc];                        \
+      if (index_elt == 1) {                                            \
+        SET(out, out_loc, p_value[SLICE_VALUE ? out_loc : value_loc]); \
       }                                                                \
-                                                                       \
-      k += VALUE_POST_INDEX_INCREMENT;                                 \
+      ++out_loc;                                                       \
+      value_loc += VALUE_LOC_POST_INDEX_INCREMENT;                     \
     }                                                                  \
-                                                                       \
-    vec_shape_index_increment(p_info);                                 \
-    k += VALUE_POST_SHAPE_INCREMENT;                                   \
+    value_loc += VALUE_LOC_POST_SHAPE_INCREMENT;                       \
   }                                                                    \
                                                                        \
-  UNPROTECT(1);                                                        \
-  return out
-
-#define ASSIGN_BARRIER_SHAPED_COMPACT(                                 \
-  CTYPE,                                                               \
-  CONST_DEREF,                                                         \
-  SET,                                                                 \
-  VALUE_POST_INDEX_INCREMENT,                                          \
-  VALUE_POST_SHAPE_INCREMENT                                           \
-)                                                                      \
-  SEXP out = PROTECT(vec_clone_referenced(proxy, ownership));          \
-                                                                       \
-  const R_len_t start = p_info->p_index[0];                            \
-  const R_len_t step = p_info->p_index[2];                             \
-                                                                       \
-  CTYPE const* p_value = CONST_DEREF(value);                           \
-  R_len_t k = 0;                                                       \
-                                                                       \
-  for (R_len_t i = 0; i < p_info->shape_elem_n; ++i) {                 \
-    R_len_t loc = vec_strided_loc(                                     \
-      p_info->p_shape_index,                                           \
-      p_info->p_strides,                                               \
-      p_info->shape_n                                                  \
-    );                                                                 \
-                                                                       \
-    loc += start;                                                      \
-                                                                       \
-    for (R_len_t j = 0; j < p_info->index_n; ++j) {                    \
-      SET(out, loc, p_value[k]);                                       \
-      loc += step;                                                     \
-      k += VALUE_POST_INDEX_INCREMENT;                                 \
-    }                                                                  \
-                                                                       \
-    vec_shape_index_increment(p_info);                                 \
-    k += VALUE_POST_SHAPE_INCREMENT;                                   \
-  }                                                                    \
-                                                                       \
-  UNPROTECT(1);                                                        \
+  UNPROTECT(2);                                                        \
   return out
 
 // -----------------------------------------------------------------------------
 
-#define ASSIGN_BARRIER_SHAPED(CTYPE, CONST_DEREF, SET)                         \
-  r_ssize value_size = vec_size(value);                                        \
-                                                                               \
-  if (is_compact_seq(index)) {                                                 \
-    if (value_size == 1) {                                                     \
-      ASSIGN_BARRIER_SHAPED_COMPACT(CTYPE, CONST_DEREF, SET, 0, 1);            \
-    } else if (value_size == p_info->index_n) {                                \
-      ASSIGN_BARRIER_SHAPED_COMPACT(CTYPE, CONST_DEREF, SET, 1, 0);            \
-    } else {                                                                   \
-      r_stop_internal("`value` should have been recycled to match `index`.");  \
-    }                                                                          \
-  } else {                                                                     \
-    if (value_size == 1) {                                                     \
-      ASSIGN_BARRIER_SHAPED_INDEX(CTYPE, CONST_DEREF, SET, 0, 1);              \
-    } else if (value_size == p_info->index_n) {                                \
-      ASSIGN_BARRIER_SHAPED_INDEX(CTYPE, CONST_DEREF, SET, 1, 0);              \
-    } else {                                                                   \
-      r_stop_internal("`value` should have been recycled to match `index`.");  \
-    }                                                                          \
+#define ASSIGN_BARRIER_SHAPED_LOCATION(CTYPE, CONST_DEREF, SET)                         \
+  const r_ssize value_size = vec_size(value);                                           \
+  check_assign_sizes(proxy, index, value_size, slice_value, index_style);               \
+                                                                                        \
+  if (is_compact_seq(index)) {                                                          \
+    if (value_size == 1) {                                                              \
+      ASSIGN_BARRIER_SHAPED_LOCATION_COMPACT(CTYPE, CONST_DEREF, SET, false, 0, 1);     \
+    } else if (should_slice_value(slice_value)) {                                       \
+      ASSIGN_BARRIER_SHAPED_LOCATION_COMPACT(CTYPE, CONST_DEREF, SET, true, 0, 0);      \
+    } else {                                                                            \
+      ASSIGN_BARRIER_SHAPED_LOCATION_COMPACT(CTYPE, CONST_DEREF, SET, false, 1, 0);     \
+    }                                                                                   \
+  } else {                                                                              \
+    if (value_size == 1) {                                                              \
+      ASSIGN_BARRIER_SHAPED_LOCATION_INDEX(CTYPE, CONST_DEREF, SET, false, 0, 1);       \
+    } else if (should_slice_value(slice_value)) {                                       \
+      ASSIGN_BARRIER_SHAPED_LOCATION_INDEX(CTYPE, CONST_DEREF, SET, true, 0, 0);        \
+    } else {                                                                            \
+      ASSIGN_BARRIER_SHAPED_LOCATION_INDEX(CTYPE, CONST_DEREF, SET, false, 1, 0);       \
+    }                                                                                   \
+  }
+
+#define ASSIGN_BARRIER_SHAPED_CONDITION(CTYPE, CONST_DEREF, SET)                                \
+  const r_ssize value_size = vec_size(value);                                                   \
+  check_assign_sizes(proxy, index, value_size, slice_value, index_style);                       \
+                                                                                                \
+  if (is_compact_seq(index)) {                                                                  \
+    r_stop_internal(                                                                            \
+      "Compact sequence `index` are not supported in the condition path."                       \
+    );                                                                                          \
+  } else {                                                                                      \
+    if (value_size == 1) {                                                                      \
+      ASSIGN_BARRIER_SHAPED_CONDITION_INDEX(CTYPE, CONST_DEREF, SET, false, 0, 1);              \
+    } else if (should_slice_value(slice_value)) {                                               \
+      ASSIGN_BARRIER_SHAPED_CONDITION_INDEX(CTYPE, CONST_DEREF, SET, true, 0, 0);               \
+    } else {                                                                                    \
+      ASSIGN_BARRIER_SHAPED_CONDITION_INDEX(CTYPE, CONST_DEREF, SET, false, index_elt != 0, 0); \
+    }                                                                                           \
+  }
+
+#define ASSIGN_BARRIER_SHAPED(CTYPE, CONST_DEREF, SET)                  \
+  switch (index_style) {                                                \
+  case VCTRS_INDEX_STYLE_location: {                                    \
+    ASSIGN_BARRIER_SHAPED_LOCATION(CTYPE, CONST_DEREF, SET);            \
+  }                                                                     \
+  case VCTRS_INDEX_STYLE_condition: {                                   \
+    ASSIGN_BARRIER_SHAPED_CONDITION(CTYPE, CONST_DEREF, SET);           \
+  }                                                                     \
+  default: r_stop_unreachable();                                        \
   }
 
 static SEXP list_assign_shaped(
@@ -238,34 +447,18 @@ static SEXP list_assign_shaped(
   SEXP index,
   SEXP value,
   const enum vctrs_ownership ownership,
-  struct strides_info* p_info
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
 ) {
   ASSIGN_BARRIER_SHAPED(SEXP, VECTOR_PTR_RO, SET_VECTOR_ELT);
 }
 
 #undef ASSIGN_BARRIER_SHAPED
-#undef ASSIGN_BARRIER_SHAPED_COMPACT
-#undef ASSIGN_BARRIER_SHAPED_INDEX
-
-// -----------------------------------------------------------------------------
-
-static inline SEXP vec_assign_shaped_switch(SEXP proxy,
-                                            SEXP index,
-                                            SEXP value,
-                                            const enum vctrs_ownership ownership,
-                                            struct strides_info* p_info) {
-  switch (vec_proxy_typeof(proxy)) {
-  case VCTRS_TYPE_logical:   return lgl_assign_shaped(proxy, index, value, ownership, p_info);
-  case VCTRS_TYPE_integer:   return int_assign_shaped(proxy, index, value, ownership, p_info);
-  case VCTRS_TYPE_double:    return dbl_assign_shaped(proxy, index, value, ownership, p_info);
-  case VCTRS_TYPE_complex:   return cpl_assign_shaped(proxy, index, value, ownership, p_info);
-  case VCTRS_TYPE_character: return chr_assign_shaped(proxy, index, value, ownership, p_info);
-  case VCTRS_TYPE_raw:       return raw_assign_shaped(proxy, index, value, ownership, p_info);
-  case VCTRS_TYPE_list:      return list_assign_shaped(proxy, index, value, ownership, p_info);
-  default:                   stop_unimplemented_vctrs_type("vec_assign_shaped_switch",
-                                                           vec_proxy_typeof(proxy));
-  }
-}
+#undef ASSIGN_BARRIER_SHAPED_LOCATION
+#undef ASSIGN_BARRIER_SHAPED_LOCATION_COMPACT
+#undef ASSIGN_BARRIER_SHAPED_LOCATION_INDEX
+#undef ASSIGN_BARRIER_SHAPED_CONDITION
+#undef ASSIGN_BARRIER_SHAPED_CONDITION_INDEX
 
 // -----------------------------------------------------------------------------
 
@@ -274,15 +467,18 @@ SEXP vec_assign_shaped(
   SEXP proxy,
   SEXP index,
   SEXP value,
-  enum vctrs_ownership ownership
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
 ) {
-  int n_protect = 0;
-
-  struct strides_info info = new_strides_info(proxy, index);
-  PROTECT_STRIDES_INFO(&info, &n_protect);
-
-  SEXP out = vec_assign_shaped_switch(proxy, index, value, ownership, &info);
-
-  UNPROTECT(n_protect);
-  return out;
+  switch (vec_proxy_typeof(proxy)) {
+  case VCTRS_TYPE_logical:   return lgl_assign_shaped(proxy, index, value, ownership, slice_value, index_style);
+  case VCTRS_TYPE_integer:   return int_assign_shaped(proxy, index, value, ownership, slice_value, index_style);
+  case VCTRS_TYPE_double:    return dbl_assign_shaped(proxy, index, value, ownership, slice_value, index_style);
+  case VCTRS_TYPE_complex:   return cpl_assign_shaped(proxy, index, value, ownership, slice_value, index_style);
+  case VCTRS_TYPE_character: return chr_assign_shaped(proxy, index, value, ownership, slice_value, index_style);
+  case VCTRS_TYPE_raw:       return raw_assign_shaped(proxy, index, value, ownership, slice_value, index_style);
+  case VCTRS_TYPE_list:      return list_assign_shaped(proxy, index, value, ownership, slice_value, index_style);
+  default:                   stop_unimplemented_vctrs_type("vec_assign_shaped", vec_proxy_typeof(proxy));
+  }
 }

--- a/src/slice-assign.h
+++ b/src/slice-assign.h
@@ -4,10 +4,34 @@
 #include "vctrs-core.h"
 #include "ownership.h"
 
+/**
+ * Optional `value` slicing
+ *
+ * - For `ASSIGNMENT_SLICE_VALUE_no`, assignment is treated the standard `[<-`
+ *   way, i.e. `x[i] <- value`.
+ *
+ *   `value` must be size 1 or the same size as `i` after `i` has been converted
+ *   to a positive integer location vector with `vec_as_location()` (but note
+ *   that we don't actually make that conversion in the
+ *   `VCTRS_INDEX_STYLE_condition` case, we just count the number of `TRUE` and
+ *   `NA` values to perform the size check between `i` and `value`).
+ *
+ * - For `ASSIGNMENT_SLICE_VALUE_yes`, assignment proceeds as an optimized form
+ *   of: `x[i] <- value[i]`. Internally, we avoid actually materializing the
+ *   slice of `value`.
+ *
+ *   `value` must be size 1 or the same size as `x`.
+ */
+enum assignment_slice_value {
+  ASSIGNMENT_SLICE_VALUE_no,
+  ASSIGNMENT_SLICE_VALUE_yes
+};
+
 struct vec_assign_opts {
   bool assign_names;
   bool ignore_outer_names;
   enum vctrs_ownership ownership;
+  enum assignment_slice_value slice_value;
   struct vctrs_arg* x_arg;
   struct vctrs_arg* value_arg;
   struct r_lazy call;
@@ -17,6 +41,8 @@ struct vec_proxy_assign_opts {
   bool assign_names;
   bool ignore_outer_names;
   enum vctrs_ownership ownership;
+  enum assignment_slice_value slice_value;
+  enum vctrs_index_style index_style;
   struct vctrs_arg* x_arg;
   struct vctrs_arg* value_arg;
   struct r_lazy call;
@@ -24,25 +50,37 @@ struct vec_proxy_assign_opts {
   bool recursively_proxied;
 };
 
-r_obj* vec_assign_opts(r_obj* x,
-                       r_obj* index,
-                       r_obj* value,
-                       const struct vec_assign_opts* p_opts);
+r_obj* vec_assign_opts(
+  r_obj* x,
+  r_obj* index,
+  r_obj* value,
+  const struct vec_assign_opts* p_opts
+);
 
-r_obj* vec_proxy_assign_opts(r_obj* proxy,
-                             r_obj* index,
-                             r_obj* value,
-                             const struct vec_proxy_assign_opts* p_opts);
+r_obj* vec_proxy_assign_opts(
+  r_obj* proxy,
+  r_obj* index,
+  r_obj* value,
+  const struct vec_proxy_assign_opts* p_opts
+);
 
-r_obj* chr_assign(r_obj* out,
-                  r_obj* index,
-                  r_obj* value,
-                  const enum vctrs_ownership ownership);
+r_obj* chr_assign(
+  r_obj* x,
+  r_obj* index,
+  r_obj* value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+);
 
-r_obj* list_assign(r_obj* out,
-                   r_obj* index,
-                   r_obj* value,
-                   const enum vctrs_ownership ownership);
+r_obj* list_assign(
+  r_obj* x,
+  r_obj* index,
+  r_obj* value,
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+);
 
 r_obj* df_assign(
   r_obj* x,
@@ -55,7 +93,34 @@ r_obj* vec_assign_shaped(
   r_obj* proxy,
   r_obj* index,
   r_obj* value,
-  enum vctrs_ownership ownership
+  enum vctrs_ownership ownership,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
 );
+
+bool is_condition_index(r_obj* index, r_ssize size);
+
+void check_value_recyclable(
+  r_obj* value,
+  r_obj* index,
+  r_ssize x_size,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style,
+  struct vctrs_arg* p_value_arg,
+  struct r_lazy call
+);
+
+void check_assign_sizes(
+  r_obj* x,
+  r_obj* index,
+  r_ssize value_size,
+  enum assignment_slice_value slice_value,
+  enum vctrs_index_style index_style
+);
+
+static inline
+bool should_slice_value(enum assignment_slice_value slice_value) {
+  return slice_value == ASSIGNMENT_SLICE_VALUE_yes;
+}
 
 #endif

--- a/src/strides.h
+++ b/src/strides.h
@@ -148,6 +148,21 @@ static inline void vec_shape_index_increment(struct strides_info* p_info) {
   }
 }
 
+// Given array dimensions like:
+// [i, j, k, l]
+// this gives you a count of:
+// j * k * l
+// which tells you the number of times an outer loop would
+// need to iterate to walk over the array if some inner loop
+// handled iteration over `i`, i.e. size.
+static inline R_len_t vec_shape_elem_n(const int* p_dim, const R_len_t dim_n) {
+  R_len_t shape_elem_n = 1;
+  for (int i = 1; i < dim_n; ++i) {
+    shape_elem_n *= p_dim[i];
+  }
+  return shape_elem_n;
+}
+
 static inline struct strides_info new_strides_info(SEXP x, SEXP index) {
   SEXP dim = PROTECT(vec_dim(x));
   const int* p_dim = INTEGER_RO(dim);
@@ -179,10 +194,7 @@ static inline struct strides_info new_strides_info(SEXP x, SEXP index) {
     p_shape_index[i] = 0;
   }
 
-  R_len_t shape_elem_n = 1;
-  for (int i = 1; i < dim_n; ++i) {
-    shape_elem_n *= p_dim[i];
-  }
+  R_len_t shape_elem_n = vec_shape_elem_n(p_dim, dim_n);
 
   struct strides_info info = {
     .dim = dim,

--- a/src/utils.c
+++ b/src/utils.c
@@ -1613,6 +1613,8 @@ SEXP syms_required = NULL;
 SEXP syms_call = NULL;
 SEXP syms_dot_call = NULL;
 SEXP syms_which = NULL;
+SEXP syms_slice_value = NULL;
+SEXP syms_index_style = NULL;
 
 SEXP fns_bracket = NULL;
 SEXP fns_quote = NULL;
@@ -1895,6 +1897,8 @@ void vctrs_init_utils(SEXP ns) {
   syms_call = Rf_install("call");
   syms_dot_call = Rf_install(".call");
   syms_which = Rf_install("which");
+  syms_slice_value = Rf_install("slice_value");
+  syms_index_style = Rf_install("index_style");
 
   fns_bracket = Rf_findVar(syms_bracket, R_BaseEnv);
   fns_quote = Rf_findVar(Rf_install("quote"), R_BaseEnv);

--- a/src/utils.h
+++ b/src/utils.h
@@ -507,6 +507,8 @@ extern SEXP syms_required;
 extern SEXP syms_call;
 extern SEXP syms_dot_call;
 extern SEXP syms_which;
+extern SEXP syms_slice_value;
+extern SEXP syms_index_style;
 
 static const char * const c_strs_vctrs_common_class_fallback = "vctrs:::common_class_fallback";
 

--- a/src/vctrs-core.h
+++ b/src/vctrs-core.h
@@ -51,6 +51,30 @@ enum vctrs_ownership {
 };
 
 /**
+ * Index style
+ *
+ * - Location indices can be integer, character, or logical, but are ultimately
+ *   converted to positive integer locations by `vec_as_location()` before the
+ *   core assignment loop.
+ *
+ * - Condition indices are logical vectors the same size as `x`, where `TRUE`
+ *   denotes that you should assign to that spot. They are not converted to
+ *   integer locations before assignment.
+ *
+ * `vec_assign()` has separate optimized paths for each index style.
+ *
+ * TODO: `vec_slice()` should also have an optimized path for condition indices!
+ * i.e. `vec_slice(x, <lgl>)` should not call `vec_as_location()`.
+ *
+ * Condition indices are the inputs to `dplyr::if_else()` and `dplyr::case_when()`,
+ * so having an optimized path for these is very helpful.
+ */
+enum vctrs_index_style {
+  VCTRS_INDEX_STYLE_location,
+  VCTRS_INDEX_STYLE_condition
+};
+
+/**
  * Structure for argument tags
  *
  * Argument tags are used in error messages to provide information

--- a/tests/testthat/_snaps/slice-assign.md
+++ b/tests/testthat/_snaps/slice-assign.md
@@ -1,7 +1,141 @@
+# assign throws error with non-vector `value`
+
+    Code
+      vec_assign(x, 1L, NULL)
+    Condition
+      Error in `vec_assign()`:
+      ! Input must be a vector, not `NULL`.
+
+---
+
+    Code
+      vec_assign(x, 1L, NULL, slice_value = TRUE)
+    Condition
+      Error in `vec_assign()`:
+      ! Input must be a vector, not `NULL`.
+
+---
+
+    Code
+      vec_assign(x, 1L, NULL, value_arg = "foo")
+    Condition
+      Error in `vec_assign()`:
+      ! `foo` must be a vector, not `NULL`.
+
+---
+
+    Code
+      vec_assign(x, 1L, NULL, slice_value = TRUE, value_arg = "foo")
+    Condition
+      Error in `vec_assign()`:
+      ! `foo` must be a vector, not `NULL`.
+
+---
+
+    Code
+      vec_assign(x, 1L, environment(), value_arg = "foo")
+    Condition
+      Error in `vec_assign()`:
+      ! `foo` must be a vector, not an environment.
+
+---
+
+    Code
+      vec_assign(x, 1L, environment(), slice_value = TRUE, value_arg = "foo")
+    Condition
+      Error in `vec_assign()`:
+      ! `foo` must be a vector, not an environment.
+
+# can assign using logical index
+
+    Code
+      (expect_error(vec_assign(x, c(TRUE, FALSE, TRUE), 5), class = "vctrs_error_subscript_size")
+      )
+    Output
+      <error/vctrs_error_subscript_size>
+      Error:
+      ! Can't assign elements.
+      x Logical subscript must be size 1 or 2, not 3.
+
+---
+
+    Code
+      (expect_error(vec_assign(x, c(TRUE, FALSE, TRUE), 5, slice_value = TRUE),
+      class = "vctrs_error_subscript_size"))
+    Output
+      <error/vctrs_error_subscript_size>
+      Error:
+      ! Can't assign elements.
+      x Logical subscript must be size 1 or 2, not 3.
+
+---
+
+    Code
+      (expect_error(vec_assign(mtcars, c(TRUE, FALSE), mtcars[1, ]), class = "vctrs_error_subscript_size")
+      )
+    Output
+      <error/vctrs_error_subscript_size>
+      Error:
+      ! Can't assign elements.
+      x Logical subscript must be size 1 or 32, not 2.
+
+---
+
+    Code
+      (expect_error(vec_assign(mtcars, c(TRUE, FALSE), mtcars[1, ], slice_value = TRUE),
+      class = "vctrs_error_subscript_size"))
+    Output
+      <error/vctrs_error_subscript_size>
+      Error:
+      ! Can't assign elements.
+      x Logical subscript must be size 1 or 32, not 2.
+
+# assign `value` size depends on `slice_value`
+
+    Code
+      vec_assign(x, c(TRUE, NA, FALSE), c(1, 2, 3))
+    Condition
+      Error in `vec_assign()`:
+      ! Can't recycle input of size 3 to size 2.
+
+---
+
+    Code
+      vec_assign(x, c(TRUE, NA, FALSE), c(1, 2), slice_value = TRUE)
+    Condition
+      Error in `vec_assign()`:
+      ! Can't recycle input of size 2 to size 3.
+
+# can use names to assign with a named object
+
+    Code
+      vec_assign(x, c("c", "a"), c(4, 5, 6))
+    Condition
+      Error in `vec_assign()`:
+      ! Can't recycle input of size 3 to size 2.
+
+---
+
+    Code
+      vec_assign(x, c("c", "a"), c(4, 5), slice_value = TRUE)
+    Condition
+      Error in `vec_assign()`:
+      ! Can't recycle input of size 2 to size 3.
+
 # `vec_assign()` requires recyclable value
 
     Code
-      (expect_error(vec_assign(1:3, 1:3, 1:2), class = "vctrs_error_recycle_incompatible_size")
+      (expect_error(vec_assign(1:3, 1:2, 1:3), class = "vctrs_error_recycle_incompatible_size")
+      )
+    Output
+      <error/vctrs_error_incompatible_size>
+      Error in `vec_assign()`:
+      ! Can't recycle input of size 3 to size 2.
+
+---
+
+    Code
+      (expect_error(vec_assign(1:3, 1:2, 1:2, slice_value = TRUE), class = "vctrs_error_recycle_incompatible_size")
       )
     Output
       <error/vctrs_error_incompatible_size>


### PR DESCRIPTION
Two improvements in this PR

- `assignment_index_style` which allows for either integer _location_ indices or logical _condition_ indices. Each have their own optimized path inside of `vec_assign()`. This is auto detected for the user in `vec_assign()`. If it doesn't look like a simple logical condition index, we run it through `vec_as_location()` and use the location path. The logical condition index path is the new one.

- `assignment_slice_value` which says whether or not to optionally slice `value` by `i` before assignment as well.
    - If no, the default, assignment is done as expected, `x[i] <- value`.
    - If yes, assignment is done as an optimized form of `x[i] <- value[i]`, where `value[i]` is not actually materialized internally.
    - This is exposed as `vec_assign(slice_value = FALSE/TRUE)`

Note that `slice_value = TRUE` works regardless of the index style. These are orthogonal ideas. Figuring this out was a key part of this PR.

Taken together, this allows for optimal assignment in `dplyr::if_else()` and `dplyr::case_when()` style assignments where you have:
- LHSs that are logical condition indices, which we can now assign with directly rather than doing `which(i)` first
- RHSs that are length 1 or the length of the output, which can use `slice_value = TRUE` during assignment

This should allow for creation of the output with minimal extra allocations and overhead.

In a follow up PR I will create `list_multi_assign()`, which will eventually benefit from these optimizations and expose `slice_values = FALSE/TRUE`, and `vec_case_when()` and `vec_if_else()` will use that function directly. But getting these core assign details out of the way is the hard part.

---

Here's an example of the intended use case. `vec_assign()` with a logical index and a `value` that can benefit from `slice_value = TRUE`. This would be used `N` times by `dplyr::case_when()` where `N` is the number of provided cases.

``` r
library(vctrs)
set.seed(123)

x <- sample(1e7)
value <- sample(1e7)

# When `x > 100000`, put `value`, otherwise keep `x`
loc <- x > 100000

bench::mark(
  old = {
    # Improvements in `vec_assign()` logical `loc` handling
    vec_assign(x, loc, vec_slice(value, loc))
  },
  new = {
    # Additional optimization with `slice_value`
    vec_assign(x, loc, value, slice_value = TRUE)
  }
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old          26.8ms   27.5ms      36.0   113.7MB     36.0
#> 2 new           7.1ms   7.49ms     114.     38.1MB     26.0

# This is CRAN vctrs with no optimizations
bench::mark(
  cran = {
    vec_assign(x, loc, vec_slice(value, loc))
  },
  iterations = 50
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 cran         35.9ms   36.8ms      26.8     151MB     27.3
```

``` r
profmem::profmem(vec_assign(x, loc, value, slice_value = TRUE))
#> Rprofmem memory profiling of:
#> vec_assign(x, loc, value, slice_value = TRUE)
#> 
#> Memory allocations:
#> Number of 'new page' entries not displayed: 3
#>        what    bytes        calls
#> 3     alloc 40000048 vec_assign()
#> total       40000048
```

Here's an even more compelling example with a data frame, which has multiple columns so the overhead of slicing it is higher.

```r
library(vctrs)
set.seed(123)

dictionary <- data.frame(a = 1:10, b = 1:10, c = 1:10 + 0, d = letters[1:10])

x <- dplyr::slice_sample(dictionary, n = 1e7, replace = TRUE)
value <- dplyr::slice_sample(dictionary, n = 1e7, replace = TRUE)

# When `sample(1e7) > 100000`, put `value`, otherwise keep `x`
loc <- sample(1e7) > 100000

# This PR
bench::mark(
  old = {
    # Improvements in `vec_assign()` logical `loc` handling
    vec_assign(x, loc, vec_slice(value, loc))
  },
  new = {
    # Additional optimization with `slice_value`
    vec_assign(x, loc, value, slice_value = TRUE)
  },
  iterations = 20
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old         129.5ms  130.7ms      7.65     493MB     29.1
#> 2 new          64.4ms   65.1ms     15.3      229MB     10.2


# This is CRAN vctrs with no optimizations
bench::mark(
  cran = {
    vec_assign(x, loc, vec_slice(value, loc))
  },
  iterations = 50
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 cran          147ms    148ms      6.75     531MB     169.
```