### PR TITLE
Add back temporary defunct C callable for `vec_is_vector()`

### DIFF
--- a/src/callables.c
+++ b/src/callables.c
@@ -16,6 +16,13 @@ SEXP maturing_short_vec_recycle(SEXP x, R_len_t size) {
 }
 
 // -----------------------------------------------------------------------------
+// Defunct
+
+bool defunct_vec_is_vector(SEXP x) {
+  Rf_errorcall(R_NilValue, "`vec_is_vector()` is defunct.");
+}
+
+// -----------------------------------------------------------------------------
 // Experimental
 
 SEXP exp_vec_cast(SEXP x, SEXP to) {

--- a/src/init.c
+++ b/src/init.c
@@ -181,6 +181,13 @@ extern bool maturing_obj_is_vector(SEXP);
 extern R_len_t maturing_short_vec_size(SEXP);
 extern SEXP maturing_short_vec_recycle(SEXP, R_len_t);
 
+// Defunct
+// Previously were in the public header, but have since been removed
+// Must be removed from the public header but still exist as a C callable for 1 CRAN release of vctrs,
+// so that dependent CRAN binaries (slider or tibblify) can be rebuilt with the new public header that
+// no longer looks for these callables.
+extern bool defunct_vec_is_vector(SEXP);
+
 // Experimental
 // Exported but not available in the public header
 extern SEXP exp_vec_cast(SEXP, SEXP);
@@ -416,6 +423,10 @@ export void R_init_vctrs(DllInfo *dll)
     R_RegisterCCallable("vctrs", "obj_is_vector",      (DL_FUNC) &maturing_obj_is_vector);
     R_RegisterCCallable("vctrs", "short_vec_size",     (DL_FUNC) &maturing_short_vec_size);
     R_RegisterCCallable("vctrs", "short_vec_recycle",  (DL_FUNC) &maturing_short_vec_recycle);
+
+    // Defunct
+    // Previously were in the public header, but have since been removed
+    R_RegisterCCallable("vctrs", "vec_is_vector", (DL_FUNC) &defunct_vec_is_vector);
 
     // Experimental
     // Exported but not available in the public header


### PR DESCRIPTION
Follow up to #2104 

When running revdeps, any package that depended on slider or tibblify failed (both link to vctrs and use the public api header we provide) when trying to load slider or tibblify with an error like:

> callable 'vec_is_vector' not found in 'vctrs'

This is a tricky issue, but here's the idea:

- CRAN slider is built against current CRAN vctrs. This means CRAN slider is built against the CRAN version of `inst/include/vctrs.c`, which includes `vctrs_init_api()` to initialize the vctrs C callables, which slider calls.
- CRAN vctrs's `vctrs_init_api()` tries to run `R_GetCCallable("vctrs", "vec_is_vector")`, so this gets embedded into CRAN slider
- When CRAN slider is loaded with dev vctrs, the loading of slider fails because the embedded `vctrs_init_api()` call fails to to `R_GetCCallable("vctrs", "vec_is_vector")` failing, since `vec_is_vector()` is no longer an exposed C callable in vctrs.

I don't know how long it takes CRAN to rebuild dependent binaries after a package release (i.e. how long does it take CRAN to rebuild slider/tibblify after vctrs is released?), but as is there would be a window where CRAN slider (built against old vctrs) and newly pushed CRAN vctrs would be incompatible.

We can avoid this by still removing `vec_is_vector()` from `inst/include/vctrs.c` and `inst/include/vctrs.h`, but keeping around a "defunct" version of the C callable for exactly 1 vctrs release. This gives CRAN time to rebuild the slider and tibblify packages against new CRAN vctrs, which means it would rebuild against new `inst/include/vctrs.c` and `inst/include/vctrs.h`, which no longer try and reference the `vec_is_vector()` callable.

On the next vctrs release after this one, we can remove the defunct C callable as well, because the rebuilt slider and tibblify should no longer reference it.