### PR TITLE
Simplify C entry points for size and recycle

### DIFF
--- a/src/bind.c
+++ b/src/bind.c
@@ -447,13 +447,13 @@ r_obj* vec_cbind(r_obj* xs,
 
   r_ssize nrow;
   if (size == r_null) {
-    nrow = vec_check_size_common(xs, 0, p_arg, error_call);
+    nrow = vec_size_common(xs, 0, p_arg, error_call);
   } else {
     nrow = vec_as_short_length(size, vec_args.dot_size, error_call);
   }
 
   if (rownames != r_null && r_length(rownames) != nrow) {
-    rownames = KEEP(vec_check_recycle(rownames, nrow, vec_args.empty, error_call));
+    rownames = KEEP(vec_recycle(rownames, nrow, vec_args.empty, error_call));
     rownames = vec_as_unique_names(rownames, false);
     FREE(1);
   }
@@ -472,7 +472,7 @@ r_obj* vec_cbind(r_obj* xs,
       continue;
     }
 
-    x = KEEP(vec_check_recycle(x, nrow, vec_args.empty, r_lazy_null));
+    x = KEEP(vec_recycle(x, nrow, vec_args.empty, r_lazy_null));
 
     r_obj* outer_name = has_names ? xs_names_p[i] : strings_empty;
     bool allow_packing;

--- a/src/callables.c
+++ b/src/callables.c
@@ -12,7 +12,7 @@ R_len_t short_vec_size(SEXP x) {
 }
 
 SEXP short_vec_recycle(SEXP x, R_len_t size) {
-  return vec_recycle(x, size);
+  return vec_recycle(x, size, vec_args.x, lazy_calls.vec_recycle);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/equal.c
+++ b/src/equal.c
@@ -57,11 +57,7 @@ SEXP vec_equal(
 
   args = PROTECT(vec_cast_common(args, ptype, vec_args.empty, error_call));
 
-  struct size_common_opts size_common_opts = {
-    vec_args.empty,
-    error_call
-  };
-  const R_len_t size = vec_size_common_opts(args, -1, &size_common_opts);
+  const R_len_t size = vec_size_common(args, -1, vec_args.empty, error_call);
 
   x = r_list_get(args, 0);
   y = r_list_get(args, 1);

--- a/src/globals.c
+++ b/src/globals.c
@@ -103,7 +103,5 @@ void vctrs_init_globals(r_obj* ns) {
   INIT_CALL(vec_init);
   INIT_CALL(vec_ptype_finalise);
   INIT_CALL(vec_recycle);
-  INIT_CALL(vec_recycle_common);
   INIT_CALL(vec_size);
-  INIT_CALL(vec_size_common);
 }

--- a/src/globals.h
+++ b/src/globals.h
@@ -82,9 +82,7 @@ struct lazy_calls {
   struct r_lazy vec_init;
   struct r_lazy vec_ptype_finalise;
   struct r_lazy vec_recycle;
-  struct r_lazy vec_recycle_common;
   struct r_lazy vec_size;
-  struct r_lazy vec_size_common;
 };
 
 extern struct syms syms;

--- a/src/order.c
+++ b/src/order.c
@@ -378,8 +378,8 @@ SEXP vec_order_info_impl(SEXP x,
   // Call on `x` before potentially flattening cols with `vec_proxy_order()`
   SEXP args = PROTECT_N(vec_order_expand_args(x, decreasing, na_largest), &n_prot);
 
-  R_len_t arg_size = vec_check_size_common(args, 0, vec_args.empty, call);
-  args = PROTECT_N(vec_check_recycle_common(args, arg_size, vec_args.empty, call), &n_prot);
+  R_len_t arg_size = vec_size_common(args, 0, vec_args.empty, call);
+  args = PROTECT_N(vec_recycle_common(args, arg_size, vec_args.empty, call), &n_prot);
 
   decreasing = VECTOR_ELT(args, 0);
   na_largest = VECTOR_ELT(args, 1);

--- a/src/rep.c
+++ b/src/rep.c
@@ -18,7 +18,7 @@ r_obj* vec_rep(r_obj* x,
   const r_ssize x_size = vec_size(x);
 
   if (x_size == 1) {
-    return vec_check_recycle(x, times_, p_x_arg, error_call);
+    return vec_recycle(x, times_, p_x_arg, error_call);
   }
 
   if (multiply_would_overflow(x_size, times_)) {

--- a/src/size-common.h
+++ b/src/size-common.h
@@ -3,61 +3,18 @@
 
 #include "vctrs-core.h"
 
-struct size_common_opts {
-  struct vctrs_arg* p_arg;
-  struct r_lazy call;
-};
+r_ssize vec_size_common(
+  r_obj* xs,
+  r_ssize absent,
+  struct vctrs_arg* p_xs_arg,
+  struct r_lazy call
+);
 
-r_ssize vec_size_common_opts(r_obj* xs,
-                             r_ssize absent,
-                             const struct size_common_opts* opts);
-
-r_obj* vec_recycle_common_opts(r_obj* xs,
-                               r_ssize size,
-                               const struct size_common_opts* opts);
-
-static inline
-r_ssize vec_size_common(r_obj* xs, r_ssize absent) {
-  struct size_common_opts args = {
-    .p_arg = vec_args.empty,
-    .call = lazy_calls.vec_size_common
-  };
-  return vec_size_common_opts(xs, absent, &args);
-}
-
-static inline
-r_obj* vec_recycle_common(r_obj* xs, r_ssize size) {
-  struct size_common_opts args = {
-    .p_arg = vec_args.empty,
-    .call = lazy_calls.vec_recycle_common
-  };
-  return vec_recycle_common_opts(xs, size, &args);
-}
-
-
-
-static inline
-r_ssize vec_check_size_common(r_obj* xs,
-                              r_ssize absent,
-                              struct vctrs_arg* p_arg,
-                              struct r_lazy call) {
-  struct size_common_opts args = {
-    .p_arg = p_arg,
-    .call = call
-  };
-  return vec_size_common_opts(xs, absent, &args);
-}
-
-static inline
-r_obj* vec_check_recycle_common(r_obj* xs,
-                                r_ssize size,
-                                struct vctrs_arg* p_arg,
-                                struct r_lazy call) {
-  struct size_common_opts args = {
-    .p_arg = p_arg,
-    .call = call
-  };
-  return vec_recycle_common_opts(xs, size, &args);
-}
+r_obj* vec_recycle_common(
+  r_obj* xs,
+  r_ssize size,
+  struct vctrs_arg* p_xs_arg,
+  struct r_lazy call
+);
 
 #endif

--- a/src/size.c
+++ b/src/size.c
@@ -160,10 +160,12 @@ SEXP vctrs_df_size(SEXP x) {
   return r_int(df_raw_size(x));
 }
 
-r_obj* vec_check_recycle(r_obj* x,
-                         r_ssize size,
-                         struct vctrs_arg* x_arg,
-                         struct r_lazy call) {
+r_obj* vec_recycle(
+  r_obj* x,
+  r_ssize size,
+  struct vctrs_arg* p_x_arg,
+  struct r_lazy call
+) {
   if (x == r_null) {
     return r_null;
   }
@@ -182,7 +184,7 @@ r_obj* vec_check_recycle(r_obj* x,
     return out;
   }
 
-  stop_recycle_incompatible_size(n_x, size, x_arg, call);
+  stop_recycle_incompatible_size(n_x, size, p_x_arg, call);
 }
 
 // [[ register() ]]
@@ -208,7 +210,7 @@ r_obj* ffi_recycle(r_obj* x,
 
   struct r_lazy call = { .x = syms_call, .env = frame };
 
-  return vec_check_recycle(x, size, &x_arg, call);
+  return vec_recycle(x, size, &x_arg, call);
 }
 
 r_obj* vec_recycle_fallback(r_obj* x,

--- a/src/size.h
+++ b/src/size.h
@@ -7,16 +7,12 @@
 r_ssize vec_size(r_obj* x);
 r_ssize vec_size_3(r_obj* x, struct vctrs_arg* p_arg, struct r_lazy call);
 
-r_obj* vec_check_recycle(r_obj* x,
-                         r_ssize size,
-                         struct vctrs_arg* x_arg,
-                         struct r_lazy call);
-
-static inline
-r_obj* vec_recycle(r_obj* x,
-                   r_ssize size) {
-  return vec_check_recycle(x, size, vec_args.x, lazy_calls.vec_recycle);
-}
+r_obj* vec_recycle(
+  r_obj* x,
+  r_ssize size,
+  struct vctrs_arg* p_x_arg,
+  struct r_lazy call
+);
 
 r_obj* vec_recycle_fallback(r_obj* x,
                             r_ssize size,

--- a/src/slice-interleave.c
+++ b/src/slice-interleave.c
@@ -54,7 +54,7 @@ r_obj* list_interleave(
   obj_check_list(x, p_x_arg, error_call);
 
   const r_ssize elt_size = (size == -1) ?
-    vec_check_size_common(x, 0, p_x_arg, error_call) :
+    vec_size_common(x, 0, p_x_arg, error_call) :
     size;
 
   r_obj* const* v_x = r_list_cbegin(x);

--- a/src/type-data-frame.c
+++ b/src/type-data-frame.c
@@ -174,7 +174,7 @@ r_obj* ffi_data_frame(r_obj* x,
 
   r_ssize c_size = 0;
   if (size == r_null) {
-    c_size = vec_check_size_common(x, 0, vec_args.empty, error_call);
+    c_size = vec_size_common(x, 0, vec_args.empty, error_call);
   } else {
     c_size = vec_as_short_length(size, vec_args.dot_size, error_call);
   }
@@ -214,7 +214,7 @@ r_obj* ffi_df_list(r_obj* x,
 
   r_ssize c_size = 0;
   if (size == r_null) {
-    c_size = vec_check_size_common(x, 0, vec_args.empty, error_call);
+    c_size = vec_size_common(x, 0, vec_args.empty, error_call);
   } else {
     c_size = vec_as_short_length(size, vec_args.dot_size, error_call);
   }
@@ -237,7 +237,7 @@ r_obj* df_list(r_obj* x,
     r_stop_internal("`x` must be a list.");
   }
 
-  x = KEEP(vec_check_recycle_common(x, size, vec_args.empty, error_call));
+  x = KEEP(vec_recycle_common(x, size, vec_args.empty, error_call));
 
   r_ssize n_cols = r_length(x);
 


### PR DESCRIPTION
Nowadays we always supply the arg and call, so let's just make them required arguments, which simplifies everything and better mirrors the R level API