### PR TITLE
Prefer `info.inner` over `info.proxy`

### DIFF
--- a/src/size.c
+++ b/src/size.c
@@ -25,9 +25,9 @@ r_ssize vec_size_3(r_obj* x,
 static
 r_ssize vec_size_opts(r_obj* x, const struct vec_error_opts* opts) {
   struct vctrs_proxy_info info = vec_proxy_info(x);
-  KEEP_1_PROXY_INFO(info);
+  KEEP(info.inner);
 
-  r_obj* data = info.proxy;
+  r_obj* data = info.inner;
 
   r_ssize size;
   switch (info.type) {

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -247,12 +247,12 @@ r_obj* vec_proxy_assign_opts(r_obj* proxy,
   opts_copy.ignore_outer_names = false;
 
   struct vctrs_proxy_info value_info = vec_proxy_info(value);
-  KEEP_N_PROXY_INFO(value_info, &n_protect);
+  KEEP_N(value_info.inner, &n_protect);
 
-  if (r_typeof(proxy) != r_typeof(value_info.proxy)) {
+  if (r_typeof(proxy) != r_typeof(value_info.inner)) {
     r_stop_internal("`proxy` of type `%s` incompatible with `value` proxy of type `%s`.",
                     r_type_as_c_string(r_typeof(proxy)),
-                    r_type_as_c_string(r_typeof(value_info.proxy)));
+                    r_type_as_c_string(r_typeof(value_info.inner)));
   }
 
   // If a fallback is required, the `proxy` is identical to the output container
@@ -263,13 +263,13 @@ r_obj* vec_proxy_assign_opts(r_obj* proxy,
     index = KEEP_N(vec_subscript_materialize(index), &n_protect);
     out = KEEP_N(vec_assign_fallback(proxy, index, value, opts_copy.slice_value, opts_copy.index_style), &n_protect);
   } else if (has_dim(proxy)) {
-    out = KEEP_N(vec_assign_shaped(proxy, index, value_info.proxy, opts_copy.ownership, opts_copy.slice_value, opts_copy.index_style), &n_protect);
+    out = KEEP_N(vec_assign_shaped(proxy, index, value_info.inner, opts_copy.ownership, opts_copy.slice_value, opts_copy.index_style), &n_protect);
   } else {
-    out = KEEP_N(vec_assign_switch(proxy, index, value_info.proxy, &opts_copy), &n_protect);
+    out = KEEP_N(vec_assign_switch(proxy, index, value_info.inner, &opts_copy), &n_protect);
   }
 
   if (!ignore_outer_names && p_opts->assign_names) {
-    out = vec_proxy_assign_names(out, index, value_info.proxy, opts_copy.ownership, opts_copy.slice_value, opts_copy.index_style);
+    out = vec_proxy_assign_names(out, index, value_info.inner, opts_copy.ownership, opts_copy.slice_value, opts_copy.index_style);
   }
 
   FREE(n_protect);

--- a/src/slice-chop.c
+++ b/src/slice-chop.c
@@ -196,7 +196,7 @@ r_obj* vec_chop(r_obj* x, r_obj* indices, r_obj* sizes) {
 // Performance variant that doesn't check the types or values of `indices` / `sizes`
 r_obj* vec_chop_unsafe(r_obj* x, r_obj* indices, r_obj* sizes) {
   struct vctrs_proxy_info info = vec_proxy_info(x);
-  KEEP_1_PROXY_INFO(info);
+  KEEP(info.inner);
 
   struct vctrs_chop_indices* p_indices = new_chop_indices(x, indices, sizes);
   KEEP(p_indices->shelter);
@@ -252,7 +252,7 @@ static
 r_obj* chop(r_obj* x,
             struct vctrs_proxy_info info,
             struct vctrs_chop_indices* p_indices) {
-  r_obj* proxy = info.proxy;
+  r_obj* proxy = info.inner;
   r_obj* names = KEEP(r_names(proxy));
   const enum vctrs_type type = info.type;
 
@@ -300,7 +300,7 @@ static
 r_obj* chop_df(r_obj* x,
                struct vctrs_proxy_info info,
                struct vctrs_chop_indices* p_indices) {
-  r_obj* proxy = info.proxy;
+  r_obj* proxy = info.inner;
   r_obj* const* v_proxy = r_list_cbegin(proxy);
 
   const r_ssize n_cols = r_length(proxy);
@@ -374,7 +374,7 @@ static
 r_obj* chop_shaped(r_obj* x,
                    struct vctrs_proxy_info info,
                    struct vctrs_chop_indices* p_indices) {
-  r_obj* proxy = info.proxy;
+  r_obj* proxy = info.inner;
   const enum vctrs_type type = info.type;
 
   r_obj* dim_names = KEEP(r_dim_names(proxy));

--- a/src/slice.c
+++ b/src/slice.c
@@ -285,7 +285,7 @@ r_obj* vec_slice_unsafe(r_obj* x, r_obj* subscript) {
   int nprot = 0;
 
   struct vctrs_proxy_info info = vec_proxy_info(x);
-  KEEP_N_PROXY_INFO(info, &nprot);
+  KEEP_N(info.inner, &nprot);
 
   // Fallback to `[` if the class doesn't implement a proxy. This is
   // to be maximally compatible with existing classes.
@@ -335,7 +335,7 @@ r_obj* vec_slice_unsafe(r_obj* x, r_obj* subscript) {
     r_obj* out;
 
     if (has_dim(x)) {
-      out = KEEP_N(vec_slice_shaped(info.type, info.proxy, subscript), &nprot);
+      out = KEEP_N(vec_slice_shaped(info.type, info.inner, subscript), &nprot);
 
       r_obj* names = KEEP_N(r_attrib_get(x, r_syms.dim_names), &nprot);
       if (names != r_null) {
@@ -346,7 +346,7 @@ r_obj* vec_slice_unsafe(r_obj* x, r_obj* subscript) {
         r_attrib_poke(out, r_syms.dim_names, names);
       }
     } else {
-      out = KEEP_N(vec_slice_base(info.type, info.proxy, subscript, VCTRS_MATERIALIZE_false), &nprot);
+      out = KEEP_N(vec_slice_base(info.type, info.inner, subscript, VCTRS_MATERIALIZE_false), &nprot);
 
       r_obj* names = KEEP_N(r_names(x), &nprot);
       names = KEEP_N(slice_names(names, subscript), &nprot);
@@ -369,7 +369,7 @@ r_obj* vec_slice_unsafe(r_obj* x, r_obj* subscript) {
   }
 
   case VCTRS_TYPE_dataframe: {
-    r_obj* out = KEEP_N(df_slice(info.proxy, subscript), &nprot);
+    r_obj* out = KEEP_N(df_slice(info.inner, subscript), &nprot);
 
     // Sliced `out` is a fresh list container from `df_slice()`, but we don't
     // necessarily own the sliced columns (an individual column could have gone

--- a/src/type-info.c
+++ b/src/type-info.c
@@ -11,13 +11,13 @@ struct vctrs_proxy_info vec_proxy_info(r_obj* x) {
   r_obj* x_proxy_method = r_is_object(x) ? vec_proxy_method(x) : r_null;
 
   if (x_proxy_method == r_null) {
-    info.proxy = x;
+    info.inner = x;
     info.type = vec_base_typeof(x, false);
     info.had_proxy_method = false;
   } else {
     KEEP(x_proxy_method);
-    info.proxy = KEEP(vec_proxy_invoke(x, x_proxy_method));
-    info.type = vec_base_typeof(info.proxy, true);
+    info.inner = KEEP(vec_proxy_invoke(x, x_proxy_method));
+    info.type = vec_base_typeof(info.inner, true);
     info.had_proxy_method = true;
     FREE(2);
   }
@@ -43,12 +43,12 @@ r_obj* ffi_type_info(r_obj* x) {
 // [[ register() ]]
 r_obj* ffi_proxy_info(r_obj* x) {
   struct vctrs_proxy_info info = vec_proxy_info(x);
-  KEEP_1_PROXY_INFO(info);
+  KEEP(info.inner);
 
   r_obj* out = KEEP(Rf_mkNamed(R_TYPE_list, (const char*[]) { "type", "had_proxy_method", "proxy", "" }));
   r_list_poke(out, 0, r_chr(vec_type_as_str(info.type)));
   r_list_poke(out, 1, r_lgl(info.had_proxy_method));
-  r_list_poke(out, 2, info.proxy);
+  r_list_poke(out, 2, info.inner);
 
   FREE(2);
   return out;

--- a/src/type-info.h
+++ b/src/type-info.h
@@ -21,7 +21,7 @@ enum vctrs_type {
 /**
  * Proxy info
  *
- * @member proxy If a `proxy_method` was found, the result of invoking
+ * @member inner If a `proxy_method` was found, the result of invoking
  *   the method. Otherwise, the original data.
  * @member type If a `proxy_method` was found, the vector type of the
  *   proxy data. Otherwise, the vector type of the original data.
@@ -32,22 +32,14 @@ enum vctrs_type {
  * NOTE: Resist the urge to add a `shelter` here. `vec_proxy_info()` is called
  * in EXTREMELY tight loops, like `list_sizes()`, `vec_size_common()`, and
  * `vec_ptype_common()`. The overhead of creating and protecting a `shelter`
- * list is very noticeable! Instead use `KEEP_1_PROXY_INFO()` or
- * `KEEP_N_PROXY_INFO()` (#2042).
+ * list is very noticeable! Instead we use `inner` to denote that this struct
+ * "wraps" an inner object, and we `KEEP()` that directly at call sites (#2042).
  */
 struct vctrs_proxy_info {
-  r_obj* proxy;
+  r_obj* inner;
   enum vctrs_type type;
   bool had_proxy_method;
 };
-
-#define KEEP_1_PROXY_INFO(INFO) do { \
-  KEEP(INFO.proxy);                  \
-} while (0)
-
-#define KEEP_N_PROXY_INFO(INFO, P_N_PROTECT) do { \
-  KEEP_N(INFO.proxy, P_N_PROTECT);                \
-} while (0)
 
 /**
  * Return type information of a vector's proxy


### PR DESCRIPTION
Where `inner` is a standard name of ours used to say that the struct "wraps" an inner `r_obj*`, and is a signal to callers that they must protect `inner`, but don't need to protect anything else.