### PR TITLE
Handle rchk results after updating rlang C API

### DIFF
--- a/src/arg-counter.c
+++ b/src/arg-counter.c
@@ -74,7 +74,7 @@ r_obj* reduce(
   void* data
 ) {
   const r_ssize n = r_length(rest);
-  r_obj* names = r_names(rest);
+  r_obj* names = KEEP(r_names(rest));
   r_obj* const* v_rest = r_list_cbegin(rest);
 
   struct counters* counters = new_counters(
@@ -94,6 +94,6 @@ r_obj* reduce(
     counters_increment(counters);
   }
 
-  FREE(2);
+  FREE(3);
   return current;
 }

--- a/src/assert.c
+++ b/src/assert.c
@@ -127,7 +127,7 @@ bool list_all_size(
   r_ssize i = 0;
 
   const r_ssize xs_size = r_length(xs);
-  r_obj* xs_names = r_names(xs);
+  r_obj* xs_names = KEEP(r_names(xs));
   r_obj* const* v_xs = r_list_cbegin(xs);
 
   struct vctrs_arg* p_x_arg = new_subscript_arg(p_xs_arg, xs_names, xs_size, &i);
@@ -143,7 +143,7 @@ bool list_all_size(
     }
   }
 
-  FREE(1);
+  FREE(2);
   return out;
 }
 

--- a/src/assert.c
+++ b/src/assert.c
@@ -183,7 +183,7 @@ void list_check_all_size(
   r_ssize i = 0;
 
   const r_ssize xs_size = r_length(xs);
-  r_obj* xs_names = r_names(xs);
+  r_obj* xs_names = KEEP(r_names(xs));
   r_obj* const* v_xs = r_list_cbegin(xs);
 
   struct vctrs_arg* p_x_arg = new_subscript_arg(p_xs_arg, xs_names, xs_size, &i);
@@ -193,7 +193,7 @@ void list_check_all_size(
     vec_check_size(v_xs[i], size, allow_null, p_x_arg, call);
   }
 
-  FREE(1);
+  FREE(2);
 }
 
 r_obj* ffi_obj_is_list(r_obj* x) {

--- a/src/assert.c
+++ b/src/assert.c
@@ -325,7 +325,7 @@ void list_check_all_recyclable(
   r_ssize i = 0;
 
   const r_ssize xs_size = r_length(xs);
-  r_obj* xs_names = r_names(xs);
+  r_obj* xs_names = KEEP(r_names(xs));
   r_obj* const* v_xs = r_list_cbegin(xs);
 
   struct vctrs_arg* p_x_arg = new_subscript_arg(p_xs_arg, xs_names, xs_size, &i);
@@ -335,5 +335,5 @@ void list_check_all_recyclable(
     vec_check_recyclable(v_xs[i], size, allow_null, p_x_arg, call);
   }
 
-  FREE(1);
+  FREE(2);
 }

--- a/src/assert.c
+++ b/src/assert.c
@@ -269,7 +269,7 @@ bool list_all_recyclable(
   r_ssize i = 0;
 
   const r_ssize xs_size = r_length(xs);
-  r_obj* xs_names = r_names(xs);
+  r_obj* xs_names = KEEP(r_names(xs));
   r_obj* const* v_xs = r_list_cbegin(xs);
 
   struct vctrs_arg* p_x_arg = new_subscript_arg(p_xs_arg, xs_names, xs_size, &i);
@@ -285,7 +285,7 @@ bool list_all_recyclable(
     }
   }
 
-  FREE(1);
+  FREE(2);
   return out;
 }
 

