### PR TITLE
Make `size2_common()` look more like `ptype2_common()`

### DIFF
--- a/src/decl/size-common-decl.h
+++ b/src/decl/size-common-decl.h
@@ -1,5 +1,5 @@
 static
-r_obj* vctrs_size2_common(
+r_obj* size2_common(
   r_obj* x,
   r_obj* y,
   struct counters* counters,


### PR DESCRIPTION
Nicely isolates `vec_size2_impl()` away from all the counter related stuff