### PR TITLE
Use `conditions` not `cases` in `vec_case_when()`

### DIFF
--- a/R/case-when.R
+++ b/R/case-when.R
@@ -3,13 +3,14 @@
 #' @description
 #'
 #' - `vec_case_when()` constructs an entirely new vector by recoding the `TRUE`
-#'   `cases` to their corresponding `values`. If there are locations not matched
-#'   by `cases`, then they are recoded to the `default` value.
+#'   `conditions` to their corresponding `values`. If there are locations not
+#'   matched by `conditions`, then they are recoded to the `default` value.
 #'
 #' - `vec_replace_when()` updates an existing vector by replacing the values
-#'   from `x` matched by the `TRUE` `cases` with their corresponding `values`.
-#'   In this case, each element of `values` must have the same type as `x` and
-#'   locations not matched by `cases` retain their original `x` value.
+#'   from `x` matched by the `TRUE` `conditions` with their corresponding
+#'   `values`. In this case, each element of `values` must have the same type as
+#'   `x` and locations not matched by `conditions` retain their original `x`
+#'   value.
 #'
 #' `vec_case_when()` is often thought of as a way to vectorize multiple if-else
 #' statements, and is an R equivalent of the SQL "searched" `CASE WHEN`
@@ -20,30 +21,30 @@
 #'
 #' @param x A vector.
 #'
-#' @param cases A list of logical vectors.
+#' @param conditions A list of logical condition vectors.
 #'
 #'   For `vec_case_when()`, each vector should be the same size.
 #'
 #'   For `vec_replace_when()`, each vector should be the same size as `x`.
 #'
-#'   Where a value in `cases` is `TRUE`, the corresponding value in `values`
-#'   will be assigned to the result.
+#'   Where a value in `conditions` is `TRUE`, the corresponding value in
+#'   `values` will be assigned to the result.
 #'
 #' @param values A list of vectors.
 #'
 #'   For `vec_case_when()`, each vector should be size 1 or the size implied by
-#'   `cases`. The common type of `values` and `default` determine the output
-#'   type, unless overridden by `ptype`.
+#'   `conditions`. The common type of `values` and `default` determine the
+#'   output type, unless overridden by `ptype`.
 #'
 #'   For `vec_replace_when()`, each vector should be size 1 or the same size
 #'   as `x`. Each vector will be cast to the type of `x`.
 #'
-#' @param default Default value to use when `cases` does not match every
+#' @param default Default value to use when `conditions` does not match every
 #'   location in the output.
 #'
 #'   By default, a missing value is used as the default value.
 #'
-#'   If supplied, `default` must be size 1 or the size implied by `cases`.
+#'   If supplied, `default` must be size 1 or the size implied by `conditions`.
 #'
 #'   Can only be set when `unmatched = "default"`.
 #'
@@ -59,12 +60,12 @@
 #'   computed as the common type of `values` and `default`.
 #'
 #' @param size An optional override for the output size, which is usually
-#'   computed as the size of the first element of `cases`.
+#'   computed as the size of the first element of `conditions`.
 #'
-#'   Only useful for requiring a fixed size when `cases` is an empty list.
+#'   Only useful for requiring a fixed size when `conditions` is an empty list.
 #'
-#' @param x_arg,cases_arg,values_arg,default_arg Argument names used in error
-#'   messages.
+#' @param x_arg,conditions_arg,values_arg,default_arg Argument names used in
+#'   error messages.
 #'
 #' @returns
 #' A vector.
@@ -72,7 +73,7 @@
 #' - For `vec_case_when()`, the type of the output is computed as the common
 #'   type of `values` and `default`, unless overridden by `ptype`. The names of
 #'   the output come from the names of `values` and `default`. The size of the
-#'   output comes from the implied size from `cases`, unless overridden by
+#'   output comes from the implied size from `conditions`, unless overridden by
 #'   `size`.
 #'
 #' - For `vec_replace_when()`, the type of the output will have the same type as
@@ -86,7 +87,7 @@
 #' # Also note how the `NA` falls through to `default`.
 #' x <- seq(-2L, 2L, by = 1L)
 #' x <- c(x, NA)
-#' cases <- list(
+#' conditions <- list(
 #'   x < 0,
 #'   x < 1
 #' )
@@ -95,14 +96,14 @@
 #'   "<1"
 #' )
 #' vec_case_when(
-#'   cases,
+#'   conditions,
 #'   values,
 #'   default = "other"
 #' )
 #'
 #' # Missing values need to be handled with their own case
 #' # if you want them to have a special value
-#' cases <- list(
+#' conditions <- list(
 #'   x < 0,
 #'   x < 1,
 #'   is.na(x)
@@ -113,7 +114,7 @@
 #'   NA
 #' )
 #' vec_case_when(
-#'   cases,
+#'   conditions,
 #'   values,
 #'   default = "other"
 #' )
@@ -125,14 +126,14 @@
 #'   NA
 #' )
 #' vec_case_when(
-#'   cases,
+#'   conditions,
 #'   values,
 #'   default = x * 100
 #' )
 #'
 #' # Use `vec_replace_when()` if you need to update `x`, retaining
 #' # all previous values in locations that you don't match
-#' cases <- list(
+#' conditions <- list(
 #'   x < 0,
 #'   x < 1
 #' )
@@ -142,7 +143,7 @@
 #' )
 #' out <- vec_replace_when(
 #'   x,
-#'   cases,
+#'   conditions,
 #'   values
 #' )
 #' out
@@ -155,30 +156,30 @@
 #' # and `default`. `vec_replace_when()` modifies an existing vector, so
 #' # names come from `x` no matter what, just like `[<-` and `base::replace()`
 #' x <- c(a = 1, b = 2, c = 3)
-#' cases <- list(x == 1, x == 2)
+#' conditions <- list(x == 1, x == 2)
 #' values <- list(c(x = 0), c(y = -1))