--- a/src/bind.c
+++ b/src/bind.c
@@ -371,23 +371,22 @@ r_obj* as_df_row_impl(r_obj* x,
 
   int nprot = 0;
 
-  r_obj* dim = vec_bare_dim(x);
+  r_obj* dim = KEEP_N(vec_bare_dim(x), &nprot);
   r_ssize ndim = (dim == r_null) ? 1 : r_length(dim);
 
   if (ndim > 2) {
     r_abort_lazy_call(error_call, "Can't bind arrays.");
   }
   if (ndim == 2) {
-    r_obj* out = KEEP(r_as_data_frame(x));
-    r_attrib_poke_names(out, vec_as_names(KEEP(colnames2(x)), name_repair));
-
-    FREE(2); FREE(nprot);
+    r_obj* out = KEEP_N(r_as_data_frame(x), &nprot);
+    r_attrib_poke_names(out, vec_as_names(KEEP_N(colnames2(x), &nprot), name_repair));
+    FREE(nprot);
     return out;
   }
 
   // Take names before removing dimensions so we get colnames if needed
-  r_obj* nms = KEEP(vec_names2(x));
-  nms = KEEP(vec_as_names(nms, name_repair));
+  r_obj* nms = KEEP_N(vec_names2(x), &nprot);
+  nms = KEEP_N(vec_as_names(nms, name_repair), &nprot);
 
   if (dim != r_null) {
     x = KEEP_N(r_clone_referenced(x), &nprot);
@@ -397,13 +396,13 @@ r_obj* as_df_row_impl(r_obj* x,
 
   // Remove names first as they are promoted to data frame column names.
   // Can be a user side object, so use `VCTRS_OWNERSHIP_foreign`.
-  x = KEEP(vec_set_names(x, r_null, VCTRS_OWNERSHIP_foreign));
+  x = KEEP_N(vec_set_names(x, r_null, VCTRS_OWNERSHIP_foreign), &nprot);
 
-  x = KEEP(vec_chop_unsafe(x, r_null, r_null));
+  x = KEEP_N(vec_chop_unsafe(x, r_null, r_null), &nprot);
   r_attrib_poke_names(x, nms);
   x = new_data_frame(x, 1);
 
-  FREE(4); FREE(nprot);
+  FREE(nprot);
   return x;
 }
 

--- a/src/cast.c
+++ b/src/cast.c
@@ -65,15 +65,15 @@ r_obj* vec_cast_opts(const struct cast_opts* opts) {
   }
 
   if (has_dim(x) || has_dim(to)) {
-    r_obj* x_dim = r_dim(x);
-    r_obj* x_dim_names = r_dim_names(x);
+    r_obj* x_dim = KEEP(r_dim(x));
+    r_obj* x_dim_names = KEEP(r_dim_names(x));
+
+    r_obj* out_dim = KEEP(r_dim(out));
+    r_obj* out_dim_names = KEEP(r_dim_names(out));
 
     // Ensure `out` has the shape of `x`.
     // Native casting doesn't propagate shape.
-    if (
-      !obj_equal(r_dim(out), x_dim) ||
-      !obj_equal(r_dim_names(out), x_dim_names)
-    ) {
+    if (!obj_equal(out_dim, x_dim) || !obj_equal(out_dim_names, x_dim_names)) {
       out = KEEP(r_clone_referenced(out));
       r_attrib_poke_dim(out, x_dim);
       r_attrib_poke_dim_names(out, x_dim_names);
@@ -84,7 +84,7 @@ r_obj* vec_cast_opts(const struct cast_opts* opts) {
     // Broadcast `out` to the shape of `to`
     out = vec_shape_broadcast(out, to, p_x_arg, p_to_arg, call);
 
-    FREE(1);
+    FREE(5);
   }
 
   FREE(1);

--- a/src/cast.c
+++ b/src/cast.c
@@ -282,16 +282,17 @@ r_obj* vec_cast_common_opts(r_obj* xs,
   ));
 
   const r_ssize xs_size = r_length(xs);
+  r_obj* xs_names = KEEP(r_names(xs));
   r_obj* const* v_xs = r_list_cbegin(xs);
 
   r_obj* out = KEEP(r_alloc_list(xs_size));
-  r_attrib_poke_names(out, r_names(xs));
+  r_attrib_poke_names(out, xs_names);
 
   r_ssize i = 0;
 
   struct vctrs_arg* p_x_arg = new_subscript_arg(
     opts->p_arg,
-    r_names(xs),
+    xs_names,
     xs_size,
     &i
   );
@@ -309,7 +310,7 @@ r_obj* vec_cast_common_opts(r_obj* xs,
     r_list_poke(out, i, vec_cast_opts(&cast_opts));
   }
 
-  FREE(3);
+  FREE(4);
   return out;
 }
 r_obj* vec_cast_common_params(r_obj* xs,

--- a/src/equal.c
+++ b/src/equal.c
@@ -572,15 +572,13 @@ static r_obj* obj_attrib_equal_cb(r_obj* tag, r_obj* value, void* data) {
   struct attrib_equal_data* p_data = (struct attrib_equal_data*) data;
   p_data->x_size++;
 
-  r_obj* y_value = r_attrib_get(p_data->y, tag);
+  r_obj* y_value = KEEP(r_attrib_get(p_data->y, tag));
 
-  if (!obj_equal_utf8(value, y_value)) {
-    // Different!
-    return r_null;
-  }
+  // Return `r_null` when different to signal that we are done
+  SEXP out = obj_equal_utf8(value, y_value) ? NULL : r_null;
 
-  // Continue
-  return NULL;
+  FREE(1);
+  return out;
 }
 
 static r_obj* obj_attrib_count_cb(r_obj* _tag, r_obj* _value, void* data) {

--- a/src/if-else.c
+++ b/src/if-else.c
@@ -207,9 +207,9 @@ r_obj* atomic_if_else(
 
   // Grab names before casting as casting may drop them
   // https://github.com/r-lib/vctrs/issues/623
-  r_obj* true_names = r_names(true_);
-  r_obj* false_names = r_names(false_);
-  r_obj* missing_names = has_missing ? r_names(missing) : r_null;
+  r_obj* true_names = KEEP_N(r_names(true_), &n_prot);
+  r_obj* false_names = KEEP_N(r_names(false_), &n_prot);
+  r_obj* missing_names = KEEP_N(has_missing ? r_names(missing) : r_null, &n_prot);
 
   const bool has_true_names = true_names != r_null;
   const bool has_false_names = false_names != r_null;

--- a/src/list-combine.c
+++ b/src/list-combine.c
@@ -1417,7 +1417,7 @@ r_obj* vec_recycle_xs_fallback(
   struct r_lazy error_call
 ) {
   r_ssize xs_size = vec_size(xs);
-  r_obj* xs_names = r_names(xs);
+  r_obj* xs_names = KEEP(r_names(xs));
   xs = KEEP(r_clone_referenced(xs));
 
   r_ssize i = 0;
@@ -1439,7 +1439,7 @@ r_obj* vec_recycle_xs_fallback(
     r_list_poke(xs, i, vec_recycle_fallback(x, index_size, p_x_arg, error_call));
   }
 
-  FREE(2);
+  FREE(3);
   return xs;
 }
 

--- a/src/list-combine.c
+++ b/src/list-combine.c
@@ -1458,7 +1458,7 @@ r_obj* vec_slice_xs_fallback(
   struct r_lazy error_call
 ) {
   r_ssize xs_size = vec_size(xs);
-  r_obj* xs_names = r_names(xs);
+  r_obj* xs_names = KEEP(r_names(xs));
   xs = KEEP(r_clone_referenced(xs));
 
   r_ssize i = 0;
@@ -1495,7 +1495,7 @@ r_obj* vec_slice_xs_fallback(
     r_list_poke(xs, i, x);
   }
 
-  FREE(2);
+  FREE(3);
   return xs;
 }
 

--- a/src/names.c
+++ b/src/names.c
@@ -774,8 +774,6 @@ r_obj* vec_set_rownames(r_obj* x, r_obj* names, bool proxy, const enum vctrs_own
     return set_rownames_dispatch(x, names);
   }
 
-  int nprot = 0;
-
   r_obj* dim_names = r_attrib_get(x, r_syms.dim_names);
 
   // Early exit when no new row names and no existing row names
@@ -785,20 +783,22 @@ r_obj* vec_set_rownames(r_obj* x, r_obj* names, bool proxy, const enum vctrs_own
     }
   }
 
-  x = KEEP_N(vec_clone_referenced(x, ownership), &nprot);
+  // Okay, now protect `dim_names`
+  KEEP(dim_names);
+
+  x = KEEP(vec_clone_referenced(x, ownership));
 
   if (dim_names == r_null) {
-    dim_names = KEEP_N(r_alloc_list(vec_dim_n(x)), &nprot);
+    dim_names = KEEP(r_alloc_list(vec_dim_n(x)));
   } else {
     // Also clone attribute
-    dim_names = KEEP_N(r_clone(dim_names), &nprot);
+    dim_names = KEEP(r_clone(dim_names));
   }
 
   r_list_poke(dim_names, 0, names);
-
   r_attrib_poke(x, r_syms.dim_names, dim_names);
 
-  FREE(nprot);
+  FREE(3);
   return x;
 }
 

--- a/src/shape.c
+++ b/src/shape.c
@@ -46,6 +46,18 @@ r_obj* ffi_vec_shape2(r_obj* x, r_obj* y, r_obj* frame) {
   return vec_shape2(x, y, &x_arg, &y_arg);
 }
 
+// This function is fairly important for performance, because `vec_shaped_ptype()`
+// is called on every ptype2 iteration. This example runs roughly 15% faster if
+// we completely avoid any `KEEP()` and `FREE()` calls in the happy path, which
+// justifies the somewhat ugly code flow.
+//
+// ```r
+// x <- as.list(1:1e6)
+// vec_ptype_common(!!!x)
+// ```
+//
+// rchk asserts that `r_dim()` creates a potentially fresh variable, even though
+// we are mostly confident it does not
 static inline
 r_obj* vec_shape2(
   r_obj* x,
@@ -53,23 +65,32 @@ r_obj* vec_shape2(
   struct vctrs_arg* p_x_arg,
   struct vctrs_arg* p_y_arg
 ) {
-  // Expect that `r_dim()` does not allocate, so we don't protect these!
-  // This is somewhat important for performance, because `vec_shaped_ptype()`
-  // is called on every ptype2 iteration.
   r_obj* x_dimensions = r_dim(x);
-  r_obj* y_dimensions = r_dim(y);
 
   if (x_dimensions == r_null) {
+    r_obj* y_dimensions = r_dim(y);
+
     if (y_dimensions == r_null) {
       return r_null;
     } else {
-      return dims_shape(y_dimensions);
+      KEEP(y_dimensions);
+      r_obj* out = dims_shape(y_dimensions);
+      FREE(1);
+      return out;
     }
   } else {
+    KEEP(x_dimensions);
+    r_obj* y_dimensions = r_dim(y);
+
     if (y_dimensions == r_null) {
-      return dims_shape(x_dimensions);
+      r_obj* out = dims_shape(x_dimensions);
+      FREE(1);
+      return out;
     } else {
-      return dims_shape2(x_dimensions, y_dimensions, x, y, p_x_arg, p_y_arg);
+      KEEP(y_dimensions);
+      r_obj* out = dims_shape2(x_dimensions, y_dimensions, x, y, p_x_arg, p_y_arg);
+      FREE(2);
+      return out;
     }
   }
 }

--- a/src/size-common.c
+++ b/src/size-common.c
@@ -234,13 +234,14 @@ r_obj* vec_recycle_common(
   }
 
   r_obj* const* v_xs = r_list_cbegin(xs);
+  r_obj* xs_names = KEEP(r_names(xs));
   const r_ssize xs_size = r_length(xs);
 
   r_ssize xs_index = 0;
 
   struct vctrs_arg* p_x_arg = new_subscript_arg(
     p_xs_arg,
-    r_names(xs),
+    xs_names,
     xs_size,
     &xs_index
   );
@@ -259,13 +260,13 @@ r_obj* vec_recycle_common(
   }
 
   if (xs_index == xs_size) {
-    FREE(1);
+    FREE(2);
     return xs;
   }
 
   // Otherwise we need a new list
   r_obj* out = KEEP(r_alloc_list(xs_size));
-  r_attrib_poke_names(out, r_names(xs));
+  r_attrib_poke_names(out, xs_names);
 
   // Copy over everything before `xs_index`
   for (r_ssize i = 0; i < xs_index; ++i) {
@@ -280,6 +281,6 @@ r_obj* vec_recycle_common(
     ++xs_index;
   }
 
-  FREE(2);
+  FREE(3);
   return out;
 }

--- a/src/slice-assign.c
+++ b/src/slice-assign.c
@@ -966,7 +966,7 @@ void list_check_all_condition_indices(
   r_ssize i = 0;
 
   const r_ssize xs_size = r_length(xs);
-  r_obj* xs_names = r_names(xs);
+  r_obj* xs_names = KEEP(r_names(xs));
   r_obj* const* v_xs = r_list_cbegin(xs);
 
   struct vctrs_arg* p_x_arg = new_subscript_arg(p_xs_arg, xs_names, xs_size, &i);
@@ -976,7 +976,7 @@ void list_check_all_condition_indices(
     check_condition_index(v_xs[i], p_x_arg, call);
   }
 
-  FREE(1);
+  FREE(2);
 }
 
 // Cheap internal checks done right before assignment to avoid R crashes in corrupt cases


### PR DESCRIPTION
`r_attrib_get()` now looks to rchk like it allocates. I don't think it does, but rchk doesn't know this.

This means `r_names()` and `r_dim()` and friends now look like they allocate a fresh object, which has lots of downstream consequences.

I think most of these changes are good, they probably make vctrs safer in the long run.

Passing now https://github.com/r-lib/vctrs/actions/runs/23359661571/job/67959411290