### PR TITLE
Cache `current_size` between size2 iterations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # vctrs (development version)
 
-* `vec_c()`, `list_unchop()`, `vec_size_common()`, `vec_ptype_common()`, `list_sizes()`, `list_check_all_vectors()`, and other vctrs functions that take a list of objects are now more performant, particularly when many small objects are provided (#2034, #2035, #2041, #2042).
+* `vec_c()`, `list_unchop()`, `vec_size_common()`, `vec_ptype_common()`, `list_sizes()`, `list_check_all_vectors()`, and other vctrs functions that take a list of objects are now more performant, particularly when many small objects are provided (#2034, #2035, #2041, #2042, #2043).
 
 * New `vec_if_else()` for performing a vectorized if-else. It is exactly the same as `dplyr::if_else()`, but much faster and memory efficient (#2030).
 

--- a/src/arg-counter.c
+++ b/src/arg-counter.c
@@ -71,12 +71,14 @@ void counters_shift(struct counters* p_counters) {
   p_counters->curr = p_counters->next;
 }
 
-r_obj* reduce(r_obj* current,
-              struct vctrs_arg* p_current_arg,
-              struct vctrs_arg* p_parent_arg,
-              r_obj* rest,
-              r_obj* (*impl)(r_obj* current, r_obj* next, struct counters* counters, void* data),
-              void* data) {
+r_obj* reduce(
+  r_obj* current,
+  struct vctrs_arg* p_current_arg,
+  struct vctrs_arg* p_parent_arg,
+  r_obj* rest,
+  r_obj* (*impl)(r_obj* current, r_obj* next, struct counters* counters, void* data),
+  void* data
+) {
   const r_ssize n = r_length(rest);
   r_obj* names = r_names(rest);
   r_obj* const* v_rest = r_list_cbegin(rest);

--- a/src/arg-counter.h
+++ b/src/arg-counter.h
@@ -52,12 +52,14 @@ enum counters_shelter {
  */
 void counters_shift(struct counters* counters);
 
-r_obj* reduce(r_obj* current,
-              struct vctrs_arg* p_current_arg,
-              struct vctrs_arg* p_parent_arg,
-              r_obj* rest,
-              r_obj* (*impl)(r_obj* current, r_obj* next, struct counters* counters, void* data),
-              void* data);
+r_obj* reduce(
+  r_obj* current,
+  struct vctrs_arg* p_current_arg,
+  struct vctrs_arg* p_parent_arg,
+  r_obj* rest,
+  r_obj* (*impl)(r_obj* current, r_obj* next, struct counters* counters, void* data),
+  void* data
+);
 
 
 #endif

--- a/src/decl/size-common-decl.h
+++ b/src/decl/size-common-decl.h
@@ -1,5 +1,7 @@
 static
-r_obj* vctrs_size2_common(r_obj* x,
-                          r_obj* y,
-                          struct counters* counters,
-                          void* data);
+r_obj* vctrs_size2_common(
+  r_obj* x,
+  r_obj* y,
+  struct counters* counters,
+  void* data
+);


### PR DESCRIPTION
```r
cross::bench_versions(
  pkgs = c(
    # Main before doing any of these PRs
    "r-lib/vctrs@0279470c6de6ee2db3a9b333c198754080554ee7",
    # Current main
    "r-lib/vctrs",
    # This PR
    "r-lib/vctrs#2043"
  ),
  fn = \() {
    library(vctrs)
    x <- as.list(1:1e6)
    bench::mark(vec_size_common(!!!x), iterations = 200)
  }
)
```

```
# A tibble: 3 × 14
  pkg   expression     min  median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
  <chr> <bch:expr> <bch:t> <bch:t>     <dbl> <bch:byt>    <dbl> <int> <dbl>
1 r-li… vec_size_…   103ms 113.3ms      8.32    7.63MB    28.5    200   686
2 r-li… vec_size_…  39.4ms  40.6ms     24.6     7.63MB     6.14   160    40
3 r-li… vec_size_…  17.7ms  18.1ms     54.7     7.63MB    13.7    160    40
# ℹ 5 more variables: total_time <bch:tm>, result <list>, memory <list>,
#   time <list>, gc <list>
```
