### PR TITLE
Fix `list_combine(list(NA), default =)` and add `vec_ptype_common(.finalise=)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `vec_ptype_common()` has gained a `.finalise` argument that defaults to `TRUE`. Setting this to `FALSE` lets you opt out of prototype finalisation, which allows `vec_ptype_common()` to act like `vec_ptype()` and `vec_ptype2()`, which don't finalise. This can be useful in some advanced common type determination cases (#2100).
+
 * New `vec_pany()` and `vec_pall()`, parallel variants of `any()` and `all()` (in the same way that `pmin()` and `pmax()` are parallel variants of `min()` and `max()`).
 
 * The deprecated C callable for `vec_is_vector()` has been removed.

--- a/R/type-unspecified.R
+++ b/R/type-unspecified.R
@@ -1,18 +1,28 @@
-#' A 1d vector of unspecified type
+#' Unspecified vectors and prototype finalisation
 #'
 #' @description
-#' This is the underlying type used to represent logical vectors that only
-#' contain `NA`. These require special handling because we want to allow logical
-#' `NA` to specify missingness that can be cast to any other type.
+#' `unspecified()` is the underlying type used to represent logical vectors that
+#' only contain `NA`. These require special handling because we want to allow
+#' logical `NA` to specify missingness that can be cast to any other type.
 #'
-#' [vec_ptype()] and [vec_ptype2()] convert a logical vector of `NA` into an
-#' empty `<unspecified>` type. This type can combine with any other type.
+#' In vctrs, the `<unspecified>` type is considered _unfinalised_ and is not
+#' suitable for use in most vctrs functions that take a `ptype` argument, like
+#' [vec_c()]. The purpose of `vec_ptype_finalise()` is to finalise any
+#' `<unspecified>` types into `<logical>` after common type determination
+#' has been completed.
+#'
+#' [vec_ptype()] and [vec_ptype2()] return _unfinalised_ types, and will convert
+#' a logical vector of `NA` into an empty `<unspecified>` type that can combine
+#' with any other type. It is unlikely that you will call these yourself, but,
+#' if you do, you'll need to manually finalise with `vec_ptype_finalise()` to
+#' take care of any `<unspecified>` types.
 #'
 #' [vec_ptype_common()] uses both [vec_ptype()] and [vec_ptype2()] to compute
-#' the common type, but then returns a _finalised_ type using
-#' [vec_ptype_finalise()]. The purpose of `vec_ptype_finalise()` is to turn any
-#' remaining `<unspecified>` types back into `<logical>`, which is the more
-#' useful type for callers of `vec_ptype_common()`.
+#' the common type, but typically returns a _finalised_ type for immediate usage
+#' in other vctrs functions. You can optionally skip finalisation by setting
+#' `.finalise = FALSE`, in which case `vec_ptype_common()` can return
+#' `<unspecified>` and you'll need to manually call `vec_ptype_finalise()`
+#' yourself.
 #'
 #' `vec_ptype_finalise()` is an S3 generic, but it is extremely rare to need to
 #' write an S3 method for this. Data frames (and data frame subclasses) are
@@ -63,6 +73,10 @@
 #' vec_ptype_common(NA)
 #' vec_ptype_common(NA, NA)
 #' vec_ptype_show(vec_ptype_common(df))
+#'
+#' # `vec_ptype_common()` lets you opt out of finalisation using `.finalise`
+#' vec_ptype_common(NA, .finalise = FALSE)
+#' vec_ptype_show(vec_ptype_common(df, .finalise = FALSE))
 NULL
 
 #' @param n Length of vector
@@ -102,8 +116,9 @@ ununspecify <- function(x) {
 
 #' @inheritParams rlang::args_dots_empty
 #'
-#' @param x A `ptype` to finalize, typically a result of [vec_ptype()] or
-#'   [vec_ptype2()].
+#' @param x A `ptype` to finalize, typically a result of [vec_ptype()],
+#'   [vec_ptype2()], or [`vec_ptype_common(.finalise =
+#'   FALSE)`][vec_ptype_common].
 #'
 #' @rdname vctrs-unspecified
 #' @export

--- a/man/vctrs-unspecified.Rd
+++ b/man/vctrs-unspecified.Rd
@@ -4,7 +4,7 @@
 \alias{vctrs-unspecified}
 \alias{unspecified}
 \alias{vec_ptype_finalise}
-\title{A 1d vector of unspecified type}
+\title{Unspecified vectors and prototype finalisation}
 \usage{
 unspecified(n = 0)
 
@@ -13,24 +13,34 @@ vec_ptype_finalise(x, ...)
 \arguments{
 \item{n}{Length of vector}
 
-\item{x}{A \code{ptype} to finalize, typically a result of \code{\link[=vec_ptype]{vec_ptype()}} or
-\code{\link[=vec_ptype2]{vec_ptype2()}}.}
+\item{x}{A \code{ptype} to finalize, typically a result of \code{\link[=vec_ptype]{vec_ptype()}},
+\code{\link[=vec_ptype2]{vec_ptype2()}}, or \code{\link[=vec_ptype_common]{vec_ptype_common(.finalise = FALSE)}}.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 }
 \description{
-This is the underlying type used to represent logical vectors that only
-contain \code{NA}. These require special handling because we want to allow logical
-\code{NA} to specify missingness that can be cast to any other type.
+\code{unspecified()} is the underlying type used to represent logical vectors that
+only contain \code{NA}. These require special handling because we want to allow
+logical \code{NA} to specify missingness that can be cast to any other type.
 
-\code{\link[=vec_ptype]{vec_ptype()}} and \code{\link[=vec_ptype2]{vec_ptype2()}} convert a logical vector of \code{NA} into an
-empty \verb{<unspecified>} type. This type can combine with any other type.
+In vctrs, the \verb{<unspecified>} type is considered \emph{unfinalised} and is not
+suitable for use in most vctrs functions that take a \code{ptype} argument, like
+\code{\link[=vec_c]{vec_c()}}. The purpose of \code{vec_ptype_finalise()} is to finalise any
+\verb{<unspecified>} types into \verb{<logical>} after common type determination
+has been completed.
+
+\code{\link[=vec_ptype]{vec_ptype()}} and \code{\link[=vec_ptype2]{vec_ptype2()}} return \emph{unfinalised} types, and will convert
+a logical vector of \code{NA} into an empty \verb{<unspecified>} type that can combine
+with any other type. It is unlikely that you will call these yourself, but,
+if you do, you'll need to manually finalise with \code{vec_ptype_finalise()} to
+take care of any \verb{<unspecified>} types.
 
 \code{\link[=vec_ptype_common]{vec_ptype_common()}} uses both \code{\link[=vec_ptype]{vec_ptype()}} and \code{\link[=vec_ptype2]{vec_ptype2()}} to compute
-the common type, but then returns a \emph{finalised} type using
-\code{\link[=vec_ptype_finalise]{vec_ptype_finalise()}}. The purpose of \code{vec_ptype_finalise()} is to turn any
-remaining \verb{<unspecified>} types back into \verb{<logical>}, which is the more
-useful type for callers of \code{vec_ptype_common()}.
+the common type, but typically returns a \emph{finalised} type for immediate usage
+in other vctrs functions. You can optionally skip finalisation by setting
+\code{.finalise = FALSE}, in which case \code{vec_ptype_common()} can return
+\verb{<unspecified>} and you'll need to manually call \code{vec_ptype_finalise()}
+yourself.
 
 \code{vec_ptype_finalise()} is an S3 generic, but it is extremely rare to need to
 write an S3 method for this. Data frames (and data frame subclasses) are
@@ -78,5 +88,9 @@ vec_ptype_show(vec_ptype_finalise(vec_ptype(df)))
 vec_ptype_common(NA)
 vec_ptype_common(NA, NA)
 vec_ptype_show(vec_ptype_common(df))
+
+# `vec_ptype_common()` lets you opt out of finalisation using `.finalise`
+vec_ptype_common(NA, .finalise = FALSE)
+vec_ptype_show(vec_ptype_common(df, .finalise = FALSE))
 }
 \keyword{internal}

--- a/man/vec_ptype.Rd
+++ b/man/vec_ptype.Rd
@@ -8,7 +8,13 @@
 \usage{
 vec_ptype(x, ..., x_arg = "", call = caller_env())
 
-vec_ptype_common(..., .ptype = NULL, .arg = "", .call = caller_env())
+vec_ptype_common(
+  ...,
+  .ptype = NULL,
+  .finalise = TRUE,
+  .arg = "",
+  .call = caller_env()
+)
 
 vec_ptype_show(...)
 }
@@ -35,21 +41,40 @@ Alternatively, you can supply \code{.ptype} to give the output known type.
 If \code{getOption("vctrs.no_guessing")} is \code{TRUE} you must supply this value:
 this is a convenient way to make production code demand fixed types.}
 
+\item{.finalise}{Should \code{vec_ptype_common()} \link[=vec_ptype_finalise]{finalise}
+its output?
+\itemize{
+\item If \code{TRUE}, \code{\link[=vec_ptype_finalise]{vec_ptype_finalise()}} is called on the final \code{ptype} before
+it is returned. Practically this has the effect of converting any
+types from \link{unspecified} to logical.
+\item If \code{FALSE}, \link{unspecified} types are left unfinalised, which can be useful
+for advanced cases where you combine one common type result with another
+type via \code{\link[=vec_ptype2]{vec_ptype2()}}. Note that you must manually call
+\code{\link[=vec_ptype_finalise]{vec_ptype_finalise()}} on the final \code{ptype} before supplying it to any
+other vctrs functions.
+}}
+
 \item{.arg}{An argument name as a string. This argument
 will be mentioned in error messages as the input that is at the
 origin of a problem.}
 }
 \value{
 \code{vec_ptype()} and \code{vec_ptype_common()} return a prototype
-(a size-0 vector)
+(a size-0 vector).
 }
 \description{
-\code{vec_ptype()} returns the unfinalised prototype of a single vector.
-\code{vec_ptype_common()} finds the common type of multiple vectors.
-\code{vec_ptype_show()} nicely prints the common type of any number of
-inputs, and is designed for interactive exploration.
+\itemize{
+\item \code{vec_ptype()} returns the \link[=vec_ptype_finalise]{unfinalised} prototype of a
+single vector.
+\item \code{vec_ptype_common()} returns the common type of multiple vectors. By
+default, this is \link[=vec_ptype_finalise]{finalised} for immediate usage, but
+can optionally be left unfinalised for advanced common type determination.
+\item \code{vec_ptype_show()} nicely prints the common type of any number of inputs,
+and is designed for interactive exploration.
+}
 }
 \section{\code{vec_ptype()}}{
+
 
 \code{vec_ptype()} returns \link[=vec_size]{size} 0 vectors potentially
 containing attributes but no data. Generally, this is just
@@ -62,7 +87,8 @@ the \code{vec_ptype2()} monoid.
 \item The prototype of logical vectors that only contain missing values
 is the special \link{unspecified} type, which can be coerced to any
 other 1d type. This allows bare \code{NA}s to represent missing values
-for any 1d vector type.
+for any 1d vector type. \link[=vec_ptype_finalise]{Finalising} this type
+converts it from unspecified back to logical.
 }
 
 See \link{internal-faq-ptype2-identity} for more information about
@@ -75,17 +101,18 @@ performance costs. If your class has a static prototype, you might consider
 implementing a custom \code{vec_ptype()} method that returns a constant. This will
 improve the performance of your class in many cases (\link[=vec_ptype2]{common type} imputation in particular).
 
-Because it may contain unspecified vectors, the prototype returned
-by \code{vec_ptype()} is said to be \strong{unfinalised}. Call
-\code{\link[=vec_ptype_finalise]{vec_ptype_finalise()}} to finalise it. Commonly you will need the
-finalised prototype as returned by \code{vec_slice(x, 0L)}.
+Because it may contain unspecified vectors, the prototype returned by
+\code{vec_ptype()} is said to be \strong{unfinalised}. Call \code{\link[=vec_ptype_finalise]{vec_ptype_finalise()}} to
+finalise it.
 }
 
 \section{\code{vec_ptype_common()}}{
 
+
 \code{vec_ptype_common()} first finds the prototype of each input, then
-successively calls \code{\link[=vec_ptype2]{vec_ptype2()}} to find a common type. It returns
-a \link[=vec_ptype_finalise]{finalised} prototype.
+successively calls \code{\link[=vec_ptype2]{vec_ptype2()}} to find a common type. It returns a
+\link[=vec_ptype_finalise]{finalised} prototype by default, but can optionally be
+left unfinalised for advanced common type determination.
 }
 
 \section{Dependencies of \code{vec_ptype()}}{
@@ -106,7 +133,6 @@ a \link[=vec_ptype_finalise]{finalised} prototype.
 \examples{
 # Unknown types ------------------------------------------
 vec_ptype_show()
-vec_ptype_show(NA)
 vec_ptype_show(NULL)
 
 # Vectors ------------------------------------------------
@@ -136,4 +162,28 @@ vec_ptype_show(
   data.frame(y = 2),
   data.frame(z = "a")
 )
+
+# Finalisation -------------------------------------------
+
+# `vec_ptype()` and `vec_ptype2()` return unfinalised ptypes so that they
+# can be coerced to any other type
+vec_ptype(NA)
+vec_ptype2(NA, NA)
+
+# By default `vec_ptype_common()` finalises so that you can use its result
+# directly in other vctrs functions
+vec_ptype_common(NA, NA)
+
+# You can opt out of finalisation to make it work like `vec_ptype()` and
+# `vec_ptype2()` with `.finalise = FALSE`, but don't forget that you must
+# call `vec_ptype_finalise()` manually if you do so!
+vec_ptype_common(NA, NA, .finalise = FALSE)
+vec_ptype_finalise(vec_ptype_common(NA, NA, .finalise = FALSE))
+
+# This can be useful in rare scenarios, like including a separate `default`
+# argument in the ptype computation
+xs <- list(NA, NA)
+default <- "a"
+try(vec_ptype2(vec_ptype_common(!!!xs), default))
+vec_ptype2(vec_ptype_common(!!!xs, .finalise = FALSE), default)
 }

--- a/src/bind.c
+++ b/src/bind.c
@@ -74,6 +74,7 @@ r_obj* vec_rbind(r_obj* xs,
   ptype = vec_ptype_common(
     xs,
     ptype,
+    PTYPE_FINALISE_DEFAULT,
     S3_FALLBACK_true,
     p_arg,
     error_call
@@ -498,6 +499,7 @@ r_obj* vec_cbind(r_obj* xs,
   r_obj* type = KEEP(vec_ptype_common(
     xs_data_frames,
     ptype,
+    PTYPE_FINALISE_DEFAULT,
     S3_FALLBACK_false,
     p_arg,
     error_call

--- a/src/cast.c
+++ b/src/cast.c
@@ -255,6 +255,7 @@ r_obj* vec_cast_common_opts(r_obj* xs,
   r_obj* type = KEEP(vec_ptype_common(
     xs,
     to,
+    PTYPE_FINALISE_DEFAULT,
     opts->s3_fallback,
     opts->p_arg,
     opts->call

--- a/src/init.c
+++ b/src/init.c
@@ -393,8 +393,8 @@ extern r_obj* ffi_new_data_frame(r_obj*);
 
 static
 const R_ExternalMethodDef ExtEntries[] = {
-  {"ffi_ptype_common",                 (DL_FUNC) &ffi_ptype_common, 2},
-  {"ffi_ptype_common_params",          (DL_FUNC) &ffi_ptype_common_params, 3},
+  {"ffi_ptype_common",                 (DL_FUNC) &ffi_ptype_common, 3},
+  {"ffi_ptype_common_params",          (DL_FUNC) &ffi_ptype_common_params, 4},
   {"ffi_size_common",                  (DL_FUNC) &ffi_size_common, 3},
   {"ffi_recycle_common",               (DL_FUNC) &ffi_recycle_common, 2},
   {"ffi_cast_common",                  (DL_FUNC) &ffi_cast_common, 2},

--- a/src/list-combine.c
+++ b/src/list-combine.c
@@ -809,6 +809,7 @@ r_obj* list_combine_common_class_fallback(
     vec_ptype_common(
       xs,
       ptype,
+      PTYPE_FINALISE_DEFAULT,
       s3_fallback,
       p_xs_arg,
       error_call
@@ -1802,10 +1803,12 @@ r_obj* ptype_common_with_default(
 
   // Okay `ptype` is `NULL`. We determine it from `xs` and `default`.
 
-  // Use only `xs` and `p_xs_arg` first for best errors
+  // Use only `xs` and `p_xs_arg` first for best errors.
+  // Not finalising `ptype` yet in case we need to incorporate `default`!
   ptype = KEEP(vec_ptype_common(
     xs,
     ptype,
+    PTYPE_FINALISE_false,
     s3_fallback,
     p_xs_arg,
     error_call
@@ -1826,7 +1829,10 @@ r_obj* ptype_common_with_default(
   }
   KEEP(ptype);
 
-  FREE(2);
+  // Now finalise after incorporating `default`
+  ptype = KEEP(vec_ptype_finalise(ptype));
+
+  FREE(3);
   return ptype;
 }
 

--- a/src/ptype-common.h
+++ b/src/ptype-common.h
@@ -3,6 +3,7 @@
 
 #include "vctrs-core.h"
 #include "ptype2.h"
+#include "unspecified.h"
 #include "utils.h"
 
 static inline
@@ -13,6 +14,7 @@ bool vec_is_common_class_fallback(r_obj* ptype) {
 r_obj* vec_ptype_common(
   r_obj* dots,
   r_obj* ptype,
+  enum ptype_finalise finalise,
   enum s3_fallback s3_fallback,
   struct vctrs_arg* p_arg,
   struct r_lazy call

--- a/src/recode.c
+++ b/src/recode.c
@@ -777,6 +777,7 @@ r_obj* ptype_finalize(
     ptype = KEEP(vec_ptype_common(
       to,
       r_null,
+      PTYPE_FINALISE_DEFAULT,
       S3_FALLBACK_DEFAULT,
       p_to_arg,
       error_call

--- a/src/unspecified.h
+++ b/src/unspecified.h
@@ -6,6 +6,18 @@
 SEXP vec_unspecified(R_len_t n);
 bool vec_is_unspecified(SEXP x);
 
+enum ptype_finalise {
+  PTYPE_FINALISE_false,
+  PTYPE_FINALISE_true
+};
+
+#define PTYPE_FINALISE_DEFAULT PTYPE_FINALISE_true
+
+static inline
+bool should_finalise(enum ptype_finalise finalise) {
+  return finalise == PTYPE_FINALISE_true;
+}
+
 r_obj* vec_ptype_finalise(r_obj* x);
 
 #endif

--- a/tests/testthat/_snaps/type.md
+++ b/tests/testthat/_snaps/type.md
@@ -169,3 +169,19 @@
       Error:
       ! Can't combine `a` <character> and `z` <double>.
 
+# `.finalise` is validated
+
+    Code
+      vec_ptype_common(.finalise = 1)
+    Condition
+      Error in `vec_ptype_common()`:
+      ! `.finalise` must be `TRUE` or `FALSE`.
+
+---
+
+    Code
+      vec_ptype_common_params(.finalise = 1)
+    Condition
+      Error in `vec_ptype_common_params()`:
+      ! `.finalise` must be `TRUE` or `FALSE`.
+

--- a/tests/testthat/test-case-when.R
+++ b/tests/testthat/test-case-when.R
@@ -272,6 +272,17 @@ test_that("`default` that is an unused logical `NA` can still be cast to `values
   expect_identical(vec_case_when(list(TRUE), list("x"), default = NA), "x")
 })
 
+test_that("`default` type is used when all values are logical `NA` (#2094)", {
+  expect_identical(
+    vec_case_when(list(TRUE), list(NA), default = "a"),
+    NA_character_
+  )
+  expect_identical(
+    vec_case_when(list(c(TRUE, FALSE)), list(NA), default = "a"),
+    c(NA_character_, "a")
+  )
+})
+
 test_that("`default_arg` can be customized", {
   expect_snapshot(error = TRUE, {
     vec_case_when(list(FALSE), list(1L), default = 2:3, default_arg = "foo")

--- a/tests/testthat/test-list-combine.R
+++ b/tests/testthat/test-list-combine.R
@@ -1886,6 +1886,27 @@ test_that("can specify a ptype to override common type", {
   })
 })
 
+test_that("common type is correctly computed with unspecified values and a `default` (#2094)", {
+  expect_identical(
+    list_combine(
+      x = list(NA),
+      indices = list(1),
+      size = 1,
+      default = "a"
+    ),
+    NA_character_
+  )
+  expect_identical(
+    list_combine(
+      x = list(NA),
+      indices = list(1),
+      size = 2,
+      default = "a"
+    ),
+    c(NA, "a")
+  )
+})
+
 test_that("outer names are kept", {
   x <- list(x = 1, y = 2)
   expect_named_list_combine(

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -333,3 +333,53 @@ test_that("vec_ptype_common() always finalizes its output (#2099)", {
     logical()
   )
 })
+
+test_that("vec_ptype_common() lets you opt out of ptype finalization (#2094)", {
+  expect_identical(
+    vec_ptype_common(NA, .finalise = FALSE),
+    unspecified()
+  )
+  expect_identical(
+    vec_ptype_common(NA, NA, .finalise = FALSE),
+    unspecified()
+  )
+  expect_identical(
+    vec_ptype_common(unspecified(1), .finalise = FALSE),
+    unspecified()
+  )
+  expect_identical(
+    vec_ptype_common(unspecified(1), unspecified(1), .finalise = FALSE),
+    unspecified()
+  )
+
+  # Works for explicit `.ptype` too
+  expect_identical(
+    vec_ptype_common(.ptype = NA, .finalise = FALSE),
+    unspecified()
+  )
+  expect_identical(
+    vec_ptype_common(.ptype = unspecified(1), .finalise = FALSE),
+    unspecified()
+  )
+})
+
+test_that("vec_ptype_common_params() lets you opt out of ptype finalization", {
+  expect_identical(
+    vec_ptype_common_params(NA, .finalise = FALSE),
+    unspecified()
+  )
+  # Works for explicit `.ptype` too
+  expect_identical(
+    vec_ptype_common_params(.ptype = NA, .finalise = FALSE),
+    unspecified()
+  )
+})
+
+test_that("`.finalise` is validated", {
+  expect_snapshot(error = TRUE, {
+    vec_ptype_common(.finalise = 1)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_ptype_common_params(.finalise = 1)
+  })
+})


### PR DESCRIPTION
Closes https://github.com/r-lib/vctrs/issues/2094

Basic idea is that when we see this

```r
list_combine(
  x = list(NA),
  indices = list(1),
  size = 1,
  default = "a"
)
```

We need the common type across `!!!x` and `default`.

We "optimize" the ptype computation in `list_combine()` as

```r
vec_ptype2(
  vec_ptype_common(!!!x, .arg = x_arg),
  default,
  y_arg = default_arg
)
```

rather than as

```r
vec_ptype_common(!!!x, default_arg := default)
```

Because this avoids us having to reallocate a possibly very large list just to slip `default` in there. It also avoids forcing `default_arg`. I'm also not entirely sure how we'd use `x_arg` if we did that.

But in this particular `list_combine()` example, we get

```r
vec_ptype2(
  vec_ptype_common(x), # this returns a finalized `logical()`
  default, # this is `character()`
  y_arg = default_arg
)
# Error cant combine <logical> and <character>
```

So we actually need a way to tell `vec_ptype_common()` that we'd like to opt out of ptype finalization and promise to do it "manually" later on. Now that we've ensured that:
- `vec_ptype()` and `vec_ptype2()` _never_ finalize
- `vec_ptype_common()` _always_ finalizes

I think it makes some sense that we should have an internal way to make `vec_ptype_common()` act exactly like repeated `vec_ptype2()` for cases like this one.