### PR TITLE
Make `obj_is_list()` return `FALSE` for list arrays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vctrs (development version)
 
+* `obj_is_list()` now returns `FALSE` for list arrays. Functions such as `list_drop_empty()` and `list_combine()` validate their input using `obj_is_list()`, but aren't well defined on list arrays.
+
 * `vec_cast()` with arrays no longer clones when no casting is required (#2006).
 
 * `vec_rank()` now throws an improved error on non-vector types, like `NULL` (#1967).

--- a/R/assert.R
+++ b/R/assert.R
@@ -320,9 +320,11 @@ vec_check_recyclable <- function(
 #'
 #' @description
 #' - `obj_is_list()` tests if `x` is considered a list in the vctrs sense. It
-#'   returns `TRUE` if:
-#'   - `x` is a bare list with no class.
-#'   - `x` is a list explicitly inheriting from `"list"`.
+#'   returns `TRUE` if all of the following hold:
+#'   - `x` must have list storage, i.e. `typeof(x)` returns `"list"`
+#'   - `x` must not have a `dim` attribute
+#'   - `x` must not have a `class` attribute, or must explicitly inherit from
+#'     `"list"` as the last class
 #'
 #' - `list_all_vectors()` takes a list and returns `TRUE` if all elements of
 #'   that list are vectors.

--- a/man/obj_is_list.Rd
+++ b/man/obj_is_list.Rd
@@ -70,10 +70,12 @@ automatically or not.}
 \description{
 \itemize{
 \item \code{obj_is_list()} tests if \code{x} is considered a list in the vctrs sense. It
-returns \code{TRUE} if:
+returns \code{TRUE} if all of the following hold:
 \itemize{
-\item \code{x} is a bare list with no class.
-\item \code{x} is a list explicitly inheriting from \code{"list"}.
+\item \code{x} must have list storage, i.e. \code{typeof(x)} returns \code{"list"}
+\item \code{x} must not have a \code{dim} attribute
+\item \code{x} must not have a \code{class} attribute, or must explicitly inherit from
+\code{"list"} as the last class
 }
 \item \code{list_all_vectors()} takes a list and returns \code{TRUE} if all elements of
 that list are vectors.

--- a/src/assert.h
+++ b/src/assert.h
@@ -3,6 +3,7 @@
 
 #include "vctrs-core.h"
 #include "conditions.h"
+#include "dim.h"
 #include "size.h"
 #include "utils-dispatch.h"
 
@@ -130,6 +131,14 @@ static inline
 bool obj_is_list(r_obj* x) {
   // Require `x` to be a list internally
   if (r_typeof(x) != R_TYPE_list) {
+    return false;
+  }
+
+  // List arrays are not lists for vctrs purposes. We have pretty deep
+  // assumptions that if an object is a list, then `r_length(x) == vec_size(x)`.
+  // See `list_drop_empty()` and `list_combine()` for examples of
+  // implementations that would be broken if this wasn't true.
+  if (has_dim(x)) {
     return false;
   }
 

--- a/tests/testthat/_snaps/empty.md
+++ b/tests/testthat/_snaps/empty.md
@@ -1,0 +1,9 @@
+# validates `x`
+
+    Code
+      x <- array(list(1), dim = c(1, 1))
+      list_drop_empty(x)
+    Condition
+      Error in `list_drop_empty()`:
+      ! `x` must be a list.
+

--- a/tests/testthat/_snaps/list-combine.md
+++ b/tests/testthat/_snaps/list-combine.md
@@ -626,6 +626,14 @@
       Error in `list_combine()`:
       ! `x` must be a list, not a <data.frame> object.
 
+---
+
+    Code
+      list_combine(array(list(1)), indices = list(1), size = 1)
+    Condition
+      Error in `list_combine()`:
+      ! `x` must be a list, not a list 1D array.
+
 # `indices` must be a list
 
     Code

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -432,6 +432,16 @@ test_that("Vectors with a non-VECSXP type are not lists", {
   expect_false(obj_is_list(quote(name)))
 })
 
+test_that("List arrays are not lists", {
+  # Bare list arrays
+  x <- array(list(1))
+  expect_false(obj_is_list(x))
+
+  # Classed list arrays
+  x <- structure(list(1), class = "list", dim = 1)
+  expect_false(obj_is_list(x))
+})
+
 test_that("explicitly classed lists are lists", {
   x <- structure(list(), class = "list")
 

--- a/tests/testthat/test-empty.R
+++ b/tests/testthat/test-empty.R
@@ -38,4 +38,11 @@ test_that("retains list type", {
 test_that("validates `x`", {
   expect_error(list_drop_empty(1), "must be a list")
   expect_error(list_drop_empty(data_frame()), "must be a list")
+
+  # List arrays are not allowed, because we would not iterate over them
+  # correctly
+  expect_snapshot(error = TRUE, {
+    x <- array(list(1), dim = c(1, 1))
+    list_drop_empty(x)
+  })
 })

--- a/tests/testthat/test-list-combine.R
+++ b/tests/testthat/test-list-combine.R
@@ -1460,6 +1460,9 @@ test_that("`x` must be a list", {
   expect_snapshot(error = TRUE, {
     list_combine(data.frame(x = 1), indices = list(1), size = 1)
   })
+  expect_snapshot(error = TRUE, {
+    list_combine(array(list(1)), indices = list(1), size = 1)
+  })
 })
 
 test_that("`indices` must be a list", {


### PR DESCRIPTION
Closes https://github.com/r-lib/vctrs/issues/2012

Both feisr and merTools break with dev vctrs. They both try to call `list_unchop()` with a _list array_.

Internally we assume that if `obj_is_list()` is `true`, then `r_length(x) == vec_size(x)` and are interchangeable. This is what broke `list_unchop()` for these two packages. We switched to `vec_size()` instead of `r_length()` in the C code after a call to `obj_check_list()`
https://github.com/r-lib/vctrs/blob/e1c33081f2a2c986c6f5498d6206d0dc5c68e3a0/src/list-combine.c#L291-L294

It's not clear what `list_unchop()` should even do with a list array. It's also not clear for functions like `list_drop_empty()`, where the output is unconditionally an atomic list vector. I'd argue that most vctrs `list_*()` functions that check their input with `obj_is_list()` are not prepared for list arrays, so `obj_is_list()` should simply return `FALSE` on them.

So the example from https://github.com/r-lib/vctrs/issues/2012 no longer silently succeeds with an incorrect answer, but instead returns a clear failure of:

``` r
library(vctrs)

xs <- list(
  data.frame(x = 1:2, y = 1:2),
  data.frame(x = 3:4, y = 3:4),
  data.frame(x = 4:5, y = 4:5)
)
dim(xs) <- c(1, 3)

dplyr::bind_rows(xs)
#> Error in `list_flatten()`:
#> ! `x` must be a list, not a list matrix.
```