### PR TITLE
Remove `chr_appearance()` related code

### DIFF
--- a/R/order.R
+++ b/R/order.R
@@ -250,8 +250,7 @@ vec_order_info <- function(
   direction = "asc",
   na_value = "largest",
   nan_distinct = FALSE,
-  chr_proxy_collate = NULL,
-  chr_ordered = TRUE
+  chr_proxy_collate = NULL
 ) {
   check_dots_empty0(...)
   .Call(
@@ -260,8 +259,7 @@ vec_order_info <- function(
     direction,
     na_value,
     nan_distinct,
-    chr_proxy_collate,
-    chr_ordered
+    chr_proxy_collate
   )
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -133,7 +133,7 @@ extern SEXP vctrs_normalize_encoding(SEXP);
 extern r_obj* ffi_chr_is_normalized(r_obj*);
 extern SEXP vctrs_order(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vctrs_locate_sorted_groups(SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP vctrs_order_info(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP vctrs_order_info(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern r_obj* ffi_vec_unrep(r_obj*, r_obj*);
 extern SEXP vctrs_fill_missing(SEXP, SEXP, SEXP);
 extern r_obj* ffi_chr_paste_prefix(r_obj*, r_obj*, r_obj*);
@@ -343,7 +343,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"ffi_chr_is_normalized",                     (DL_FUNC) &ffi_chr_is_normalized, 1},
   {"vctrs_order",                               (DL_FUNC) &vctrs_order, 5},
   {"vctrs_locate_sorted_groups",                (DL_FUNC) &vctrs_locate_sorted_groups, 5},
-  {"vctrs_order_info",                          (DL_FUNC) &vctrs_order_info, 6},
+  {"vctrs_order_info",                          (DL_FUNC) &vctrs_order_info, 5},
   {"ffi_vec_unrep",                             (DL_FUNC) &ffi_vec_unrep, 2},
   {"vctrs_fill_missing",                        (DL_FUNC) &vctrs_fill_missing, 3},
   {"ffi_chr_paste_prefix",                      (DL_FUNC) &ffi_chr_paste_prefix, 3},

--- a/src/match-joint.c
+++ b/src/match-joint.c
@@ -114,8 +114,7 @@ r_obj* vec_joint_xtfrm(r_obj* x,
     chrs_asc,
     chrs_smallest,
     nan_distinct,
-    r_null,
-    true
+    r_null
   ), &n_prot);
 
   r_obj* y_info = KEEP_N(vec_order_info(
@@ -123,8 +122,7 @@ r_obj* vec_joint_xtfrm(r_obj* x,
     chrs_asc,
     chrs_smallest,
     nan_distinct,
-    r_null,
-    true
+    r_null
   ), &n_prot);
 
   const int* v_x_o = r_int_cbegin(r_list_get(x_info, 0));

--- a/src/match.c
+++ b/src/match.c
@@ -2262,8 +2262,7 @@ r_obj* compute_nesting_container_info(r_obj* haystack,
     chrs_asc,
     chrs_smallest,
     true,
-    r_null,
-    true
+    r_null
   ), &n_prot);
 
   r_obj* o_haystack = r_list_get(info, 0);
@@ -2324,8 +2323,7 @@ r_obj* compute_nesting_container_info(r_obj* haystack,
       chrs_asc,
       chrs_smallest,
       true,
-      r_null,
-      true
+      r_null
     );
     r_obj* outer_group_sizes = KEEP_N(r_list_get(info, 1), &n_prot);
     v_outer_group_sizes = r_int_cbegin(outer_group_sizes);

--- a/src/order.c
+++ b/src/order.c
@@ -194,7 +194,6 @@ static SEXP vec_order_info_impl(SEXP x,
                                 SEXP na_value,
                                 bool nan_distinct,
                                 SEXP chr_proxy_collate,
-                                bool chr_ordered,
                                 bool group_sizes);
 
 // [[ include("order.h") ]]
@@ -203,9 +202,8 @@ SEXP vec_order(SEXP x,
                SEXP na_value,
                bool nan_distinct,
                SEXP chr_proxy_collate) {
-  const bool chr_ordered = true;
   const bool group_sizes = false;
-  SEXP info = vec_order_info_impl(x, direction, na_value, nan_distinct, chr_proxy_collate, chr_ordered, group_sizes);
+  SEXP info = vec_order_info_impl(x, direction, na_value, nan_distinct, chr_proxy_collate, group_sizes);
   return r_list_get(info, 0);
 }
 
@@ -240,15 +238,12 @@ SEXP vec_locate_sorted_groups(SEXP x,
                               SEXP na_value,
                               bool nan_distinct,
                               SEXP chr_proxy_collate) {
-  const bool chr_ordered = true;
-
   SEXP info = KEEP(vec_order_info(
     x,
     direction,
     na_value,
     nan_distinct,
-    chr_proxy_collate,
-    chr_ordered
+    chr_proxy_collate
   ));
 
   SEXP o = r_list_get(info, 0);
@@ -317,10 +312,9 @@ SEXP vec_order_info(SEXP x,
                     SEXP direction,
                     SEXP na_value,
                     bool nan_distinct,
-                    SEXP chr_proxy_collate,
-                    bool chr_ordered) {
+                    SEXP chr_proxy_collate) {
   const bool group_sizes = true;
-  return vec_order_info_impl(x, direction, na_value, nan_distinct, chr_proxy_collate, chr_ordered, group_sizes);
+  return vec_order_info_impl(x, direction, na_value, nan_distinct, chr_proxy_collate, group_sizes);
 }
 
 // [[ register() ]]
@@ -328,11 +322,9 @@ SEXP vctrs_order_info(SEXP x,
                       SEXP direction,
                       SEXP na_value,
                       SEXP nan_distinct,
-                      SEXP chr_proxy_collate,
-                      SEXP chr_ordered) {
+                      SEXP chr_proxy_collate) {
   bool c_nan_distinct = parse_nan_distinct(nan_distinct);
-  bool c_chr_ordered = r_bool_as_int(chr_ordered);
-  return vec_order_info(x, direction, na_value, c_nan_distinct, chr_proxy_collate, c_chr_ordered);
+  return vec_order_info(x, direction, na_value, c_nan_distinct, chr_proxy_collate);
 }
 
 static inline size_t vec_compute_n_bytes_lazy_raw(SEXP x, const enum vctrs_type type);
@@ -347,7 +339,6 @@ static void vec_order_switch(SEXP x,
                              SEXP decreasing,
                              SEXP na_last,
                              bool nan_distinct,
-                             bool chr_ordered,
                              r_ssize size,
                              const enum vctrs_type type,
                              struct order* p_order,
@@ -365,7 +356,6 @@ SEXP vec_order_info_impl(SEXP x,
                          SEXP na_value,
                          bool nan_distinct,
                          SEXP chr_proxy_collate,
-                         bool chr_ordered,
                          bool group_sizes) {
   // TODO call
   struct r_lazy call = r_lazy_null;
@@ -455,7 +445,6 @@ SEXP vec_order_info_impl(SEXP x,
     decreasing,
     na_last,
     nan_distinct,
-    chr_ordered,
     size,
     type,
     p_order,
@@ -489,7 +478,6 @@ static void df_order(SEXP x,
                      SEXP decreasing,
                      SEXP na_last,
                      bool nan_distinct,
-                     bool chr_ordered,
                      r_ssize size,
                      struct order* p_order,
                      struct lazy_raw* p_lazy_x_chunk,
@@ -504,7 +492,6 @@ static void vec_order_base_switch(SEXP x,
                                   bool decreasing,
                                   bool na_last,
                                   bool nan_distinct,
-                                  bool chr_ordered,
                                   r_ssize size,
                                   const enum vctrs_type type,
                                   struct order* p_order,
@@ -521,7 +508,6 @@ void vec_order_switch(SEXP x,
                       SEXP decreasing,
                       SEXP na_last,
                       bool nan_distinct,
-                      bool chr_ordered,
                       r_ssize size,
                       const enum vctrs_type type,
                       struct order* p_order,
@@ -538,7 +524,6 @@ void vec_order_switch(SEXP x,
       decreasing,
       na_last,
       nan_distinct,
-      chr_ordered,
       size,
       p_order,
       p_lazy_x_chunk,
@@ -577,7 +562,6 @@ void vec_order_switch(SEXP x,
     c_decreasing,
     c_na_last,
     nan_distinct,
-    chr_ordered,
     size,
     type,
     p_order,
@@ -656,26 +640,12 @@ static void chr_order(SEXP x,
                       struct group_infos* p_group_infos,
                       struct truelength_info* p_truelength_info);
 
-static void chr_appearance(SEXP x,
-                           bool decreasing,
-                           bool na_last,
-                           r_ssize size,
-                           struct order* p_order,
-                           struct lazy_raw* p_lazy_x_chunk,
-                           struct lazy_raw* p_lazy_x_aux,
-                           struct lazy_raw* p_lazy_o_aux,
-                           struct lazy_raw* p_lazy_bytes,
-                           struct lazy_raw* p_lazy_counts,
-                           struct group_infos* p_group_infos,
-                           struct truelength_info* p_truelength_info);
-
 // Used on bare vectors and the first column of data frame `x`s
 static
 void vec_order_base_switch(SEXP x,
                            bool decreasing,
                            bool na_last,
                            bool nan_distinct,
-                           bool chr_ordered,
                            r_ssize size,
                            const enum vctrs_type type,
                            struct order* p_order,
@@ -758,37 +728,20 @@ void vec_order_base_switch(SEXP x,
     break;
   }
   case VCTRS_TYPE_character: {
-    if (chr_ordered) {
-      chr_order(
-        x,
-        decreasing,
-        na_last,
-        size,
-        p_order,
-        p_lazy_x_chunk,
-        p_lazy_x_aux,
-        p_lazy_o_aux,
-        p_lazy_bytes,
-        p_lazy_counts,
-        p_group_infos,
-        p_truelength_info
-      );
-    } else {
-      chr_appearance(
-        x,
-        decreasing,
-        na_last,
-        size,
-        p_order,
-        p_lazy_x_chunk,
-        p_lazy_x_aux,
-        p_lazy_o_aux,
-        p_lazy_bytes,
-        p_lazy_counts,
-        p_group_infos,
-        p_truelength_info
-      );
-    }
+    chr_order(
+      x,
+      decreasing,
+      na_last,
+      size,
+      p_order,
+      p_lazy_x_chunk,
+      p_lazy_x_aux,
+      p_lazy_o_aux,
+      p_lazy_bytes,
+      p_lazy_counts,
+      p_group_infos,
+      p_truelength_info
+    );
 
     break;
   }
@@ -3470,277 +3423,11 @@ bool chr_str_ge(SEXP x, SEXP y, int x_size, const R_len_t pass) {
 
 // -----------------------------------------------------------------------------
 
-static void chr_appearance_counting(const SEXP* p_x,
-                                    r_ssize size,
-                                    bool initialized,
-                                    int* p_o,
-                                    int* p_o_aux,
-                                    struct group_infos* p_group_infos,
-                                    struct truelength_info* p_truelength_info);
-
-static
-void chr_appearance_chunk(bool decreasing,
-                          bool na_last,
-                          r_ssize size,
-                          int* p_o,
-                          struct lazy_raw* p_lazy_x_chunk,
-                          struct lazy_raw* p_lazy_x_aux,
-                          struct lazy_raw* p_lazy_o_aux,
-                          struct lazy_raw* p_lazy_bytes,
-                          struct lazy_raw* p_lazy_counts,
-                          struct group_infos* p_group_infos,
-                          struct truelength_info* p_truelength_info) {
-  const SEXP* p_x_chunk = (const SEXP*) p_lazy_x_chunk->p_data;
-
-  const bool initialized = true;
-  int* p_o_aux = (int*) init_lazy_raw(p_lazy_o_aux);
-
-  chr_appearance_counting(
-    p_x_chunk,
-    size,
-    initialized,
-    p_o,
-    p_o_aux,
-    p_group_infos,
-    p_truelength_info
-  );
-}
-
-
-struct chr_appearance_info {
-  SEXP x;
-  bool decreasing;
-  bool na_last;
-  r_ssize size;
-  struct order* p_order;
-  struct lazy_raw* p_lazy_x_chunk;
-  struct lazy_raw* p_lazy_x_aux;
-  struct lazy_raw* p_lazy_o_aux;
-  struct lazy_raw* p_lazy_bytes;
-  struct lazy_raw* p_lazy_counts;
-  struct group_infos* p_group_infos;
-  struct truelength_info* p_truelength_info;
-};
-
-struct chr_appearance_cleanup_info {
-  struct truelength_info* p_truelength_info;
-};
-
-static SEXP chr_appearance_exec(void* p_data);
-static void chr_appearance_cleanup(void* p_data);
-
-/*
- * `chr_appearance()` directly modifies the `TRUELENGTH()` values of the
- * CHARSXPs in `x`. These must be reset after the call with
- * `truelength_reset()`. In practice, `chr_appearance_counting()` will call
- * `truelength_reset()` for us, however, to ensure that this function is called
- * (even on a longjump), `R_ExecWithCleanup()` is used.
- */
-static
-void chr_appearance(SEXP x,
-                    bool decreasing,
-                    bool na_last,
-                    r_ssize size,
-                    struct order* p_order,
-                    struct lazy_raw* p_lazy_x_chunk,
-                    struct lazy_raw* p_lazy_x_aux,
-                    struct lazy_raw* p_lazy_o_aux,
-                    struct lazy_raw* p_lazy_bytes,
-                    struct lazy_raw* p_lazy_counts,
-                    struct group_infos* p_group_infos,
-                    struct truelength_info* p_truelength_info) {
-  struct chr_appearance_info info = {
-   .x = x,
-   .decreasing = decreasing,
-   .na_last = na_last,
-   .size = size,
-   .p_order = p_order,
-   .p_lazy_x_chunk = p_lazy_x_chunk,
-   .p_lazy_x_aux = p_lazy_x_aux,
-   .p_lazy_o_aux = p_lazy_o_aux,
-   .p_lazy_bytes = p_lazy_bytes,
-   .p_lazy_counts = p_lazy_counts,
-   .p_group_infos = p_group_infos,
-   .p_truelength_info = p_truelength_info
-  };
-
-  struct chr_appearance_cleanup_info cleanup_info = {
-    .p_truelength_info = p_truelength_info
-  };
-
-  R_ExecWithCleanup(
-    chr_appearance_exec,
-    &info,
-    chr_appearance_cleanup,
-    &cleanup_info
-  );
-}
-
-static void chr_appearance_internal(SEXP x,
-                                    bool decreasing,
-                                    bool na_last,
-                                    r_ssize size,
-                                    struct order* p_order,
-                                    struct lazy_raw* p_lazy_x_chunk,
-                                    struct lazy_raw* p_lazy_x_aux,
-                                    struct lazy_raw* p_lazy_o_aux,
-                                    struct lazy_raw* p_lazy_bytes,
-                                    struct lazy_raw* p_lazy_counts,
-                                    struct group_infos* p_group_infos,
-                                    struct truelength_info* p_truelength_info);
-
-static
-SEXP chr_appearance_exec(void* p_data) {
-  struct chr_appearance_info* p_info = (struct chr_appearance_info*) p_data;
-
-  chr_appearance_internal(
-    p_info->x,
-    p_info->decreasing,
-    p_info->na_last,
-    p_info->size,
-    p_info->p_order,
-    p_info->p_lazy_x_chunk,
-    p_info->p_lazy_x_aux,
-    p_info->p_lazy_o_aux,
-    p_info->p_lazy_bytes,
-    p_info->p_lazy_counts,
-    p_info->p_group_infos,
-    p_info->p_truelength_info
-  );
-
-  return R_NilValue;
-}
-
-static
-void chr_appearance_cleanup(void* p_data) {
-  struct chr_appearance_cleanup_info* p_info = (struct chr_appearance_cleanup_info*) p_data;
-  truelength_reset(p_info->p_truelength_info);
-}
-
-static
-void chr_appearance_internal(SEXP x,
-                             bool decreasing,
-                             bool na_last,
-                             r_ssize size,
-                             struct order* p_order,
-                             struct lazy_raw* p_lazy_x_chunk,
-                             struct lazy_raw* p_lazy_x_aux,
-                             struct lazy_raw* p_lazy_o_aux,
-                             struct lazy_raw* p_lazy_bytes,
-                             struct lazy_raw* p_lazy_counts,
-                             struct group_infos* p_group_infos,
-                             struct truelength_info* p_truelength_info) {
-  const SEXP* p_x = STRING_PTR_RO(x);
-
-  const bool initialized = false;
-  int* p_o = p_order->p_data;
-  int* p_o_aux = NULL;
-
-  chr_appearance_counting(
-    p_x,
-    size,
-    initialized,
-    p_o,
-    p_o_aux,
-    p_group_infos,
-    p_truelength_info
-  );
-}
-
-
-/*
- * `chr_appearance_counting()` groups elements of `p_x` in order
- * of appearance using an algorithm that is extremely similar to the
- * counting sort used in `int_order_counting()`.
- *
- * For algorithms that end up calling `vec_order()` twice to compute order by
- * appearance, the first ordering can use appearance order for character
- * vectors, which is faster than lexicographical order, while still actually
- * sorting other atomic types. The final result after the second ordering will
- * still end up being in appearance order.
- */
-static
-void chr_appearance_counting(const SEXP* p_x,
-                             r_ssize size,
-                             bool initialized,
-                             int* p_o,
-                             int* p_o_aux,
-                             struct group_infos* p_group_infos,
-                             struct truelength_info* p_truelength_info) {
-  for (r_ssize i = 0; i < size; ++i) {
-    SEXP elt = p_x[i];
-    r_ssize truelength = TRUELENGTH(elt);
-
-    // We have already seen and saved this string, so "increment" its counter
-    if (truelength < 0) {
-      SET_TRUELENGTH(elt, truelength - 1);
-      continue;
-    }
-
-    if (truelength > 0) {
-      // Retain R's usage of TRUELENGTH. Normally defaults to 0, so if the value
-      // is positive, it means R is using it. Should be extremely rare.
-      truelength_save_string(elt, truelength, p_truelength_info);
-    }
-
-    // Save the unique string for appearance ordering below
-    truelength_save_unique(elt, p_truelength_info);
-
-    // Mark as negative to note that we have seen this string.
-    // R uses positive or zero truelengths.
-    SET_TRUELENGTH(elt, -1);
-  }
-
-  r_ssize cumulative = 0;
-
-  SEXP* p_uniques = p_truelength_info->p_uniques;
-  r_ssize n_uniques = p_truelength_info->n_uniques_used;
-
-  for (r_ssize i = 0; i < n_uniques; ++i) {
-    SEXP elt = p_uniques[i];
-    r_ssize group_size = -TRUELENGTH(elt);
-
-    // Push group sizes accumulated in order of appearance
-    groups_size_maybe_push(group_size, p_group_infos);
-
-    // Set cumulative value (i.e. group start location), then increment
-    SET_TRUELENGTH(elt, cumulative);
-    cumulative += group_size;
-  }
-
-  // If order is not initialized, we are on the first column / atomic vector
-  // and can place the order directly into the result. Much faster than
-  // initializing, placing in `p_o_aux`, and copying back over.
-  if (initialized) {
-    for (r_ssize i = 0; i < size; ++i) {
-      const SEXP elt = p_x[i];
-      const r_ssize loc = TRUELENGTH(elt);
-      SET_TRUELENGTH(elt, loc + 1);
-      p_o_aux[loc] = p_o[i];
-    }
-
-    r_memcpy(p_o, p_o_aux, size * sizeof(*p_o_aux));
-  } else {
-    for (r_ssize i = 0; i < size; ++i) {
-      const SEXP elt = p_x[i];
-      const r_ssize loc = TRUELENGTH(elt);
-      SET_TRUELENGTH(elt, loc + 1);
-      p_o[loc] = i + 1;
-    }
-  }
-
-  // Reset truelengths for next chunk/column
-  truelength_reset(p_truelength_info);
-}
-
-// -----------------------------------------------------------------------------
-
 struct df_order_info {
   SEXP x;
   SEXP decreasing;
   SEXP na_last;
   bool nan_distinct;
-  bool chr_ordered;
   r_ssize size;
   struct order* p_order;
   struct lazy_raw* p_lazy_x_chunk;
@@ -3782,7 +3469,6 @@ void df_order(SEXP x,
               SEXP decreasing,
               SEXP na_last,
               bool nan_distinct,
-              bool chr_ordered,
               r_ssize size,
               struct order* p_order,
               struct lazy_raw* p_lazy_x_chunk,
@@ -3797,7 +3483,6 @@ void df_order(SEXP x,
     .decreasing = decreasing,
     .na_last = na_last,
     .nan_distinct = nan_distinct,
-    .chr_ordered = chr_ordered,
     .size = size,
     .p_order = p_order,
     .p_lazy_x_chunk = p_lazy_x_chunk,
@@ -3825,7 +3510,6 @@ static void df_order_internal(SEXP x,
                               SEXP decreasing,
                               SEXP na_last,
                               bool nan_distinct,
-                              bool chr_ordered,
                               r_ssize size,
                               struct order* p_order,
                               struct lazy_raw* p_lazy_x_chunk,
@@ -3845,7 +3529,6 @@ SEXP df_order_exec(void* p_data) {
     p_info->decreasing,
     p_info->na_last,
     p_info->nan_distinct,
-    p_info->chr_ordered,
     p_info->size,
     p_info->p_order,
     p_info->p_lazy_x_chunk,
@@ -3870,7 +3553,6 @@ void df_order_cleanup(void* p_data) {
 static void vec_order_chunk_switch(bool decreasing,
                                    bool na_last,
                                    bool nan_distinct,
-                                   bool chr_ordered,
                                    r_ssize size,
                                    const enum vctrs_type type,
                                    int* p_o,
@@ -3919,7 +3601,6 @@ void df_order_internal(SEXP x,
                        SEXP decreasing,
                        SEXP na_last,
                        bool nan_distinct,
-                       bool chr_ordered,
                        r_ssize size,
                        struct order* p_order,
                        struct lazy_raw* p_lazy_x_chunk,
@@ -3986,7 +3667,6 @@ void df_order_internal(SEXP x,
     col_decreasing,
     col_na_last,
     nan_distinct,
-    chr_ordered,
     size,
     type,
     p_order,
@@ -4031,9 +3711,8 @@ void df_order_internal(SEXP x,
     col = VECTOR_ELT(x, i);
     type = vec_proxy_typeof(col);
 
-    // Pre-sort unique characters once for the whole column.
-    // Don't sort uniques if computing appearance ordering.
-    if (chr_ordered && type == VCTRS_TYPE_character) {
+    // Pre-sort unique characters once for the whole column
+    if (type == VCTRS_TYPE_character) {
       const SEXP* p_col = STRING_PTR_RO(col);
 
       chr_mark_sorted_uniques(
@@ -4084,7 +3763,6 @@ void df_order_internal(SEXP x,
         col_decreasing,
         col_na_last,
         nan_distinct,
-        chr_ordered,
         group_size,
         type,
         p_o_col,
@@ -4112,10 +3790,8 @@ void df_order_internal(SEXP x,
       }
     }
 
-    // Reset TRUELENGTHs between columns if ordering character vectors.
-    // When ordering by appearance, `chr_appearance_counting()` resets the
-    // TRUELENGTHs between chunks.
-    if (chr_ordered && type == VCTRS_TYPE_character) {
+    // Reset TRUELENGTHs between columns if ordering character vectors
+    if (type == VCTRS_TYPE_character) {
       truelength_reset(p_truelength_info);
     }
   }
@@ -4134,7 +3810,6 @@ static
 void vec_order_chunk_switch(bool decreasing,
                             bool na_last,
                             bool nan_distinct,
-                            bool chr_ordered,
                             r_ssize size,
                             const enum vctrs_type type,
                             int* p_o,
@@ -4214,34 +3889,18 @@ void vec_order_chunk_switch(bool decreasing,
     break;
   }
   case VCTRS_TYPE_character: {
-    if (chr_ordered) {
-      chr_order_chunk(
-        decreasing,
-        na_last,
-        size,
-        p_o,
-        p_lazy_x_chunk,
-        p_lazy_x_aux,
-        p_lazy_o_aux,
-        p_lazy_bytes,
-        p_lazy_counts,
-        p_group_infos
-      );
-    } else {
-      chr_appearance_chunk(
-        decreasing,
-        na_last,
-        size,
-        p_o,
-        p_lazy_x_chunk,
-        p_lazy_x_aux,
-        p_lazy_o_aux,
-        p_lazy_bytes,
-        p_lazy_counts,
-        p_group_infos,
-        p_truelength_info
-      );
-    }
+    chr_order_chunk(
+      decreasing,
+      na_last,
+      size,
+      p_o,
+      p_lazy_x_chunk,
+      p_lazy_x_aux,
+      p_lazy_o_aux,
+      p_lazy_bytes,
+      p_lazy_counts,
+      p_group_infos
+    );
 
     break;
   }

--- a/src/order.h
+++ b/src/order.h
@@ -27,8 +27,7 @@ SEXP vec_order_info(SEXP x,
                     SEXP direction,
                     SEXP na_value,
                     bool nan_distinct,
-                    SEXP chr_proxy_collate,
-                    bool chr_ordered);
+                    SEXP chr_proxy_collate);
 
 // -----------------------------------------------------------------------------
 

--- a/src/rank.c
+++ b/src/rank.c
@@ -83,9 +83,7 @@ r_obj* vec_rank(r_obj* x,
   r_obj* rank = KEEP(r_alloc_integer(rank_size));
   int* v_rank = r_int_begin(rank);
 
-  const bool chr_ordered = true;
-
-  r_obj* info = KEEP(vec_order_info(x, direction, na_value, nan_distinct, chr_proxy_collate, chr_ordered));
+  r_obj* info = KEEP(vec_order_info(x, direction, na_value, nan_distinct, chr_proxy_collate));
 
   r_obj* order = r_list_get(info, 0);
   const int* v_order = r_int_cbegin(order);

--- a/tests/testthat/test-order.R
+++ b/tests/testthat/test-order.R
@@ -1699,51 +1699,6 @@ test_that("`chr_proxy_collate` can result in keys being seen as identical", {
 })
 
 # ------------------------------------------------------------------------------
-# `vec_order_info(chr_ordered = FALSE)`
-
-test_that("can order character vectors in appearance order", {
-  x <- c("b", "a", "B", "B", "a")
-  info <- vec_order_info(x, chr_ordered = FALSE)
-
-  expect_identical(info[[1]], c(1L, 2L, 5L, 3L, 4L))
-  expect_identical(info[[2]], c(1L, 2L, 2L))
-  expect_identical(info[[3]], 2L)
-})
-
-test_that("using appearance order means `direction` has no effect", {
-  x <- c("b", "a", "B", "B", "a")
-
-  info1 <- vec_order_info(x, direction = "asc", chr_ordered = FALSE)
-  info2 <- vec_order_info(x, direction = "desc", chr_ordered = FALSE)
-
-  expect_identical(info1[[1]], info2[[1]])
-  expect_identical(info1[[2]], info2[[2]])
-  expect_identical(info1[[3]], info2[[3]])
-})
-
-test_that("appearance order works with NA - `na_value` has no effect", {
-  x <- c(NA, "foo", NA, "bar")
-  info <- vec_order_info(x, chr_ordered = FALSE)
-
-  expect_identical(info[[1]], c(1L, 3L, 2L, 4L))
-  expect_identical(info[[2]], c(2L, 1L, 1L))
-  expect_identical(info[[3]], 2L)
-})
-
-test_that("appearance order can be mixed with regular ordering", {
-  x <- c("b", "a", "B", "B", "a", "a")
-  y <- c(1, 2, 3, 4, 1, 2)
-  df <- data_frame(x = x, y = y)
-
-  # `y` breaks ties
-  info <- vec_order_info(df, chr_ordered = FALSE)
-
-  expect_identical(info[[1]], c(1L, 5L, 2L, 6L, 3L, 4L))
-  expect_identical(info[[2]], c(1L, 1L, 2L, 1L, 1L))
-  expect_identical(info[[3]], 2L)
-})
-
-# ------------------------------------------------------------------------------
 # `vec_order_info(nan_distinct = FALSE)`
 
 test_that("Indistinct NA and NaN are reported in the same group", {


### PR DESCRIPTION
Because we are going to use `TRUELENGTH()` access, and this basically relied on that.

Luckily we never actually exposed this anywhere.