### PR TITLE
Expose `list_check_all_*()` helpers at C level

### DIFF
--- a/src/assert.h
+++ b/src/assert.h
@@ -16,4 +16,24 @@ void obj_check_list(r_obj* x,
                     struct vctrs_arg* arg,
                     struct r_lazy call);
 
+void list_check_all_vectors(
+  r_obj* xs,
+  struct vctrs_arg* p_xs_arg,
+  struct r_lazy call
+);
+
+void list_check_all_size(
+  r_obj* xs,
+  r_ssize size,
+  struct vctrs_arg* p_xs_arg,
+  struct r_lazy call
+);
+
+void list_check_all_recyclable(
+  r_obj* xs,
+  r_ssize size,
+  struct vctrs_arg* p_xs_arg,
+  struct r_lazy call
+);
+
 #endif

--- a/src/decl/assert-decl.h
+++ b/src/decl/assert-decl.h
@@ -2,9 +2,3 @@ static r_no_return
 void stop_non_list_type(r_obj* x,
                         struct vctrs_arg* arg,
                         struct r_lazy call);
-
-static
-void list_check_all_size(r_obj* xs,
-                         r_ssize size,
-                         struct vctrs_arg* p_arg,
-                         struct r_lazy call);


### PR DESCRIPTION
Extracted from https://github.com/r-lib/vctrs/pull/1996