### PR TITLE
Fix `exp_short_init_compact_seq()` signature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* Fixed the C level signature for the `exp_short_init_compact_seq()` callable.
+
 * Experimental "partial" type support has been removed. This idea never panned out and was not widely used. The following functions have been removed (#2101):
 
   * `is_partial()`

--- a/src/init.c
+++ b/src/init.c
@@ -187,7 +187,7 @@ extern SEXP exp_vec_slice_impl(SEXP, SEXP);
 extern SEXP exp_vec_names(SEXP);
 extern SEXP exp_vec_set_names(SEXP, SEXP);
 extern SEXP exp_short_compact_seq(R_len_t, R_len_t, bool);
-extern SEXP exp_short_init_compact_seq(int*, R_len_t, R_len_t, bool);
+extern void exp_short_init_compact_seq(int*, R_len_t, R_len_t, bool);
 
 // Defined below
 SEXP vctrs_init_library(SEXP);


### PR DESCRIPTION
Goes with https://github.com/r-lib/slider/pull/224, but doesn't require it

The actual implementation of this was right

```c
void exp_short_init_compact_seq(int* p, R_len_t start, R_len_t size, bool increasing) {
  init_compact_seq(p, start, size, increasing);
}
```

but the signature here in vctrs was wrong. And then we copied over that wrong signature into slider as well.

Luckily because it returns `void` and we never look at the return value, it was fine. But CRAN picked up on it in one of their checks awhile back.