### PR TITLE
Fix names assignment with overlapping `indices`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `list_unchop()` now assigns names correctly when overlapping `indices` are involved (#2019).
+
 * New `.name_spec = "inner"` option for `vec_c()`, `list_unchop()`, and `vec_rbind()`. This efficiently ignores all outer names, while retaining any inner names (#1988).
 
 * `list_unchop()` now works in an edge case with a single `NA` recycled to size 0 (#1989).

--- a/src/decl/slice-assign-decl.h
+++ b/src/decl/slice-assign-decl.h
@@ -14,7 +14,7 @@ static
 r_obj* vec_proxy_assign_names(
   r_obj* proxy,
   r_obj* index,
-  r_obj* value,
+  r_obj* value_proxy,
   enum vctrs_ownership ownership,
   enum assignment_slice_value slice_value,
   enum vctrs_index_style index_style

--- a/src/list-combine.c
+++ b/src/list-combine.c
@@ -586,22 +586,24 @@ r_obj* list_combine_impl(
       r_obj* inner = KEEP(vec_names(x));
       r_obj* x_names = KEEP(apply_name_spec(name_spec, outer, inner, index_size));
 
+      if (has_indices && x_names == r_null && out_names != r_null) {
+        // We don't have names on this element, but `out_names` will exist.
+        // Someone before us may have written to `out_names` at this `index` by
+        // providing an overlapping `index`, so we must clear that.
+        x_names = r_chrs.empty_string;
+      }
+
       if (x_names != r_null) {
         R_LAZY_ALLOC(out_names, out_names_pi, R_TYPE_character, size);
-
-        // If there is no name to assign, skip the assignment since
-        // `out_names` already contains empty strings
-        if (x_names != chrs_empty) {
-          out_names = chr_assign(
-            out_names,
-            index,
-            x_names,
-            VCTRS_OWNERSHIP_deep,
-            slice_xs,
-            indices_style
-          );
-          KEEP_AT(out_names, out_names_pi);
-        }
+        out_names = chr_assign(
+          out_names,
+          index,
+          x_names,
+          VCTRS_OWNERSHIP_deep,
+          slice_xs,
+          indices_style
+        );
+        KEEP_AT(out_names, out_names_pi);
       }
 
       FREE(2);
@@ -645,22 +647,23 @@ r_obj* list_combine_impl(
       r_obj* inner = KEEP(vec_names(default_));
       r_obj* x_names = KEEP(apply_name_spec(name_spec, outer, inner, size));
 
+      // `default` assigns at the unmatched locations, so there won't be
+      // anything to clear here, unlike in the main loop
+      // if (has_indices && x_names == r_null && out_names != r_null) {
+      //   x_names = r_chrs.empty_string;
+      // }
+
       if (x_names != r_null) {
         R_LAZY_ALLOC(out_names, out_names_pi, R_TYPE_character, size);
-
-        // If there is no name to assign, skip the assignment since
-        // `out_names` already contains empty strings
-        if (x_names != chrs_empty) {
-          out_names = chr_assign(
-            out_names,
-            index,
-            x_names,
-            VCTRS_OWNERSHIP_deep,
-            ASSIGNMENT_SLICE_VALUE_yes,
-            VCTRS_INDEX_STYLE_condition
-          );
-          KEEP_AT(out_names, out_names_pi);
-        }
+        out_names = chr_assign(
+          out_names,
+          index,
+          x_names,
+          VCTRS_OWNERSHIP_deep,
+          ASSIGNMENT_SLICE_VALUE_yes,
+          VCTRS_INDEX_STYLE_condition
+        );
+        KEEP_AT(out_names, out_names_pi);
       }
 
       FREE(2);

--- a/tests/testthat/test-slice-assign.R
+++ b/tests/testthat/test-slice-assign.R
@@ -1213,6 +1213,30 @@ test_that("can optionally assign names (OO case)", {
   )
 })
 
+test_that("assigning names clears existing names even if the new value doesn't have any (#2019)", {
+  x <- c(a = 1, b = 2)
+
+  # Keeps existing names
+  expect_identical(
+    vec_assign_params(x, 1L, 0),
+    c(a = 0, b = 2)
+  )
+  expect_identical(
+    vec_assign_params(x, 1L, c(c = 0)),
+    c(a = 0, b = 2)
+  )
+
+  # Clears or replaces names
+  expect_identical(
+    vec_assign_params(x, 1L, 0, assign_names = TRUE),
+    set_names(c(0, 2), c("", "b"))
+  )
+  expect_identical(
+    vec_assign_params(x, 1L, c(c = 0), assign_names = TRUE),
+    set_names(c(0, 2), c("c", "b"))
+  )
+})
+
 test_that("assignment requires that the value proxy is the same type as the output proxy", {
   x <- foobar(1)
   y <- foobar("a")


### PR DESCRIPTION
Closes #2019

``` r
library(vctrs)

list_unchop(
  list(c(a = 1), 2),
  indices = list(1, 1)
)
#>       
#>  2 NA

x <- list(
  data_frame(
    x = c(a = 1),
    y = "foo"
  ),
  data_frame(
    x = 2,
    y = "bar"
  )
)

out <- list_unchop(
  x,
  indices = list(1, 1)
)

out$x
#>       
#>  2 NA
```