### PR TITLE
Inline `r_pairlist_find()`

### DIFF
--- a/src/rlang/node.c
+++ b/src/rlang/node.c
@@ -52,17 +52,6 @@ r_obj* r_node_tree_clone(r_obj* x) {
   return x;
 }
 
-r_obj* r_pairlist_find(r_obj* node, r_obj* tag) {
-  while (node != r_null) {
-    if (r_node_tag(node) == tag) {
-      return node;
-    }
-    node = r_node_cdr(node);
-  }
-
-  return r_null;
-}
-
 r_obj* r_pairlist_rev(r_obj* node) {
   if (node == r_null) {
     return node;

--- a/src/rlang/node.h
+++ b/src/rlang/node.h
@@ -37,8 +37,20 @@ r_obj* r_new_pairlist(const struct r_pair* args, int n, r_obj** tail);
 #define r_pairlist4 Rf_list4
 #define r_pairlist5 Rf_list5
 
-r_obj* r_pairlist_find(r_obj* node, r_obj* tag);
 r_obj* r_pairlist_rev(r_obj* node);
+
+// Used by `r_attrib_get()` via `r_pairlist_get()`,
+// so we want it to be fully inlined
+static inline
+r_obj* r_pairlist_find(r_obj* node, r_obj* tag) {
+  while (node != r_null) {
+    if (r_node_tag(node) == tag) {
+      return node;
+    }
+    node = r_node_cdr(node);
+  }
+  return r_null;
+}
 
 static inline
 r_obj* r_pairlist_get(r_obj* node, r_obj* tag) {


### PR DESCRIPTION
Pushed upstream in https://github.com/r-lib/rlang/pull/1830

Used by `r_dim()`, `r_class()`, etc, which is in our deepest loops (size-common, ptype-common), so we want these helpers to be fully inlined.

In particular `r_dim()` was slower than `Rf_getAttrib(x, R_DimSymbol)` and would show up in Instruments profiling, and I don't want to have to decide between the two.

```r
cross::bench_versions(
  pkgs = c(
    # Main before doing any of these PRs
    "r-lib/vctrs@0279470c6de6ee2db3a9b333c198754080554ee7",
    # Current main
    "r-lib/vctrs",
    # This PR
    "r-lib/vctrs#2039"
  ),
  fn = \() {
    library(vctrs)
    x <- as.list(1:1e6)
    bench::mark(list_unchop(x), iterations = 200)
  }
)
```

```
# A tibble: 3 × 14
  pkg           expression   min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result
  <chr>         <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>
1 r-lib/vctrs@… list_unch… 150ms  158ms      6.17    11.4MB     10.2   200   332      32.4s <int> 
2 r-lib/vctrs   list_unch… 141ms  150ms      6.52    11.4MB     10.8   200   332      30.7s <int> 
3 r-lib/vctrs#… list_unch… 140ms  147ms      6.64    11.4MB     11.0   200   332      30.1s <int> 
# ℹ 3 more variables: memory <list>, time <list>, gc <list>
```