### PR TITLE
Use `r_keep_loc` in `reduce_impl()`

### DIFF
--- a/src/arg-counter.c
+++ b/src/arg-counter.c
@@ -142,10 +142,10 @@ r_obj* reduce_impl(r_obj* current,
                                   void* data),
                    void* data) {
   r_ssize n = r_length(rest);
+  r_keep_loc current_pi;
+  KEEP_HERE(current, &current_pi);
 
   for (r_ssize i = 0; i < n; ++i, counters_inc(counters)) {
-    KEEP(current);
-
     r_obj* next = r_list_get(rest, i);
 
     // Don't call `rlang_is_splice_box()` if we're already looking at a
@@ -163,9 +163,10 @@ r_obj* reduce_impl(r_obj* current,
       FREE(1);
     }
 
-    FREE(1);
+    KEEP_AT(current, current_pi);
   }
 
+  FREE(1);
   return current;
 }
 


### PR DESCRIPTION
Minor performance improvements PR 1

Each of these are minor, but end up adding up meaningfully. The goal is to speed up `list_unchop()` with many small objects, where `unlist()` currently does much better. We won't ever beat `unlist()` because it has access to macros where we have to make actual function calls, but we can close the gap a little.

```r
cross::bench_versions(
  pkgs = c(
    # Main before doing any of these PRs
    "r-lib/vctrs@0279470c6de6ee2db3a9b333c198754080554ee7",
    # Current main
    "r-lib/vctrs",
    # This PR
    "r-lib/vctrs#2034"
  ),
  fn = \() {
    library(vctrs)
    x <- as.list(1:1e6)
    bench::mark(list_unchop(x), iterations = 500)
  }
)
```

```
# A tibble: 3 × 14
  pkg                                           expression   min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory     time       gc      
  <chr>                                         <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>     <list>     <list>  
1 r-lib/vctrs@0279470c6de6ee2db3a9b333c1987540… list_unch… 152ms  157ms      6.20    11.4MB    10.2    500   825      1.34m <int>  <Rprofmem> <bench_tm> <tibble>
2 r-lib/vctrs                                   list_unch… 151ms  159ms      5.99    11.4MB     9.89   500   825      1.39m <int>  <Rprofmem> <bench_tm> <tibble>
3 r-lib/vctrs#2034                              list_unch… 148ms  155ms      6.28    11.4MB    10.4    500   825      1.33m <int>  <Rprofmem> <bench_tm> <tibble>
```
