### PR TITLE
Avoid `STDVEC_DATAPTR()` in ALTREP classes

### DIFF
--- a/src/altrep-lazy-character.c
+++ b/src/altrep-lazy-character.c
@@ -40,7 +40,16 @@ r_obj* altrep_lazy_character_Materialize(r_obj* vec) {
 }
 
 void* altrep_lazy_character_Dataptr(r_obj* vec, Rboolean writeable) {
-  return STDVEC_DATAPTR(altrep_lazy_character_Materialize(vec));
+  if (writeable) {
+    r_stop_internal("Can't get writeable `DATAPTR()` to `<altrep_lazy_character>`");
+  } else {
+    // R promises not to write to this array, but we still have to return a
+    // `void*` pointer rather than a `const void*` pointer. `STRING_PTR()` is
+    // non-API so we use `STRING_PTR_RO()` and cast. This is really a bad ALTREP
+    // API. It should have been separated into `void* Dataptr()` and `const
+    // void* Dataptr_ro()`.
+    return (void*) STRING_PTR_RO(altrep_lazy_character_Materialize(vec));
+  }
 }
 
 const void* altrep_lazy_character_Dataptr_or_null(r_obj* vec) {
@@ -49,7 +58,7 @@ const void* altrep_lazy_character_Dataptr_or_null(r_obj* vec) {
   if (out == r_null) {
     return NULL;
   } else {
-    return STDVEC_DATAPTR(out);
+    return r_chr_cbegin(out);
   }
 }
 


### PR DESCRIPTION
Part of https://github.com/r-lib/vctrs/issues/1933

When we are looking at the result of `R_altrep_data2()` we know we have a STRSXP that isn't ALTREP, so we can just use `STRING_PTR_RO()` on it to get at the underlying buffer.

There is some funny casting business that results from the ALTREP API being `void* Dataptr(x, bool writeable)` when it probably should have been two functions of `void* Dataptr(x)` and `const void* Dataptr_ro(x)`, but I think I asked Luke about this years ago for something else and he said what we are doing here is probably the right thing to do.