### PR TITLE
Handle `NA`s up front

### DIFF
--- a/src/decl/order-decl.h
+++ b/src/decl/order-decl.h
@@ -42,8 +42,6 @@ static void vec_order_switch(
   struct lazy_raw* p_lazy_o_aux,
   struct lazy_raw* p_lazy_bytes,
   struct lazy_raw* p_lazy_counts,
-  struct lazy_raw* p_lazy_x_string_sizes,
-  struct lazy_raw* p_lazy_x_string_sizes_aux,
   struct group_infos* p_group_infos
 );
 
@@ -59,8 +57,6 @@ static void df_order(
   struct lazy_raw* p_lazy_o_aux,
   struct lazy_raw* p_lazy_bytes,
   struct lazy_raw* p_lazy_counts,
-  struct lazy_raw* p_lazy_x_string_sizes,
-  struct lazy_raw* p_lazy_x_string_sizes_aux,
   struct group_infos* p_group_infos
 );
 
@@ -77,8 +73,6 @@ static void vec_order_base_switch(
   struct lazy_raw* p_lazy_o_aux,
   struct lazy_raw* p_lazy_bytes,
   struct lazy_raw* p_lazy_counts,
-  struct lazy_raw* p_lazy_x_string_sizes,
-  struct lazy_raw* p_lazy_x_string_sizes_aux,
   struct group_infos* p_group_infos
 );
 
@@ -150,8 +144,6 @@ static void chr_order(
   struct lazy_raw* p_lazy_x_aux,
   struct lazy_raw* p_lazy_o_aux,
   struct lazy_raw* p_lazy_bytes,
-  struct lazy_raw* p_lazy_x_string_sizes,
-  struct lazy_raw* p_lazy_x_string_sizes_aux,
   struct group_infos* p_group_infos
 );
 
@@ -313,11 +305,10 @@ static void dbl_order_radix_recurse(
 static inline uint8_t dbl_extract_uint64_byte(uint64_t x, uint8_t shift);
 
 static
-r_ssize chr_extract_without_missings(
+struct r_ssize_int_pair chr_extract_without_missings(
   r_ssize size,
   const SEXP* p_x,
-  const char** p_x_strings,
-  int* p_x_string_sizes
+  const char** p_x_strings
 );
 
 static
@@ -340,8 +331,6 @@ void chr_order_radix(
   const char** p_x_aux,
   int* p_o_aux,
   uint8_t* p_bytes,
-  int* p_x_string_sizes,
-  int* p_x_string_sizes_aux,
   struct group_infos* p_group_infos
 );
 
@@ -356,8 +345,6 @@ void chr_order_radix_recurse(
   const char** p_x_aux,
   int* p_o_aux,
   uint8_t* p_bytes,
-  int* p_x_string_sizes,
-  int* p_x_string_sizes_aux,
   struct group_infos* p_group_infos
 );
 
@@ -365,9 +352,7 @@ static
 void chr_order_insertion(
   const r_ssize size,
   const bool decreasing,
-  const int pass,
   const char** p_x,
-  int* p_x_string_sizes,
   int* p_o,
   struct group_infos* p_group_infos
 );
@@ -381,19 +366,14 @@ bool chr_all_same(
 static inline
 bool chr_all_same_byte(
   const char** p_x,
-  const int* p_x_string_sizes,
-  const r_ssize size,
-  const int pass,
-  const uint8_t too_short_bucket
+  const r_ssize size
 );
 
 static inline
-bool str_ge_with_pass(
+bool str_ge(
   const char* x,
   const char* y,
-  const int x_string_size,
-  const int direction,
-  const int pass
+  const int direction
 );
 
 static void vec_order_chunk_switch(
@@ -408,8 +388,6 @@ static void vec_order_chunk_switch(
   struct lazy_raw* p_lazy_o_aux,
   struct lazy_raw* p_lazy_bytes,
   struct lazy_raw* p_lazy_counts,
-  struct lazy_raw* p_lazy_x_string_sizes,
-  struct lazy_raw* p_lazy_x_string_sizes_aux,
   struct group_infos* p_group_infos
 );
 

--- a/src/order-sortedness.c
+++ b/src/order-sortedness.c
@@ -350,7 +350,7 @@ enum vctrs_sortedness chr_sortedness(const SEXP* p_x,
     SEXP current = p_x[i];
     const char* current_string = CHAR(current);
 
-    int cmp = str_cmp(
+    int cmp = str_cmp_maybe_na(
       current,
       previous,
       current_string,
@@ -394,7 +394,7 @@ enum vctrs_sortedness chr_sortedness(const SEXP* p_x,
     SEXP current = p_x[i];
     const char* current_string = CHAR(current);
 
-    int cmp = str_cmp(
+    int cmp = str_cmp_maybe_na(
       current,
       previous,
       current_string,

--- a/src/vctrs-core.h
+++ b/src/vctrs-core.h
@@ -27,6 +27,11 @@ extern bool vctrs_debug_verbose;
   y = tmp;                 \
 } while (0)
 
+struct r_ssize_int_pair {
+  r_ssize x;
+  int y;
+};
+
 /**
  * Ownership modeling
  *


### PR DESCRIPTION
Avoiding the need for `p_x_string_nas_aux` altogether, and nicely simplifying and speeding up the radix and insertion paths