### PR TITLE
Use `list2()` in `vec_c()`

### DIFF
--- a/R/c.R
+++ b/R/c.R
@@ -80,6 +80,6 @@ vec_c <- function(
   .error_arg = "",
   .error_call = current_env()
 ) {
-  .External2(ffi_vec_c, .ptype, .name_spec, .name_repair)
+  .External2(ffi_vec_c, list2(...), .ptype, .name_spec, .name_repair)
 }
 vec_c <- fn_inline_formals(vec_c, ".name_repair")

--- a/src/c.c
+++ b/src/c.c
@@ -3,26 +3,27 @@
 r_obj* ffi_vec_c(r_obj* ffi_call, r_obj* op, r_obj* args, r_obj* frame) {
   args = r_node_cdr(args);
 
-  r_obj* xs = KEEP(rlang_env_dots_list(frame));
-  r_obj* ptype = KEEP(r_eval(r_node_car(args), frame)); args = r_node_cdr(args);
-  r_obj* name_spec = KEEP(r_eval(r_node_car(args), frame)); args = r_node_cdr(args);
-  r_obj* name_repair = KEEP(r_eval(r_node_car(args), frame));
+  r_obj* xs = r_node_car(args); args = r_node_cdr(args);
+  r_obj* ptype = r_node_car(args); args = r_node_cdr(args);
+  r_obj* name_spec = r_node_car(args); args = r_node_cdr(args);
+  r_obj* name_repair = r_node_car(args);
 
   struct r_lazy error_arg_lazy = { .x = syms.dot_error_arg, .env = frame };
   struct vctrs_arg error_arg = new_lazy_arg(&error_arg_lazy);
 
   struct r_lazy error_call = { .x = syms.dot_error_call, .env = frame };
 
-  struct name_repair_opts name_repair_opts =
-    new_name_repair_opts(name_repair,
-                         r_lazy_null,
-                         false,
-                         error_call);
+  struct name_repair_opts name_repair_opts = new_name_repair_opts(
+    name_repair,
+    r_lazy_null,
+    false,
+    error_call
+  );
   KEEP(name_repair_opts.shelter);
 
   r_obj* out = vec_c(xs, ptype, name_spec, &name_repair_opts, &error_arg, error_call);
 
-  FREE(5);
+  FREE(1);
   return out;
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -399,7 +399,7 @@ const R_ExternalMethodDef ExtEntries[] = {
   {"ffi_cast_common_opts",             (DL_FUNC) &ffi_cast_common_opts, 2},
   {"ffi_rbind",                        (DL_FUNC) &ffi_rbind, 4},
   {"ffi_cbind",                        (DL_FUNC) &ffi_cbind, 3},
-  {"ffi_vec_c",                        (DL_FUNC) &ffi_vec_c, 3},
+  {"ffi_vec_c",                        (DL_FUNC) &ffi_vec_c, 4},
   {"ffi_new_data_frame",               (DL_FUNC) &ffi_new_data_frame, -1},
   {NULL, NULL, 0}
 };

--- a/tests/testthat/_snaps/c.md
+++ b/tests/testthat/_snaps/c.md
@@ -177,22 +177,22 @@
       # Integers
       with_memory_prof(vec_c_list(ints))
     Output
-      [1] 2.31KB
+      [1] 1.48KB
     Code
       # Doubles
       with_memory_prof(vec_c_list(dbls))
     Output
-      [1] 2.7KB
+      [1] 1.87KB
     Code
       # Integers to integer
       with_memory_prof(vec_c_list(ints, ptype = int()))
     Output
-      [1] 2.09KB
+      [1] 1.27KB
     Code
       # Doubles to integer
       with_memory_prof(vec_c_list(dbls, ptype = int()))
     Output
-      [1] 2.09KB
+      [1] 1.27KB
     Code
       # # `list_unchop()` 
       # Integers


### PR DESCRIPTION
```r
pkgs <- tibble::tribble(
  ~vctrs             , ~rlang        ,
  "vctrs"            , "rlang"       ,
  "r-lib/vctrs"      , "r-lib/rlang" ,
  "r-lib/vctrs#2073" , "r-lib/rlang" ,
)

cross::bench_versions(pkgs = pkgs, {
  library(vctrs)
  x <- as.list(1:1e6)
  bench::mark(vec_c(!!!x), iterations = 10)
})
#> # A tibble: 3 × 7
#>   pkg                       expression   min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                     <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 vctrs, rlang              vec_c(!!!… 150ms  158ms      6.11    15.3MB    12.8 
#> 2 r-lib/vctrs, r-lib/rlang  vec_c(!!!… 108ms  112ms      8.91    19.1MB     8.91
#> 3 r-lib/vctrs#2073, r-lib/… vec_c(!!!… 101ms  102ms      9.75    11.4MB     4.18
```

Went up with dev vctrs and dev rlang compared to CRAN because in `vec_c()` we now correctly store sizes in a `r_ssize` array rather than an `int` array, which is twice as big. But then with this PR we no longer clone `x` on the way in, so it goes back down to 11mb.