-#' vec_case_when(cases, values)
-#' vec_replace_when(x, cases, values)
+#' vec_case_when(conditions, values)
+#' vec_replace_when(x, conditions, values)
 #'
 #' # If you want to enforce that you've covered all of the locations in your
-#' # `cases`, use `unmatched = "error"` rather than providing a `default`
+#' # `conditions`, use `unmatched = "error"` rather than providing a `default`
 #' x <- c(0, 1, 2)
-#' cases <- list(x == 1, x == 2)
+#' conditions <- list(x == 1, x == 2)
 #' values <- list("a", "b")
-#' try(vec_case_when(cases, values, unmatched = "error"))
+#' try(vec_case_when(conditions, values, unmatched = "error"))
 NULL
 
 #' @rdname vec-case-and-replace
 #' @export
 vec_case_when <- function(
-  cases,
+  conditions,
   values,
   ...,
   default = NULL,
   unmatched = "default",
   ptype = NULL,
   size = NULL,
-  cases_arg = "cases",
+  conditions_arg = "conditions",
   values_arg = "values",
   default_arg = "default",
   error_call = current_env()
@@ -186,7 +187,7 @@ vec_case_when <- function(
   check_dots_empty0(...)
   .Call(
     ffi_vec_case_when,
-    cases,
+    conditions,
     values,
     default,
     unmatched,
@@ -200,11 +201,11 @@ vec_case_when <- function(
 #' @export
 vec_replace_when <- function(
   x,
-  cases,
+  conditions,
   values,
   ...,
   x_arg = "x",
-  cases_arg = "cases",
+  conditions_arg = "conditions",
   values_arg = "values",
   error_call = current_env()
 ) {
@@ -212,7 +213,7 @@ vec_replace_when <- function(
   .Call(
     ffi_vec_replace_when,
     x,
-    cases,
+    conditions,
     values,
     environment()
   )

--- a/man/vec-case-and-replace.Rd
+++ b/man/vec-case-and-replace.Rd
@@ -7,14 +7,14 @@
 \title{Recode and replace using logical conditions}
 \usage{
 vec_case_when(
-  cases,
+  conditions,
   values,
   ...,
   default = NULL,
   unmatched = "default",
   ptype = NULL,
   size = NULL,
-  cases_arg = "cases",
+  conditions_arg = "conditions",
   values_arg = "values",
   default_arg = "default",
   error_call = current_env()
@@ -22,42 +22,42 @@ vec_case_when(
 
 vec_replace_when(
   x,
-  cases,
+  conditions,
   values,
   ...,
   x_arg = "x",
-  cases_arg = "cases",
+  conditions_arg = "conditions",
   values_arg = "values",
   error_call = current_env()
 )
 }
 \arguments{
-\item{cases}{A list of logical vectors.
+\item{conditions}{A list of logical condition vectors.
 
 For \code{vec_case_when()}, each vector should be the same size.
 
 For \code{vec_replace_when()}, each vector should be the same size as \code{x}.
 
-Where a value in \code{cases} is \code{TRUE}, the corresponding value in \code{values}
-will be assigned to the result.}
+Where a value in \code{conditions} is \code{TRUE}, the corresponding value in
+\code{values} will be assigned to the result.}
 
 \item{values}{A list of vectors.
 
 For \code{vec_case_when()}, each vector should be size 1 or the size implied by
-\code{cases}. The common type of \code{values} and \code{default} determine the output
-type, unless overridden by \code{ptype}.
+\code{conditions}. The common type of \code{values} and \code{default} determine the
+output type, unless overridden by \code{ptype}.
 
 For \code{vec_replace_when()}, each vector should be size 1 or the same size
 as \code{x}. Each vector will be cast to the type of \code{x}.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{default}{Default value to use when \code{cases} does not match every
+\item{default}{Default value to use when \code{conditions} does not match every
 location in the output.
 
 By default, a missing value is used as the default value.
 
-If supplied, \code{default} must be size 1 or the size implied by \code{cases}.
+If supplied, \code{default} must be size 1 or the size implied by \code{conditions}.
 
 Can only be set when \code{unmatched = "default"}.}
 
@@ -73,9 +73,9 @@ One of:
 computed as the common type of \code{values} and \code{default}.}
 
 \item{size}{An optional override for the output size, which is usually
-computed as the size of the first element of \code{cases}.
+computed as the size of the first element of \code{conditions}.
 
-Only useful for requiring a fixed size when \code{cases} is an empty list.}
+Only useful for requiring a fixed size when \code{conditions} is an empty list.}
 
 \item{error_call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be
@@ -84,8 +84,8 @@ mentioned in error messages as the source of the error. See the
 
 \item{x}{A vector.}
 
-\item{x_arg, cases_arg, values_arg, default_arg}{Argument names used in error
-messages.}
+\item{x_arg, conditions_arg, values_arg, default_arg}{Argument names used in
+error messages.}
 }
 \value{
 A vector.
@@ -93,7 +93,7 @@ A vector.
 \item For \code{vec_case_when()}, the type of the output is computed as the common
 type of \code{values} and \code{default}, unless overridden by \code{ptype}. The names of
 the output come from the names of \code{values} and \code{default}. The size of the
-output comes from the implied size from \code{cases}, unless overridden by
+output comes from the implied size from \code{conditions}, unless overridden by
 \code{size}.
 \item For \code{vec_replace_when()}, the type of the output will have the same type as
 \code{x}. The names of the output will be the same as the names of \code{x}. The size
@@ -103,12 +103,13 @@ of the output will be the same size as \code{x}.
 \description{
 \itemize{
 \item \code{vec_case_when()} constructs an entirely new vector by recoding the \code{TRUE}
-\code{cases} to their corresponding \code{values}. If there are locations not matched
-by \code{cases}, then they are recoded to the \code{default} value.
+\code{conditions} to their corresponding \code{values}. If there are locations not
+matched by \code{conditions}, then they are recoded to the \code{default} value.
 \item \code{vec_replace_when()} updates an existing vector by replacing the values
-from \code{x} matched by the \code{TRUE} \code{cases} with their corresponding \code{values}.
-In this case, each element of \code{values} must have the same type as \code{x} and
-locations not matched by \code{cases} retain their original \code{x} value.
+from \code{x} matched by the \code{TRUE} \code{conditions} with their corresponding
+\code{values}. In this case, each element of \code{values} must have the same type as
+\code{x} and locations not matched by \code{conditions} retain their original \code{x}
+value.
 }
 
 \code{vec_case_when()} is often thought of as a way to vectorize multiple if-else
@@ -120,7 +121,7 @@ statement.
 # Also note how the `NA` falls through to `default`.
 x <- seq(-2L, 2L, by = 1L)
 x <- c(x, NA)
-cases <- list(
+conditions <- list(
   x < 0,
   x < 1
 )
@@ -129,14 +130,14 @@ values <- list(
   "<1"
 )
 vec_case_when(
-  cases,
+  conditions,
   values,
   default = "other"
 )
 
 # Missing values need to be handled with their own case
 # if you want them to have a special value
-cases <- list(
+conditions <- list(
   x < 0,
   x < 1,
   is.na(x)
@@ -147,7 +148,7 @@ values <- list(
   NA
 )
 vec_case_when(
-  cases,
+  conditions,
   values,
   default = "other"
 )
@@ -159,14 +160,14 @@ values <- list(
   NA
 )
 vec_case_when(
-  cases,
+  conditions,
   values,
   default = x * 100
 )
 
 # Use `vec_replace_when()` if you need to update `x`, retaining
 # all previous values in locations that you don't match
-cases <- list(
+conditions <- list(
   x < 0,
   x < 1
 )
@@ -176,7 +177,7 @@ values <- list(
 )
 out <- vec_replace_when(
   x,
-  cases,
+  conditions,
   values
 )
 out
@@ -189,15 +190,15 @@ typeof(out)
 # and `default`. `vec_replace_when()` modifies an existing vector, so
 # names come from `x` no matter what, just like `[<-` and `base::replace()`
 x <- c(a = 1, b = 2, c = 3)
-cases <- list(x == 1, x == 2)
+conditions <- list(x == 1, x == 2)
 values <- list(c(x = 0), c(y = -1))
-vec_case_when(cases, values)
-vec_replace_when(x, cases, values)
+vec_case_when(conditions, values)
+vec_replace_when(x, conditions, values)
 
 # If you want to enforce that you've covered all of the locations in your
-# `cases`, use `unmatched = "error"` rather than providing a `default`
+# `conditions`, use `unmatched = "error"` rather than providing a `default`
 x <- c(0, 1, 2)
-cases <- list(x == 1, x == 2)
+conditions <- list(x == 1, x == 2)
 values <- list("a", "b")
-try(vec_case_when(cases, values, unmatched = "error"))
+try(vec_case_when(conditions, values, unmatched = "error"))
 }

--- a/src/case-when.c
+++ b/src/case-when.c
@@ -3,36 +3,36 @@
 #include "decl/case-when-decl.h"
 
 r_obj* vec_case_when(
-  r_obj* cases,
+  r_obj* conditions,
   r_obj* values,
   r_obj* default_,
   enum list_combine_unmatched unmatched,
   r_obj* ptype,
   r_ssize size,
-  struct vctrs_arg* p_cases_arg,
+  struct vctrs_arg* p_conditions_arg,
   struct vctrs_arg* p_values_arg,
   struct vctrs_arg* p_default_arg,
   struct r_lazy error_call
 ) {
-  obj_check_list(cases, p_cases_arg, error_call);
-  list_check_all_condition_indices(cases, p_cases_arg, error_call);
+  obj_check_list(conditions, p_conditions_arg, error_call);
+  list_check_all_condition_indices(conditions, p_conditions_arg, error_call);
 
   obj_check_list(values, p_values_arg, error_call);
   list_check_all_vectors(values, VCTRS_ALLOW_NULL_no, p_values_arg, error_call);
 
-  // Infer `size` from first element of `cases` unless specified.
+  // Infer `size` from first element of `conditions` unless specified.
   // We do this in `vec_case_when()` but not in `list_combine()`
   // because `vec_case_when()` only takes logical indices, which
   // has less ambiguity about the output size.
-  size = compute_size(size, cases);
-  list_check_all_size(cases, size, VCTRS_ALLOW_NULL_no, p_cases_arg, error_call);
+  size = compute_size(size, conditions);
+  list_check_all_size(conditions, size, VCTRS_ALLOW_NULL_no, p_conditions_arg, error_call);
 
   const enum list_combine_multiple multiple = LIST_COMBINE_MULTIPLE_first;
   const enum assignment_slice_value slice_values = ASSIGNMENT_SLICE_VALUE_yes;
 
   return list_combine(
     values,
-    cases,
+    conditions,
     size,
     default_,
     unmatched,
@@ -42,7 +42,7 @@ r_obj* vec_case_when(
     name_spec_inner,
     p_no_repair_opts,
     p_values_arg,
-    p_cases_arg,
+    p_conditions_arg,
     p_default_arg,
     error_call
   );
@@ -50,10 +50,10 @@ r_obj* vec_case_when(
 
 r_obj* vec_replace_when(
   r_obj* x,
-  r_obj* cases,
+  r_obj* conditions,
   r_obj* values,
   struct vctrs_arg* p_x_arg,
-  struct vctrs_arg* p_cases_arg,
+  struct vctrs_arg* p_conditions_arg,
   struct vctrs_arg* p_values_arg,
   struct r_lazy error_call
 ) {
@@ -68,13 +68,13 @@ r_obj* vec_replace_when(
   r_obj* ptype = KEEP(vec_ptype_final(x, p_x_arg, error_call));
 
   r_obj* out = KEEP(vec_case_when(
-    cases,
+    conditions,
     values,
     default_,
     unmatched,
     ptype,
     size,
-    p_cases_arg,
+    p_conditions_arg,
     p_values_arg,
     p_default_arg,
     error_call
@@ -93,7 +93,7 @@ r_obj* vec_replace_when(
 }
 
 r_obj* ffi_vec_case_when(
-  r_obj* ffi_cases,
+  r_obj* ffi_conditions,
   r_obj* ffi_values,
   r_obj* ffi_default,
   r_obj* ffi_unmatched,
@@ -101,8 +101,8 @@ r_obj* ffi_vec_case_when(
   r_obj* ffi_size,
   r_obj* ffi_frame
 ) {
-  struct r_lazy cases_arg_lazy = { .x = syms.cases_arg, .env = ffi_frame };
-  struct vctrs_arg cases_arg = new_lazy_arg(&cases_arg_lazy);
+  struct r_lazy conditions_arg_lazy = { .x = syms.conditions_arg, .env = ffi_frame };
+  struct vctrs_arg conditions_arg = new_lazy_arg(&conditions_arg_lazy);
 
   struct r_lazy values_arg_lazy = { .x = syms.values_arg, .env = ffi_frame };
   struct vctrs_arg values_arg = new_lazy_arg(&values_arg_lazy);
@@ -116,13 +116,13 @@ r_obj* ffi_vec_case_when(
   const enum list_combine_unmatched unmatched = parse_list_combine_unmatched(ffi_unmatched, error_call);
 
   return vec_case_when(
-    ffi_cases,
+    ffi_conditions,
     ffi_values,
     ffi_default,
     unmatched,
     ffi_ptype,
     size,
-    &cases_arg,
+    &conditions_arg,
     &values_arg,
     &default_arg,
     error_call
@@ -131,15 +131,15 @@ r_obj* ffi_vec_case_when(
 
 r_obj* ffi_vec_replace_when(
   r_obj* ffi_x,
-  r_obj* ffi_cases,
+  r_obj* ffi_conditions,
   r_obj* ffi_values,
   r_obj* ffi_frame
 ) {
   struct r_lazy x_arg_lazy = { .x = syms.x_arg, .env = ffi_frame };
   struct vctrs_arg x_arg = new_lazy_arg(&x_arg_lazy);
 
-  struct r_lazy cases_arg_lazy = { .x = syms.cases_arg, .env = ffi_frame };
-  struct vctrs_arg cases_arg = new_lazy_arg(&cases_arg_lazy);
+  struct r_lazy conditions_arg_lazy = { .x = syms.conditions_arg, .env = ffi_frame };
+  struct vctrs_arg conditions_arg = new_lazy_arg(&conditions_arg_lazy);
 
   struct r_lazy values_arg_lazy = { .x = syms.values_arg, .env = ffi_frame };
   struct vctrs_arg values_arg = new_lazy_arg(&values_arg_lazy);
@@ -148,10 +148,10 @@ r_obj* ffi_vec_replace_when(
 
   return vec_replace_when(
     ffi_x,
-    ffi_cases,
+    ffi_conditions,
     ffi_values,
     &x_arg,
-    &cases_arg,
+    &conditions_arg,
     &values_arg,
     error_call
   );
@@ -159,17 +159,17 @@ r_obj* ffi_vec_replace_when(
 
 // Figure out the output size
 // - `size` if supplied
-// - Size of 1st `cases` element if one exists
-// - Size 0 if `cases` is empty
+// - Size of 1st `conditions` element if one exists
+// - Size 0 if `conditions` is empty
 static
-r_ssize compute_size(r_ssize size, r_obj* cases) {
+r_ssize compute_size(r_ssize size, r_obj* conditions) {
   if (size != -1) {
     return size;
   }
 
-  if (r_length(cases) == 0) {
+  if (r_length(conditions) == 0) {
     return 0;
   }
 
-  return r_length(r_list_get(cases, 0));
+  return r_length(r_list_get(conditions, 0));
 }

--- a/src/case-when.h
+++ b/src/case-when.h
@@ -5,13 +5,13 @@
 #include "list-combine.h"
 
 r_obj* vec_case_when(
-  r_obj* cases,
+  r_obj* conditions,
   r_obj* values,
   r_obj* default_,
   enum list_combine_unmatched unmatched,
   r_obj* ptype,
   r_ssize size,
-  struct vctrs_arg* p_cases_arg,
+  struct vctrs_arg* p_conditions_arg,
   struct vctrs_arg* p_values_arg,
   struct vctrs_arg* p_default_arg,
   struct r_lazy error_call
@@ -19,10 +19,10 @@ r_obj* vec_case_when(
 
 r_obj* vec_replace_when(
   r_obj* x,
-  r_obj* cases,
+  r_obj* conditions,
   r_obj* values,
   struct vctrs_arg* p_x_arg,
-  struct vctrs_arg* p_cases_arg,
+  struct vctrs_arg* p_conditions_arg,
   struct vctrs_arg* p_values_arg,
   struct r_lazy error_call
 );

--- a/src/decl/case-when-decl.h
+++ b/src/decl/case-when-decl.h
@@ -1,2 +1,2 @@
 static
-r_ssize compute_size(r_ssize size, r_obj* cases);
+r_ssize compute_size(r_ssize size, r_obj* conditions);

--- a/src/globals.c
+++ b/src/globals.c
@@ -49,8 +49,8 @@ void vctrs_init_globals(r_obj* ns) {
 
   // Symbols -----------------------------------------------------------
   syms.arg = r_sym("arg");
-  syms.cases_arg = r_sym("cases_arg");
   syms.condition_arg = r_sym("condition_arg");
+  syms.conditions_arg = r_sym("conditions_arg");
   syms.default_arg = r_sym("default_arg");
   syms.dot_arg = r_sym(".arg");
   syms.dot_call = r_sym(".call");

--- a/src/globals.h
+++ b/src/globals.h
@@ -6,8 +6,8 @@
 
 struct syms {
   r_obj* arg;
-  r_obj* cases_arg;
   r_obj* condition_arg;
+  r_obj* conditions_arg;
   r_obj* default_arg;
   r_obj* dot_arg;
   r_obj* dot_call;

--- a/src/if-else.c
+++ b/src/if-else.c
@@ -124,12 +124,12 @@ r_obj* generic_if_else(
   struct vctrs_arg* p_missing_arg,
   struct r_lazy error_call
 ) {
-  r_obj* cases = KEEP(r_alloc_list(2));
-  r_list_poke(cases, 0, condition);
+  r_obj* conditions = KEEP(r_alloc_list(2));
+  r_list_poke(conditions, 0, condition);
   // TODO: This is another place where we could use a compact-condition
   // if `list_combine()` could take them as `indices`. Would be 3x less
   // memory, which probably does matter quite a bit for simple cases.
-  r_list_poke(cases, 1, r_lgl_invert(condition));
+  r_list_poke(conditions, 1, r_lgl_invert(condition));
 
   r_obj* values = KEEP(r_alloc_list(2));
   r_list_poke(values, 0, true_);
@@ -161,11 +161,11 @@ r_obj* generic_if_else(
 
   // Don't use outer names if any errors occur
   struct vctrs_arg* p_values_arg = vec_args.empty;
-  struct vctrs_arg* p_cases_arg = vec_args.empty;
+  struct vctrs_arg* p_conditions_arg = vec_args.empty;
 
   r_obj* out = list_combine(
     values,
-    cases,
+    conditions,
     size,
     missing,
     unmatched,
@@ -175,7 +175,7 @@ r_obj* generic_if_else(
     name_spec,
     p_name_repair_opts,
     p_values_arg,
-    p_cases_arg,
+    p_conditions_arg,
     p_missing_arg,
     error_call
   );

--- a/tests/testthat/_snaps/case-when.md
+++ b/tests/testthat/_snaps/case-when.md
@@ -1,4 +1,4 @@
-# `cases` inputs can be size zero
+# `conditions` inputs can be size zero
 
     Code
       vec_case_when(list(logical()), list(1:2))
@@ -14,7 +14,7 @@
       Error in `vec_case_when()`:
       ! Can't combine `values[[1]]` <double> and `values[[2]]` <character>.
 
-# `values` must be size 1 or same size as the `cases`
+# `values` must be size 1 or same size as the `conditions`
 
     Code
       vec_case_when(list(c(TRUE, FALSE, TRUE, TRUE)), list(1:3))
@@ -22,7 +22,7 @@
       Error in `vec_case_when()`:
       ! Can't recycle `values[[1]]` (size 3) to size 4.
 
-# `default` must be size 1 or same size as `cases` (exact same as any other `values` input)
+# `default` must be size 1 or same size as `conditions` (exact same as any other `values` input)
 
     Code
       vec_case_when(list(FALSE), list(1L), default = 2:3)
@@ -46,10 +46,10 @@
       Error in `vec_case_when()`:
       ! Can't combine <integer> and `foo` <character>.
 
-# `cases_arg` is validated
+# `conditions_arg` is validated
 
     Code
-      vec_case_when(list("x"), list(1), cases_arg = 1)
+      vec_case_when(list("x"), list(1), conditions_arg = 1)
     Condition
       Error in `vec_case_when()`:
       ! `arg` must be a string.
@@ -70,13 +70,13 @@
       Error in `vec_case_when()`:
       ! `arg` must be a string.
 
-# `cases` must all be the same size
+# `conditions` must all be the same size
 
     Code
       vec_case_when(list(c(TRUE, FALSE), TRUE), list(1, 2))
     Condition
       Error in `vec_case_when()`:
-      ! `cases[[2]]` must have size 2, not size 1.
+      ! `conditions[[2]]` must have size 2, not size 1.
 
 ---
 
@@ -84,15 +84,15 @@
       vec_case_when(list(c(TRUE, FALSE), c(TRUE, FALSE, TRUE)), list(1, 2))
     Condition
       Error in `vec_case_when()`:
-      ! `cases[[2]]` must have size 2, not size 3.
+      ! `conditions[[2]]` must have size 2, not size 3.
 
-# `cases` must be logical (and aren't cast to logical!)
+# `conditions` must be logical (and aren't cast to logical!)
 
     Code
       vec_case_when(list(1), list(2))
     Condition
       Error in `vec_case_when()`:
-      ! `cases[[1]]` must be a logical vector, not the number 1.
+      ! `conditions[[1]]` must be a logical vector, not the number 1.
 
 ---
 
@@ -100,7 +100,7 @@
       vec_case_when(list(TRUE, 3.5), list(2, 4))
     Condition
       Error in `vec_case_when()`:
-      ! `cases[[2]]` must be a logical vector, not the number 3.5.
+      ! `conditions[[2]]` must be a logical vector, not the number 3.5.
 
 ---
 
@@ -108,15 +108,15 @@
       vec_case_when(list(x), list(1), default = 2)
     Condition
       Error in `vec_case_when()`:
-      ! `cases[[1]]` must be a logical vector, not a <my_logical> object.
+      ! `conditions[[1]]` must be a logical vector, not a <my_logical> object.
 
-# `cases` can't be arrays (#6862)
+# `conditions` can't be arrays (#6862)
 
     Code
       vec_case_when(list(x), list(y))
     Condition
       Error in `vec_case_when()`:
-      ! `cases[[1]]` must be a logical vector, not a logical matrix.
+      ! `conditions[[1]]` must be a logical vector, not a logical matrix.
 
 ---
 
@@ -124,7 +124,7 @@
       vec_case_when(list(x), list(y), size = 3)
     Condition
       Error in `vec_case_when()`:
-      ! `cases[[1]]` must be a logical vector, not a logical matrix.
+      ! `conditions[[1]]` must be a logical vector, not a logical matrix.
 
 ---
 
@@ -132,15 +132,15 @@
       vec_case_when(list(x), list(y))
     Condition
       Error in `vec_case_when()`:
-      ! `cases[[1]]` must be a logical vector, not a logical 1D array.
+      ! `conditions[[1]]` must be a logical vector, not a logical 1D array.
 
-# `size` overrides the `cases` sizes
+# `size` overrides the `conditions` sizes
 
     Code
       vec_case_when(list(TRUE), list(1), size = 5)
     Condition
       Error in `vec_case_when()`:
-      ! `cases[[1]]` must have size 5, not size 1.
+      ! `conditions[[1]]` must have size 5, not size 1.
 
 ---
 
@@ -148,7 +148,7 @@
       vec_case_when(list(c(TRUE, FALSE), c(TRUE, FALSE, TRUE)), list(1, 2), size = 2)
     Condition
       Error in `vec_case_when()`:
-      ! `cases[[2]]` must have size 2, not size 3.
+      ! `conditions[[2]]` must have size 2, not size 3.
 
 # `ptype` overrides the `values` types
 
@@ -158,13 +158,13 @@
       Error in `vec_case_when()`:
       ! Can't convert `values[[2]]` <double> to <character>.
 
-# number of `cases` and `values` must be the same
+# number of `conditions` and `values` must be the same
 
     Code
       vec_case_when(list(TRUE), list())
     Condition
       Error in `vec_case_when()`:
-      ! `cases` must have size 0, not size 1.
+      ! `conditions` must have size 0, not size 1.
 
 ---
 
@@ -172,7 +172,7 @@
       vec_case_when(list(TRUE, TRUE), list(1))
     Condition
       Error in `vec_case_when()`:
-      ! `cases` must have size 1, not size 2.
+      ! `conditions` must have size 1, not size 2.
 
 # dots must be empty
 
@@ -185,13 +185,13 @@
       * ..1 = 2
       i Did you forget to name an argument?
 
-# `cases` must be a list
+# `conditions` must be a list
 
     Code
       vec_case_when(1, list(2))
     Condition
       Error in `vec_case_when()`:
-      ! `cases` must be a list, not the number 1.
+      ! `conditions` must be a list, not the number 1.
 
 # `values` must be a list
 
@@ -207,12 +207,12 @@
       vec_case_when(list(x = 1.5), list(1))
     Condition
       Error in `vec_case_when()`:
-      ! `cases$x` must be a logical vector, not the number 1.5.
+      ! `conditions$x` must be a logical vector, not the number 1.5.
 
 ---
 
     Code
-      vec_case_when(list(x = 1.5), list(1), cases_arg = "foo")
+      vec_case_when(list(x = 1.5), list(1), conditions_arg = "foo")
     Condition
       Error in `vec_case_when()`:
       ! `foo$x` must be a logical vector, not the number 1.5.
@@ -220,7 +220,7 @@
 ---
 
     Code
-      vec_case_when(list(x = 1.5), list(1), cases_arg = "")
+      vec_case_when(list(x = 1.5), list(1), conditions_arg = "")
     Condition
       Error in `vec_case_when()`:
       ! `x` must be a logical vector, not the number 1.5.
@@ -231,12 +231,12 @@
       vec_case_when(list(x = TRUE, y = c(TRUE, FALSE)), list(1, 2))
     Condition
       Error in `vec_case_when()`:
-      ! `cases$y` must have size 1, not size 2.
+      ! `conditions$y` must have size 1, not size 2.
 
 ---
 
     Code
-      vec_case_when(list(x = TRUE, y = c(TRUE, FALSE)), list(1, 2), cases_arg = "foo")
+      vec_case_when(list(x = TRUE, y = c(TRUE, FALSE)), list(1, 2), conditions_arg = "foo")
     Condition
       Error in `vec_case_when()`:
       ! `foo$y` must have size 1, not size 2.
@@ -244,7 +244,7 @@
 ---
 
     Code
-      vec_case_when(list(x = TRUE, y = c(TRUE, FALSE)), list(1, 2), cases_arg = "")
+      vec_case_when(list(x = TRUE, y = c(TRUE, FALSE)), list(1, 2), conditions_arg = "")
     Condition
       Error in `vec_case_when()`:
       ! `y` must have size 1, not size 2.
@@ -324,7 +324,7 @@
 # `unmatched` errors are correct
 
     Code
-      vec_case_when(cases, values, unmatched = "error")
+      vec_case_when(conditions, values, unmatched = "error")
     Condition
       Error in `vec_case_when()`:
       ! Each location must be matched.

--- a/tests/testthat/test-case-when.R
+++ b/tests/testthat/test-case-when.R
@@ -1,5 +1,5 @@
 test_that("works with data frames", {
-  cases <- list(
+  conditions <- list(
     c(FALSE, TRUE, FALSE, FALSE),
     c(TRUE, TRUE, FALSE, FALSE),
     c(FALSE, TRUE, FALSE, TRUE)
@@ -10,7 +10,7 @@ test_that("works with data frames", {
     data_frame(x = 3:6, y = 4:7)
   )
 
-  out <- vec_case_when(cases, values)
+  out <- vec_case_when(conditions, values)
 
   expect_identical(
     out,
@@ -22,7 +22,7 @@ test_that("works with data frames", {
 })
 
 test_that("first `TRUE` case wins", {
-  cases <- list(
+  conditions <- list(
     c(TRUE, FALSE),
     c(TRUE, TRUE),
     c(TRUE, TRUE)
@@ -34,7 +34,7 @@ test_that("first `TRUE` case wins", {
   )
 
   expect_identical(
-    vec_case_when(cases, values),
+    vec_case_when(conditions, values),
     c(1, 2)
   )
 })
@@ -42,7 +42,7 @@ test_that("first `TRUE` case wins", {
 test_that("can replace missing values by catching with `is.na()`", {
   x <- c(1:3, NA)
 
-  cases <- list(
+  conditions <- list(
     x <= 1,
     x <= 2,
     is.na(x)
@@ -54,7 +54,7 @@ test_that("can replace missing values by catching with `is.na()`", {
   )
 
   expect_identical(
-    vec_case_when(cases, values),
+    vec_case_when(conditions, values),
     c(1, 2, NA, 0)
   )
 })
@@ -72,7 +72,7 @@ test_that("Unused logical `NA` can still be cast to `values` ptype", {
   )
 })
 
-test_that("`cases` inputs can be size zero", {
+test_that("`conditions` inputs can be size zero", {
   expect_identical(
     vec_case_when(
       list(logical(), logical()),
@@ -118,7 +118,7 @@ test_that("`values` are cast to their common type", {
   })
 })
 
-test_that("`values` must be size 1 or same size as the `cases`", {
+test_that("`values` must be size 1 or same size as the `conditions`", {
   expect_identical(
     vec_case_when(
       list(c(TRUE, TRUE)),
@@ -174,7 +174,7 @@ test_that("`NA` is overridden by any `TRUE` values", {
   expect <- c("one", "not_one", "missing", "not_one")
 
   # `TRUE` overriding before the `NA`
-  cases <- list(
+  conditions <- list(
     is.na(x),
     x == 1
   )
@@ -184,7 +184,7 @@ test_that("`NA` is overridden by any `TRUE` values", {
   )
   expect_identical(
     vec_case_when(
-      cases,
+      conditions,
       values,
       default = "not_one"
     ),
@@ -192,7 +192,7 @@ test_that("`NA` is overridden by any `TRUE` values", {
   )
 
   # `TRUE` overriding after the `NA`
-  cases <- list(
+  conditions <- list(
     x == 1,
     is.na(x)
   )
@@ -202,7 +202,7 @@ test_that("`NA` is overridden by any `TRUE` values", {
   )
   expect_identical(
     vec_case_when(
-      cases,
+      conditions,
       values,
       default = "not_one"
     ),
@@ -256,7 +256,7 @@ test_that("`default` can be vectorized, and is sliced to fit as needed", {
   expect_identical(out, c(11L, 2L, 13L, 4L, 10L))
 })
 
-test_that("`default` must be size 1 or same size as `cases` (exact same as any other `values` input)", {
+test_that("`default` must be size 1 or same size as `conditions` (exact same as any other `values` input)", {
   expect_snapshot(error = TRUE, {
     vec_case_when(list(FALSE), list(1L), default = 2:3)
   })
@@ -281,9 +281,9 @@ test_that("`default_arg` can be customized", {
   })
 })
 
-test_that("`cases_arg` is validated", {
+test_that("`conditions_arg` is validated", {
   expect_snapshot(error = TRUE, {
-    vec_case_when(list("x"), list(1), cases_arg = 1)
+    vec_case_when(list("x"), list(1), conditions_arg = 1)
   })
 })
 
@@ -299,7 +299,7 @@ test_that("`default_arg` is validated", {
   })
 })
 
-test_that("`cases` must all be the same size", {
+test_that("`conditions` must all be the same size", {
   expect_snapshot(error = TRUE, {
     vec_case_when(
       list(c(TRUE, FALSE), TRUE),
@@ -314,7 +314,7 @@ test_that("`cases` must all be the same size", {
   })
 })
 
-test_that("`cases` must be logical (and aren't cast to logical!)", {
+test_that("`conditions` must be logical (and aren't cast to logical!)", {
   expect_snapshot(error = TRUE, {
     vec_case_when(list(1), list(2))
   })
@@ -331,12 +331,12 @@ test_that("`cases` must be logical (and aren't cast to logical!)", {
   })
 })
 
-test_that("`cases` are allowed to have attributes", {
+test_that("`conditions` are allowed to have attributes", {
   x <- structure(c(FALSE, TRUE), label = "foo")
   expect_identical(vec_case_when(list(x), list(1), default = 2), c(2, 1))
 })
 
-test_that("`cases` can't be arrays (#6862)", {
+test_that("`conditions` can't be arrays (#6862)", {
   x <- array(TRUE, dim = c(3, 3))
   y <- c("a", "b", "c")
 
@@ -355,7 +355,7 @@ test_that("`cases` can't be arrays (#6862)", {
   })
 })
 
-test_that("`size` overrides the `cases` sizes", {
+test_that("`size` overrides the `conditions` sizes", {
   expect_snapshot(error = TRUE, {
     vec_case_when(list(TRUE), list(1), size = 5)
   })
@@ -369,10 +369,10 @@ test_that("`size` overrides the `cases` sizes", {
   })
 })
 
-test_that("0 `cases` result depends on `size` and `default` and `ptype`", {
+test_that("0 `conditions` result depends on `size` and `default` and `ptype`", {
   expect_identical(
     vec_case_when(
-      cases = list(),
+      conditions = list(),
       values = list()
     ),
     unspecified()
@@ -380,7 +380,7 @@ test_that("0 `cases` result depends on `size` and `default` and `ptype`", {
 
   expect_identical(
     vec_case_when(
-      cases = list(),
+      conditions = list(),
       values = list(),
       size = 0
     ),
@@ -388,7 +388,7 @@ test_that("0 `cases` result depends on `size` and `default` and `ptype`", {
   )
   expect_identical(
     vec_case_when(
-      cases = list(),
+      conditions = list(),
       values = list(),
       size = 2
     ),
@@ -397,7 +397,7 @@ test_that("0 `cases` result depends on `size` and `default` and `ptype`", {
 
   expect_identical(
     vec_case_when(
-      cases = list(),
+      conditions = list(),
       values = list(),
       default = integer()
     ),
@@ -405,7 +405,7 @@ test_that("0 `cases` result depends on `size` and `default` and `ptype`", {
   )
   expect_identical(
     vec_case_when(
-      cases = list(),
+      conditions = list(),
       values = list(),
       default = 1L
     ),
@@ -413,7 +413,7 @@ test_that("0 `cases` result depends on `size` and `default` and `ptype`", {
   )
   expect_identical(
     vec_case_when(
-      cases = list(),
+      conditions = list(),
       values = list(),
       ptype = integer()
     ),
@@ -422,7 +422,7 @@ test_that("0 `cases` result depends on `size` and `default` and `ptype`", {
 
   expect_identical(
     vec_case_when(
-      cases = list(),
+      conditions = list(),
       values = list(),
       size = 2L,
       default = 1L
@@ -431,7 +431,7 @@ test_that("0 `cases` result depends on `size` and `default` and `ptype`", {
   )
   expect_identical(
     vec_case_when(
-      cases = list(),
+      conditions = list(),
       values = list(),
       size = 2L,
       default = 1:2
@@ -440,7 +440,7 @@ test_that("0 `cases` result depends on `size` and `default` and `ptype`", {
   )
   expect_identical(
     vec_case_when(
-      cases = list(),
+      conditions = list(),
       values = list(),
       size = 2L,
       ptype = integer()
@@ -449,11 +449,11 @@ test_that("0 `cases` result depends on `size` and `default` and `ptype`", {
   )
 })
 
-test_that("`vec_replace_when()` with empty `cases` is a no-op", {
+test_that("`vec_replace_when()` with empty `conditions` is a no-op", {
   x <- 1:5
 
   expect_identical(
-    vec_replace_when(x, cases = list(), values = list()),
+    vec_replace_when(x, conditions = list(), values = list()),
     x
   )
 })
@@ -469,7 +469,7 @@ test_that("`ptype` overrides the `values` types", {
   })
 })
 
-test_that("number of `cases` and `values` must be the same", {
+test_that("number of `conditions` and `values` must be the same", {
   expect_snapshot(error = TRUE, {
     vec_case_when(list(TRUE), list())
   })
@@ -484,7 +484,7 @@ test_that("dots must be empty", {
   })
 })
 
-test_that("`cases` must be a list", {
+test_that("`conditions` must be a list", {
   expect_snapshot(error = TRUE, {
     vec_case_when(1, list(2))
   })
@@ -501,10 +501,10 @@ test_that("named inputs show up in the error message", {
     vec_case_when(list(x = 1.5), list(1))
   })
   expect_snapshot(error = TRUE, {
-    vec_case_when(list(x = 1.5), list(1), cases_arg = "foo")
+    vec_case_when(list(x = 1.5), list(1), conditions_arg = "foo")
   })
   expect_snapshot(error = TRUE, {
-    vec_case_when(list(x = 1.5), list(1), cases_arg = "")
+    vec_case_when(list(x = 1.5), list(1), conditions_arg = "")
   })
 
   expect_snapshot(error = TRUE, {
@@ -514,14 +514,14 @@ test_that("named inputs show up in the error message", {
     vec_case_when(
       list(x = TRUE, y = c(TRUE, FALSE)),
       list(1, 2),
-      cases_arg = "foo"
+      conditions_arg = "foo"
     )
   })
   expect_snapshot(error = TRUE, {
     vec_case_when(
       list(x = TRUE, y = c(TRUE, FALSE)),
       list(1, 2),
-      cases_arg = ""
+      conditions_arg = ""
     )
   })
 
@@ -559,7 +559,7 @@ test_that("proof that `ptype` finalization is important", {
   # Imagine you have an input logical vector you are remapping
   # and it happens to only have `NA`s
   x <- c(NA, NA)
-  cases <- list(x %in% NA)
+  conditions <- list(x %in% NA)
   values <- list(FALSE)
 
   # If no `ptype` finalization happened, then `ptype = x` would result in
@@ -567,17 +567,17 @@ test_that("proof that `ptype` finalization is important", {
   # now does `ptype` finalization when an explicit `ptype` is provided, so this
   # works.
   expect_identical(
-    vec_case_when(cases, values, default = x, ptype = x),
+    vec_case_when(conditions, values, default = x, ptype = x),
     c(FALSE, FALSE)
   )
   expect_identical(
-    vec_replace_when(x, cases, values),
+    vec_replace_when(x, conditions, values),
     c(FALSE, FALSE)
   )
 })
 
 test_that("`unmatched` errors are correct", {
-  cases <- list(
+  conditions <- list(
     c(TRUE, FALSE, TRUE, FALSE, FALSE, NA, NA, NA, TRUE),
     c(FALSE, TRUE, TRUE, FALSE, NA, FALSE, NA, TRUE, NA)
   )
@@ -586,6 +586,6 @@ test_that("`unmatched` errors are correct", {
     2
   )
   expect_snapshot(error = TRUE, {
-    vec_case_when(cases, values, unmatched = "error")
+    vec_case_when(conditions, values, unmatched = "error")
   })
 })


### PR DESCRIPTION
This now seems obvious to me

- `vec_if_else(condition, true, false, ...)`
- `vec_case_when(conditions, values, ...)`
- `vec_replace_when(x, conditions, values, ...)`
- `vec_pany(...)` and `vec_pall(...)` would take condition vectors #1675 
- We internally call all of these logical condition vectors