### PR TITLE
Use `vec_size_params()`

### DIFF
--- a/src/assert.h
+++ b/src/assert.h
@@ -73,7 +73,7 @@ bool vec_is_size(
   struct vctrs_arg* p_x_arg,
   struct r_lazy call
 ) {
-  const r_ssize x_size = vec_size_3(x, p_x_arg, call);
+  const r_ssize x_size = vec_size_params(x, p_x_arg, call);
 
   if (x_size == size) {
     return true;
@@ -95,7 +95,7 @@ void vec_check_size(
   struct r_lazy call
 ) {
   if (!vec_is_size(x, size, allow_null, p_x_arg, call)) {
-    const r_ssize x_size = vec_size_3(x, p_x_arg, call);
+    const r_ssize x_size = vec_size_params(x, p_x_arg, call);
     stop_assert_size(x_size, size, p_x_arg, call);
   }
 }
@@ -167,7 +167,7 @@ bool vec_is_recyclable(
   struct vctrs_arg* p_x_arg,
   struct r_lazy call
 ) {
-  const r_ssize x_size = vec_size_3(x, p_x_arg, call);
+  const r_ssize x_size = vec_size_params(x, p_x_arg, call);
 
   if (x_size == size || x_size == 1) {
     return true;
@@ -188,7 +188,7 @@ r_ssize vec_check_recyclable(
   struct vctrs_arg* p_x_arg,
   struct r_lazy call
 ) {
-  const r_ssize x_size = vec_size_3(x, p_x_arg, call);
+  const r_ssize x_size = vec_size_params(x, p_x_arg, call);
 
   if (x_size == size || x_size == 1) {
     return x_size;

--- a/src/decl/size-decl.h
+++ b/src/decl/size-decl.h
@@ -1,5 +1,2 @@
 static
-r_ssize vec_size_opts(r_obj* x, const struct vec_error_opts* opts);
-
-static
 r_ssize vec_raw_size(r_obj* x);

--- a/src/expand.c
+++ b/src/expand.c
@@ -50,12 +50,7 @@ r_obj* vec_expand_grid(r_obj* xs,
   names = vec_as_names(names, p_name_repair_opts);
   r_attrib_poke_names(out, names);
 
-  const struct vec_error_opts error_opts = {
-    .p_arg = vec_args.empty,
-    .call = error_call
-  };
-
-  r_obj* sizes = KEEP(list_sizes(xs, &error_opts));
+  r_obj* sizes = KEEP(list_sizes(xs, vec_args.empty, error_call));
   const int* v_sizes = r_int_cbegin(sizes);
 
   r_obj* cumulative = KEEP(r_alloc_raw(n * sizeof(r_ssize)));

--- a/src/recode.c
+++ b/src/recode.c
@@ -749,14 +749,8 @@ r_obj* build_from_flat_map(r_obj* from, r_ssize from_size) {
 // ```
 static
 r_obj* build_repeated_to(r_obj* to, r_obj* from) {
-  const struct vec_error_opts from_error_opts = {
-    .p_arg = vec_args.empty,
-    .call = r_lazy_null
-  };
-  r_obj* from_sizes = KEEP(list_sizes(from, &from_error_opts));
-
+  r_obj* from_sizes = KEEP(list_sizes(from, vec_args.empty, r_lazy_null));
   to = vec_rep_each(to, from_sizes, r_lazy_null, vec_args.empty, vec_args.empty);
-
   FREE(1);
   return to;
 }

--- a/src/size-common.c
+++ b/src/size-common.c
@@ -171,7 +171,7 @@ r_obj* size2_common(
   struct size_common_reduce_opts* reduce_opts = data;
 
   const r_ssize x_size = reduce_opts->current_size;
-  const r_ssize y_size = vec_size_3(y, counters->next_arg, reduce_opts->call);
+  const r_ssize y_size = vec_size_params(y, counters->next_arg, reduce_opts->call);
 
   int left = -1;
 

--- a/src/size.h
+++ b/src/size.h
@@ -5,7 +5,12 @@
 #include "globals.h"
 
 r_ssize vec_size(r_obj* x);
-r_ssize vec_size_3(r_obj* x, struct vctrs_arg* p_arg, struct r_lazy call);
+
+r_ssize vec_size_params(
+  r_obj* x,
+  struct vctrs_arg* p_x_arg,
+  struct r_lazy call
+);
 
 r_obj* vec_recycle(
   r_obj* x,
@@ -19,7 +24,11 @@ r_obj* vec_recycle_fallback(r_obj* x,
                             struct vctrs_arg* x_arg,
                             struct r_lazy call);
 
-r_obj* list_sizes(r_obj* x, const struct vec_error_opts* opts);
+r_obj* list_sizes(
+  r_obj* xs,
+  struct vctrs_arg* p_xs_arg,
+  struct r_lazy call
+);
 
 r_ssize df_size(r_obj* x);
 r_ssize df_raw_size(r_obj* x);

--- a/src/vctrs-core.h
+++ b/src/vctrs-core.h
@@ -94,12 +94,6 @@ struct vctrs_arg {
   void* data;
 };
 
-struct vec_error_opts {
-  struct vctrs_arg* p_arg;
-  struct r_lazy call;
-};
-
-
 // Annex F of C99 specifies that `double` should conform to the IEEE 754
 // type `binary64`, which is defined as:
 // * 1  bit : sign


### PR DESCRIPTION
Instead of `vec_size_3()` and `vec_size_opts()`, again simplifying nicely based on how we actually use these