### PR TITLE
`vec_rank(NULL)` now throws a scalar object error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `vec_rank()` now throws an improved error on non-vector types, like `NULL` (#1967).
+
 * `vec_ptype_common()` has gained a `.finalise` argument that defaults to `TRUE`. Setting this to `FALSE` lets you opt out of prototype finalisation, which allows `vec_ptype_common()` to act like `vec_ptype()` and `vec_ptype2()`, which don't finalise. This can be useful in some advanced common type determination cases (#2100).
 
 * New `vec_pany()` and `vec_pall()`, parallel variants of `any()` and `all()` (in the same way that `pmin()` and `pmax()` are parallel variants of `min()` and `max()`).

--- a/src/rank.c
+++ b/src/rank.c
@@ -45,6 +45,8 @@ r_obj* vec_rank(r_obj* x,
                 r_obj* na_value,
                 bool nan_distinct,
                 r_obj* chr_proxy_collate) {
+  obj_check_vector(x, VCTRS_ALLOW_NULL_no, vec_args.x, r_lazy_null);
+
   r_ssize size = vec_size(x);
 
   r_keep_loc pi_x;

--- a/tests/testthat/_snaps/rank.md
+++ b/tests/testthat/_snaps/rank.md
@@ -1,10 +1,11 @@
-# `x` must not be `NULL` (#1823)
+# `x` must not be `NULL` (#1823, #1967)
 
     Code
       vec_rank(NULL)
     Condition
       Error:
-      ! This type is not supported by `vec_order()`.
+      ! `x` must be a vector, not `NULL`.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
 
 ---
 
@@ -12,7 +13,17 @@
       vec_rank(NULL, incomplete = "na")
     Condition
       Error:
-      ! This type is not supported by `vec_order()`.
+      ! `x` must be a vector, not `NULL`.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
+
+---
+
+    Code
+      vec_rank(NULL, ties = "sequential", incomplete = "na")
+    Condition
+      Error:
+      ! `x` must be a vector, not `NULL`.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
 
 # `ties` is validated
 

--- a/tests/testthat/test-rank.R
+++ b/tests/testthat/test-rank.R
@@ -191,12 +191,15 @@ test_that("`x` must be a vector", {
   expect_error(vec_rank(identity), class = "vctrs_error_scalar_type")
 })
 
-test_that("`x` must not be `NULL` (#1823)", {
+test_that("`x` must not be `NULL` (#1823, #1967)", {
   expect_snapshot(error = TRUE, {
     vec_rank(NULL)
   })
   expect_snapshot(error = TRUE, {
     vec_rank(NULL, incomplete = "na")
+  })
+  expect_snapshot(error = TRUE, {
+    vec_rank(NULL, ties = "sequential", incomplete = "na")
   })
 })
 


### PR DESCRIPTION
Closes #1967